### PR TITLE
Rackspace Load Balancer - simple edits

### DIFF
--- a/libcloud/common/base.py
+++ b/libcloud/common/base.py
@@ -618,14 +618,16 @@ class PollingConnection(Connection):
                                          context=context)
         response = request(**kwargs)
         kwargs = self.get_poll_request_kwargs(response=response,
-                                              context=context)
+                                              context=context,
+                                              request_kwargs=kwargs)
 
         end = time.time() + self.timeout
         completed = False
         while time.time() < end and not completed:
             response = request(**kwargs)
             completed = self.has_completed(response=response)
-            time.sleep(self.poll_interval)
+            if not completed:
+                time.sleep(self.poll_interval)
 
         if not completed:
             raise LibcloudError('Job did not complete in %s seconds' %
@@ -643,13 +645,17 @@ class PollingConnection(Connection):
                   'headers': headers, 'method': method}
         return kwargs
 
-    def get_poll_request_kwargs(self, response, context):
+    def get_poll_request_kwargs(self, response, context, request_kwargs):
         """
         Return keyword arguments which are passed to the request() method when
         polling for the job status.
 
         @param response: Response object returned by poll request.
         @type response: C{HTTPResponse}
+
+        @param request_kwargs: Kwargs previously used to initiate the
+                                  poll request.
+        @type response: C{dict}
 
         @return C{dict} Keyword arguments
         """

--- a/libcloud/common/cloudstack.py
+++ b/libcloud/common/cloudstack.py
@@ -73,7 +73,7 @@ class CloudStackConnection(ConnectionUserAndKey, PollingConnection):
                            method='GET', context=None):
         return context
 
-    def get_poll_request_kwargs(self, response, context):
+    def get_poll_request_kwargs(self, response, context, request_kwargs):
         job_id = response['jobid']
         kwargs = {'command': 'queryAsyncJobResult', 'jobid': job_id}
         return kwargs

--- a/libcloud/dns/drivers/rackspace.py
+++ b/libcloud/dns/drivers/rackspace.py
@@ -87,7 +87,7 @@ class RackspaceDNSConnection(OpenStack_1_1_Connection, PollingConnection):
     poll_interval = 2.5
     timeout = 30
 
-    def get_poll_request_kwargs(self, response, context):
+    def get_poll_request_kwargs(self, response, context, request_kwargs):
         job_id = response.object['jobId']
         kwargs = {'action': '/status/%s' % (job_id),
                 'params': {'showDetails': True}}

--- a/libcloud/loadbalancer/base.py
+++ b/libcloud/loadbalancer/base.py
@@ -165,7 +165,7 @@ class Driver(BaseDriver):
 
     def update_balancer(self, balancer, **kwargs):
         """
-        Sets the name, algorithm, protocol, or port on a Rackspace load balancer.
+        Sets the name, algorithm, protocol, or port on a load balancer.
 
         @keyword    name: New load balancer name
         @type       metadata: C{str}

--- a/libcloud/loadbalancer/base.py
+++ b/libcloud/loadbalancer/base.py
@@ -163,6 +163,25 @@ class Driver(BaseDriver):
         raise NotImplementedError(
                 'get_balancer not implemented for this driver')
 
+    def update_balancer(self, balancer, **kwargs):
+        """
+        Sets the name, algorithm, protocol, or port on a Rackspace load balancer.
+
+        @keyword    name: New load balancer name
+        @type       metadata: C{str}
+
+        @keyword    algorithm: New load balancer algorithm
+        @type       metadata: C{libcloud.loadbalancer.base.Algorithm}
+
+        @keyword    protocol: New load balancer protocol
+        @type       metadata: C{str}
+
+        @keyword    port: New load balancer port
+        @type       metadata: C{int}
+        """
+        raise NotImplementedError(
+                'update_balancer not implemented for this driver')
+
     def balancer_attach_compute_node(self, balancer, node):
         """
         Attach a compute node as a member to the load balancer.

