### PR TITLE
Set metadata - OpenStack driver

### DIFF
--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -912,12 +912,11 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
         """
         return self._update_node(node, name=name)
 
-    def ex_get_metadata(self, node, metadata):
+    def ex_get_metadata(self, node):
         """
         Get a Node's metadata.
 
-        @return     Key/Value metadata to associate with a node
-        @type       C{dict}
+        @return C{dict} : Key/Value metadata to associate with a node
         """
         return self.connection.request(
                 '/servers/%s/metadata' % (node.id,), method='GET',

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -916,11 +916,22 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
         """
         Sets the Node's metadata.
 
-        @param metadata server metadata, a dict with string keys and values
+        @keyword    metadata: Key/Value metadata to associate with a node
+        @type       metadata: C{dict}
         """
         return self._update_node(node, metadata=metadata)
 
     def ex_update_node(self, node, **node_updates):
+        """
+        Update the Node's editable attributes.  Currently this driver
+        supports editing name and metadata.
+
+        @keyword    ex_metadata: Key/Value metadata to associate with a node
+        @type       ex_metadata: C{dict}
+
+        @keyword    name:   New name for the server
+        @type       name:   C{str}
+        """
         potential_data = self._create_args_to_params(node, node_updates)
         updates = {'name': potential_data['name'],
                    'metadata': potential_data['metadata']}

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -912,6 +912,17 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
         """
         return self._update_node(node, name=name)
 
+    def ex_get_metadata(self, node, metadata):
+        """
+        Get a Node's metadata.
+
+        @return     Key/Value metadata to associate with a node
+        @type       C{dict}
+        """
+        return self.connection.request(
+                '/servers/%s/metadata' % (node.id,), method='GET',
+            ).object['metadata']
+
     def ex_set_metadata(self, node, metadata):
         """
         Sets the Node's metadata.
@@ -919,22 +930,23 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
         @keyword    metadata: Key/Value metadata to associate with a node
         @type       metadata: C{dict}
         """
-        return self._update_node(node, metadata=metadata)
+        return self.connection.request(
+                '/servers/%s/metadata' % (node.id,), method='PUT',
+                data={'metadata': metadata}
+            ).object['metadata']
 
     def ex_update_node(self, node, **node_updates):
         """
-        Update the Node's editable attributes.  Currently this driver
-        supports editing name and metadata.
+        Update the Node's editable attributes.  The OpenStack API currently
+        supports editing name and IPv4/IPv6 access addresses.
 
-        @keyword    ex_metadata: Key/Value metadata to associate with a node
-        @type       ex_metadata: C{dict}
+        The driver currently only supports updating the node name.
 
         @keyword    name:   New name for the server
         @type       name:   C{str}
         """
         potential_data = self._create_args_to_params(node, node_updates)
-        updates = {'name': potential_data['name'],
-                   'metadata': potential_data['metadata']}
+        updates = {'name': potential_data['name']}
         return self._update_node(node, **updates)
 
     def ex_get_size(self, size_id):
