### PR TITLE
Modified AtmosError so that the message argument is actually useful.

### DIFF
--- a/libcloud/storage/drivers/atmos.py
+++ b/libcloud/storage/drivers/atmos.py
@@ -44,8 +44,8 @@ def collapse(s):
 
 class AtmosError(Exception):
     def __init__(self, code, message):
+        super(AtmosError, self).__init__(message)
         self.code = code
-        self.message = message
 
 class AtmosResponse(XmlResponse):
     def success(self):


### PR DESCRIPTION
As currently implemented, AtmosError (in the Atmos storage backend) extends Exception, but then doesn't pass the message argument to the superclass. As a result, when an AtmosError is raised, the printed error message is useless.

Simply passing the message argument up to the superclass means that the message handling of the base Exception class is used, which means printed exceptions actually make sense.
