### PR TITLE
xml utf-8 workaround for python 2

### DIFF
--- a/libcloud/common/base.py
+++ b/libcloud/common/base.py
@@ -43,6 +43,12 @@ from libcloud.httplib_ssl import LibcloudHTTPSConnection
 
 LibcloudHTTPConnection = httplib.HTTPConnection
 
+# If cloud WebService returns utf-8 caracters
+# Usage:
+# import libcloud.common.base
+# libcloud.common.base.HTTP_RESPONSE_UTF8 = True
+HTTP_RESPONSE_UTF8 = False
+
 
 class HTTPResponse(httplib.HTTPResponse):
     # On python 2.6 some calls can hang because HEAD isn't quite properly
@@ -180,6 +186,10 @@ class XmlResponse(Response):
     def parse_body(self):
         if len(self.body) == 0 and not self.parse_zero_length_body:
             return self.body
+
+        if HTTP_RESPONSE_UTF8 and not PY3:
+            self.body = self.body.decode('utf-8')\
+                .encode('ascii', 'xmlcharrefreplace')
 
         try:
             body = ET.XML(self.body)


### PR DESCRIPTION
Working withopennebula with french network names like 'réseau mutualisé', libcloud failed with and encoding error on python2.

Here is a ondemand workaround for that (like SSL_VERIFY workaround).

thanks for your review
