### PR TITLE
Sleep for a while to avoid errno 104

### DIFF
--- a/libcloud/common/base.py
+++ b/libcloud/common/base.py
@@ -593,6 +593,12 @@ class Connection(object):
         # Removed terrible hack...this a less-bad hack that doesn't execute a
         # request twice, but it's still a hack.
         self.connect()
+
+        # And because on some weird ocasions the GIL will dead-lock on this
+        # code triggering a 104 connection reset by peer, let's sleep just for
+        # a litle while.
+        time.sleep(0.01)
+
         try:
             # @TODO: Should we just pass File object as body to request method
             # instead of dealing with splitting and sending the file ourselves?


### PR DESCRIPTION
On some weird and random occasions the GIL deadlocks while connecting forcing the remote servers to 104 the connection. A simple sleep avoids this issue(after googling, I found http://goo.gl/0LpLvJ which helped)

```
Traceback (most recent call last):
  File "/usr/src/salt-cloud/saltcloud/clouds/openstack.py", line 386, in create
    data = conn.create_node(**kwargs)
  File "/usr/lib/python2.6/site-packages/libcloud/compute/drivers/openstack.py", line 1111, in create_node
    data={'server': server_params})
  File "/usr/lib/python2.6/site-packages/libcloud/compute/drivers/openstack.py", line 145, in request
    method=method, headers=headers)
  File "/usr/lib/python2.6/site-packages/libcloud/common/openstack.py", line 580, in request
    return super(OpenStackBaseConnection, self).request(**kwargs)
  File "/usr/lib/python2.6/site-packages/libcloud/common/base.py", line 632, in request
    else:
  File "/usr/lib64/python2.6/httplib.py", line 990, in getresponse
    response.begin()
  File "/usr/lib64/python2.6/httplib.py", line 391, in begin
    version, status, reason = self._read_status()
  File "/usr/lib64/python2.6/httplib.py", line 349, in _read_status
    line = self.fp.readline()
  File "/usr/lib64/python2.6/socket.py", line 433, in readline
    data = recv(1)
  File "/usr/lib64/python2.6/ssl.py", line 215, in recv
    return self.read(buflen)
  File "/usr/lib64/python2.6/ssl.py", line 136, in read
    return self._sslobj.read(len)
error: [Errno 104] Connection reset by peer
```
