### PR TITLE
Rackspace LB Driver: Bulk deletes

### DIFF
--- a/libcloud/loadbalancer/drivers/rackspace.py
+++ b/libcloud/loadbalancer/drivers/rackspace.py
@@ -280,6 +280,14 @@ class RackspaceLBDriver(Driver):
 
         return resp.status == httplib.ACCEPTED
 
+    def ex_destroy_balancers(self, *balancers):
+        ids = [("id", balancer.id) for balancer in balancers]
+        resp = self.connection.request('/loadbalancers',
+            method='DELETE',
+            params=ids)
+
+        return resp.status == httplib.ACCEPTED
+
     def get_balancer(self, balancer_id):
         uri = '/loadbalancers/%s' % (balancer_id)
         resp = self.connection.request(uri)
@@ -307,6 +315,13 @@ class RackspaceLBDriver(Driver):
         # the balancer.
         uri = '/loadbalancers/%s/nodes/%s' % (balancer.id, member.id)
         resp = self.connection.request(uri, method='DELETE')
+
+        return resp.status == httplib.ACCEPTED
+
+    def ex_balancer_detach_members(self, balancer, members):
+        uri = '/loadbalancers/%s/nodes' % (balancer.id)
+        ids = [("id", member.id) for member in members]
+        resp = self.connection.request(uri, method='DELETE', params=ids)
 
         return resp.status == httplib.ACCEPTED
 

--- a/libcloud/loadbalancer/drivers/rackspace.py
+++ b/libcloud/loadbalancer/drivers/rackspace.py
@@ -280,7 +280,7 @@ class RackspaceLBDriver(Driver):
 
         return resp.status == httplib.ACCEPTED
 
