### PR TITLE
Specify condition weight when adding lb members

### DIFF
--- a/libcloud/loadbalancer/drivers/rackspace.py
+++ b/libcloud/loadbalancer/drivers/rackspace.py
@@ -383,11 +383,16 @@ class RackspaceLBDriver(Driver):
         ip = member.ip
         port = member.port
 
-        member_object = {"nodes":
-                [{"port": port,
-                    "address": ip,
-                    "condition": "ENABLED"}]
-                }
+        # If the condition is not specified on the member, then it should be set
+        # be set to ENABLED by default
+        if 'condition' not in member.extra:
+            member.extra['condition'] = MemberCondition.ENABLED
+
+        member_attributes = self._kwargs_to_mutable_member_attrs(**member.extra)
+        member_attributes.update({"port": port,
+                                  "address": ip
+                                 })
+        member_object = {"nodes": [member_attributes]}
 
         uri = '/loadbalancers/%s/nodes' % (balancer.id)
         resp = self.connection.request(uri, method='POST',

--- a/test/loadbalancer/fixtures/rackspace/v1_slug_loadbalancers_8291.json
+++ b/test/loadbalancer/fixtures/rackspace/v1_slug_loadbalancers_8291.json
@@ -1,0 +1,56 @@
+{
+    "loadBalancer": {
+        "algorithm": "RANDOM",
+        "cluster": {
+            "name": "ztm-n05.lbaas.ord1.rackspace.net"
+        },
+        "connectionLogging": {
+            "enabled": false
+        },
+        "created": {
+            "time": "2011-04-07T16:27:50Z"
+        },
+        "id": 8291,
+        "name": "test8291",
+        "nodes": [
+            {
+                "address": "10.1.0.11",
+                "condition": "ENABLED",
+                "id": 30944,
+                "port": 80,
+                "status": "ONLINE",
+                "weight": 12
+            },
+            {
+                "address": "10.1.0.10",
+                "condition": "DISABLED",
+                "id": 30945,
+                "port": 80,
+                "status": "OFFLINE",
+                "weight": 8
+            },
+            {
+                "address": "10.1.0.9",
+                "condition": "DRAINING",
+                "id": 30946,
+                "port": 8080,
+                "status": "DRAINING",
+                "weight": 20
+            }
+        ],
+        "port": 80,
+        "protocol": "HTTP",
+        "status": "ACTIVE",
+        "updated": {
+            "time": "2011-04-07T16:28:12Z"
+        },
+        "virtualIps": [
+            {
+                "address": "1.1.1.1",
+                "id": 1151,
+                "ipVersion": "IPV4",
+                "type": "PUBLIC"
+            }
+        ]
+    }
+}

--- a/test/loadbalancer/test_rackspace.py
+++ b/test/loadbalancer/test_rackspace.py
@@ -596,6 +596,16 @@ class RackspaceLBTests(unittest.TestCase):
 
     def test_balancer_attach_member(self):
         balancer = self.driver.get_balancer(balancer_id='8290')
+        extra = {'condition': MemberCondition.DISABLED,
+                 'weight': 10}
+        member = balancer.attach_member(Member(None, ip='10.1.0.12',
+                                               port='80', extra=extra))
+
+        self.assertEquals(member.ip, '10.1.0.12')
+        self.assertEquals(member.port, 80)
+
+    def test_balancer_attach_member_with_no_condition_specified(self):
+        balancer = self.driver.get_balancer(balancer_id='8291')
         member = balancer.attach_member(Member(None, ip='10.1.0.12',
                                                port='80'))
 
@@ -837,8 +847,12 @@ class RackspaceLBMockHttp(MockHttpTestCase):
             body = self.fixtures.load('v1_slug_loadbalancers_8290_nodes.json')
             return (httplib.OK, body, {}, httplib.responses[httplib.OK])
         elif method == "POST":
-            body = self.fixtures.load('v1_slug_loadbalancers_8290_nodes_post.json')
-            return (httplib.ACCEPTED, body, {},
+            json_body = json.loads(body)
+            json_node = json_body['nodes'][0]
+            self.assertEqual('DISABLED', json_node['condition'])
+            self.assertEqual(10, json_node['weight'])
+            response_body = self.fixtures.load('v1_slug_loadbalancers_8290_nodes_post.json')
+            return (httplib.ACCEPTED, response_body, {},
                     httplib.responses[httplib.ACCEPTED])
         elif method == "DELETE":
             nodes = self.fixtures.load('v1_slug_loadbalancers_8290_nodes.json')
@@ -850,6 +864,24 @@ class RackspaceLBMockHttp(MockHttpTestCase):
                     msg='Did not delete member with id %d' % id)
 
             return (httplib.ACCEPTED, '', {}, httplib.responses[httplib.ACCEPTED])
+
+        raise NotImplementedError
+
+    def _v1_0_slug_loadbalancers_8291(self, method, url, body, headers):
+        if method == "GET":
+            body = self.fixtures.load('v1_slug_loadbalancers_8291.json')
+            return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+
+        raise NotImplementedError
+
+    def _v1_0_slug_loadbalancers_8291_nodes(self, method, url, body, headers):
+        if method == "POST":
+            json_body = json.loads(body)
+            json_node = json_body['nodes'][0]
+            self.assertEqual('ENABLED', json_node['condition'])
+            response_body = self.fixtures.load('v1_slug_loadbalancers_8290_nodes_post.json')
+            return (httplib.ACCEPTED, response_body, {},
+                    httplib.responses[httplib.ACCEPTED])
 
         raise NotImplementedError
 

--- a/test/loadbalancer/test_rackspace.py
+++ b/test/loadbalancer/test_rackspace.py
@@ -808,10 +808,10 @@ class RackspaceLBMockHttp(MockHttpTestCase):
         elif method == "POST":
             body_json = json.loads(body)
             loadbalancer_json = body_json['loadBalancer']
+            member_1_json, member_2_json = loadbalancer_json['nodes']
+
             self.assertEqual(loadbalancer_json['protocol'], 'HTTP')
             self.assertEqual(loadbalancer_json['algorithm'], 'ROUND_ROBIN')
-            member_1_json = loadbalancer_json['nodes'][0]
-            member_2_json = loadbalancer_json['nodes'][1]
             self.assertEqual(member_1_json['condition'], 'DISABLED')
             self.assertEqual(member_1_json['weight'], 10)
             self.assertEqual(member_2_json['condition'], 'ENABLED')


### PR DESCRIPTION
Weight or condition couldn't be specified when adding members to a rackspace load balancer. This fixes that.
