### PR TITLE
Add protocol to rackspace lb extra

### DIFF
--- a/libcloud/loadbalancer/drivers/rackspace.py
+++ b/libcloud/loadbalancer/drivers/rackspace.py
@@ -343,6 +343,9 @@ class RackspaceLBDriver(Driver):
             "ipv4PrivateSource": sourceAddresses.get("ipv4Servicenet"),
         }
 
+        if 'protocol' in el:
+            extra["protocol"] = el["protocol"]
+
         if 'algorithm' in el and el["algorithm"] in self._VALUE_TO_ALGORITHM_MAP:
             extra["algorithm"] = self._value_to_algorithm(el["algorithm"])
 

--- a/test/loadbalancer/test_rackspace.py
+++ b/test/loadbalancer/test_rackspace.py
@@ -141,6 +141,10 @@ class RackspaceLBTests(unittest.TestCase):
         balancer = self.driver.get_balancer(balancer_id='8290')
         self.assertEquals(balancer.extra["algorithm"], Algorithm.RANDOM)
 
+    def test_get_balancer_protocol(self):
+        balancer = self.driver.get_balancer(balancer_id='94695')
+        self.assertEquals(balancer.extra["protocol"], "HTTP")
+
     def test_get_balancer_weighted_round_robin_algorithm(self):
         balancer = self.driver.get_balancer(balancer_id='94692')
         self.assertEquals(balancer.extra["algorithm"],


### PR DESCRIPTION
This adds "protocol" to the extra attributes for a RackspaceLB, if it is available.
