### PR TITLE
Populate openstack connection's auth_user_info

### DIFF
--- a/libcloud/common/openstack.py
+++ b/libcloud/common/openstack.py
@@ -383,6 +383,7 @@ class OpenStackBaseConnection(ConnectionUserAndKey):
     auth_url = None
     auth_token = None
     auth_token_expires = None
+    auth_user_info = None
     service_catalog = None
     service_type = None
     service_name = None

--- a/libcloud/common/openstack.py
+++ b/libcloud/common/openstack.py
@@ -147,6 +147,7 @@ class OpenStackAuthConnection(ConnectionUserAndKey):
             self.urls['cloudFiles'] = \
                 [{'publicURL': headers.get('x-storage-url', None)}]
             self.auth_token = headers.get('x-auth-token', None)
+            self.auth_auth_user_info = None
 
             if not self.auth_token:
                 raise MalformedResponseError('Missing X-Auth-Token in \
@@ -177,6 +178,7 @@ class OpenStackAuthConnection(ConnectionUserAndKey):
                 self.auth_token = body['auth']['token']['id']
                 self.auth_token_expires = body['auth']['token']['expires']
                 self.urls = body['auth']['serviceCatalog']
+                self.auth_user_info = None
             except KeyError:
                 e = sys.exc_info()[1]
                 raise MalformedResponseError('Auth JSON response is \
@@ -229,6 +231,7 @@ class OpenStackAuthConnection(ConnectionUserAndKey):
                 self.auth_token = access['token']['id']
                 self.auth_token_expires = access['token']['expires']
                 self.urls = access['serviceCatalog']
+                self.auth_user_info = access.get('user', {})
             except KeyError:
                 e = sys.exc_info()[1]
                 raise MalformedResponseError('Auth JSON response is \
@@ -480,6 +483,7 @@ class OpenStackBaseConnection(ConnectionUserAndKey):
 
             self.auth_token = osa.auth_token
             self.auth_token_expires = osa.auth_token_expires
+            self.auth_user_info = osa.auth_user_info
 
             # pull out and parse the service catalog
             self.service_catalog = OpenStackServiceCatalog(osa.urls,

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -1046,5 +1046,15 @@ class OpenStack_1_1_Auth_2_0_Tests(OpenStack_1_1_Tests):
         clear_pricing_data()
         self.node = self.driver.list_nodes()[1]
 
+    def test_auth_user_info_is_set(self):
+        self.driver.connection._populate_hosts_and_request_paths()
+        self.assertEquals(self.driver.connection.auth_user_info, {
+            'id': '7',
+            'name': 'testuser',
+            'roles': [{'description': 'Default Role.',
+                        'id': 'identity:default',
+                        'name': 'identity:default'}]})
+
+
 if __name__ == '__main__':
     sys.exit(unittest.main())


### PR DESCRIPTION
Keystone Auth 2.0 returns user information, including roles, with a successful authentication request.  This pull request adds the ability to get to that information via the `auth_user_info` attribute of the Openstack driver's connection.

http://docs.rackspace.com/auth/api/v2.0/auth-client-devguide/content/Sample_Request_Response-d1e64.html
