### PR TITLE
Rackspace LB Driver: update member attributes

### DIFF
--- a/libcloud/loadbalancer/drivers/rackspace.py
+++ b/libcloud/loadbalancer/drivers/rackspace.py
@@ -341,17 +341,17 @@ class RackspaceLBDriver(Driver):
         )
 
         if resp.status != httplib.ACCEPTED:
-            raise LibcloudError("Update member attributes was not accepted")
+            raise LibcloudError('Update member attributes was not accepted')
 
-        # Updating a member puts a balancer into "PENDING_UPDATE" status.
+        # Updating a member puts a balancer into 'PENDING_UPDATE' status.
         # Wait until the balancer is back in 'ACTIVE' status and fetch
         # the updated member.
         balancer_resp = self.connection.async_request(
             action='/loadbalancers/%s' % balancer.id,
             method='GET')
 
-        balancer = self._to_balancer(balancer_resp.object["loadBalancer"])
-        extra_members = balancer.extra["members"]
+        balancer = self._to_balancer(balancer_resp.object['loadBalancer'])
+        extra_members = balancer.extra['members']
 
         updated_members = [extra_member for extra_member in extra_members \
                            if extra_member.id == member.id]
@@ -503,11 +503,11 @@ class RackspaceLBDriver(Driver):
 
     def _kwargs_to_mutable_member_attrs(self, **attrs):
         update_attrs = {}
-        if "condition" in attrs:
-            update_attrs["condition"] = self.CONDITION_LB_MEMBER_MAP.get(attrs["condition"])
+        if 'condition' in attrs:
+            update_attrs['condition'] = self.CONDITION_LB_MEMBER_MAP.get(attrs['condition'])
 
-        if "weight" in attrs:
-            update_attrs["weight"] = attrs["weight"]
+        if 'weight' in attrs:
+            update_attrs['weight'] = attrs['weight']
 
         return update_attrs
 

--- a/test/loadbalancer/fixtures/rackspace/v1_slug_loadbalancers_8290_nodes_30944.json
+++ b/test/loadbalancer/fixtures/rackspace/v1_slug_loadbalancers_8290_nodes_30944.json
@@ -1,0 +1,1 @@
+{"node":{"address":"10.1.0.11","id":30944,"port":80,"status":"ONLINE","condition":"ENABLED","weight":12}}

--- a/test/loadbalancer/fixtures/rackspace/v1_slug_loadbalancers_8290_nodes_30944.json
+++ b/test/loadbalancer/fixtures/rackspace/v1_slug_loadbalancers_8290_nodes_30944.json
@@ -1,1 +1,0 @@
-{"node":{"address":"10.1.0.11","id":30944,"port":80,"status":"ONLINE","condition":"ENABLED","weight":12}}

--- a/test/loadbalancer/test_rackspace.py
+++ b/test/loadbalancer/test_rackspace.py
@@ -406,8 +406,8 @@ class RackspaceLBTests(unittest.TestCase):
         member = self.driver.ex_balancer_update_member(balancer, first_member,
             condition=MemberCondition.ENABLED, weight=12)
 
-        self.assertEquals(MemberCondition.ENABLED, member.extra["condition"])
-        self.assertEquals(12, member.extra["weight"])
+        self.assertEquals(MemberCondition.ENABLED, member.extra['condition'])
+        self.assertEquals(12, member.extra['weight'])
 
     def test_ex_update_balancer_member_no_poll_extra_attributes(self):
         balancer = self.driver.get_balancer(balancer_id='8290')
@@ -498,7 +498,7 @@ class RackspaceLBMockHttp(MockHttpTestCase):
             json_body = json.loads(body)
             self.assertEqual('ENABLED', json_body['condition'])
             self.assertEqual(12, json_body['weight'])
-            return (httplib.ACCEPTED, "", {}, httplib.responses[httplib.ACCEPTED])
+            return (httplib.ACCEPTED, '', {}, httplib.responses[httplib.ACCEPTED])
         elif method == "DELETE":
             return (httplib.ACCEPTED, "", {}, httplib.responses[httplib.ACCEPTED])
 

--- a/test/loadbalancer/test_rackspace.py
+++ b/test/loadbalancer/test_rackspace.py
@@ -397,6 +397,29 @@ class RackspaceLBTests(unittest.TestCase):
         else:
             self.fail('Should have thrown exception with bad algorithm value')
 
+    def test_ex_update_balancer_member_extra_attributes(self):
+        balancer = self.driver.get_balancer(balancer_id='8290')
+        members = self.driver.balancer_list_members(balancer)
+
+        first_member = members[0]
+
+        member = self.driver.ex_balancer_update_member(balancer, first_member,
+            condition=MemberCondition.ENABLED, weight=12)
+
+        self.assertEquals(MemberCondition.ENABLED, member.extra["condition"])
+        self.assertEquals(12, member.extra["weight"])
+
+    def test_ex_update_balancer_member_no_poll_extra_attributes(self):
+        balancer = self.driver.get_balancer(balancer_id='8290')
+        members = self.driver.balancer_list_members(balancer)
+
+        first_member = members[0]
+
+        resp = self.driver.ex_balancer_update_member_no_poll(balancer, first_member,
+            condition=MemberCondition.ENABLED, weight=12)
+        self.assertTrue(resp)
+
+
 class RackspaceUKLBTests(RackspaceLBTests):
 
     def setUp(self):
@@ -471,7 +494,12 @@ class RackspaceLBMockHttp(MockHttpTestCase):
         raise NotImplementedError
 
     def _v1_0_slug_loadbalancers_8290_nodes_30944(self, method, url, body, headers):
-        if method == "DELETE":
+        if method == "PUT":
+            json_body = json.loads(body)
+            self.assertEqual('ENABLED', json_body['condition'])
+            self.assertEqual(12, json_body['weight'])
+            return (httplib.ACCEPTED, "", {}, httplib.responses[httplib.ACCEPTED])
+        elif method == "DELETE":
             return (httplib.ACCEPTED, "", {}, httplib.responses[httplib.ACCEPTED])
 
         raise NotImplementedError


### PR DESCRIPTION
This adds the following functions to the Rackspace LB Driver for updating the extra attributes on a Rackspace Member (condition and weight).
- ex_balancer_update_member

This makes the request, then waits for the parent balancer to go from PENDING_UPDATE (Libcloud 'Build' status) into ACTIVE (Libcloud 'Running' status.)
- ex_balancer_update_member_no_poll

This makes the request and immediately returns.
