### PR TITLE
Add Homebrew support to CA_CERTS_PATH

### DIFF
--- a/libcloud/security.py
+++ b/libcloud/security.py
@@ -42,6 +42,9 @@ CA_CERTS_PATH = [
 
     # macports: curl-ca-bundle
     '/opt/local/share/curl/curl-ca-bundle.crt',
+
+    # homebrew: curl-ca-bundle
+    '/usr/local/opt/curl-ca-bundle/share/ca-bundle.crt',
 ]
 
 # Allow user to explicitly specify which CA bundle to use, using an environment


### PR DESCRIPTION
Same patch I added to [LIBCLOUD-324](https://issues.apache.org/jira/browse/LIBCLOUD-324), just offering  you a PR in case that's more convenient.
