### PR TITLE
Fix OpenStack Alpha No Longer Returning Node Data on Server Create

### DIFF
--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -805,7 +805,12 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
                                        method='POST',
                                        data={'server': server_params})
 
-        return self._to_node(resp.object['server'])
+        create_response = resp.object['server']
+        server_resp = self.connection.request('/servers/%s' % create_response['id'])
+        server_object = server_resp.object['server']
+        server_object['adminPass'] = create_response['adminPass']
+
+        return self._to_node(server_object)
 
     def _to_images(self, obj, ex_only_active):
         images = []

--- a/test/compute/fixtures/openstack_v1.1/_servers_26f7fbee_8ce1_4c28_887a_bfe8e4bb10fe.json
+++ b/test/compute/fixtures/openstack_v1.1/_servers_26f7fbee_8ce1_4c28_887a_bfe8e4bb10fe.json
@@ -1,0 +1,49 @@
+{
+    "server": {
+        "status": "BUILD",
+        "updated": "2011-11-30T16:39:19Z",
+        "hostId": "",
+        "user_id": "reach6",
+        "name": "racktest",
+        "links": [
+            {
+                "href": "http://127.0.0.1/v1.1/68/servers/39d04103-984b-4a52-b4ec-ffec452e284c",
+                "rel": "self"
+            },
+            {
+                "href": "http://127.0.0.1/68/servers/39d04103-984b-4a52-b4ec-ffec452e284c",
+                "rel": "bookmark"
+            }
+        ],
+        "created": "2011-11-30T16:39:18Z",
+        "tenant_id": "68",
+        "image": {
+            "id": "fcf5582a-ad13-4d98-90a6-742116f1793c",
+            "links": [
+                {
+                    "href": "http://127.0.0.1/68/images/fcf5582a-ad13-4d98-90a6-742116f1793c",
+                    "rel": "bookmark"
+                }
+            ]
+        },
+        "addresses": {},
+        "accessIPv4": "",
+        "accessIPv6": "",
+        "key_name": "",
+        "progress": null,
+        "flavor": {
+            "id": "1",
+            "links": [
+                {
+                    "href": "http://127.0.0.1/68/flavors/1",
+                    "rel": "bookmark"
+                }
+            ]
+        },
+        "config_drive": "",
+        "id": "26f7fbee-8ce1-4c28-887a-bfe8e4bb10fe",
+        "metadata": {
+            "My Server Name" : "Apache1"
+        }
+    }
+}

--- a/test/compute/fixtures/openstack_v1.1/_servers_create.json
+++ b/test/compute/fixtures/openstack_v1.1/_servers_create.json
@@ -1,0 +1,16 @@
+{
+    "server": {
+        "id": "26f7fbee-8ce1-4c28-887a-bfe8e4bb10fe",
+        "links": [
+            {
+                "href": "http://127.0.0.1/v1.1/68/servers/26f7fbee-8ce1-4c28-887a-bfe8e4bb10fe",
+                "rel": "self"
+            },
+            {
+                "href": "http://127.0.0.1/68/servers/26f7fbee-8ce1-4c28-887a-bfe8e4bb10fe",
+                "rel": "bookmark"
+            }
+        ],
+        "adminPass": "racktestvJq7d3"
+    }
+}

--- a/test/compute/test_openstack.py
+++ b/test/compute/test_openstack.py
@@ -550,9 +550,9 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
         image = NodeImage(id=11, name='Ubuntu 8.10 (intrepid)', driver=self.driver)
         size = NodeSize(1, '256 slice', None, None, None, None, driver=self.driver)
         node = self.driver.create_node(name='racktest', image=image, size=size)
-        self.assertEqual(node.id, '52415800-8b69-11e0-9b19-734f565bc83b')
-        self.assertEqual(node.name, 'new-server-test')
-        self.assertEqual(node.extra['password'], 'GFf1j9aP')
+        self.assertEqual(node.id, '26f7fbee-8ce1-4c28-887a-bfe8e4bb10fe')
+        self.assertEqual(node.name, 'racktest')
+        self.assertEqual(node.extra['password'], 'racktestvJq7d3')
         self.assertEqual(node.extra['metadata']['My Server Name'], 'Apache1')
 
     def test_destroy_node(self):
@@ -705,7 +705,21 @@ class OpenStack_1_1_MockHttp(MockHttpTestCase):
         return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
 
     def _v1_1_slug_servers(self, method, url, body, headers):
-        body = self.fixtures.load('_servers.json')
+        if method == "POST":
+            body = self.fixtures.load('_servers_create.json')
+        elif method == "GET":
+            body = self.fixtures.load('_servers.json')
+        else:
+            raise NotImplementedError()
+
+        return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
+
+    def _v1_1_slug_servers_26f7fbee_8ce1_4c28_887a_bfe8e4bb10fe(self, method, url, body, headers):
+        if method == "GET":
+            body = self.fixtures.load('_servers_26f7fbee_8ce1_4c28_887a_bfe8e4bb10fe.json')
+        else:
+            raise NotImplementedError()
+
         return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
 
     def _v1_1_slug_servers_12065_action(self, method, url, body, headers):


### PR DESCRIPTION
WHY THIS HAD TO BE DONE

OpenStack Alpha at http://alpha.auth.api.rackspacecloud.com:5000/v2.0/ has started conforming to the spec and not returning any node data back except for new password on node create.

See: http://docs.openstack.org/cactus/openstack-compute/developer/openstack-compute-api-1.1/content/CreateServers.html

"Note that when creating a server only the server ID, its links, and the admin password are guaranteed to be returned in the request. Additional attributes may be retrieved by performing subsequent GETs on the server."

Specifically the OpenStack 1.1 node driver was failing on create_node as it was attempting to fill the information to create a libcloud node from the server response (which is not just returning ID and admin password).

WHAT

The implementation I took here was to do the follow-up GET to get the node information.  There is enough information returned there to make a libcloud node object, though some of it won't be filled in until the server has gone from BUILD to ACTIVE (for example, ip addresses).

I changed some of the create_node test data to match the existing asserts.
