### PR TITLE
Modified timeout in deploy_node method.

### DIFF
--- a/libcloud/compute/base.py
+++ b/libcloud/compute/base.py
@@ -658,7 +658,8 @@ class NodeDriver(BaseDriver):
         try:
             node, ip_addresses = self.wait_until_running(
                 nodes=[node],
-                wait_period=3, timeout=NODE_ONLINE_WAIT_TIMEOUT,
+                wait_period=3,
+                timeout=kwargs.get('timeout', NODE_ONLINE_WAIT_TIMEOUT),
                 ssh_interface=ssh_interface)[0]
         except Exception:
             e = sys.exc_info()[1]


### PR DESCRIPTION
Description - This was modified such that the timeout is respected when passed
as a kwargs.

Problem - When using deploy_node, the timeout function is not respected and
goes directly to the  "NODE_ONLINE_WAIT_TIMEOUT" constant.  This fix adds a get
for "timeout" from kwargs in the "self.wait_until_running" method. If no timeout is
specified in kwargs "NODE_ONLINE_WAIT_TIMEOUT" is used.
