### PR TITLE
Issue LIBCLOUD-356: Provide user-data for Openstack driver

### DIFF
--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -1169,8 +1169,13 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
             server_params['key_name'] = kwargs['ex_keyname']
 
         if 'ex_userdata' in kwargs:
-            server_params['user_data'] = base64.b64encode(
-                b(kwargs['ex_userdata'])).decode('ascii')
+            f = open(kwargs['ex_userdata'], 'r')
+            content = f.read()
+            f.close()
+                
+            server_params['user_data'] = base64.b64encode( 
+                b(content)).decode('ascii')
+                
 
         if 'networks' in kwargs:
             networks = kwargs['networks']


### PR DESCRIPTION
This implements a mimic of Nova client behavior: fails if the provided user-data does not point to a readable file, provides the content of the file as user-data if the file is readable.
