### PR TITLE
Change default service name for devstack compatibility

### DIFF
--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -129,7 +129,7 @@ class OpenStackResponse(Response):
 class OpenStackComputeConnection(OpenStackBaseConnection):
     # default config for http://devstack.org/
     service_type = 'compute'
-    service_name = 'nova'
+    service_name = 'Compute Service'
     service_region = 'RegionOne'
 
     def request(self, action, params=None, data='', headers=None,

--- a/test/compute/fixtures/openstack/_v2_0__auth.json
+++ b/test/compute/fixtures/openstack/_v2_0__auth.json
@@ -59,7 +59,7 @@
                         "versionId": "2"
                     }
                 ],
-                "name": "nova",
+                "name": "Compute Service",
                 "type": "compute"
             },
             {


### PR DESCRIPTION
Recent updates in OpenStack's API have changed the compute service name from "nova" to "Compute Service".

This patch eliminates the need to pass ex_force_service_name='Compute Service' into the openstack driver when working with devstack.