-    def ex_destroy_balancers(self, *balancers):
+    def ex_destroy_balancers(self, balancers):
         ids = [("id", balancer.id) for balancer in balancers]
         resp = self.connection.request('/loadbalancers',
             method='DELETE',

--- a/libcloud/loadbalancer/drivers/rackspace.py
+++ b/libcloud/loadbalancer/drivers/rackspace.py
@@ -281,7 +281,7 @@ class RackspaceLBDriver(Driver):
         return resp.status == httplib.ACCEPTED
 
     def ex_destroy_balancers(self, balancers):
-        ids = [("id", balancer.id) for balancer in balancers]
+        ids = [('id', balancer.id) for balancer in balancers]
         resp = self.connection.request('/loadbalancers',
             method='DELETE',
             params=ids)
@@ -320,7 +320,7 @@ class RackspaceLBDriver(Driver):
 
     def ex_balancer_detach_members(self, balancer, members):
         uri = '/loadbalancers/%s/nodes' % (balancer.id)
-        ids = [("id", member.id) for member in members]
+        ids = [('id', member.id) for member in members]
         resp = self.connection.request(uri, method='DELETE', params=ids)
 
         return resp.status == httplib.ACCEPTED

--- a/test/loadbalancer/test_rackspace.py
+++ b/test/loadbalancer/test_rackspace.py
@@ -23,6 +23,7 @@ except ImportError:
     import json
 
 from libcloud.utils.py3 import httplib
+from libcloud.utils.py3 import urllib
 
 from libcloud.loadbalancer.base import LoadBalancer, Member, Algorithm
 from libcloud.loadbalancer.types import MemberCondition
@@ -106,6 +107,11 @@ class RackspaceLBTests(unittest.TestCase):
         balancer = self.driver.list_balancers()[0]
 
         ret = self.driver.destroy_balancer(balancer)
+        self.assertTrue(ret)
+
+    def test_ex_destroy_balancers(self):
+        balancers = self.driver.list_balancers()
+        ret = self.driver.ex_destroy_balancers(*balancers)
         self.assertTrue(ret)
 
     def test_get_balancer(self):
@@ -308,6 +314,13 @@ class RackspaceLBTests(unittest.TestCase):
         ret = balancer.detach_member(member)
         self.assertTrue(ret)
 
+    def test_ex_detach_members(self):
+        balancer = self.driver.get_balancer(balancer_id='8290')
+        members = balancer.list_members()
+
+        ret = self.driver.ex_balancer_detach_members(balancer, members)
+        self.assertTrue(ret)
+
     def test_update_balancer_protocol(self):
         balancer = LoadBalancer(id='3130', name='LB_update',
                                          state='PENDING_UPDATE', ip='10.34.4.3',
@@ -442,6 +455,16 @@ class RackspaceLBMockHttp(MockHttpTestCase):
             body = self.fixtures.load('v1_slug_loadbalancers_post.json')
             return (httplib.ACCEPTED, body, {},
                     httplib.responses[httplib.ACCEPTED])
+        elif method == "DELETE":
+            balancers = self.fixtures.load('v1_slug_loadbalancers.json')
+            balancers_json = json.loads(balancers)
+
+            for balancer in balancers_json["loadBalancers"]:
+                id = balancer["id"]
+                self.assertTrue(urllib.urlencode([("id", id)]) in url,
+                    msg="Did not delete balancer with id %d" % id)
+
+            return (httplib.ACCEPTED, "", {}, httplib.responses[httplib.ACCEPTED])
 
         raise NotImplementedError
 
@@ -456,8 +479,11 @@ class RackspaceLBMockHttp(MockHttpTestCase):
         raise NotImplementedError
 
     def _v1_0_slug_loadbalancers_8290(self, method, url, body, headers):
-        body = self.fixtures.load('v1_slug_loadbalancers_8290.json')
-        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+        if method == "GET":
+            body = self.fixtures.load('v1_slug_loadbalancers_8290.json')
+            return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+
+        raise NotImplementedError
 
     def _v1_0_slug_loadbalancers_8290_nodes(self, method, url, body, headers):
         if method == "GET":
@@ -467,6 +493,16 @@ class RackspaceLBMockHttp(MockHttpTestCase):
             body = self.fixtures.load('v1_slug_loadbalancers_8290_nodes_post.json')
             return (httplib.ACCEPTED, body, {},
                     httplib.responses[httplib.ACCEPTED])
+        elif method == "DELETE":
+            nodes = self.fixtures.load('v1_slug_loadbalancers_8290_nodes.json')
+            json_nodes = json.loads(nodes)
+
+            for node in json_nodes["nodes"]:
+                id = node["id"]
+                self.assertTrue(urllib.urlencode([("id", id)]) in url,
+                    msg="Did not delete member with id %d" % id)
+
+            return (httplib.ACCEPTED, "", {}, httplib.responses[httplib.ACCEPTED])
 
         raise NotImplementedError
 

--- a/test/loadbalancer/test_rackspace.py
+++ b/test/loadbalancer/test_rackspace.py
@@ -111,7 +111,7 @@ class RackspaceLBTests(unittest.TestCase):
 
     def test_ex_destroy_balancers(self):
         balancers = self.driver.list_balancers()
-        ret = self.driver.ex_destroy_balancers(*balancers)
+        ret = self.driver.ex_destroy_balancers(balancers)
         self.assertTrue(ret)
 
     def test_get_balancer(self):

--- a/test/loadbalancer/test_rackspace.py
+++ b/test/loadbalancer/test_rackspace.py
@@ -459,12 +459,12 @@ class RackspaceLBMockHttp(MockHttpTestCase):
             balancers = self.fixtures.load('v1_slug_loadbalancers.json')
             balancers_json = json.loads(balancers)
 
-            for balancer in balancers_json["loadBalancers"]:
-                id = balancer["id"]
-                self.assertTrue(urllib.urlencode([("id", id)]) in url,
-                    msg="Did not delete balancer with id %d" % id)
+            for balancer in balancers_json['loadBalancers']:
+                id = balancer['id']
+                self.assertTrue(urllib.urlencode([('id', id)]) in url,
+                    msg='Did not delete balancer with id %d' % id)
 
-            return (httplib.ACCEPTED, "", {}, httplib.responses[httplib.ACCEPTED])
+            return (httplib.ACCEPTED, '', {}, httplib.responses[httplib.ACCEPTED])
 
         raise NotImplementedError
 
@@ -497,12 +497,12 @@ class RackspaceLBMockHttp(MockHttpTestCase):
             nodes = self.fixtures.load('v1_slug_loadbalancers_8290_nodes.json')
             json_nodes = json.loads(nodes)
 
-            for node in json_nodes["nodes"]:
-                id = node["id"]
-                self.assertTrue(urllib.urlencode([("id", id)]) in url,
-                    msg="Did not delete member with id %d" % id)
+            for node in json_nodes['nodes']:
+                id = node['id']
+                self.assertTrue(urllib.urlencode([('id', id)]) in url,
+                    msg='Did not delete member with id %d' % id)
 
-            return (httplib.ACCEPTED, "", {}, httplib.responses[httplib.ACCEPTED])
+            return (httplib.ACCEPTED, '', {}, httplib.responses[httplib.ACCEPTED])
 
         raise NotImplementedError
 


### PR DESCRIPTION
The Rackspace LB API supports bulk deletes of balancers and members (up to 10).  

This pull request adds two new functions to the Rackspace LB Driver:

ex_destroy_balancers
ex_balancer_detach_members

For testing I just chose arbitrary fixtures and wrote tests for the 'delete all balancers/members on that fixture' behavior.

Let me know what can be improved -- I think I imported urllib in the correct way in the tests but I may have messed that up.
