### PR TITLE
Update Cloud Files and Load Balancer Rackspace Connection Classes to pass on kwargs

### DIFF
--- a/libcloud/loadbalancer/drivers/rackspace.py
+++ b/libcloud/loadbalancer/drivers/rackspace.py
@@ -45,8 +45,9 @@ class RackspaceConnection(OpenStackBaseConnection):
     auth_url = AUTH_URL_US
     _url_key = "lb_url"
 
-    def __init__(self, user_id, key, secure=True):
-        super(RackspaceConnection, self).__init__(user_id, key, secure)
+    def __init__(self, user_id, key, secure=True, **kwargs):
+        super(RackspaceConnection, self).__init__(user_id, key, secure, 
+                                                  **kwargs)
         self.api_version = 'v1.0'
         self.accept_format = 'application/json'
 

--- a/libcloud/storage/drivers/cloudfiles.py
+++ b/libcloud/storage/drivers/cloudfiles.py
@@ -1,3 +1,4 @@
+
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -93,8 +94,9 @@ class CloudFilesConnection(OpenStackBaseConnection):
     rawResponseCls = CloudFilesRawResponse
     _url_key = "storage_url"
 
-    def __init__(self, user_id, key, secure=True):
-        super(CloudFilesConnection, self).__init__(user_id, key, secure=secure)
+    def __init__(self, user_id, key, secure=True, **kwargs):
+        super(CloudFilesConnection, self).__init__(user_id, key, secure=secure, 
+                                                   **kwargs)
         self.api_version = API_VERSION
         self.accept_format = 'application/json'
 


### PR DESCRIPTION
WHY

Rackspace is currently rolling out Auth 2.0.  The existing libcloud connection classes for Load Balancers and Cloud Files do not pass on kwargs to their superclass, essentially forcing these drivers to always use Auth 1.0/Auth 1.1 (whatever their particular defaults are).

The OpenStack Nova Driver does not define a constructor so we get this behavior for free there.

WHAT

Just pass on any kwargs that are passed into the superclass.

Tests pass.  Let me know if you'd like me to write some tests around this specific change.  When Load Balancers are in the Auth 2.0 service catalog we will aim at a more complete patch.  (Would we prefer extra connection classes for CloudFiles_Auth_2_0 in this situation?)
