### PR TITLE
crash when debug is enabled and no paramiko: 

### DIFF
--- a/libcloud/__init__.py
+++ b/libcloud/__init__.py
@@ -26,6 +26,7 @@ try:
     import paramiko
     have_paramiko = True
 except ImportError:
+    have_paramiko = False
     pass
 
 


### PR DESCRIPTION
libcloud/**init**.py", line 61, in _init_once
    if have_paramiko:
NameError: global name 'have_paramiko' is not defined
