### PR TITLE
Fix - auth_auth_user_info -> auth_user_info

### DIFF
--- a/libcloud/common/openstack.py
+++ b/libcloud/common/openstack.py
@@ -147,7 +147,7 @@ class OpenStackAuthConnection(ConnectionUserAndKey):
             self.urls['cloudFiles'] = \
                 [{'publicURL': headers.get('x-storage-url', None)}]
             self.auth_token = headers.get('x-auth-token', None)
-            self.auth_auth_user_info = None
+            self.auth_user_info = None
 
             if not self.auth_token:
                 raise MalformedResponseError('Missing X-Auth-Token in \


### PR DESCRIPTION
#68 had a typo in the `authenticate_1_0` method.
