### PR TITLE
LIBCLOUD-254 : Generator based iteration instead of LazyList

### DIFF
--- a/libcloud/dns/base.py
+++ b/libcloud/dns/base.py
@@ -164,14 +164,34 @@ class DNSDriver(BaseDriver):
         """
         return list(self.RECORD_TYPE_MAP.keys())
 
+    def iterate_zones(self):
+        """
+        Return a generator to iterate over available zones.
+
+        @rtype: C{generator} of L{Zone}
+        """
+        raise NotImplementedError(
+            'iterate_zones not implemented for this driver')
+
     def list_zones(self):
         """
         Return a list of zones.
 
         @rtype: C{list} of L{Zone}
         """
+        return list(self.iterate_zones())
+
+    def iterate_records(self, zone):
+        """
+        Return a generator to iterate over records for the provided zone.
+
+        @param zone: Zone to list records for.
+        @type zone: L{Zone}
+
+        @rtype: C{generator} of L{Record}
+        """
         raise NotImplementedError(
-            'list_zones not implemented for this driver')
+            'iterate_records not implemented for this driver')
 
     def list_records(self, zone):
         """
@@ -182,8 +202,7 @@ class DNSDriver(BaseDriver):
 
         @rtype: C{list} of L{Record}
         """
-        raise NotImplementedError(
-            'list_records not implemented for this driver')
+        return list(self.iterate_records(zone))
 
     def get_zone(self, zone_id):
         """

--- a/libcloud/dns/drivers/zerigo.py
+++ b/libcloud/dns/drivers/zerigo.py
@@ -30,7 +30,7 @@ from libcloud.utils.misc import merge_valid_keys, get_new_obj
 from libcloud.utils.xml import findtext, findall
 from libcloud.common.base import XmlResponse, ConnectionUserAndKey
 from libcloud.common.types import InvalidCredsError, LibcloudError
-from libcloud.common.types import MalformedResponseError, LazyList
+from libcloud.common.types import MalformedResponseError
 from libcloud.dns.types import Provider, RecordType
 from libcloud.dns.types import ZoneDoesNotExistError, RecordDoesNotExistError
 from libcloud.dns.base import DNSDriver, Zone, Record
@@ -143,13 +143,11 @@ class ZerigoDNSDriver(DNSDriver):
         RecordType.URL: 'URL',
     }
 
-    def list_zones(self):
-        value_dict = {'type': 'zones'}
-        return LazyList(get_more=self._get_more, value_dict=value_dict)
+    def iterate_zones(self):
+        return self._get_more('zones')
 
-    def list_records(self, zone):
-        value_dict = {'type': 'records', 'zone': zone}
-        return LazyList(get_more=self._get_more, value_dict=value_dict)
+    def iterate_records(self, zone):
+        return self._get_more('records', zone=zone)
 
     def get_zone(self, zone_id):
         path = API_ROOT + 'zones/%s.xml' % (zone_id)
@@ -433,36 +431,44 @@ class ZerigoDNSDriver(DNSDriver):
                         zone=zone, driver=self, extra=extra)
         return record
 
-    def _get_more(self, last_key, value_dict):
+    def _get_more(self, rtype, **kwargs):
+        exhausted = False
+        last_key = None
+
+        while not exhausted:
+            items, last_key, exhausted = self._get_data(
+                                            rtype, last_key, **kwargs)
+
+            for item in items:
+                yield item
+
+    def _get_data(self, rtype, last_key, **kwargs):
         # Note: last_key in this case really is a "last_page".
         # TODO: Update base driver and change last_key to something more
         # generic - e.g. marker
         params = {}
         params['per_page'] = ITEMS_PER_PAGE
         params['page'] = last_key + 1 if last_key else 1
-        transform_func_kwargs = {}
 
-        if value_dict['type'] == 'zones':
+        if rtype == 'zones':
             path = API_ROOT + 'zones.xml'
             response = self.connection.request(path)
             transform_func = self._to_zones
