### PR TITLE
Rackspace Load Balancers - 'created' and 'updated' extras

### DIFF
--- a/libcloud/loadbalancer/drivers/rackspace.py
+++ b/libcloud/loadbalancer/drivers/rackspace.py
@@ -15,6 +15,7 @@
 
 import os
 import binascii
+from datetime import datetime
 
 try:
     import simplejson as json
@@ -376,6 +377,12 @@ class RackspaceLBDriver(Driver):
         if 'nodes' in el:
             extra['members'] = self._to_members(el)
 
+        if 'created' in el:
+            extra['created'] = self._iso_to_datetime(el['created']['time'])
+
+        if 'updated' in el:
+            extra['updated'] = self._iso_to_datetime(el['updated']['time'])
+
         return LoadBalancer(id=el["id"],
                 name=el["name"],
                 state=self.LB_STATE_MAP.get(
@@ -470,6 +477,15 @@ class RackspaceLBDriver(Driver):
         elif type == "DENY":
             return RackspaceAccessRuleType.DENY
 
+    def _iso_to_datetime(self, isodate):
+        date_formats = ('%Y-%m-%dT%H:%M:%SZ', '%Y-%m-%dT%H:%M:%S%z')
+        date = None
+        for date_format in date_formats:
+            try:
+                date = date or datetime.strptime(isodate, date_format)
+            except ValueError:
+                date = None
+        return date
 
 class RackspaceUKLBDriver(RackspaceLBDriver):
     connectionCls = RackspaceUKConnection

--- a/test/loadbalancer/test_rackspace.py
+++ b/test/loadbalancer/test_rackspace.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import sys
+import datetime
 import unittest
 
 try:
@@ -145,6 +146,18 @@ class RackspaceLBTests(unittest.TestCase):
         self.assertEquals('10.1.0.11', members[0].ip)
         self.assertEquals('10.1.0.10', members[1].ip)
         self.assertEquals('10.1.0.9', members[2].ip)
+
+    def test_get_balancer_extra_created(self):
+        balancer = self.driver.get_balancer(balancer_id='8290')
+
+        created_8290 = datetime.datetime(2011, 4, 7, 16, 27, 50)
+        self.assertEquals(created_8290, balancer.extra['created'])
+
+    def test_get_balancer_extra_updated(self):
+        balancer = self.driver.get_balancer(balancer_id='8290')
+
+        updated_8290 = datetime.datetime(2011, 4, 7, 16, 28, 12)
+        self.assertEquals(updated_8290, balancer.extra['updated'])
 
     def test_get_balancer_algorithm(self):
         balancer = self.driver.get_balancer(balancer_id='8290')


### PR DESCRIPTION
This patch adds support for 'created' and 'updated' extras.  In writing this, I discovered that some of the API endpoints return the date in different formats.  This should handle the ones I've seen, and all of the tests pass.
