### PR TITLE
Enable create image for OpenStack 1.1 driver.

### DIFF
--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -929,16 +929,13 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
         return resp.status == httplib.ACCEPTED
 
     def ex_save_image(self, node, name, metadata=None):
-        # This has not yet been implemented by OpenStack 1.1
-        raise NotImplementedError()
-
         optional_params = {}
         if metadata:
             optional_params['metadata'] = metadata
         resp = self._node_action(node, 'createImage', name=name,
                                  **optional_params)
         # TODO: concevt location header into NodeImage object
-        return resp.status == httplib.NO_CONTENT
+        return resp.status == httplib.ACCEPTED
 
     def ex_set_server_name(self, node, name):
         """

--- a/test/compute/test_openstack.py
+++ b/test/compute/test_openstack.py
@@ -608,12 +608,9 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
             self.fail('An error was raised: ' + repr(e))
 
     def test_ex_save_image(self):
-        try:
-            self.driver.ex_save_image(self.node, 'new_image')
-        except NotImplementedError:
-            pass
-        else:
-            self.fail('An expected error was not raised')
+        OpenStackMockHttp.type = 'CREATE_IMAGE_1_1'
+        result = self.driver.ex_save_image(self.node, 'new_image')
+        self.assertTrue(result)
 
     def test_ex_set_server_name(self):
         old_node = Node(


### PR DESCRIPTION
- Remove raise NotImplementedError() from OpenStack 1.1 driver's ex_save_image function.
- Return resp == httplib.ACCEPTED in OpenStack 1.1 driver's ex_save_image function since normal response code for create image in OpenStack 1.1 is 202.
- Fix test for OpenStack 1.1 driver's ex_save_image function.

https://issues.apache.org/jira/browse/LIBCLOUD-135
