### PR TITLE
LIBCLOUD-288 - Do xmlrpc requests using the libcloud http layer

### DIFF
--- a/libcloud/common/gandi.py
+++ b/libcloud/common/gandi.py
@@ -55,7 +55,8 @@ class GandiConnection(XMLRPCConnection, ConnectionKey):
 
     responseCls = GandiResponse
     host = 'rpc.gandi.net'
-
+    endpoint = '/xmlrpc/'
+    
     def pre_marshall_hook(self, method_name, args):
         return (self.key, ) + args
 

--- a/libcloud/common/gandi.py
+++ b/libcloud/common/gandi.py
@@ -57,8 +57,9 @@ class GandiConnection(XMLRPCConnection, ConnectionKey):
     host = 'rpc.gandi.net'
     endpoint = '/xmlrpc/'
     
-    def pre_marshall_hook(self, method_name, args):
-        return (self.key, ) + args
+    def request(self, method, *args):
+        args = (self.key, ) + args
+        return super(GandiConnection, self).request(method, *args)
 
 
 class BaseGandiDriver(object):

--- a/libcloud/common/gandi.py
+++ b/libcloud/common/gandi.py
@@ -56,7 +56,7 @@ class GandiConnection(XMLRPCConnection, ConnectionKey):
     responseCls = GandiResponse
     host = 'rpc.gandi.net'
     endpoint = '/xmlrpc/'
-    
+
     def request(self, method, *args):
         args = (self.key, ) + args
         return super(GandiConnection, self).request(method, *args)

--- a/libcloud/common/gandi.py
+++ b/libcloud/common/gandi.py
@@ -20,13 +20,12 @@ import time
 import hashlib
 import sys
 
-from libcloud.utils.py3 import xmlrpclib
 from libcloud.utils.py3 import b
 
-from libcloud.common.base import Response, ConnectionKey
+from libcloud.common.base import ConnectionKey
+from libcloud.common.xmlrpc import XMLRPCResponse, XMLRPCConnection
 
 # Global constants
-
 
 DEFAULT_TIMEOUT = 600   # operation pooling max seconds
 DEFAULT_INTERVAL = 20   # seconds between 2 operation.info
@@ -43,33 +42,13 @@ class GandiException(Exception):
         return '<GandiException code %u "%s">' % (self.args[0], self.args[1])
 
 
-class GandiResponse(Response):
+class GandiResponse(XMLRPCResponse):
     """
     A Base Gandi Response class to derive from.
     """
 
-    def parse_body(self):
-        try:
-            params, methodname = xmlrpclib.loads(self.body)
 
-            if len(params) == 1:
-                return params[0]
-
-            return params
-        except xmlrpclib.Fault:
-            e = sys.exc_info()[1]
-            self.parse_error(e.faultCode, e.faultString)
-            raise GandiException(1000, e)
-
-    def parse_error(self, code=None, message=None):
-        """
-        This hook allows you to inspect any xmlrpclib errors and
-        potentially raise a more useful and specific exception.
-        """
-        pass
-
-
-class GandiConnection(ConnectionKey):
+class GandiConnection(XMLRPCConnection, ConnectionKey):
     """
     Connection class for the Gandi driver
     """
@@ -77,17 +56,8 @@ class GandiConnection(ConnectionKey):
     responseCls = GandiResponse
     host = 'rpc.gandi.net'
 
-    def request(self, method, *args):
-        """ Request xmlrpc method with given args"""
-        args = (self.key, ) + args
-        data = xmlrpclib.dumps(args, methodname=method, allow_none=True)
-        headers = {
-            'Content-Type': 'text/xml',
-        }
-        return super(GandiConnection, self).request('/xmlrpc/',
-                                                    data=data,
-                                                    headers=headers,
-                                                    method='POST')
+    def pre_marshall_hook(self, method_name, args):
+        return (self.key, ) + args
 
 
 class BaseGandiDriver(object):

--- a/libcloud/common/xmlrpc.py
+++ b/libcloud/common/xmlrpc.py
@@ -52,6 +52,8 @@ class ErrorCodeMixin(object):
 
 class XMLRPCResponse(ErrorCodeMixin, Response):
 
+    defaultExceptionCls = Exception
+
     def success(self):
         return self.status == 200
 
@@ -64,7 +66,7 @@ class XMLRPCResponse(ErrorCodeMixin, Response):
         except xmlrpclib.Fault:
             e = sys.exc_info()[1]
             self.raise_exception_for_error(e.faultCode, e.faultString)