-        elif value_dict['type'] == 'records':
-            zone = value_dict['zone']
+        elif rtype == 'records':
+            zone = kwargs['zone']
             path = API_ROOT + 'zones/%s/hosts.xml' % (zone.id)
             self.connection.set_context({'resource': 'zone', 'id': zone.id})
             response = self.connection.request(path, params=params)
             transform_func = self._to_records
-            transform_func_kwargs['zone'] = value_dict['zone']
 
         exhausted = False
         result_count = int(response.headers.get('x-query-count', 0))
-        transform_func_kwargs['elem'] = response.object
 
         if (params['page'] * ITEMS_PER_PAGE) >= result_count:
             exhausted = True
 
         if response.status == httplib.OK:
-            items = transform_func(**transform_func_kwargs)
+            items = transform_func(elem=response.object, **kwargs)
             return items, params['page'], exhausted
         else:
             return [], None, True

--- a/libcloud/storage/base.py
+++ b/libcloud/storage/base.py
@@ -118,6 +118,9 @@ class Container(object):
         self.extra = extra or {}
         self.driver = driver
 
+    def iterate_objects(self):
+        return self.driver.iterate_container_objects(container=self)
+
     def list_objects(self):
         return self.driver.list_container_objects(container=self)
 
@@ -185,6 +188,19 @@ class StorageDriver(BaseDriver):
         raise NotImplementedError(
             'list_containers not implemented for this driver')
 
+    def iterate_container_objects(self, container):
+        """
+        Return a generator of objects for the given container.
+
+        @param container: Container instance
+        @type container: L{Container}
+
+        @return: A generator of Object instances.
+        @rtype: C{generator} of L{Object}
+        """
+        raise NotImplementedError(
+            'iterate_container_objects not implemented for this driver')
+
     def list_container_objects(self, container):
         """
         Return a list of objects for the given container.
@@ -195,8 +211,7 @@ class StorageDriver(BaseDriver):
         @return: A list of Object instances.
         @rtype: C{list} of L{Object}
         """
-        raise NotImplementedError(
-            'list_objects not implemented for this driver')
+        return list(self.iterate_container_objects(container))
 
     def get_container(self, container_name):
         """

--- a/libcloud/storage/drivers/local.py
+++ b/libcloud/storage/drivers/local.py
@@ -33,7 +33,7 @@ except ImportError:
 from libcloud.utils.files import read_in_chunks
 from libcloud.common.base import Connection
 from libcloud.storage.base import Object, Container, StorageDriver
-from libcloud.common.types import LibcloudError, LazyList
+from libcloud.common.types import LibcloudError
 from libcloud.storage.types import ContainerAlreadyExistsError
 from libcloud.storage.types import ContainerDoesNotExistError
 from libcloud.storage.types import ContainerIsNotEmptyError
@@ -213,28 +213,18 @@ class LocalStorageDriver(StorageDriver):
                 object_name = os.path.relpath(full_path, start=cpath)
                 yield self._make_object(container, object_name)
 
-    def _get_more(self, last_key, value_dict):
+    def iterate_container_objects(self, container):
         """
-        A handler for using with LazyList
-        """
-        container = value_dict['container']
-        objects = [obj for obj in self._get_objects(container)]
-
-        return (objects, None, True)
-
-    def list_container_objects(self, container):
-        """
-        Return a list of objects for the given container.
+        Returns a generator of objects for the given container.
 
         @param container: Container instance
         @type container: L{Container}
 
-        @return: A list of Object instances.
-        @rtype: C{list} of L{Object}
+        @return: A generator of Object instances.
+        @rtype: C{generator} of L{Object}
         """
 
-        value_dict = {'container': container}
-        return LazyList(get_more=self._get_more, value_dict=value_dict)
+        return self._get_objects(container)
 
     def get_container(self, container_name):
         """

--- a/libcloud/storage/drivers/s3.py
+++ b/libcloud/storage/drivers/s3.py
@@ -38,7 +38,6 @@ from libcloud.storage.types import InvalidContainerNameError
 from libcloud.storage.types import ContainerDoesNotExistError
 from libcloud.storage.types import ObjectDoesNotExistError
 from libcloud.storage.types import ObjectHashMismatchError