--- a/libcloud/loadbalancer/drivers/rackspace.py
+++ b/libcloud/loadbalancer/drivers/rackspace.py
@@ -294,26 +294,11 @@ class RackspaceLBDriver(Driver):
                 self.connection.request(uri).object)
 
     def update_balancer(self, balancer, **kwargs):
-        """
-        Sets the name, algorithm, protocol, or port on a Rackspace load balancer.
-
-        @keyword    name: New load balancer name
-        @type       metadata: C{str}
-
-        @keyword    algorithm: New load balancer algorithm
-        @type       metadata: C{libcloud.loadbalancer.base.Algorithm}
-
-        @keyword    protocol: New load balancer protocol
-        @type       metadata: C{str}
-
-        @keyword    port: New load balancer port
-        @type       metadata: C{int}
-        """
         attrs = self._kwargs_to_mutable_attrs(**kwargs)
-        resp = self.connection.request('/loadbalancers/%s' % balancer.id,
+        self.connection.request('/loadbalancers/%s' % balancer.id,
                 method='PUT',
                 data=json.dumps(attrs))
-        return resp.status == httplib.ACCEPTED
+        return self.get_balancer(balancer.id)
 
     def _kwargs_to_mutable_attrs(self, **attrs):
         update_attrs = {}

--- a/libcloud/loadbalancer/drivers/rackspace.py
+++ b/libcloud/loadbalancer/drivers/rackspace.py
@@ -292,6 +292,46 @@ class RackspaceLBDriver(Driver):
         return self._to_members(
                 self.connection.request(uri).object)
 
+    #def update_balancer(self, balancer, name=None, algorithm=None, protocol=None, port=None):
+    def update_balancer(self, balancer, **kwargs):
+        """
+        Sets the name, algorithm, protocol, or port on a Rackspace load balancer.
+
+        @keyword    name: New load balancer name
+        @type       metadata: C{str}
+
+        @keyword    algorithm: New load balancer algorithm
+        @type       metadata: C{str}
+
+        @keyword    protocol: New load balancer protocol
+        @type       metadata: C{str}
+
+        @keyword    port: New load balancer port
+        @type       metadata: C{int}
+        """
+        attrs = self._to_update_attrs(kwargs)
+        resp = self.connection.request('/loadbalancers/%s' % balancer.id,
+                method='PUT',
+                data=json.dumps(attrs))
+        return resp.status == 202
+
+    def _to_update_attrs(self, attrs):
+        update_attrs = {}
+        if "name" in attrs:
+            update_attrs['name'] = attrs['name']
+
+        if "algorithm" in attrs:
+            algorithm_value = self._algorithm_to_value(attrs['algorithm'])
+            update_attrs['algorithm'] = algorithm_value
+
+        if "protocol" in attrs:
+            update_attrs['protocol'] = attrs['protocol']
+
+        if "port" in attrs:
+            update_attrs['port'] = int(attrs['port'])
+
+        return update_attrs
+
     def ex_list_algorithm_names(self):
         """
         Lists algorithms supported by the API.  Returned as strings because

--- a/libcloud/loadbalancer/drivers/rackspace.py
+++ b/libcloud/loadbalancer/drivers/rackspace.py
@@ -21,6 +21,7 @@ try:
 except ImportError:
     import json
 
+from libcloud.utils.py3 import httplib
 from libcloud.utils.misc import reverse_dict
 from libcloud.common.base import JsonResponse
 from libcloud.loadbalancer.base import LoadBalancer, Member, Driver, Algorithm
@@ -255,7 +256,7 @@ class RackspaceLBDriver(Driver):
         uri = '/loadbalancers/%s' % (balancer.id)
         resp = self.connection.request(uri, method='DELETE')
 
-        return resp.status == 202
+        return resp.status == httplib.ACCEPTED
 
     def get_balancer(self, balancer_id):
         uri = '/loadbalancers/%s' % (balancer_id)
@@ -285,7 +286,7 @@ class RackspaceLBDriver(Driver):
         uri = '/loadbalancers/%s/nodes/%s' % (balancer.id, member.id)
         resp = self.connection.request(uri, method='DELETE')
 
-        return resp.status == 202
+        return resp.status == httplib.ACCEPTED
 
     def balancer_list_members(self, balancer):
         uri = '/loadbalancers/%s/nodes' % (balancer.id)
@@ -312,7 +313,7 @@ class RackspaceLBDriver(Driver):
         resp = self.connection.request('/loadbalancers/%s' % balancer.id,
                 method='PUT',
                 data=json.dumps(attrs))
-        return resp.status == 202
+        return resp.status == httplib.ACCEPTED
 
     def _to_update_attrs(self, attrs):
         update_attrs = {}

--- a/libcloud/loadbalancer/drivers/rackspace.py
+++ b/libcloud/loadbalancer/drivers/rackspace.py
@@ -292,7 +292,6 @@ class RackspaceLBDriver(Driver):
         return self._to_members(
                 self.connection.request(uri).object)
 
-    #def update_balancer(self, balancer, name=None, algorithm=None, protocol=None, port=None):
     def update_balancer(self, balancer, **kwargs):
         """
         Sets the name, algorithm, protocol, or port on a Rackspace load balancer.
@@ -301,7 +300,7 @@ class RackspaceLBDriver(Driver):
         @type       metadata: C{str}
 
         @keyword    algorithm: New load balancer algorithm
-        @type       metadata: C{str}
+        @type       metadata: C{libcloud.loadbalancer.base.Algorithm}
 
         @keyword    protocol: New load balancer protocol
         @type       metadata: C{str}

--- a/libcloud/loadbalancer/drivers/rackspace.py
+++ b/libcloud/loadbalancer/drivers/rackspace.py
@@ -192,7 +192,7 @@ class RackspaceConnection(OpenStackBaseConnection, PollingConnection):
     def has_completed(self, response):
         state = response.object['loadBalancer']['status']
         if state == 'ERROR':
-            raise LibcloudError("damnit.",
+            raise LibcloudError("Load balancer entered an ERROR state.",
                                 driver=self.driver)
 
         return state == 'ACTIVE'

--- a/test/loadbalancer/fixtures/rackspace/v1_slug_loadbalancers_3xxx.json
+++ b/test/loadbalancer/fixtures/rackspace/v1_slug_loadbalancers_3xxx.json
@@ -1,0 +1,46 @@
+{
+    "loadBalancer": {
+        "algorithm": "UUUUUUUUUU", 
+        "cluster": {
+            "name": "ztm-n05.lbaas.ord1.rackspace.net"
+        }, 
+        "connectionLogging": {
+            "enabled": false
+        }, 
+        "created": {
+            "time": "2011-04-07T16:27:50Z"
+        }, 
+        "id": 9999999, 
+        "name": "test2", 
+        "nodes": [
+            {
+                "address": "10.1.0.11", 
+                "condition": "ENABLED", 
+                "id": 30944, 
+                "port": 80, 
+                "status": "ONLINE"
+            }, 
+            {
+                "address": "10.1.0.10", 
+                "condition": "ENABLED", 
+                "id": 30945, 
+                "port": 80, 
+                "status": "ONLINE"
+            }
+        ], 
+        "port": 88888, 
+        "protocol": "XXXXX", 
+        "status": "ACTIVE", 
+        "updated": {
+            "time": "2011-04-07T16:28:12Z"
+        }, 
+        "virtualIps": [
+            {
+                "address": "1.1.1.1", 
+                "id": 1151, 
+                "ipVersion": "IPV4", 
+                "type": "PUBLIC"
+            }
+        ]
+    }
+}

--- a/test/loadbalancer/test_rackspace.py
+++ b/test/loadbalancer/test_rackspace.py
@@ -326,10 +326,6 @@ class RackspaceUKLBTests(RackspaceLBTests):
                 RackspaceLBMockHttp)
         RackspaceLBMockHttp.type = None
         self.driver = RackspaceUKLBDriver('user', 'key')
-        self.fake_lb_3131 = LoadBalancer(id='3131', name='LB_update',
-                                         state='PENDING_UPDATE', ip='10.34.4.3',
-                                         port=80, driver=self.driver)
-
 
 class RackspaceLBMockHttp(MockHttpTestCase):
     fixtures = LoadBalancerFileFixtures('rackspace')

--- a/test/loadbalancer/test_rackspace.py
+++ b/test/loadbalancer/test_rackspace.py
@@ -40,6 +40,7 @@ class RackspaceLBTests(unittest.TestCase):
                 RackspaceLBMockHttp)
         RackspaceLBMockHttp.type = None
         self.driver = RackspaceLBDriver('user', 'key')