-            raise Exception("%s: %s" % (e.faultCode, e.faultString))
+            raise self.defaultExceptionCls("%s: %s" % (e.faultCode, e.faultString))
 
     def parse_error(self):
         msg = 'Server returned an invalid xmlrpc response (%d)' % self.status

--- a/libcloud/common/xmlrpc.py
+++ b/libcloud/common/xmlrpc.py
@@ -86,24 +86,7 @@ class XMLRPCConnection(Connection):
         headers['Content-Type'] = 'text/xml'
         return headers
 
-    def pre_marshall_hook(self, method_name, args):
-        """
-        A hook which is called before marshalling the rpc arguments into XML
-        and transmitting it to the server. This is useful as it is common for
-        API's to have you pass your authorization token as the first parameter
-        of all calls or similar.
-
-        @type method_name: C{str}
-        @param method_name: The name of the remote method that will be called.
-
-        @type args: C{tuple}
-        @param args: A tuple of arguments that will be sent to the remote.
-
-        Should return a tuple of arguments
-        """
-        return args
-
-    def request(self, method_name, *args):
+    def request(self, method_name, *args, **kwargs):
         """
         Call a given `method_name`.
 
@@ -114,8 +97,8 @@ class XMLRPCConnection(Connection):
         @type args: C{tuple}
         @param args: Arguments to invoke with method with.
         """
-        args = self.pre_marshall_hook(method_name, args)
+        endpoint = kwargs.get('endpoint', self.endpoint)
         data = xmlrpclib.dumps(args, methodname=method_name, allow_none=True)
