### PR TITLE
LIBCLOUD-169: Refactor AWS connection and response to reduce code duplication

### DIFF
--- a/libcloud/common/aws.py
+++ b/libcloud/common/aws.py
@@ -17,14 +17,76 @@ import base64
 import hmac
 import time
 from hashlib import sha256
+from xml.etree import ElementTree as ET
 
-from libcloud.utils.py3 import b, urlquote
 from libcloud.common.base import ConnectionUserAndKey, XmlResponse
+from libcloud.common.types import InvalidCredsError, MalformedResponseError
+from libcloud.utils.py3 import b, httplib, urlquote
+from libcloud.utils.xml import findtext, findall
 
 
 class AWSBaseResponse(XmlResponse):
     pass
 
+
+class AWSGenericResponse(AWSBaseResponse):
+  
+    # There are multiple error messages in AWS, but they all have an Error node
+    # with Code and Message child nodes. Xpath to select them
+    # None if the root node *is* the Error node
+    xpath = None
+    
+    # This dict maps <Error><Code>CodeName</Code></Error> to a specific exception
+    # that is raised immediately.
+    # Otherwise it is returned from parse_error
+    expections = {}
+    
+    def success(self):
+        return self.status in [httplib.OK, httplib.CREATED, httplib.ACCEPTED]
+ 
+    def parse_error(self):
+        context = self.connection.context
+        status = int(self.status)
+ 
+        # FIXME: Probably ditch this as the forbidden message will have
+        # corresponding XML.
+        if status == httplib.FORBIDDEN:
+            if not self.body:
+                raise InvalidCredsError(str(self.status) + ': ' + self.error)
+            else:
+                raise InvalidCredsError(self.body)
+ 
+        try:
+            body = ET.XML(self.body)
+        except Exception:
+            raise MalformedResponseError('Failed to parse XML',
+                                         body=self.body, driver=self.connection.driver)
+ 
+        if self.xpath:
+            errs = findall(element=body, xpath=self.xpath, namespace=self.namespace)
+        else:
+            errs = [body]
+        
+        msgs = []
+        for err in errs:
+            code = findtext(element=err, xpath='Code', namespace=self.namespace)
+            message = findtext(element=err, xpath='Message', namespace=self.namespace)
+          
+            exceptionCls = self.exceptions.get(code, None)
+            if not exceptionCls:
+                msgs.append("%s: %s" % (code, message))
+                continue
+          
+            params = {}
+            if hasattr(exceptionCls, "kwargs"):
+                for key in exceptionCls.kwargs:
+                    if key in context:
+                        params[key] = context[key]
+          
+            raise exceptionCls(value=message, driver=self.connection.driver, **params)
+    
+        return "\n".join(msgs)
+ 
 
 class SignedAWSConnection(ConnectionUserAndKey):
 

--- a/libcloud/common/aws.py
+++ b/libcloud/common/aws.py
@@ -13,8 +13,61 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from libcloud.common.base import XmlResponse
+import base64
+import hmac
+import time
+from hashlib import sha256
+
+from libcloud.utils.py3 import b, urlquote
+from libcloud.common.base import ConnectionUserAndKey, XmlResponse
 
 
 class AWSBaseResponse(XmlResponse):
     pass
+
+
+class SignedAWSConnection(ConnectionUserAndKey):
+
+    def add_default_params(self, params):
+        params['SignatureVersion'] = '2'
+        params['SignatureMethod'] = 'HmacSHA256'
+        params['AWSAccessKeyId'] = self.user_id
+        params['Version'] = self.version
+        params['Timestamp'] = time.strftime('%Y-%m-%dT%H:%M:%SZ',
+                                            time.gmtime())
+        params['Signature'] = self._get_aws_auth_param(params, self.key,
+                                                       self.action)
+        return params
+
+    def _get_aws_auth_param(self, params, secret_key, path='/'):
+        """
+        Creates the signature required for AWS, per
+        http://bit.ly/aR7GaQ [docs.amazonwebservices.com]:
+
+        StringToSign = HTTPVerb + "\n" +
+                       ValueOfHostHeaderInLowercase + "\n" +
+                       HTTPRequestURI + "\n" +
+                       CanonicalizedQueryString <from the preceding step>
+        """
+        keys = list(params.keys())
+        keys.sort()
+        pairs = []
+        for key in keys:
+            pairs.append(urlquote(key, safe='') + '=' +
+                         urlquote(params[key], safe='-_~'))
+
+        qs = '&'.join(pairs)
+
+        hostname = self.host
+        if (self.secure and self.port != 443) or \
+           (not self.secure and self.port != 80):
+            hostname += ":" + str(self.port)
+
+        string_to_sign = '\n'.join(('GET', hostname, path, qs))
+
+        b64_hmac = base64.b64encode(
+            hmac.new(b(secret_key), b(string_to_sign),
+                     digestmod=sha256).digest()
+        )
+        return b64_hmac.decode('utf-8')
+

--- a/libcloud/dns/types.py
+++ b/libcloud/dns/types.py
@@ -66,7 +66,8 @@ class RecordType(object):
 
 class ZoneError(LibcloudError):
     error_type = 'ZoneError'
-
+    kwargs = ('zone_id', )
+    
     def __init__(self, value, driver, zone_id):
         self.zone_id = zone_id
         super(ZoneError, self).__init__(value=value, driver=driver)

--- a/libcloud/loadbalancer/drivers/elb.py
+++ b/libcloud/loadbalancer/drivers/elb.py
@@ -18,12 +18,10 @@ __all__ = [
 ]
 
 
-from libcloud.utils.py3 import httplib
 from libcloud.utils.xml import findtext, findall
 from libcloud.loadbalancer.types import State
 from libcloud.loadbalancer.base import Driver, LoadBalancer, Member
-from libcloud.common.types import InvalidCredsError
-from libcloud.common.aws import AWSBaseResponse, SignedAWSConnection
+from libcloud.common.aws import AWSGenericResponse, SignedAWSConnection
 
 
 VERSION = '2012-06-01'
@@ -32,21 +30,11 @@ ROOT = '/%s/' % (VERSION)
 NS = 'http://elasticloadbalancing.amazonaws.com/doc/%s/' % (VERSION, )
 
 
-class ELBResponse(AWSBaseResponse):
+class ELBResponse(AWSGenericResponse):
     """
     Amazon ELB response class.
     """
-    def success(self):
-        return self.status in [httplib.OK, httplib.CREATED, httplib.ACCEPTED]
-
-    def parse_error(self):
-        status = int(self.status)
-
-        if status == httplib.FORBIDDEN:
-            if not self.body:
-                raise InvalidCredsError(str(self.status) + ': ' + self.error)
-            else:
-                raise InvalidCredsError(self.body)
+    namespace = NS
 
 
 class ELBConnection(SignedAWSConnection):


### PR DESCRIPTION
As promised in the elb pr, here is a follow up patch to reduce code duplication. I haven't run pep8 over it yet, but the tests pass. I'm AFK for a few days, but wanted to at least get something up here.

I think this error parsing can be applied to the EC2 backend too but wanted to get some feedback on the general approach first.