+        self.driver.connection.poll_interval = 0.0
 
     def test_list_protocols(self):
         protocols = self.driver.list_protocols()
@@ -318,6 +319,54 @@ class RackspaceLBTests(unittest.TestCase):
             pass
         else:
             self.fail('Should have thrown an exception with bad algorithm value')
+
+    def test_ex_update_balancer_no_poll_protocol(self):
+        balancer = LoadBalancer(id='3130', name='LB_update',
+                                         state='PENDING_UPDATE', ip='10.34.4.3',
+                                         port=80, driver=self.driver)
+        action_succeeded = self.driver.ex_update_balancer_no_poll(
+                                                              balancer,
+                                                              protocol='HTTPS')
+        self.assertTrue(action_succeeded)
+
+    def test_ex_update_balancer_no_poll_port(self):
+        balancer = LoadBalancer(id='3131', name='LB_update',
+                                         state='PENDING_UPDATE', ip='10.34.4.3',
+                                         port=80, driver=self.driver)
+        action_succeeded = self.driver.ex_update_balancer_no_poll(
+                                                            balancer,
+                                                            port=1337)
+        self.assertTrue(action_succeeded)
+
+    def test_ex_update_balancer_no_poll_name(self):
+        balancer = LoadBalancer(id='3132', name='LB_update',
+                                         state='PENDING_UPDATE', ip='10.34.4.3',
+                                         port=80, driver=self.driver)
+
+        action_succeeded = self.driver.ex_update_balancer_no_poll(
+                                                          balancer,
+                                                          name='new_lb_name')
+        self.assertTrue(action_succeeded)
+
+    def test_ex_update_balancer_no_poll_algorithm(self):
+        balancer = LoadBalancer(id='3133', name='LB_update',
+                                         state='PENDING_UPDATE', ip='10.34.4.3',
+                                         port=80, driver=self.driver)
+        action_succeeded = self.driver.ex_update_balancer_no_poll(balancer,
+                                               algorithm=Algorithm.ROUND_ROBIN)
+        self.assertTrue(action_succeeded)
+
+    def test_ex_update_balancer_no_poll_bad_algorithm_exception(self):
+        balancer = LoadBalancer(id='3134', name='LB_update',
+                                         state='PENDING_UPDATE', ip='10.34.4.3',
+                                         port=80, driver=self.driver)
+        try:
+            self.driver.update_balancer(balancer,
+                                        algorithm='HAVE_MERCY_ON_OUR_SERVERS')
+        except LibcloudError:
+            pass
+        else:
+            self.fail('Should have thrown exception with bad algorithm value')
 
 class RackspaceUKLBTests(RackspaceLBTests):
 


### PR DESCRIPTION
Enable PUTs on `/loadbalancer/<id>`, as documented here:

http://docs-beta.rackspace.com/loadbalancers/api/v1.0/clb-devguide/content/List_Load_Balancer_Details-d1e1522.html