-        return super(XMLRPCConnection, self).request(self.endpoint,
+        return super(XMLRPCConnection, self).request(endpoint,
                                                      data=data,
                                                      method='POST')

--- a/libcloud/common/xmlrpc.py
+++ b/libcloud/common/xmlrpc.py
@@ -66,7 +66,8 @@ class XMLRPCResponse(ErrorCodeMixin, Response):
         except xmlrpclib.Fault:
             e = sys.exc_info()[1]
             self.raise_exception_for_error(e.faultCode, e.faultString)
-            raise self.defaultExceptionCls("%s: %s" % (e.faultCode, e.faultString))
+            error_string = '%s: %s' % (e.faultCode, e.faultString)
+            raise self.defaultExceptionCls(error_string)
 
     def parse_error(self):
         msg = 'Server returned an invalid xmlrpc response (%d)' % self.status

--- a/libcloud/common/xmlrpc.py
+++ b/libcloud/common/xmlrpc.py
@@ -19,7 +19,7 @@ Base classes for working with xmlrpc APIs
 import sys
 
 from libcloud.utils.py3 import xmlrpclib
-from libcloud.common.base import Response, ConnectionKey
+from libcloud.common.base import Response, Connection
 
 
 class ProtocolError(Exception):
@@ -71,7 +71,7 @@ class XMLRPCResponse(ErrorCodeMixin, Response):
         raise ProtocolError(msg)
 
 
-class XMLRPCConnection(ConnectionKey):
+class XMLRPCConnection(Connection):
     """
     Connection class which can call XMLRPC based API's.
 
@@ -116,6 +116,6 @@ class XMLRPCConnection(ConnectionKey):
         """
         args = self.pre_marshall_hook(method_name, args)
         data = xmlrpclib.dumps(args, methodname=method_name, allow_none=True)
-        return super(XMLRPCConnection, self).request('/xmlrpc/',
+        return super(XMLRPCConnection, self).request(self.endpoint,
                                                      data=data,
                                                      method='POST')

--- a/libcloud/common/xmlrpc.py
+++ b/libcloud/common/xmlrpc.py
@@ -1,0 +1,121 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Base classes for working with xmlrpc APIs
+"""
+
+import sys
+
+from libcloud.utils.py3 import xmlrpclib
+from libcloud.common.base import Response, ConnectionKey
+
+
+class ProtocolError(Exception):
+    pass
+
+
+class ErrorCodeMixin(object):
+    """
+    This is a helper for API's that have a well defined collection of error
+    codes that are easily parsed out of error messages. It acts as a factory:
+    it finds the right exception for the error code, fetches any parameters it
+    needs from the context and raises it.
+    """
+
+    exceptions = {}
+
+    def raise_exception_for_error(self, error_code, message):
+        exceptionCls = self.exceptions.get(error_code, None)
+        if exceptionCls is None:
+            return
+        context = self.connection.context
+        driver = self.connection.driver
+        params = {}
+        if hasattr(exceptionCls, 'kwargs'):
+            for key in exceptionCls.kwargs:
+                if key in context:
+                    params[key] = context[key]
+        raise exceptionCls(value=message, driver=driver, **params)
+
+
+class XMLRPCResponse(ErrorCodeMixin, Response):
+
+    def success(self):
+        return self.status == 200
+
+    def parse_body(self):
+        try:
+            body, methodname = xmlrpclib.loads(self.body)
+            if len(body) == 1:
+                body = body[0]
+            return body
+        except xmlrpclib.Fault:
+            e = sys.exc_info()[1]
+            self.raise_exception_for_error(e.faultCode, e.faultString)
+            raise Exception("%s: %s" % (e.faultCode, e.faultString))
+
+    def parse_error(self):
+        msg = 'Server returned an invalid xmlrpc response (%d)' % self.status
+        raise ProtocolError(msg)
+
+
+class XMLRPCConnection(ConnectionKey):
+    """
+    Connection class which can call XMLRPC based API's.
+
+    This class uses the xmlrpclib marshalling and demarshalling code but uses
+    the http transports provided by libcloud giving it better certificate
+    validation and debugging helpers than the core client library.
+    """
+
+    responseCls = XMLRPCResponse
+
+    def add_default_headers(self, headers):
+        headers['Content-Type'] = 'text/xml'
+        return headers
+
+    def pre_marshall_hook(self, method_name, args):
+        """
+        A hook which is called before marshalling the rpc arguments into XML
+        and transmitting it to the server. This is useful as it is common for
+        API's to have you pass your authorization token as the first parameter
+        of all calls or similar.
+
+        @type method_name: C{str}
+        @param method_name: The name of the remote method that will be called.
+
+        @type args: C{tuple}
+        @param args: A tuple of arguments that will be sent to the remote.
+
+        Should return a tuple of arguments
+        """
+        return args
+
+    def request(self, method_name, *args):
+        """
+        Call a given `method_name`.
+
+        @type method_name: C{str}
+        @param method_name: A method exposed by the xmlrpc endpoint that you
+            are connecting to.
+
+        @type args: C{tuple}
+        @param args: Arguments to invoke with method with.
+        """
+        args = self.pre_marshall_hook(method_name, args)
+        data = xmlrpclib.dumps(args, methodname=method_name, allow_none=True)
+        return super(XMLRPCConnection, self).request('/xmlrpc/',
+                                                     data=data,
+                                                     method='POST')

--- a/libcloud/compute/drivers/softlayer.py
+++ b/libcloud/compute/drivers/softlayer.py
@@ -100,12 +100,14 @@ class SoftLayerException(LibcloudError):
 
 
 class SoftLayerResponse(XMLRPCResponse):
+    defaultExceptionCls = SoftLayerException
     exceptions = {
         'SoftLayer_Account': InvalidCredsError,
     }
 
 
 class SoftLayerConnection(XMLRPCConnection, ConnectionUserAndKey):
+    responseCls = SoftLayerResponse
     endpoint = '/xmlrpc/v3/'
 
     def request(self, service, method, *args, **kwargs):

--- a/libcloud/compute/drivers/softlayer.py
+++ b/libcloud/compute/drivers/softlayer.py
@@ -122,7 +122,8 @@ class SoftLayerConnection(XMLRPCConnection, ConnectionUserAndKey):
         args = ({'headers': headers}, ) + args
         endpoint = '%s/%s' % (self.endpoint, service)
 
-        return super(SoftLayerConnection, self).request(method, *args, endpoint=endpoint)
+        return super(SoftLayerConnection, self).request(method, *args,
+                                                        endpoint=endpoint)
 
     def _get_auth_headers(self):
         return {

--- a/libcloud/dns/drivers/gandi.py
+++ b/libcloud/dns/drivers/gandi.py
@@ -65,7 +65,6 @@ class NewZoneVersion(object):
 
 
 class GandiDNSResponse(GandiResponse):
-
     exceptions = {
         581042: ZoneDoesNotExistError,
         }

--- a/libcloud/dns/drivers/gandi.py
+++ b/libcloud/dns/drivers/gandi.py
@@ -67,7 +67,7 @@ class NewZoneVersion(object):
 class GandiDNSResponse(GandiResponse):
     exceptions = {
         581042: ZoneDoesNotExistError,
-        }
+    }
 
 
 class GandiDNSConnection(GandiConnection):

--- a/libcloud/dns/drivers/gandi.py
+++ b/libcloud/dns/drivers/gandi.py
@@ -66,13 +66,9 @@ class NewZoneVersion(object):
 
 class GandiDNSResponse(GandiResponse):
 
-    def parse_error(self, code, message):
-        context = self.connection.context
-        driver = self.connection.driver
-        if code == 581042:
-            zone_id = str(context.get('zone_id', None))
-            raise ZoneDoesNotExistError(value='', driver=driver,
-                                        zone_id=zone_id)
+    exceptions = {
+        581042: ZoneDoesNotExistError,
+        }
 
 
 class GandiDNSConnection(GandiConnection):

--- a/libcloud/dns/drivers/gandi.py
+++ b/libcloud/dns/drivers/gandi.py
@@ -103,7 +103,7 @@ class GandiDNSDriver(BaseGandiDriver, DNSDriver):
 
     def _to_zone(self, zone):
         return Zone(
-            id=zone['id'],
+            id=str(zone['id']),
             domain=zone['name'],
             type='master',
             ttl=0,
@@ -123,7 +123,7 @@ class GandiDNSDriver(BaseGandiDriver, DNSDriver):
 
     def get_zone(self, zone_id):
         zid = int(zone_id)
-        self.connection.set_context({'zone_id': zid})
+        self.connection.set_context({'zone_id': zone_id})
         zone = self.connection.request('domain.zone.info', zid)
         return self._to_zone(zone.object)
 
@@ -137,13 +137,13 @@ class GandiDNSDriver(BaseGandiDriver, DNSDriver):
     def update_zone(self, zone, domain=None, type=None, ttl=None, extra=None):
         zid = int(zone.id)
         params = {'name': domain}
-        self.connection.set_context({'zone_id': zid})
+        self.connection.set_context({'zone_id': zone.id})
         zone = self.connection.request('domain.zone.update', zid, params)
         return self._to_zone(zone.object)
 
     def delete_zone(self, zone):
         zid = int(zone.id)
-        self.connection.set_context({'zone_id': zid})
+        self.connection.set_context({'zone_id': zone.id})
         res = self.connection.request('domain.zone.delete', zid)
         return res.object
 
@@ -166,7 +166,7 @@ class GandiDNSDriver(BaseGandiDriver, DNSDriver):
 
     def list_records(self, zone):
         zid = int(zone.id)
-        self.connection.set_context({'zone_id': zid})
+        self.connection.set_context({'zone_id': zone.id})
         records = self.connection.request('domain.zone.record.list', zid, 0)
         return self._to_records(records.object, zone)
 
@@ -177,7 +177,7 @@ class GandiDNSDriver(BaseGandiDriver, DNSDriver):
             'name': name,
             'type': record_type
         }
-        self.connection.set_context({'zone_id': zid})
+        self.connection.set_context({'zone_id': zone_id})
         records = self.connection.request('domain.zone.record.list',
                                           zid, 0, filter_opts).object
 
@@ -215,7 +215,7 @@ class GandiDNSDriver(BaseGandiDriver, DNSDriver):
 
         with NewZoneVersion(self, zone) as vid:
             con = self.connection
-            con.set_context({'zone_id': zid})
+            con.set_context({'zone_id': zone.id})
             rec = con.request('domain.zone.record.add',
                               zid, vid, create).object
 
@@ -242,7 +242,7 @@ class GandiDNSDriver(BaseGandiDriver, DNSDriver):
 
         with NewZoneVersion(self, record.zone) as vid:
             con = self.connection
-            con.set_context({'zone_id': zid})
+            con.set_context({'zone_id': record.zone.id})
             con.request('domain.zone.record.delete',
                         zid, vid, filter_opts)
             res = con.request('domain.zone.record.add',
@@ -260,7 +260,7 @@ class GandiDNSDriver(BaseGandiDriver, DNSDriver):
 
         with NewZoneVersion(self, record.zone) as vid:
             con = self.connection
-            con.set_context({'zone_id': zid})
+            con.set_context({'zone_id': record.zone.id})
             count = con.request('domain.zone.record.delete',
                                 zid, vid, filter_opts).object
 

--- a/libcloud/test/compute/fixtures/softlayer/SoftLayer_Account.xml
+++ b/libcloud/test/compute/fixtures/softlayer/SoftLayer_Account.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0'?>
+<methodResponse>
+  <fault>
+    <value>
+      <struct>
+        <member>
+          <name>faultCode</name>
+          <value><string>SoftLayer_Account</string></value>
+        </member>
+        <member>
+          <name>faultString</name>
+          <value><string>Failed Call</string></value>
+        </member>
+      </struct>
+    </value>
+  </fault>
+</methodResponse>

--- a/libcloud/test/compute/fixtures/softlayer/fail.xml
+++ b/libcloud/test/compute/fixtures/softlayer/fail.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0'?>
+<methodResponse>
+  <fault>
+    <value>
+      <struct>
+        <member>
+          <name>faultCode</name>
+          <value><string>fail</string></value>
+        </member>
+        <member>
+          <name>faultString</name>
+          <value><string>Failed Call</string></value>
+        </member>
+      </struct>
+    </value>
+  </fault>
+</methodResponse>

--- a/libcloud/test/compute/test_softlayer.py
+++ b/libcloud/test/compute/test_softlayer.py
@@ -141,8 +141,6 @@ class SoftLayerMockHttp(MockHttp):
         params, meth_name = xmlrpclib.loads(body)
         url = url.replace("/", "_")
         meth_name = "%s_%s" % (url, meth_name)
-        if self.type:
-            meth_name = "%s_%s" % (meth_name, self.type)
         return getattr(self, meth_name)(method, url, body, headers)
 
     def _xmlrpc_v3__SoftLayer_Virtual_Guest_getCreateObjectOptions(
@@ -150,11 +148,6 @@ class SoftLayerMockHttp(MockHttp):
         body = self.fixtures.load(
             'v3__SoftLayer_Virtual_Guest_getCreateObjectOptions.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
-
-    _xmlrpc_v3__SoftLayer_Virtual_Guest_getCreateObjectOptions_INVALIDCREDSERROR = \
-        _xmlrpc_v3__SoftLayer_Virtual_Guest_getCreateObjectOptions
-    _xmlrpc_v3__SoftLayer_Virtual_Guest_getCreateObjectOptions_SOFTLAYEREXCEPTION = \
-        _xmlrpc_v3__SoftLayer_Virtual_Guest_getCreateObjectOptions
 
     def _xmlrpc_v3__SoftLayer_Account_getVirtualGuests(
             self, method, url, body, headers):
@@ -167,25 +160,14 @@ class SoftLayerMockHttp(MockHttp):
             'v3_SoftLayer_Location_Datacenter_getDatacenters.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
-    _xmlrpc_v3__SoftLayer_Location_Datacenter_getDatacenters_INVALIDCREDSERROR = \
-        _xmlrpc_v3__SoftLayer_Location_Datacenter_getDatacenters
-    _xmlrpc_v3__SoftLayer_Location_Datacenter_getDatacenters_SOFTLAYEREXCEPTION = \
-        _xmlrpc_v3__SoftLayer_Location_Datacenter_getDatacenters
-
     def _xmlrpc_v3__SoftLayer_Virtual_Guest_createObject(
             self, method, url, body, headers):
-        body = self.fixtures.load(
-            'v3__SoftLayer_Virtual_Guest_createObject.xml')
-        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
-
-    def _xmlrpc_v3__SoftLayer_Virtual_Guest_createObject_INVALIDCREDSERROR(
-        self, method, url, body, headers):
-        body = self.fixtures.load('SoftLayer_Account.xml')
-        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
-
-    def _xmlrpc_v3__SoftLayer_Virtual_Guest_createObject_SOFTLAYEREXCEPTION(
-        self, method, url, body, headers):
-        body = self.fixtures.load('fail.xml')
+        fixture = {
+            None: 'v3__SoftLayer_Virtual_Guest_createObject.xml',
+            'INVALIDCREDSERROR': 'SoftLayer_Account.xml',
+            'SOFTLAYEREXCEPTION': 'fail.xml',
+        }[self.type]
+        body = self.fixtures.load(fixture)
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
     def _xmlrpc_v3__SoftLayer_Virtual_Guest_getObject(

--- a/libcloud/test/compute/test_vcl.py
+++ b/libcloud/test/compute/test_vcl.py
@@ -97,43 +97,31 @@ class VCLMockHttp(MockHttp):
         body = self.fixtures.load('XMLRPCgetImages.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
-    def XMLRPCextendRequest(
-        self, method, url, body, headers):
-
+    def XMLRPCextendRequest(self, method, url, body, headers):
         body = self.fixtures.load('XMLRPCextendRequest.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
-    def XMLRPCgetRequestIds(
-        self, method, url, body, headers):
-
+    def XMLRPCgetRequestIds(self, method, url, body, headers):
         body = self.fixtures.load(
             'XMLRPCgetRequestIds.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
-    def XMLRPCgetRequestStatus(
-        self, method, url, body, headers):
-
+    def XMLRPCgetRequestStatus(self, method, url, body, headers):
         body = self.fixtures.load(
             'XMLRPCgetRequestStatus.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
-    def XMLRPCendRequest(
-        self, method, url, body, headers):
-
+    def XMLRPCendRequest(self, method, url, body, headers):
         body = self.fixtures.load(
             'XMLRPCendRequest.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
-    def XMLRPCaddRequest(
-        self, method, url, body, headers):
-
+    def XMLRPCaddRequest(self, method, url, body, headers):
         body = self.fixtures.load(
             'XMLRPCaddRequest.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
-    def XMLRPCgetRequestConnectData(
-        self, method, url, body, headers):
-
+    def XMLRPCgetRequestConnectData(self, method, url, body, headers):
         body = self.fixtures.load(
             'XMLRPCgetRequestConnectData.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])

--- a/libcloud/test/dns/test_gandi.py
+++ b/libcloud/test/dns/test_gandi.py
@@ -247,39 +247,48 @@ class GandiMockHttp(BaseGandiMockHttp):
         body = self.fixtures.load('new_version.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
-    def _xmlrpc__domain_zone_record_list_ZONE_DOES_NOT_EXIST(self, method, url, body, headers):
+    def _xmlrpc__domain_zone_record_list_ZONE_DOES_NOT_EXIST(self, method, url,
+                                                             body, headers):
         body = self.fixtures.load('zone_doesnt_exist.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
-    def _xmlrpc__domain_zone_info_ZONE_DOES_NOT_EXIST(self, method, url, body, headers):
+    def _xmlrpc__domain_zone_info_ZONE_DOES_NOT_EXIST(self, method, url, body,
+                                                      headers):
         body = self.fixtures.load('zone_doesnt_exist.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
-    def _xmlrpc__domain_zone_list_ZONE_DOES_NOT_EXIST(self, method, url, body, headers):
+    def _xmlrpc__domain_zone_list_ZONE_DOES_NOT_EXIST(self, method, url, body,
+                                                      headers):
         body = self.fixtures.load('zone_doesnt_exist.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
-    def _xmlrpc__domain_zone_delete_ZONE_DOES_NOT_EXIST(self, method, url, body, headers):
+    def _xmlrpc__domain_zone_delete_ZONE_DOES_NOT_EXIST(self, method, url,
+                                                        body, headers):
         body = self.fixtures.load('zone_doesnt_exist.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
-    def _xmlrpc__domain_zone_record_list_RECORD_DOES_NOT_EXIST(self, method, url, body, headers):
+    def _xmlrpc__domain_zone_record_list_RECORD_DOES_NOT_EXIST(
+            self, method, url, body, headers):
         body = self.fixtures.load('list_records_empty.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
-    def _xmlrpc__domain_zone_info_RECORD_DOES_NOT_EXIST(self, method, url, body, headers):
+    def _xmlrpc__domain_zone_info_RECORD_DOES_NOT_EXIST(self, method, url,
+                                                        body, headers):
         body = self.fixtures.load('list_zones.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
-    def _xmlrpc__domain_zone_record_delete_RECORD_DOES_NOT_EXIST(self, method, url, body, headers):
+    def _xmlrpc__domain_zone_record_delete_RECORD_DOES_NOT_EXIST(
+            self, method, url, body, headers):
         body = self.fixtures.load('delete_record_doesnotexist.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
-    def _xmlrpc__domain_zone_version_new_RECORD_DOES_NOT_EXIST(self, method, url, body, headers):
+    def _xmlrpc__domain_zone_version_new_RECORD_DOES_NOT_EXIST(
+            self, method, url, body, headers):
         body = self.fixtures.load('new_version.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
-    def _xmlrpc__domain_zone_version_set_RECORD_DOES_NOT_EXIST(self, method, url, body, headers):
+    def _xmlrpc__domain_zone_version_set_RECORD_DOES_NOT_EXIST(
+            self, method, url, body, headers):
         body = self.fixtures.load('new_version.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 


### PR DESCRIPTION
2nd part of my XML-RPC efforts. It pulls the shared code out of my Gandi proof of concept and updates VCL and SoftLayer to use it as well.

Tests are passing, my Gandi manual tests are working, i've pep8'd all the files i've touched.

The PR contains my earlier Gandi PR as it hasn't landed in trunk yet, but I can easily rebase this patch if the earlier patch lands.
