### PR TITLE
fixed one aspect of network-label assumption in openstack driver

### DIFF
--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -1605,7 +1605,10 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
                         chain(api_node['addresses'].get('public', []),
                               api_node['addresses'].get('internet', []))],
             private_ips=[addr_desc['addr'] for addr_desc in
-                         api_node['addresses'].get('private', [])],
+                         chain(*[addrs for label, addrs in
+                                 api_node['addresses'].iteritems()
+                                 if label != 'public'
+                                 and label != 'internet'])],
             driver=self,
             extra=dict(
                 hostId=api_node['hostId'],


### PR DESCRIPTION
Hi
Some OpenStack clouds use custom network naming and not the assumed 'public' 'private' pair assumed in the OpenStack driver.
I made a small change to add all networks to private.
I am no expert, haven't tested this beyond my use, but I thought I should put it out there, in case it helps other people with my problem.
Cheers
