### PR TITLE
Update libvirt_driver.py

### DIFF
--- a/libcloud/compute/drivers/libvirt_driver.py
+++ b/libcloud/compute/drivers/libvirt_driver.py
@@ -94,7 +94,7 @@ class LibvirtNodeDriver(NodeDriver):
         domain = self._get_domain_for_node(node=node)
         return domain.destroy() == 0
 
-    def ex_start(self, node):
+    def ex_start(self, domain):
         """
         Start a stopped node.
 
@@ -103,7 +103,7 @@ class LibvirtNodeDriver(NodeDriver):
 
         @rtype: C{bool}
         """
-        domain = self._get_domain_for_node(node=node)
+        domain = self._get_domain_for_node_name(domain=domain)
         return domain.create() == 0
 
     def ex_shutdown(self, node):
@@ -144,4 +144,8 @@ class LibvirtNodeDriver(NodeDriver):
 
     def _get_domain_for_node(self, node):
         domain = self.connection.lookupByID(int(node.id))
+        return domain
+        
+    def _get_domain_for_node_name(self, domain):
+        domain = self.connection.lookupByName(domain)
         return domain


### PR DESCRIPTION
Hello,
there is another update for libcloud_driver on git, can you please validate,
for start node, the stopped node haven't an Id, this why we cannot start node from her id, here is no ID !!
we need to look_up domain by name and start this virtual domaine
cordially
