### PR TITLE
Update libvirt_driver.py

### DIFF
--- a/libcloud/compute/drivers/libvirt_driver.py
+++ b/libcloud/compute/drivers/libvirt_driver.py
@@ -94,7 +94,7 @@ class LibvirtNodeDriver(NodeDriver):
         domain = self._get_domain_for_node(node=node)
         return domain.destroy() == 0
 
-    def ex_start(self, node):
+    def ex_start(self, name):
         """
         Start a stopped node.
 
@@ -103,7 +103,7 @@ class LibvirtNodeDriver(NodeDriver):
 
         @rtype: C{bool}
         """
-        domain = self._get_domain_for_node(node=node)
+        domain = self._get_domain_for_node_by_name(name=name)
         return domain.create() == 0
 
     def ex_shutdown(self, node):
@@ -144,4 +144,8 @@ class LibvirtNodeDriver(NodeDriver):
 
     def _get_domain_for_node(self, node):
         domain = self.connection.lookupByID(int(node.id))
+        return domain
+        
+    def _get_domain_for_node_by_name(self, name):
+        domain = self.connection.lookupByName(name)
         return domain


### PR DESCRIPTION
in the management of virtual machines with libvirt, a machine has stopped ID = -1 and therefore we can never recover a blocked field through its ID, the solution is to look up the domain by its name or by its UUID, the solution I have used is the search domain with the name, 
according to :
http://libvirt.org/html/libvirt-libvirt.html#virDomainLookupByID
virDomainLookupByID
virDomainPtr    virDomainLookupByID(virConnectPtr conn, int id)
Try to find a domain based on the hypervisor ID number Note that this won't work for inactive domains which have an ID of -1, in that case a lookup based on the Name or UUId need to be done instead
