### PR TITLE
Rackspace Load Balancer 'members' - weight and condition

### DIFF
--- a/libcloud/loadbalancer/base.py
+++ b/libcloud/loadbalancer/base.py
@@ -26,10 +26,11 @@ __all__ = [
 
 class Member(object):
 
-    def __init__(self, id, ip, port):
+    def __init__(self, id, ip, port, extra=None):
         self.id = str(id) if id else None
         self.ip = ip
         self.port = port
+        self.extra = extra or {}
 
     def __repr__(self):
         return ('<Member: id=%s, address=%s:%s>' % (self.id,

--- a/libcloud/loadbalancer/drivers/rackspace.py
+++ b/libcloud/loadbalancer/drivers/rackspace.py
@@ -365,6 +365,9 @@ class RackspaceLBDriver(Driver):
             logging = el["connectionLogging"]
             extra["connectionLoggingEnabled"] = logging.get("enabled")
 
+        if 'nodes' in el:
+            extra['members'] = self._to_members(el)
+
         return LoadBalancer(id=el["id"],
                 name=el["name"],
                 state=self.LB_STATE_MAP.get(
@@ -378,9 +381,17 @@ class RackspaceLBDriver(Driver):
         return [self._to_member(el) for el in object["nodes"]]
 
     def _to_member(self, el):
+        extra = {}
+        if 'weight' in el:
+            extra['weight'] = el["weight"]
+
+        if 'condition' in el:
+            extra['condition'] = el["condition"]
+
         lbmember = Member(id=el["id"],
                 ip=el["address"],
-                port=el["port"])
+                port=el["port"],
+                extra=extra)
         return lbmember
 
     def _ex_private_virtual_ips(self, el):

--- a/test/loadbalancer/fixtures/rackspace/v1_slug_loadbalancers_8290_nodes.json
+++ b/test/loadbalancer/fixtures/rackspace/v1_slug_loadbalancers_8290_nodes.json
@@ -5,14 +5,16 @@
             "condition": "ENABLED", 
             "id": 30944, 
             "port": 80, 
-            "status": "ONLINE"
+            "status": "ONLINE",
+            "weight": 12
         }, 
         {
             "address": "10.1.0.10", 
-            "condition": "ENABLED", 
+            "condition": "DISABLED", 
             "id": 30945, 
             "port": 80, 
-            "status": "ONLINE"
+            "status": "ONLINE",
+            "weight": 8
         }
     ]
 }

--- a/test/loadbalancer/test_rackspace.py
+++ b/test/loadbalancer/test_rackspace.py
@@ -137,6 +137,13 @@ class RackspaceLBTests(unittest.TestCase):
         balancer = self.driver.get_balancer(balancer_id='18940')
         self.assertEquals(balancer.extra["ipv4PrivateSource"], '10.183.252.25')
 
+    def test_get_balancer_extra_members(self):
+        balancer = self.driver.get_balancer(balancer_id='8290')
+        members = balancer.extra['members']
+        self.assertEquals(2, len(members))
+        self.assertEquals('10.1.0.11', members[0].ip)
+        self.assertEquals('10.1.0.10', members[1].ip)
+
     def test_get_balancer_algorithm(self):
         balancer = self.driver.get_balancer(balancer_id='8290')
         self.assertEquals(balancer.extra["algorithm"], Algorithm.RANDOM)
@@ -241,6 +248,20 @@ class RackspaceLBTests(unittest.TestCase):
         self.assertEquals(len(members), 2)
         self.assertEquals(set(['10.1.0.10:80', '10.1.0.11:80']),
                 set(["%s:%s" % (member.ip, member.port) for member in members]))
+
+    def test_balancer_members_extra_weight(self):
+        balancer = self.driver.get_balancer(balancer_id='8290')
+        members = balancer.list_members()
+
+        self.assertEquals(12, members[0].extra['weight'])
+        self.assertEquals(8, members[1].extra['weight'])
+
+    def test_balancer_members_extra_condition(self):
+        balancer = self.driver.get_balancer(balancer_id='8290')
+        members = balancer.list_members()
+
+        self.assertEquals('ENABLED', members[0].extra['condition'])
+        self.assertEquals('DISABLED', members[1].extra['condition'])
 
     def test_balancer_attach_member(self):
         balancer = self.driver.get_balancer(balancer_id='8290')


### PR DESCRIPTION
This patch adds support for "weight" and "condition" attributes of Rackspace load balancer members, as [documented](http://docs-beta.rackspace.com/loadbalancers/api/v1.0/clb-devguide/content/List_Nodes-d1e2218.html)

In addition, calls to the Rackspace `driver.get_balancer()` will now return a LoadBalancer with the list of members in `extra['members']`.
