### PR TITLE
Allow CA location to be overriden with SSL_CERT_FILE env variable.

### DIFF
--- a/libcloud/security.py
+++ b/libcloud/security.py
@@ -22,13 +22,17 @@ Usage:
     # Optional.
     libcloud.security.CA_CERTS_PATH.append("/path/to/cacert.txt")
 """
-
+ import os
+ 
 VERIFY_SSL_CERT = True
 VERIFY_SSL_CERT_STRICT = True
 
 # File containing one or more PEM-encoded CA certificates
 # concatenated together.
 CA_CERTS_PATH = [
+    #Allow for the CA location to be overridden with an environment variable
+    os.getenv('SSL_CERT_FILE', ''),
+
     # centos/fedora: openssl
     '/etc/pki/tls/certs/ca-bundle.crt',
 


### PR DESCRIPTION
openssl uses this environment variable to locate the CA certificate bundle, this essentially allows the same in libcloud.
