### PR TITLE
Add support for the create_node ex_keyname argument in OpenStack_1_1_NodeDriver

### DIFF
--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -806,6 +806,10 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
         @keyword    ex_files:   File Path => File contents to create on
                                 the node
         @type       ex_files:   C{dict}
+
+        @keyword    ex_keyname:  Name of existing public key to inject into instance
+        @type       ex_keyname:  C{string}
+
         """
 
         server_params = self._create_args_to_params(None, **kwargs)
@@ -863,6 +867,9 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
             'personality': self._files_to_personality(kwargs.get("ex_files",
                                                                  {}))
         }
+
+        if 'ex_keyname' in kwargs:
+            server_params['key_name'] = kwargs['ex_keyname']
 
         if 'name' in kwargs:
             server_params['name'] = kwargs.get('name')
@@ -1047,6 +1054,7 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
                 password=api_node.get('adminPass'),
                 created=api_node['created'],
                 updated=api_node['updated'],
+                key_name=api_node['key_name'],
             ),
         )
 

--- a/test/compute/fixtures/openstack_v1.1/_servers_26f7fbee_8ce1_4c28_887a_bfe8e4bb10fe.json
+++ b/test/compute/fixtures/openstack_v1.1/_servers_26f7fbee_8ce1_4c28_887a_bfe8e4bb10fe.json
@@ -29,7 +29,7 @@
         "addresses": {},
         "accessIPv4": "",
         "accessIPv6": "",
-        "key_name": "",
+        "key_name": "devstack",
         "progress": null,
         "flavor": {
             "id": "1",

--- a/test/compute/test_openstack.py
+++ b/test/compute/test_openstack.py
@@ -673,6 +673,17 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
         self.assertEqual(node.extra['password'], 'racktestvJq7d3')
         self.assertEqual(node.extra['metadata']['My Server Name'], 'Apache1')
 
+    def test_create_node_with_ex_keyname(self):
+        image = NodeImage(id=11, name='Ubuntu 8.10 (intrepid)', driver=self.driver)
+        size = NodeSize(1, '256 slice', None, None, None, None, driver=self.driver)
+        node = self.driver.create_node(name='racktest', image=image, size=size,
+                                       ex_keyname='devstack')
+        self.assertEqual(node.id, '26f7fbee-8ce1-4c28-887a-bfe8e4bb10fe')
+        self.assertEqual(node.name, 'racktest')
+        self.assertEqual(node.extra['password'], 'racktestvJq7d3')
+        self.assertEqual(node.extra['metadata']['My Server Name'], 'Apache1')
+        self.assertEqual(node.extra['key_name'], 'devstack')
+
     def test_destroy_node(self):
         self.assertTrue(self.node.destroy())
 


### PR DESCRIPTION
Not sure if I should have just added param to existing test_create_node case, but instead created new, mostly redundant test case.