-from libcloud.common.types import LazyList
 
 # How long before the token expires
 EXPIRATION_SECONDS = 15 * 60
@@ -182,9 +181,32 @@ class S3StorageDriver(StorageDriver):
         raise LibcloudError('Unexpected status code: %s' % (response.status),
                             driver=self)
 
-    def list_container_objects(self, container):
-        value_dict = {'container': container}
-        return LazyList(get_more=self._get_more, value_dict=value_dict)
+    def iterate_container_objects(self, container):
+        params = {}
+        last_key = None
+        exhausted = False
+
+        while not exhausted:
+            if last_key:
+                params['marker'] = last_key
+
+            response = self.connection.request('/%s' % (container.name),
+                                               params=params)
+
+            if response.status != httplib.OK:
+                raise LibcloudError('Unexpected status code: %s' %
+                                    (response.status), driver=self)
+
+            objects = self._to_objs(obj=response.object,
+                                    xpath='Contents', container=container)
+            is_truncated = response.object.findtext(fixxpath(
+                    xpath='IsTruncated', namespace=self.namespace)).lower()
+            exhausted = (is_truncated == 'false')
+
+            last_key = None
+            for obj in objects:
+                last_key = obj.name
+                yield obj
 
     def get_container(self, container_name):
         # This is very inefficient, but afaik it's the only way to do it
@@ -354,32 +376,6 @@ class S3StorageDriver(StorageDriver):
     def _clean_object_name(self, name):
         name = urlquote(name)
         return name
-
-    def _get_more(self, last_key, value_dict):
-        container = value_dict['container']
-        params = {}
-
-        if last_key:
-            params['marker'] = last_key
-
-        response = self.connection.request('/%s' % (container.name),
-                                           params=params)
-
-        if response.status == httplib.OK:
-            objects = self._to_objs(obj=response.object,
-                                    xpath='Contents', container=container)
-            is_truncated = response.object.findtext(fixxpath(
-                xpath='IsTruncated', namespace=self.namespace)).lower()
-            exhausted = (is_truncated == 'false')
-
-            if (len(objects) > 0):
-                last_key = objects[-1].name
-            else:
-                last_key = None
-            return objects, last_key, exhausted
-
-        raise LibcloudError('Unexpected status code: %s' % (response.status),
-                            driver=self)
 
     def _put_object(self, container, object_name, upload_func,
                     upload_func_kwargs, extra=None, file_path=None,


### PR DESCRIPTION
`LazyList` was implemented by issue (LIBCLOUD-78) for more efficient iteration over objects stored in a container (S3, CloudFiles etc. limit the maximum number of objects returned in a single call). 

`LazyList` solved this problem, but I think it might have the following issues while handling containers with large number of objects 
1. It loads the entire list to memory 
2. caller has to wait for the entire list to be loaded in memory before any operation can be done 
3. The api invocation using `get_more()` and value_list is a bit complex (as-in, it can be simplified) 

By using python generators, the above problems can be alleviated. Results can be returned to the caller as and when it is returned from the server. 

The following changes were done to the libcloud apis 
- A new api called - `iterate_container_objects()` was introduced. The storage drivers need to implement this instead of `list_container_objects()`. This API now returns a generator. Usage of this API will alleviate the above three problems. 
- `list_container_objects()` will simply do - `list(self.iterate_container_objects(container))` - this is maintained for backwards compatibility. It would be better if users can start using `iterate_**()` api instead. 
- The same changes have been made for the DNS base class also. 
- `LazyList()` can be removed from libcloud if it is OK with everyone. 
- The generator based interface can be used (WIP) for providing paginated access to objects - This will be useful for webpages/apps where the user has to paginate through the results. The same can be implemented by providing `start_key` and `count` parameters (similar to CouchDB) instead of generating the entire list and then doing an offset. This will be more performance/memory efficient than generating the entire list for every request. 