@@ -963,7 +975,7 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
     def _update_node(self, node, **node_updates):
         """
         Updates the editable attributes of a server, which currently include
-        its name, metadata, and IPv4/IPv6 access addresses.
+        its name and IPv4/IPv6 access addresses.
         """
         return self._to_node(
             self.connection.request(

--- a/test/compute/fixtures/openstack_v1.1/_servers_12065_metadata_one_key.json
+++ b/test/compute/fixtures/openstack_v1.1/_servers_12065_metadata_one_key.json
@@ -1,0 +1,3 @@
+{
+    "metadata" :  {"Label": "dev"}
+}

--- a/test/compute/fixtures/openstack_v1.1/_servers_12065_metadata_two_keys.json
+++ b/test/compute/fixtures/openstack_v1.1/_servers_12065_metadata_two_keys.json
@@ -1,0 +1,6 @@
+{
+    "metadata" :  {
+            "Server Label" : "Web Head 1",
+            "Image Version" : "2.1"
+        }
+}

--- a/test/compute/test_openstack.py
+++ b/test/compute/test_openstack.py
@@ -597,6 +597,19 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
         else:
             self.fail('An expected error was not raised')
 
+    def test_ex_set_server_name(self):
+        try:
+            self.driver.ex_set_server_name(self.node, 'new_name')
+        except Exception, e:
+            self.fail('An error was raised: ' + repr(e))
+
+    def test_ex_set_metadata(self):
+        try:
+            self.driver.ex_set_metadata(self.node, {'a-key': 'a-value'})
+        except Exception, e:
+            self.fail('An error was raised: ' + repr(e))
+
+
     def test_ex_update_node(self):
         old_node = Node(
             id='12064',

--- a/test/compute/test_openstack.py
+++ b/test/compute/test_openstack.py
@@ -598,16 +598,21 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
             self.fail('An expected error was not raised')
 
     def test_ex_set_server_name(self):
-        try:
-            self.driver.ex_set_server_name(self.node, 'new_name')
-        except Exception, e:
-            self.fail('An error was raised: ' + repr(e))
+        old_node = Node(
+            id='12062', name=None, state=None,
+            public_ip=None, private_ip=None, driver=self.driver,
+        )
+        new_node = self.driver.ex_set_server_name(old_node, 'Bob')
+        self.assertEqual('Bob', new_node.name)
 
     def test_ex_set_metadata(self):
-        try:
-            self.driver.ex_set_metadata(self.node, {'a-key': 'a-value'})
-        except Exception, e:
-            self.fail('An error was raised: ' + repr(e))
+        old_node = Node(
+            id='12063', name=None, state=None,
+            public_ip=None, private_ip=None, driver=self.driver,
+        )
+        metadata = {'doo': 'wop'}
+        new_node = self.driver.ex_set_metadata(old_node, metadata)
+        self.assertEqual(metadata, new_node.extra['metadata'])
 
     def test_ex_update_node(self):
         old_node = Node(

--- a/test/compute/test_openstack.py
+++ b/test/compute/test_openstack.py
@@ -609,7 +609,6 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
         except Exception, e:
             self.fail('An error was raised: ' + repr(e))
 
-
     def test_ex_update_node(self):
         old_node = Node(
             id='12064',

--- a/test/compute/test_openstack.py
+++ b/test/compute/test_openstack.py
@@ -598,28 +598,24 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
             self.fail('An expected error was not raised')
 
     def test_ex_set_server_name(self):
-        old_node = Node(
-            id='12062', name=None, state=None,
-            public_ip=None, private_ip=None, driver=self.driver,
-        )
-        new_node = self.driver.ex_set_server_name(old_node, 'Bob')
+        node_12064 = self._generic_node_with_id('12064')
+        new_node = self.driver.ex_set_server_name(node_12064, 'Bob')
         self.assertEqual('Bob', new_node.name)
 
     def test_ex_set_metadata(self):
-        old_node = Node(
-            id='12063', name=None, state=None,
-            public_ip=None, private_ip=None, driver=self.driver,
-        )
-        metadata = {'doo': 'wop'}
-        new_node = self.driver.ex_set_metadata(old_node, metadata)
-        self.assertEqual(metadata, new_node.extra['metadata'])
+        node_12065 = self._generic_node_with_id('12065')
+        metadata = {"Server Label" : "Web Head 1",
+                    "Image Version" : "2.1"}
+        new_metadata = self.driver.ex_set_metadata(node_12065, metadata)
+        self.assertEqual(metadata, new_metadata)
+
+    def test_ex_get_metadata(self):
+        node_12065 = self._generic_node_with_id('12065')
+        metadata = self.driver.ex_get_metadata(node_12065)
+        self.assertEqual(metadata, {'Label': 'dev'})
 
     def test_ex_update_node(self):
-        old_node = Node(
-            id='12064',
-            name=None, state=None, public_ip=None, private_ip=None, driver=self.driver,
-        )
-
+        old_node = self._generic_node_with_id('12064')
         new_node = self.driver.ex_update_node(old_node, name='Bob')
 
         self.assertTrue(new_node)
@@ -652,6 +648,10 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
             pass
         else:
             self.fail('An expected error was not raised')
+
+    def _generic_node_with_id(self, node_id):
+        return Node(id=node_id, name=None, state=None,
+                    public_ip=None, private_ip=None, driver=self.driver)
 
 class OpenStack_1_1_FactoryMethodTests(OpenStack_1_1_Tests):
     should_list_locations = False
@@ -716,6 +716,16 @@ class OpenStack_1_1_MockHttp(MockHttpTestCase):
             return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
         elif method == "DELETE":
             return (httplib.ACCEPTED, "", {}, httplib.responses[httplib.ACCEPTED])
+        else:
+            raise NotImplementedError()
+
+    def _servers_12065_metadata(self, method, url, body, headers):
+        if method == "GET":
+            body = self.fixtures.load('_servers_12065_metadata_one_key.json')
+            return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
+        elif method == "PUT":
+            body = self.fixtures.load('_servers_12065_metadata_two_keys.json')
+            return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
         else:
             raise NotImplementedError()
 


### PR DESCRIPTION
From http://docs.openstack.org/cactus/openstack-compute/developer/openstack-compute-api-1.1/content/ServerUpdate.html:

This operation updates the editable attributes of a server: the name of the server, the server metadata, and the IPv4 and IPv6 access address. Note that while the server name is editable, the operation does not change the server host name. Note also that server names are not guaranteed to be unique.
