### PR TITLE
Brightbox compute Driver: Fixed attribute name, Added check for null data

### DIFF
--- a/libcloud/compute/drivers/brightbox.py
+++ b/libcloud/compute/drivers/brightbox.py
@@ -20,6 +20,7 @@ from libcloud.utils.py3 import httplib
 from libcloud.utils.py3 import b
 
 from libcloud.common.brightbox import BrightboxConnection
+from libcloud.common.types import LibcloudError
 from libcloud.compute.types import Provider, NodeState
 from libcloud.compute.base import NodeDriver
 from libcloud.compute.base import Node, NodeImage, NodeSize, NodeLocation
@@ -63,7 +64,7 @@ class BrightboxNodeDriver(NodeDriver):
                                                   **kwargs)
 
     def _to_node(self, data):
-        if data is not None:
+        if data:
             extra_data = _extract(data, ['fqdn', 'account', 'status',
                                      'interfaces', 'snapshots',
                                      'server_groups', 'hostname',
@@ -90,6 +91,8 @@ class BrightboxNodeDriver(NodeDriver):
                 image=self._to_image(data['image']),
                 extra=extra_data
             )
+        else:
+            raise LibcloudError('No data was provided.')
 
     def _to_image(self, data):
         extra_data = _extract(data, ['arch', 'compatibility_mode',
@@ -123,7 +126,7 @@ class BrightboxNodeDriver(NodeDriver):
     def _to_location(self, data):
         if data:
             return NodeLocation(
-               id=data['id'],
+                id=data['id'],
                 name=data['handle'],
                 country='GB',
                 driver=self

--- a/libcloud/compute/drivers/brightbox.py
+++ b/libcloud/compute/drivers/brightbox.py
@@ -63,32 +63,33 @@ class BrightboxNodeDriver(NodeDriver):
                                                   **kwargs)
 
     def _to_node(self, data):
-        extra_data = _extract(data, ['fqdn', 'user_data', 'status',
+        if data is not None:
+            extra_data = _extract(data, ['fqdn', 'account', 'status',
                                      'interfaces', 'snapshots',
                                      'server_groups', 'hostname',
                                      'started_at', 'created_at',
                                      'deleted_at'])
-        extra_data['zone'] = self._to_location(data['zone'])
-        return Node(
-            id=data['id'],
-            name=data['name'],
-            state=self.NODE_STATE_MAP[data['status']],
+            extra_data['zone'] = self._to_location(data['zone'])
+            return Node(
+                id=data['id'],
+                name=data['name'],
+                state=self.NODE_STATE_MAP[data['status']],
 
-            private_ips=[interface['ipv4_address']
-                         for interface in data['interfaces']
-                         if 'ipv4_address' in interface],
+                private_ips=[interface['ipv4_address']
+                            for interface in data['interfaces']
+                            if 'ipv4_address' in interface],
 
-            public_ips=[cloud_ip['public_ip']
-                        for cloud_ip in data['cloud_ips']] +
-                        [interface['ipv6_address']
-                        for interface in data['interfaces']
-                        if 'ipv6_address' in interface],
+                public_ips=[cloud_ip['public_ip']
+                            for cloud_ip in data['cloud_ips']] +
+                            [interface['ipv6_address']
+                            for interface in data['interfaces']
+                            if 'ipv6_address' in interface],
 
-            driver=self.connection.driver,
-            size=self._to_size(data['server_type']),
-            image=self._to_image(data['image']),
-            extra=extra_data
-        )
+                driver=self.connection.driver,
+                size=self._to_size(data['server_type']),
+                image=self._to_image(data['image']),
+                extra=extra_data
+            )
 
     def _to_image(self, data):
         extra_data = _extract(data, ['arch', 'compatibility_mode',
@@ -120,12 +121,15 @@ class BrightboxNodeDriver(NodeDriver):
         )
 
     def _to_location(self, data):
-        return NodeLocation(
-            id=data['id'],
-            name=data['handle'],
-            country='GB',
-            driver=self
-        )
+        if data:
+            return NodeLocation(
+               id=data['id'],
+                name=data['handle'],
+                country='GB',
+                driver=self
+            )
+        else:
+            return None
 
     def _post(self, path, data={}):
         headers = {'Content-Type': 'application/json'}


### PR DESCRIPTION
1. 'user_data' changed to 'account'
2. When there are deleted servers in the node_list, zone was None and it was throwing a TypeError when trying to parse it.
