### PR TITLE
Add image id filter in EC2 list images

### DIFF
--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -644,8 +644,22 @@ class EC2NodeDriver(NodeDriver):
             sizes.append(NodeSize(driver=self, **attributes))
         return sizes
 
-    def list_images(self, location=None):
+    def list_images(self, location=None, ex_image_ids=None):
+        """
+        List all images
+
+        Ex_image_ids parameter is used to filter the list of
+        images that should be returned. Only the images
+        with the corresponding image ids will be returned.
+
+        @param      ex_image_ids: List of C{NodeImage.id}
+        @type       ex_image_ids: C{list} of C{str}
+
+        @rtype: C{list} of L{NodeImage}
+        """
         params = {'Action': 'DescribeImages'}
+        if ex_image_ids:
+            params.update(self._pathlist('ImageId', ex_image_ids))
         images = self._to_images(
             self.connection.request(self.path, params=params).object
         )

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -213,6 +213,12 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
                     'ec2-public-images/fedora-8-i386-base-v1.04.manifest.xml')
         self.assertEqual(image.id, 'ami-be3adfd7')
 
+    def test_list_images_with_image_ids(self):
+        image = self.driver.list_images(ex_image_ids=['ami-be3adfd7'])
+        self.assertEqual(len(image), 1)
+        self.assertEqual(image.name,
+                    'ec2-public-images/fedora-8-i386-base-v1.04.manifest.xml')
+
     def test_ex_list_availability_zones(self):
         availability_zones = self.driver.ex_list_availability_zones()
         availability_zone = availability_zones[0]


### PR DESCRIPTION
This is very similar to what is being already done with ex_node_ids in list_nodes.

It helps you avoid the really large image list Amazon sends when you know exactly the ids you are looking for.
