### PR TITLE
Libcloud 386 GCE Load Balancer Support

### DIFF
--- a/demos/gce_demo.py
+++ b/demos/gce_demo.py
@@ -41,7 +41,13 @@ import sys
 try:
     import secrets
 except ImportError:
-    secrets = None
+    print('"demos/secrets.py" not found.\n\n'
+          'Please copy secrets.py-dist to secrets.py and update the GCE* '
+          'values with appropriate authentication information.\n'
+          'Additional information about setting these values can be found '
+          'in the docstring for:\n'
+          'libcloud/common/google.py\n')
+    sys.exit()
 
 # Add parent dir of this file's dir to sys.path (OS-agnostically)
 sys.path.append(os.path.normpath(os.path.join(os.path.dirname(__file__),

--- a/demos/gce_demo.py
+++ b/demos/gce_demo.py
@@ -58,7 +58,7 @@ MAX_NODES = 5
 DEMO_BASE_NAME = 'libcloud-demo'
 
 # Datacenter to create resources in
-DATACENTER = 'us-central1-a'
+DATACENTER = 'us-central2-a'
 
 # Clean up resources at the end (can be set to false in order to
 # inspect resources at the end of the run). Resources will be cleaned

--- a/demos/gce_demo.py
+++ b/demos/gce_demo.py
@@ -47,7 +47,7 @@ except ImportError:
           'Additional information about setting these values can be found '
           'in the docstring for:\n'
           'libcloud/common/google.py\n')
-    sys.exit()
+    sys.exit(1)
 
 # Add parent dir of this file's dir to sys.path (OS-agnostically)
 sys.path.append(os.path.normpath(os.path.join(os.path.dirname(__file__),
@@ -74,10 +74,14 @@ CLEANUP = True
 args = getattr(secrets, 'GCE_PARAMS', ())
 kwargs = getattr(secrets, 'GCE_KEYWORD_PARAMS', {})
 
+# Add datacenter to kwargs for Python 2.5 compatibility
+kwargs = kwargs.copy()
+kwargs['datacenter'] = DATACENTER
+
 
 # ==== HELPER FUNCTIONS ====
 def get_gce_driver():
-    driver = get_driver(Provider.GCE)(*args, datacenter=DATACENTER, **kwargs)
+    driver = get_driver(Provider.GCE)(*args, **kwargs)
     return driver
 
 

--- a/demos/gce_lb_demo.py
+++ b/demos/gce_lb_demo.py
@@ -26,7 +26,7 @@
 #      libcloud/common/google.py docstring)
 #    - Run 'python' in this directory, then:
 #        import gce_lb_demo
-#        gcelb = gce_lb_demo.get_gce_lb_driver()
+#        gcelb = gce_lb_demo.get_gcelb_driver()
 #        gcelb.list_balancers()
 #        etc.
 #    - Or, to run the full demo from the interactive python shell:
@@ -43,7 +43,13 @@ import time
 try:
     import secrets
 except ImportError:
-    secrets = None
+    print('"demos/secrets.py" not found.\n\n'
+          'Please copy secrets.py-dist to secrets.py and update the GCE* '
+          'values with appropriate authentication information.\n'
+          'Additional information about setting these values can be found '
+          'in the docstring for:\n'
+          'libcloud/common/google.py\n')
+    sys.exit()
 
 # Add parent dir of this file's dir to sys.path (OS-agnostically)
 sys.path.append(os.path.normpath(os.path.join(os.path.dirname(__file__),

--- a/demos/gce_lb_demo.py
+++ b/demos/gce_lb_demo.py
@@ -49,7 +49,7 @@ except ImportError:
           'Additional information about setting these values can be found '
           'in the docstring for:\n'
           'libcloud/common/google.py\n')
-    sys.exit()
+    sys.exit(1)
 
 # Add parent dir of this file's dir to sys.path (OS-agnostically)
 sys.path.append(os.path.normpath(os.path.join(os.path.dirname(__file__),
@@ -82,10 +82,14 @@ CLEANUP = True
 args = getattr(secrets, 'GCE_PARAMS', ())
 kwargs = getattr(secrets, 'GCE_KEYWORD_PARAMS', {})
 
+# Add datacenter to kwargs for Python 2.5 compatibility
+kwargs = kwargs.copy()
+kwargs['datacenter'] = DATACENTER
+
 
 # ==== HELPER FUNCTIONS ====
 def get_gce_driver():
-    driver = get_driver(Provider.GCE)(*args, datacenter=DATACENTER, **kwargs)
+    driver = get_driver(Provider.GCE)(*args, **kwargs)
     return driver
 
 

--- a/demos/gce_lb_demo.py
+++ b/demos/gce_lb_demo.py
@@ -101,8 +101,7 @@ def get_gcelb_driver(gce_driver=None):
     if gce_driver:
         driver = get_driver_lb(Provider_lb.GCE)(gce_driver=gce_driver)
     else:
-        driver = get_driver_lb(Provider_lb.GCE)(*args, datacenter=DATACENTER,
-                                                **kwargs)
+        driver = get_driver_lb(Provider_lb.GCE)(*args, **kwargs)
     return driver
 
 

--- a/demos/gce_lb_demo.py
+++ b/demos/gce_lb_demo.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# This example performs several tasks on Google Compute Engine and the GCE
+# Load Balancer.  It can be run directly or can be imported into an
+# interactive python session.  This can also serve as an integration test for
+# the GCE Load Balancer Driver.
+#
+# To run interactively:
+#    - Make sure you have valid values in secrets.py
+#      (For more information about setting up your credentials, see the
+#      libcloud/common/google.py docstring)
+#    - Run 'python' in this directory, then:
+#        import gce_lb_demo
+#        gcelb = gce_lb_demo.get_gce_lb_driver()
+#        gcelb.list_balancers()
+#        etc.
+#    - Or, to run the full demo from the interactive python shell:
+#        import gce_lb_demo
+#        gce_lb_demo.CLEANUP = False               # optional
+#        gce_lb_demo.MAX_NODES = 4                 # optional
+#        gce_lb_demo.DATACENTER = 'us-central1-a'  # optional
+#        gce_lb_demo.main()
+
+import os.path
+import sys
+import time
+
+try:
+    import secrets
+except ImportError:
+    secrets = None
+
+# Add parent dir of this file's dir to sys.path (OS-agnostically)
+sys.path.append(os.path.normpath(os.path.join(os.path.dirname(__file__),
+                                 os.path.pardir)))
+
+from libcloud.utils.py3 import urllib2
+
+# This demo uses both the Compute driver and the LoadBalancer driver
+from libcloud.compute.types import Provider
+from libcloud.compute.providers import get_driver
+from libcloud.loadbalancer.types import Provider as Provider_lb
+from libcloud.loadbalancer.providers import get_driver as get_driver_lb
+
+# String that all resource names created by the demo will start with
+# WARNING: Any resource that has a matching name will be destroyed.
+DEMO_BASE_NAME = 'libcloud-lb-demo'
+
+# Datacenter to create resources in
+DATACENTER = 'us-central1-b'
+
+# Clean up resources at the end (can be set to false in order to
+# inspect resources at the end of the run). Resources will be cleaned
+# at the beginning regardless.
+CLEANUP = True
+
+args = getattr(secrets, 'GCE_PARAMS', ())
+kwargs = getattr(secrets, 'GCE_KEYWORD_PARAMS', {})
+
+
+# ==== HELPER FUNCTIONS ====
+def get_gce_driver():
+    driver = get_driver(Provider.GCE)(*args, datacenter=DATACENTER, **kwargs)
+    return driver
+
+def get_gcelb_driver(gce_driver=None):
+    # The GCE Load Balancer driver uses the GCE Compute driver for all of its
+    # API calls.  You can either provide the driver directly, or provide the
+    # same authentication information so the the LB driver can get its own
+    # Compute driver.
+    if gce_driver:
+        driver = get_driver_lb(Provider_lb.GCE)(gce_driver=gce_driver)
+    else:
+        driver = get_driver_lb(Provider_lb.GCE)(*args, datacenter=DATACENTER,
+                                                **kwargs)
+    return driver
+
+
+def display(title, resource_list):
+    """
+    Display a list of resources.
+
+    @param  title: String to be printed at the heading of the list.
+    @type   title: C{str}
+
+    @param  resource_list: List of resources to display
+    @type   resource_list: Any C{object} with a C{name} attribute
+    """
+    print('%s:' % title)
+    for item in resource_list[:10]:
+        print('   %s' % item.name)
+
+
+def clean_up(base_name, node_list=None, resource_list=None):
+    """
+    Destroy all resources that have a name beginning with 'base_name'.
+
+    @param  base_name: String with the first part of the name of resources
+                       to destroy
+    @type   base_name: C{str}
+
+    @keyword  node_list: List of nodes to consider for deletion
+    @type     node_list: C{list} of L{Node}
+
+    @keyword  resource_list: List of resources to consider for deletion
+    @type     resource_list: C{list} of I{Resource Objects}
+    """
+    if node_list is None:
+        node_list = []
+    if resource_list is None:
+        resource_list = []
+    # Use ex_destroy_multiple_nodes to destroy nodes
+    del_nodes = []
+    for node in node_list:
+        if node.name.startswith(base_name):
+            del_nodes.append(node)
+
+    result = gce.ex_destroy_multiple_nodes(del_nodes)
+    for i, success in enumerate(result):
+        if success:
+            print('   Deleted %s' % del_nodes[i].name)
+        else:
+            print('   Failed to delete %s' % del_nodes[i].name)
+
+    # Destroy everything else with just the destroy method
+    for resource in resource_list:
+        if resource.name.startswith(base_name):
+            if resource.destroy():
+                print('   Deleted %s' % resource.name)
+            else:
+                print('   Failed to Delete %s' % resource.name)
+
+
+# ==== DEMO CODE STARTS HERE ====
+def main():
+    global gce
+    global gcelb
+    gce = get_gce_driver()
+    gcelb = get_gcelb_driver(gce)
+
+    # Existing Balancers
+    balancers = gcelb.list_balancers()
+    display('Load Balancers', balancers)
+
+    # Protocols
+    protocols = gcelb.list_protocols()
+    print('Protocols:')
+    for p in protocols:
+        print('   %s' % p)
+
+    # Healthchecks
+    healthchecks = gcelb.ex_list_healthchecks()
+    display('Health Checks', healthchecks)
+
+    # This demo is based on the GCE Load Balancing Quickstart described here:
+    # https://developers.google.com/compute/docs/load-balancing/lb-quickstart
+
+    # == Clean-up and existing demo resources ==
+    all_nodes = gce.list_nodes(ex_zone='all')
+    firewalls = gce.ex_list_firewalls()
+    print('Cleaning up any "%s" resources:' % DEMO_BASE_NAME)
+    clean_up(DEMO_BASE_NAME, all_nodes, balancers + healthchecks + firewalls)
+
+
+    # == Create 3 nodes to balance between ==
+    startup_script = ('apt-get -y update && '
+                      'apt-get -y install apache2 && '
+                      'hostname > /var/www/index.html')
+    tag = '%s-www' % DEMO_BASE_NAME
+    base_name = '%s-www' % DEMO_BASE_NAME
+    image = gce.ex_get_image('debian-7')
+    size = gce.ex_get_size('n1-standard-1')
+    number = 3
+    metadata = {'items': [{'key': 'startup-script',
+                           'value': startup_script}]}
+    lb_nodes = gce.ex_create_multiple_nodes(base_name, size, image,
+                                            number, ex_tags=[tag],
+                                            ex_metadata=metadata)
+    display('Created Nodes', lb_nodes)
+
+    # == Create a Firewall for instances ==
+    print('Creating a Firewall:')
+    name = '%s-firewall' % DEMO_BASE_NAME
+    allowed = [{'IPProtocol': 'tcp',
+                'ports': ['80']}]
+    firewall = gce.ex_create_firewall(name, allowed, source_tags=[tag])
+    print('   Firewall %s created' % firewall.name)
+
+    # == Create a Health Check ==
+    print('Creating a HealthCheck:')
+    name = '%s-healthcheck' % DEMO_BASE_NAME
+
+    # These are all the default values, but listed here as an example.  To
+    # create a healthcheck with the defaults, only name is required.
+    hc = gcelb.ex_create_healthcheck(name, host=None, path='/', port='80',
+                                     interval=5, timeout=5,
+                                     unhealthy_threshold=2,
+                                     healthy_threshold=2)
+    print('   Healthcheck %s created' % hc.name)
+
+    # == Create Load Balancer ==
+    print('Creating Load Balancer')
+    name = '%s-lb' % DEMO_BASE_NAME
+    port = 80
+    protocol = 'tcp'
+    algorithm = None
+    members = lb_nodes[:2] # Only attach the first two initially
+    healthchecks = [hc]
+    balancer = gcelb.create_balancer(name, port, protocol, algorithm, members,
+                                     ex_healthchecks=healthchecks)
+    print('   Load Balancer %s created' % balancer.name)
+
+    # == Attach third Node ==
+    print('Attaching additional node to Load Balancer:')
+    member = balancer.attach_compute_node(lb_nodes[2])
+    print('   Attached %s to %s' % (member.id, balancer.name))
+
+    # == Show Balancer Members ==
+    members = balancer.list_members()
+    print('Load Balancer Members:')
+    for member in members:
+        print('   ID: %s IP: %s' % (member.id, member.ip))
+
+    # == Remove a Member ==
+    print('Removing a Member:')
+    detached = members[0]
+    detach = balancer.detach_member(detached)
+    if detach:
+        print('   Member %s detached from %s' % (detached.id, balancer.name))
+
+    # == Show Updated Balancer Members ==
+    members = balancer.list_members()
+    print('Updated Load Balancer Members:')
+    for member in members:
+        print('   ID: %s IP: %s' % (member.id, member.ip))
+
+    # == Reattach Member ==
+    print('Reattaching Member:')
+    member = balancer.attach_member(detached)
+    print('   Member %s attached to %s' % (member.id, balancer.name))
+
+    # == Test Load Balancer by connecting to it multiple times ==
+    rounds = 200
+    url = 'http://%s/' % balancer.ip
+    line_length = 75
+    print('Connecting to %s %s times:' % (url, rounds))
+    for x in range(rounds):
+        response = urllib2.urlopen(url)
+        output = response.read().strip()
+        if 'www-001' in output:
+            padded_output = output.center(line_length)
+        elif 'www-002' in output:
+            padded_output = output.rjust(line_length)
+        else:
+            padded_output = output.ljust(line_length)
+        sys.stdout.write('\r%s' % padded_output)
+        sys.stdout.flush()
+    print('')
+
+    if CLEANUP:
+        balancers = gcelb.list_balancers()
+        healthchecks = gcelb.ex_list_healthchecks()
+        nodes = gce.list_nodes()
+        firewalls = gce.ex_list_firewalls()
+
+        print('Cleaning up %s resources created.' % DEMO_BASE_NAME)
+        clean_up(DEMO_BASE_NAME, nodes, balancers + healthchecks + firewalls)
+
+if __name__ == '__main__':
+    main()

--- a/demos/gce_lb_demo.py
+++ b/demos/gce_lb_demo.py
@@ -49,7 +49,11 @@ except ImportError:
 sys.path.append(os.path.normpath(os.path.join(os.path.dirname(__file__),
                                  os.path.pardir)))
 
-from libcloud.utils.py3 import urllib2
+from libcloud.utils.py3 import PY3
+if PY3:
+    import urllib.request as url_req
+else:
+    import urllib2 as url_req
 
 # This demo uses both the Compute driver and the LoadBalancer driver
 from libcloud.compute.types import Provider
@@ -261,8 +265,11 @@ def main():
     line_length = 75
     print('Connecting to %s %s times:' % (url, rounds))
     for x in range(rounds):
-        response = urllib2.urlopen(url)
-        output = response.read().strip()
+        response = url_req.urlopen(url)
+        if PY3:
+            output = str(response.read(), encoding='utf-8').strip()
+        else:
+            output = response.read().strip()
         if 'www-001' in output:
             padded_output = output.center(line_length)
         elif 'www-002' in output:

--- a/libcloud/common/google.py
+++ b/libcloud/common/google.py
@@ -456,7 +456,7 @@ class GoogleBaseConnection(ConnectionUserAndKey, PollingConnection):
             except Exception:
                 e = sys.exc_info()[1]
                 if (('error' in e.args[0]) and ('code' in e.args[0]['error'])
-                    and (e.args[0]['error']['code'] == 404)):
+                        and (e.args[0]['error']['code'] == 404)):
                     raise ResourceNotFoundError(e.args[0], 404)
                 else:
                     raise e

--- a/libcloud/common/google.py
+++ b/libcloud/common/google.py
@@ -73,7 +73,7 @@ import os
 import socket
 import sys
 
-from libcloud.utils.py3 import urlencode, urlparse, PY3
+from libcloud.utils.py3 import httplib, urlencode, urlparse, PY3
 from libcloud.common.base import (ConnectionUserAndKey, JsonResponse,
                                   PollingConnection)
 from libcloud.common.types import (InvalidCredsError,
@@ -103,12 +103,119 @@ class GoogleAuthError(LibcloudError):
         return repr(self.value)
 
 
-class ResourceNotFoundError(ProviderError):
+class GoogleBaseError(ProviderError):
+    def __init__(self, value, http_code, code, driver=None):
+        self.code = code
+        super(GoogleBaseError, self).__init__(value, http_code, driver)
+
+
+class JsonParseError(GoogleBaseError):
+    pass
+
+
+class ResourceNotFoundError(GoogleBaseError):
+    pass
+
+
+class QuotaExceededError(GoogleBaseError):
+    pass
+
+
+class ResourceExistsError(GoogleBaseError):
+    pass
+
+
+class ResourceInUseError(GoogleBaseError):
     pass
 
 
 class GoogleResponse(JsonResponse):
-    pass
+    """
+    Google Base Response class.
+    """
+    def success(self):
+        """
+        Determine if the request was successful.
+
+        For the Google response class, tag all responses as successful and
+        raise appropriate Exceptions from parse_body.
+
+        @return: C{True}
+        """
+        return True
+
+    def _get_error(self, body):
+        """
+        Get the error code and message from a JSON response.
+
+        Return just the first error if there are multiple errors.
+
+        @param  body: The body of the JSON response dictionary
+        @type   body: C{dict}
+
+        @return:  Tuple containing error code and message
+        @rtype:   C{tuple} of C{str} or C{int}
+        """
+        if 'errors' in body['error']:
+            err = body['error']['errors'][0]
+        else:
+            err = body['error']
+
+        code = err.get('code')
+        message = err.get('message')
+        return (code, message)
+
+    def parse_body(self):
+        """
+        Parse the JSON response body, or raise exceptions as appropriate.
+
+        @return:  JSON dictionary
+        @rtype:   C{dict}
+        """
+        if len(self.body) == 0 and not self.parse_zero_length_body:
+            return self.body
+
+        json_error = False
+        try:
+            body = json.loads(self.body)
+        except:
+            # If there is both a JSON parsing error and an unsuccessful http
+            # response (like a 404), we want to raise the http error and not
+            # the JSON one, so don't raise JsonParseError here.
+            body = self.body
+            json_error = True
+
+        if self.status in [httplib.OK, httplib.CREATED, httplib.ACCEPTED]:
+            if json_error:
+                raise JsonParseError(body, self.status, None)
+            elif 'error' in body:
+                (code, message) = self._get_error(body)
+                if code == 'QUOTA_EXCEEDED':
+                    raise QuotaExceededError(message, self.status, code)
+                elif code == 'RESOURCE_ALREADY_EXISTS':
+                    raise ResourceExistsError(message, self.status, code)
+                elif code.startswith('RESOURCE_IN_USE'):
+                    raise ResourceInUseError(message, self.status, code)
+                else:
+                    raise GoogleBaseError(message, self.status, code)
+            else:
+                return body
+
+        elif self.status == httplib.NOT_FOUND:
+            if (not json_error) and ('error' in body):
+                (code, message) = self._get_error(body)
+            else:
+                message = body
+                code = None
+            raise ResourceNotFoundError(message, self.status, code)
+
+        else:
+            if (not json_error) and ('error' in body):
+                (code, message) = self._get_error(body)
+            else:
+                message = body
+                code = None
+            raise GoogleBaseError(message, self.status, code)
 
 
 class GoogleBaseDriver(object):
@@ -450,14 +557,6 @@ class GoogleBaseConnection(ConnectionUserAndKey, PollingConnection):
                 e = sys.exc_info()[1]
                 if e.errno == errno.ECONNRESET:
                     tries = tries + 1
-                else:
-                    raise e
-            # Also, catch 404 errors and raise a ResourceNotFoundError
-            except Exception:
-                e = sys.exc_info()[1]
-                if (('error' in e.args[0]) and ('code' in e.args[0]['error'])
-                        and (e.args[0]['error']['code'] == 404)):
-                    raise ResourceNotFoundError(e.args[0], 404)
                 else:
                     raise e
         # One more time, then give up.

--- a/libcloud/common/google.py
+++ b/libcloud/common/google.py
@@ -508,6 +508,11 @@ class GoogleBaseConnection(ConnectionUserAndKey, PollingConnection):
 
         super(GoogleBaseConnection, self).__init__(user_id, key, **kwargs)
 
+        python_ver = '%s.%s.%s' % (sys.version_info[0], sys.version_info[1],
+                                   sys.version_info[2])
+        ver_platform = 'Python %s/%s' % (python_ver, sys.platform)
+        self.user_agent_append(ver_platform)
+
     def _now(self):
         return datetime.datetime.utcnow()
 

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -67,24 +67,15 @@ class GCEError(LibcloudError):
         return repr(self.code) + ": " + repr(self.value)
 
 
-class GCEKnownError(GCEError):
-    """Base class for GCE Errors that can be classified"""
-    def __init__(self, value):
-        self.value = value
-
-    def __repr__(self):
-        return repr(self.value)
-
-
-class QuotaExceededError(GCEKnownError):
+class QuotaExceededError(GCEError):
     pass
 
 
-class ResourceExistsError(GCEKnownError):
+class ResourceExistsError(GCEError):
     pass
 
 
-class ResourceInUseError(GCEKnownError):
+class ResourceInUseError(GCEError):
     pass
 
 
@@ -569,11 +560,11 @@ class GCENodeDriver(NodeDriver):
         message = err['message']
         code = err['code']
         if code == 'QUOTA_EXCEEDED':
-            raise QuotaExceededError(message)
+            raise QuotaExceededError(code, message)
         elif code == 'RESOURCE_ALREADY_EXISTS':
-            raise ResourceExistsError(message)
+            raise ResourceExistsError(code, message)
         elif code.startswith('RESOURCE_IN_USE'):
-            raise ResourceInUseError(message)
+            raise ResourceInUseError(code, message)
         else:
             raise GCEError(code, message)
 

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -662,10 +662,11 @@ class GCENodeDriver(NodeDriver):
         @return:  A region object or None if all regions should be considered
         @rtype:   L{GCERegion} or C{None}
         """
-        if region == 'all':
+        region = region or self.region
+
+        if region == 'all' or region is None:
             return None
 
-        region = region or self.region
         if not hasattr(region, 'name'):
             region = self.ex_get_region(region)
         return region
@@ -680,10 +681,11 @@ class GCENodeDriver(NodeDriver):
         @return:  A zone object or None if all zones should be considered
         @rtype:   L{GCEZone} or C{None}
         """
-        if zone == 'all':
+        zone = zone or self.zone
+
+        if zone == 'all' or zone is None:
             return None
 
-        zone = zone or self.zone
         if not hasattr(zone, 'name'):
             zone = self.ex_get_zone(zone)
         return zone

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -535,6 +535,23 @@ class GCENodeDriver(NodeDriver):
         return {'auth_type': self.auth_type,
                 'project': self.project}
 
+    def _catch_error(self, ignore_errors=False):
+        """
+        Catch an exception and raise it unless asked to ignore it.
+
+        @keyword  ignore_errors: If true, just return the error.  Otherwise,
+                                 raise the error.
+        @type     ignore_errors: C{bool}
+
+        @return:  The exception that was raised.
+        @rtype:   L{Exception}
+        """
+        e = sys.exc_info()[1]
+        if ignore_errors:
+            return e
+        else:
+            raise e
+
     def _get_components_from_path(self, path):
         """
         Return a dictionary containing name & zone/region from a request path.
@@ -1429,11 +1446,9 @@ class GCENodeDriver(NodeDriver):
                     response = self.connection.request(
                         operation['selfLink']).object
                 except:
-                    e = sys.exc_info()[1]
+                    e = self._catch_error(ignore_errors=ignore_errors)
                     error = e.value
                     code = e.code
-                    if not ignore_errors:
-                        raise e
                 if response['status'] == 'DONE':
                     responses[i] = None
                     name = '%s-%03d' % (base_name, i)
@@ -2008,10 +2023,8 @@ class GCENodeDriver(NodeDriver):
                 response = self.connection.request(request,
                                                    method='DELETE').object
             except:
-                e = sys.exc_info()[1]
+                e = self._catch_error(ignore_errors=ignore_errors)
                 response = None
-                if not ignore_errors:
-                    raise e
             responses.append(response)
 
         while not complete:
@@ -2027,10 +2040,8 @@ class GCENodeDriver(NodeDriver):
                     response = self.connection.request(
                         operation['selfLink']).object
                 except:
-                    e = sys.exc_info()[1]
+                    e = self._catch_error(ignore_errors=ignore_errors)
                     no_errors = False
-                    if not ignore_errors:
-                        raise e
                 if response['status'] == 'DONE':
                     responses[i] = None
                     success[i] = no_errors

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -84,6 +84,10 @@ class ResourceExistsError(GCEKnownError):
     pass
 
 
+class ResourceInUseError(GCEKnownError):
+    pass
+
+
 class GCEResponse(GoogleResponse):
     pass
 
@@ -568,6 +572,8 @@ class GCENodeDriver(NodeDriver):
             raise QuotaExceededError(message)
         elif code == 'RESOURCE_ALREADY_EXISTS':
             raise ResourceExistsError(message)
+        elif code == 'RESOURCE_IN_USE':
+            raise ResourceInUseError(message)
         else:
             raise GCEError(code, message)
 

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -2697,9 +2697,11 @@ class GCENodeDriver(NodeDriver):
             try:
                 node = self.ex_get_node(name, zone)
             except Exception:
+                # There is likely a better way to do this, but this seems to
+                # work in Python 2 and Python 3
                 e = sys.exc_info()[1]
-                if (('error' in e[0]) and ('code' in e[0]['error']) and
-                        (e[0]['error']['code'] == 404)):
+                str_e = str(e)
+                if '\'code\': 404' in str_e:
                     node = n
                 else:
                     raise e

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -572,7 +572,7 @@ class GCENodeDriver(NodeDriver):
             raise QuotaExceededError(message)
         elif code == 'RESOURCE_ALREADY_EXISTS':
             raise ResourceExistsError(message)
-        elif code == 'RESOURCE_IN_USE':
+        elif code.startswith('RESOURCE_IN_USE'):
             raise ResourceInUseError(message)
         else:
             raise GCEError(code, message)

--- a/libcloud/loadbalancer/drivers/gce.py
+++ b/libcloud/loadbalancer/drivers/gce.py
@@ -1,0 +1,340 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+try:
+    import simplejson as json
+except ImportError:
+    import json
+
+from libcloud.loadbalancer.base import LoadBalancer, Member, Driver, Algorithm
+from libcloud.compute.drivers.gce import GCEConnection, GCENodeDriver
+
+# GCE doesn't actually give you a algorithm choice, but this is here simply as
+# the closest match.  The actual algorithm is described here:
+# https://developers.google.com/compute/docs/load-balancing/#overview
+DEFAULT_ALGORITHM = Algorithm.RANDOM
+
+
+class GCELBDriver(Driver):
+    connectionCls = GCEConnection
+    apiname = 'googleapis'
+    name = 'Google Compute Engine'
+    website = 'https://www.googleapis.com/'
+
+    _VALUE_TO_ALGORITHM_MAP = {
+        'RANDOM': Algorithm.RANDOM
+    }
+
+    def __init__(self, *args, **kwargs):
+
+        if kwargs.get('gce_driver'):
+            self.gce = kwargs['gce_driver']
+        else:
+            self.gce = GCENodeDriver(*args, **kwargs)
+
+    def _get_node_from_ip(self, ip):
+        """
+        Return the node object that matches a given public IP address.
+
+        @param  ip: Public IP address to search for
+        @type   ip: C{str}
+
+        @return:  Node object that has the given IP, or None if not found.
+        @rtype:   L{Node} or None
+        """
+        all_nodes = self.gce.list_nodes(ex_zone='all')
+        for node in all_nodes:
+            if ip in node.public_ips:
+                return node
+        return None
+
+    def list_protocols(self):
+        """
+        Return a list of supported protocols.
+
+        For GCE, this is simply a hardcoded list.
+
+        @rtype: C{list} of C{str}
+        """
+        return ['TCP', 'UDP']
+
+    def list_balancers(self):
+        """
+        List all loadbalancers
+
+        @rtype: C{list} of L{LoadBalancer}
+        """
+        balancers = []
+        for fwr in self.gce.ex_list_forwarding_rules():
+            balancers.append(self._forwarding_rule_to_loadbalancer(fwr))
+        return balancers
+
+    def create_balancer(self, name, port, protocol, algorithm, members,
+                        ex_region=None, ex_healthchecks=None, ex_address=None):
+        """
+        Create a new load balancer instance.
+
+        For GCE, this means creating a forwarding rule and a matching target
+        pool, then adding the members to the target pool.
+
+        @param  name: Name of the new load balancer (required)
+        @type   C{str}
+
+        @param  port: Port or range of ports the load balancer should listen
+                      on, defaults to all ports.  Examples: '80', '5000-5999'
+        @type   port: C{str}
+
+        @param  protocol: Load balancer protocol.  Should be 'tcp' or 'udp',
+                          defaults to 'tcp'.
+        @type   protocol: C{str}
+
+        @param  members: List of Members to attach to balancer.  Can be Member
+                         objects or Node objects.  Node objects are preferred
+                         for GCE, but Member objects are accepted to comply
+                         with the established libcloud API.  Note that the
+                         'port' attribute of the members is ignored.
+        @type   members: C{list} of L{Member} or L{Node}
+
+        @param  algorithm: Load balancing algorithm.  Ignored for GCE which
+                           uses a hashing-based algorithm.
+        @type   algorithm: L{Algorithm} or C{None}
+
+        @keyword  ex_region:  Optional region to create the load balancer in.
+                              Defaults to the default region of the GCE Node
+                              Driver.
+        @type     ex_region:  C{GCERegion} or C{str}
+
+        @keyword  ex_healthchecks: Optional list of healthcheck objects or
+                                   names to add to the load balancer.
+        @type     ex_healthchecks: C{list} of L{GCEHealthCheck} or C{str}
+
+        @keyword  ex_address: Optional static address object to be assigned to
+                              the load balancer.
+        @type     ex_address: C{GCEAddress}
+
+        @return:  LoadBalancer object
+        @rtype:   L{LoadBalancer}
+        """
+        unused = algorithm
+
+        node_list = []
+        for member in members:
+            # Member object
+            if hasattr(member, 'ip'):
+                if member.extra.get('node'):
+                    node_list.append(member.extra['node'])
+                else:
+                    node_list.append(self._get_node_from_ip(member.ip))
+            # Node object
+            elif hasattr(member, 'name'):
+                node_list.append(member)
+            # Assume it's a node name otherwise
+            else:
+                node_list.append(self.gce.ex_get_node(member, 'all'))
+
+        # Create Target Pool
+        tp_name = '%s-tp' % name
+        targetpool = self.gce.ex_create_targetpool(
+            tp_name, region=ex_region, healthchecks=ex_healthchecks,
+            nodes=node_list)
+
+        # Create the Forwarding rule, but if it fails, delete the target pool.
+        try:
+            forwarding_rule = self.gce.ex_create_forwarding_rule(
+                name, targetpool, region=ex_region, protocol=protocol,
+                port_range=port, address=ex_address)
+        except:
+            targetpool.destroy()
+            raise
+
+        # Reformat forwarding rule to LoadBalancer object
+        return self._forwarding_rule_to_loadbalancer(forwarding_rule)
+
+    def destroy_balancer(self, balancer):
+        """
+        Destroy a load balancer.
+
+        For GCE, this means destroying the associated forwarding rule, then
+        destroying the target pool that was attached to the forwarding rule.
+
+        @param  balancer: LoadBalancer which should be used
+        @type   balancer: L{LoadBalancer}
+
+        @return:  True if successful
+        @rtype:   C{bool}
+        """
+        destroy = balancer.extra['forwarding_rule'].destroy()
+        if destroy:
+            tp_destroy = balancer.extra['targetpool'].destroy()
+            return tp_destroy
+        else:
+            return destroy
+
+    def get_balancer(self, balancer_id):
+        """
+        Return a L{LoadBalancer} object.
+
+        @param  balancer_id: Name of load balancer you wish to fetch.  For GCE,
+                             this is the name of the associated forwarding
+                             rule.
+        @param  balancer_id: C{str}
+
+        @rtype: L{LoadBalancer}
+        """
+        fwr = self.gce.ex_get_forwarding_rule(balancer_id)
+        return self._forwarding_rule_to_loadbalancer(fwr)
+
+    def balancer_attach_compute_node(self, balancer, node):
+        """
+        Attach a compute node as a member to the load balancer.
+
+        @param balancer: LoadBalancer which should be used
+        @type  balancer: L{LoadBalancer}
+
+        @param node: Node to join to the balancer
+        @type  node: L{Node}
+
+        @return: Member after joining the balancer.
+        @rtype: L{Member}
+        """
+        add_node = balancer.extra['targetpool'].add_node(node)
+        if add_node:
+            return self._node_to_member(node, balancer)
+
+    def balancer_attach_member(self, balancer, member):
+        """
+        Attach a member to balancer
+
+        @param balancer: LoadBalancer which should be used
+        @type  balancer: L{LoadBalancer}
+
+        @param member: Member to join to the balancer
+        @type member: L{Member}
+
+        @return: Member after joining the balancer.
+        @rtype: L{Member}
+        """
+        node = member.extra.get('node') or self._get_node_from_ip(member.ip)
+        add_node = balancer.extra['targetpool'].add_node(node)
+        if add_node:
+            return self._node_to_member(node, balancer)
+
+    def balancer_detach_member(self, balancer, member):
+        """
+        Detach member from balancer
+
+        @param balancer: LoadBalancer which should be used
+        @type  balancer: L{LoadBalancer}
+
+        @param member: Member which should be used
+        @type member: L{Member}
+
+        @return: True if member detach was successful, otherwise False
+        @rtype: C{bool}
+        """
+        node = member.extra.get('node') or self._get_node_from_ip(member.ip)
+        remove_node = balancer.extra['targetpool'].remove_node(node)
+        return remove_node
+
+    def balancer_list_members(self, balancer):
+        """
+        Return list of members attached to balancer
+
+        @param balancer: LoadBalancer which should be used
+        @type  balancer: L{LoadBalancer}
+
+        @rtype: C{list} of L{Member}
+        """
+        return [self._node_to_member(n, balancer) for n in
+                balancer.extra['targetpool'].nodes]
+
+    def ex_balancer_attach_healthcheck(self, balancer, healthcheck):
+        """
+        Attach a healthcheck to balancer
+
+        @param balancer: LoadBalancer which should be used
+        @type  balancer: L{LoadBalancer}
+
+        @param healthcheck: Healthcheck to add
+        @type  healthcheck: L{GCEHealthCheck}
+
+        @return: True if successful
+        @rtype:  C{bool}
+        """
+        return balancer.extra['targetpool'].add_healthcheck(healthcheck)
+
+    def ex_balancer_detach_healtcheck(self, balancer, healthcheck):
+        """
+        Detach healtcheck from balancer
+
+        @param balancer: LoadBalancer which should be used
+        @type  balancer: L{LoadBalancer}
+
+        @param healthcheck: Healthcheck to remove
+        @type  healthcheck: L{GCEHealthCheck}
+
+        @return: True if successful
+        @rtype: C{bool}
+        """
+        return balancer.extra['targetpool'].remove_healthcheck(healthcheck)
+
+    def ex_balancer_list_healthchecks(self, balancer):
+        """
+        Return list of healthchecks attached to balancer
+
+        @param  balancer: LoadBalancer which should be used
+        @type   balancer: L{LoadBalancer}
+
+        @rtype: C{list} of L{HealthChecks}
+        """
+        return balancer.extra['healthchecks']
+
+    def _node_to_member(self, node, balancer):
+        """
+        Return a Member object based on a Node.
+
+        @param  node: Node object
+        @type   node: L{Node}
+
+        @keyword  balancer: The balancer the member is attached to.
+        @type     balancer: L{LoadBalancer}
+
+        @return:  Member object
+        @rtype:   L{Member}
+        """
+        extra = {'node': node}
+        return Member(id=node.name, ip=node.public_ips[0], port=balancer.port,
+                      balancer=balancer, extra=extra)
+
+    def _forwarding_rule_to_loadbalancer(self, forwarding_rule):
+        """
+        Return a Load Balancer object based on a GCEForwardingRule object.
+
+        @param  forwarding_rule: ForwardingRule object
+        @type   forwarding_rule: L{GCEForwardingRule}
+
+        @return:  LoadBalancer object
+        @rtype:   L{LoadBalancer}
+        """
+        extra = {}
+        extra['forwarding_rule'] = forwarding_rule
+        extra['targetpool'] = forwarding_rule.targetpool
+        extra['healthchecks'] = forwarding_rule.targetpool.healthchecks
+
+        return LoadBalancer(id=forwarding_rule.id,
+                            name=forwarding_rule.name, state=None,
+                            ip=forwarding_rule.address,
+                            port=forwarding_rule.extra['portRange'],
+                            driver=self, extra=extra)

--- a/libcloud/loadbalancer/drivers/gce.py
+++ b/libcloud/loadbalancer/drivers/gce.py
@@ -260,6 +260,12 @@ class GCELBDriver(Driver):
         return [self._node_to_member(n, balancer) for n in
                 balancer.extra['targetpool'].nodes]
 
+    def ex_create_healthcheck(self, *args, **kwargs):
+        return self.gce.ex_create_healthcheck(*args, **kwargs)
+
+    def ex_list_healthchecks(self):
+        return self.gce.ex_list_healthchecks()
+
     def ex_balancer_attach_healthcheck(self, balancer, healthcheck):
         """
         Attach a healthcheck to balancer

--- a/libcloud/loadbalancer/drivers/gce.py
+++ b/libcloud/loadbalancer/drivers/gce.py
@@ -44,6 +44,8 @@ class GCELBDriver(Driver):
         else:
             self.gce = GCENodeDriver(*args, **kwargs)
 
+        self.connection = self.gce.connection
+
     def _get_node_from_ip(self, ip):
         """
         Return the node object that matches a given public IP address.

--- a/libcloud/loadbalancer/providers.py
+++ b/libcloud/loadbalancer/providers.py
@@ -36,6 +36,8 @@ DRIVERS = {
             ('libcloud.loadbalancer.drivers.brightbox', 'BrightboxLBDriver'),
         Provider.ELB:
             ('libcloud.loadbalancer.drivers.elb', 'ElasticLBDriver'),
+        Provider.CLOUDSTACK:
+            ('libcloud.loadbalancer.drivers.cloudstack', 'CloudStackLBDriver'),
         Provider.GCE:
             ('libcloud.loadbalancer.drivers.gce', 'GCELBDriver')
 }

--- a/libcloud/loadbalancer/providers.py
+++ b/libcloud/loadbalancer/providers.py
@@ -36,9 +36,8 @@ DRIVERS = {
             ('libcloud.loadbalancer.drivers.brightbox', 'BrightboxLBDriver'),
         Provider.ELB:
             ('libcloud.loadbalancer.drivers.elb', 'ElasticLBDriver'),
-        Provider.CLOUDSTACK:
-            ('libcloud.loadbalancer.drivers.cloudstack', 'CloudStackLBDriver')
-
+        Provider.GCE:
+            ('libcloud.loadbalancer.drivers.gce', 'GCELBDriver')
 }
 
 

--- a/libcloud/loadbalancer/types.py
+++ b/libcloud/loadbalancer/types.py
@@ -38,6 +38,7 @@ class Provider(object):
     RACKSPACE_UK = 'rackspace_uk'
     BRIGHTBOX = 'brightbox'
     ELB = 'elb'
+    CLOUDSTACK = 'cloudstack'
     GCE = 'gce'
 
 

--- a/libcloud/loadbalancer/types.py
+++ b/libcloud/loadbalancer/types.py
@@ -38,7 +38,7 @@ class Provider(object):
     RACKSPACE_UK = 'rackspace_uk'
     BRIGHTBOX = 'brightbox'
     ELB = 'elb'
-    CLOUDSTACK = 'cloudstack'
+    GCE = 'gce'
 
 
 class State(object):

--- a/libcloud/test/compute/fixtures/gce/aggregated_forwardingRules.json
+++ b/libcloud/test/compute/fixtures/gce/aggregated_forwardingRules.json
@@ -1,0 +1,57 @@
+{
+  "id": "projects/project_name/aggregated/forwardingRules",
+  "items": {
+    "regions/europe-west1": {
+      "warning": {
+        "code": "NO_RESULTS_ON_PAGE",
+        "data": [
+          {
+            "key": "scope",
+            "value": "regions/europe-west1"
+          }
+        ],
+        "message": "There are no results for scope 'regions/europe-west1' on this page."
+      }
+    },
+    "regions/us-central1": {
+      "forwardingRules": [
+        {
+          "IPAddress": "173.255.119.224",
+          "IPProtocol": "TCP",
+          "creationTimestamp": "2013-09-03T00:17:25.544-07:00",
+          "id": "10901665092293158938",
+          "kind": "compute#forwardingRule",
+          "name": "lcforwardingrule",
+          "portRange": "8000-8500",
+          "region": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1",
+          "target": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/targetPools/libcloud-lb-demo-lb-tp"
+        },
+        {
+          "IPAddress": "173.255.119.185",
+          "IPProtocol": "TCP",
+          "creationTimestamp": "2013-09-02T22:25:50.575-07:00",
+          "id": "15826316229163619337",
+          "kind": "compute#forwardingRule",
+          "name": "libcloud-lb-demo-lb",
+          "portRange": "80-80",
+          "region": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1",
+          "target": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/targetPools/libcloud-lb-demo-lb-tp"
+        }
+      ]
+    },
+    "regions/us-central2": {
+      "warning": {
+        "code": "NO_RESULTS_ON_PAGE",
+        "data": [
+          {
+            "key": "scope",
+            "value": "regions/us-central2"
+          }
+        ],
+        "message": "There are no results for scope 'regions/us-central2' on this page."
+      }
+    }
+  },
+  "kind": "compute#forwardingRuleAggregatedList",
+  "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/aggregated/forwardingRules"
+}

--- a/libcloud/test/compute/fixtures/gce/aggregated_targetPools.json
+++ b/libcloud/test/compute/fixtures/gce/aggregated_targetPools.json
@@ -1,0 +1,64 @@
+{
+  "id": "projects/project_name/aggregated/targetPools",
+  "items": {
+    "regions/europe-west1": {
+      "warning": {
+        "code": "NO_RESULTS_ON_PAGE",
+        "data": [
+          {
+            "key": "scope",
+            "value": "regions/europe-west1"
+          }
+        ],
+        "message": "There are no results for scope 'regions/europe-west1' on this page."
+      }
+    },
+    "regions/us-central1": {
+      "targetPools": [
+        {
+          "creationTimestamp": "2013-09-03T00:51:05.300-07:00",
+          "healthChecks": [
+            "https://www.googleapis.com/compute/v1beta15/projects/project_name/global/httpHealthChecks/libcloud-lb-demo-healthcheck"
+          ],
+          "id": "11690726329826021866",
+          "instances": [
+            "https://www.googleapis.com/compute/v1beta15/projects/project_name/zones/us-central1-b/instances/libcloud-lb-demo-www-000",
+            "https://www.googleapis.com/compute/v1beta15/projects/project_name/zones/us-central1-b/instances/libcloud-lb-demo-www-001"
+          ],
+          "kind": "compute#targetPool",
+          "name": "lctargetpool",
+          "region": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1"
+        },
+        {
+          "creationTimestamp": "2013-09-02T22:25:45.817-07:00",
+          "healthChecks": [
+            "https://www.googleapis.com/compute/v1beta15/projects/project_name/global/httpHealthChecks/libcloud-lb-demo-healthcheck"
+          ],
+          "id": "16605251746746338499",
+          "instances": [
+            "https://www.googleapis.com/compute/v1beta15/projects/project_name/zones/us-central1-b/instances/libcloud-lb-demo-www-002",
+            "https://www.googleapis.com/compute/v1beta15/projects/project_name/zones/us-central1-b/instances/libcloud-lb-demo-www-001",
+            "https://www.googleapis.com/compute/v1beta15/projects/project_name/zones/us-central1-b/instances/libcloud-lb-demo-www-000"
+          ],
+          "kind": "compute#targetPool",
+          "name": "libcloud-lb-demo-lb-tp",
+          "region": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1"
+        }
+      ]
+    },
+    "regions/us-central2": {
+      "warning": {
+        "code": "NO_RESULTS_ON_PAGE",
+        "data": [
+          {
+            "key": "scope",
+            "value": "regions/us-central2"
+          }
+        ],
+        "message": "There are no results for scope 'regions/us-central2' on this page."
+      }
+    }
+  },
+  "kind": "compute#targetPoolAggregatedList",
+  "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/aggregated/targetPools"
+}

--- a/libcloud/test/compute/fixtures/gce/global_httpHealthChecks.json
+++ b/libcloud/test/compute/fixtures/gce/global_httpHealthChecks.json
@@ -1,0 +1,35 @@
+{
+  "id": "projects/project_name/global/httpHealthChecks",
+  "items": [
+    {
+      "checkIntervalSec": 5,
+      "creationTimestamp": "2013-08-19T14:42:28.947-07:00",
+      "description": "",
+      "healthyThreshold": 2,
+      "host": "",
+      "id": "7660832580304455442",
+      "kind": "compute#httpHealthCheck",
+      "name": "basic-check",
+      "port": 80,
+      "requestPath": "/",
+      "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/global/httpHealthChecks/basic-check",
+      "timeoutSec": 5,
+      "unhealthyThreshold": 2
+    },
+    {
+      "checkIntervalSec": 5,
+      "creationTimestamp": "2013-09-02T22:25:44.759-07:00",
+      "healthyThreshold": 2,
+      "id": "16372093408499501663",
+      "kind": "compute#httpHealthCheck",
+      "name": "libcloud-lb-demo-healthcheck",
+      "port": 80,
+      "requestPath": "/",
+      "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/global/httpHealthChecks/libcloud-lb-demo-healthcheck",
+      "timeoutSec": 5,
+      "unhealthyThreshold": 2
+    }
+  ],
+  "kind": "compute#httpHealthCheckList",
+  "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/global/httpHealthChecks"
+}

--- a/libcloud/test/compute/fixtures/gce/global_httpHealthChecks_basic-check.json
+++ b/libcloud/test/compute/fixtures/gce/global_httpHealthChecks_basic-check.json
@@ -1,0 +1,15 @@
+{
+  "checkIntervalSec": 5,
+  "creationTimestamp": "2013-08-19T14:42:28.947-07:00",
+  "description": "",
+  "healthyThreshold": 2,
+  "host": "",
+  "id": "7660832580304455442",
+  "kind": "compute#httpHealthCheck",
+  "name": "basic-check",
+  "port": 80,
+  "requestPath": "/",
+  "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/global/httpHealthChecks/basic-check",
+  "timeoutSec": 5,
+  "unhealthyThreshold": 2
+}

--- a/libcloud/test/compute/fixtures/gce/global_httpHealthChecks_lchealthcheck.json
+++ b/libcloud/test/compute/fixtures/gce/global_httpHealthChecks_lchealthcheck.json
@@ -1,0 +1,14 @@
+{
+  "checkIntervalSec": 10,
+  "creationTimestamp": "2013-09-02T22:18:01.180-07:00",
+  "healthyThreshold": 3,
+  "host": "lchost",
+  "id": "06860603312991823381",
+  "kind": "compute#httpHealthCheck",
+  "name": "lchealthcheck",
+  "port": 8000,
+  "requestPath": "/lc",
+  "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/global/httpHealthChecks/lchealthcheck",
+  "timeoutSec": 10,
+  "unhealthyThreshold": 4
+}

--- a/libcloud/test/compute/fixtures/gce/global_httpHealthChecks_lchealthcheck_delete.json
+++ b/libcloud/test/compute/fixtures/gce/global_httpHealthChecks_lchealthcheck_delete.json
@@ -1,0 +1,14 @@
+{
+  "id": "1159296103027566387",
+  "insertTime": "2013-09-02T22:18:02.509-07:00",
+  "kind": "compute#operation",
+  "name": "operation-global_httpHealthChecks_lchealthcheck_delete",
+  "operationType": "delete",
+  "progress": 0,
+  "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/global/operations/operation-global_httpHealthChecks_lchealthcheck_delete",
+  "startTime": "2013-09-02T22:18:02.558-07:00",
+  "status": "PENDING",
+  "targetId": "06860603312991823381",
+  "targetLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/global/healthChecks/lchealthcheck",
+  "user": "user@gserviceaccount.com"
+}

--- a/libcloud/test/compute/fixtures/gce/global_httpHealthChecks_lchealthcheck_put.json
+++ b/libcloud/test/compute/fixtures/gce/global_httpHealthChecks_lchealthcheck_put.json
@@ -1,0 +1,14 @@
+{
+  "id": "6717642434182216609",
+  "insertTime": "2013-09-03T02:19:55.574-07:00",
+  "kind": "compute#operation",
+  "name": "operation-global_httpHealthChecks_lchealthcheck_put",
+  "operationType": "update",
+  "progress": 0,
+  "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/global/operations/operation-global_httpHealthChecks_lchealthcheck_put",
+  "startTime": "2013-09-03T02:19:55.628-07:00",
+  "status": "PENDING",
+  "targetId": "0742691415598204878",
+  "targetLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/global/healthChecks/lchealthcheck",
+  "user": "user@gserviceaccount.com"
+}

--- a/libcloud/test/compute/fixtures/gce/global_httpHealthChecks_libcloud-lb-demo-healthcheck.json
+++ b/libcloud/test/compute/fixtures/gce/global_httpHealthChecks_libcloud-lb-demo-healthcheck.json
@@ -1,0 +1,13 @@
+{
+  "checkIntervalSec": 5,
+  "creationTimestamp": "2013-09-02T22:25:44.759-07:00",
+  "healthyThreshold": 2,
+  "id": "16372093408499501663",
+  "kind": "compute#httpHealthCheck",
+  "name": "libcloud-lb-demo-healthcheck",
+  "port": 80,
+  "requestPath": "/",
+  "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/global/httpHealthChecks/libcloud-lb-demo-healthcheck",
+  "timeoutSec": 5,
+  "unhealthyThreshold": 2
+}

--- a/libcloud/test/compute/fixtures/gce/global_httpHealthChecks_post.json
+++ b/libcloud/test/compute/fixtures/gce/global_httpHealthChecks_post.json
@@ -1,0 +1,13 @@
+{
+  "id": "3903393118268087410",
+  "insertTime": "2013-09-03T02:19:54.629-07:00",
+  "kind": "compute#operation",
+  "name": "operation-global_httpHealthChecks_post",
+  "operationType": "insert",
+  "progress": 0,
+  "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/global/operations/operation-global_httpHealthChecks_post",
+  "startTime": "2013-09-03T02:19:54.718-07:00",
+  "status": "PENDING",
+  "targetLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/global/healthChecks/lchealthcheck",
+  "user": "user@gserviceaccount.com"
+}

--- a/libcloud/test/compute/fixtures/gce/operations_operation_global_httpHealthChecks_lchealthcheck_delete.json
+++ b/libcloud/test/compute/fixtures/gce/operations_operation_global_httpHealthChecks_lchealthcheck_delete.json
@@ -1,0 +1,14 @@
+{
+  "id": "1159296103027566387",
+  "insertTime": "2013-09-02T22:18:02.509-07:00",
+  "kind": "compute#operation",
+  "name": "operation-global_httpHealthChecks_lchealthcheck_delete",
+  "operationType": "delete",
+  "progress": 100,
+  "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/global/operations/operation-global_httpHealthChecks_lchealthcheck_delete",
+  "startTime": "2013-09-02T22:18:02.558-07:00",
+  "status": "DONE",
+  "targetId": "06860603312991823381",
+  "targetLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/global/healthChecks/lchealthcheck",
+  "user": "user@gserviceaccount.com"
+}

--- a/libcloud/test/compute/fixtures/gce/operations_operation_global_httpHealthChecks_lchealthcheck_put.json
+++ b/libcloud/test/compute/fixtures/gce/operations_operation_global_httpHealthChecks_lchealthcheck_put.json
@@ -1,0 +1,15 @@
+{
+  "endTime": "2013-09-03T02:20:02.194-07:00",
+  "id": "6717642434182216609",
+  "insertTime": "2013-09-03T02:19:55.574-07:00",
+  "kind": "compute#operation",
+  "name": "operation-global_httpHealthChecks_lchealthcheck_put",
+  "operationType": "update",
+  "progress": 100,
+  "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/global/operations/operation-global_httpHealthChecks_lchealthcheck_put",
+  "startTime": "2013-09-03T02:19:55.628-07:00",
+  "status": "DONE",
+  "targetId": "0742691415598204878",
+  "targetLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/global/healthChecks/lchealthcheck",
+  "user": "user@gserviceaccount.com"
+}

--- a/libcloud/test/compute/fixtures/gce/operations_operation_global_httpHealthChecks_post.json
+++ b/libcloud/test/compute/fixtures/gce/operations_operation_global_httpHealthChecks_post.json
@@ -1,0 +1,14 @@
+{
+  "id": "3903393118268087410",
+  "insertTime": "2013-09-03T02:19:54.629-07:00",
+  "kind": "compute#operation",
+  "name": "operation-global_httpHealthChecks_post",
+  "operationType": "insert",
+  "progress": 100,
+  "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/global/operations/operation-global_httpHealthChecks_post",
+  "startTime": "2013-09-03T02:19:54.718-07:00",
+  "status": "DONE",
+  "targetId": "0742691415598204878",
+  "targetLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/global/healthChecks/lchealthcheck",
+  "user": "user@gserviceaccount.com"
+}

--- a/libcloud/test/compute/fixtures/gce/operations_operation_regions_us-central1_forwardingRules_lcforwardingrule_delete.json
+++ b/libcloud/test/compute/fixtures/gce/operations_operation_regions_us-central1_forwardingRules_lcforwardingrule_delete.json
@@ -1,0 +1,16 @@
+{
+  "endTime": "2013-09-03T00:17:43.917-07:00",
+  "id": "09064254309855814339",
+  "insertTime": "2013-09-03T00:17:36.062-07:00",
+  "kind": "compute#operation",
+  "name": "operation-regions_us-central1_forwardingRules_lcforwardingrule_delete",
+  "operationType": "delete",
+  "progress": 100,
+  "region": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/operations/operation-regions_us-central1_forwardingRules_lcforwardingrule_delete",
+  "startTime": "2013-09-03T00:17:36.168-07:00",
+  "status": "DONE",
+  "targetId": "10901665092293158938",
+  "targetLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/forwardingRules/lcforwardingrule",
+  "user": "user@gserviceaccount.com"
+}

--- a/libcloud/test/compute/fixtures/gce/operations_operation_regions_us-central1_forwardingRules_post.json
+++ b/libcloud/test/compute/fixtures/gce/operations_operation_regions_us-central1_forwardingRules_post.json
@@ -1,0 +1,16 @@
+{
+  "endTime": "2013-09-03T00:17:33.965-07:00",
+  "id": "0651769405845333112",
+  "insertTime": "2013-09-03T00:17:25.381-07:00",
+  "kind": "compute#operation",
+  "name": "operation-regions_us-central1_forwardingRules_post",
+  "operationType": "insert",
+  "progress": 100,
+  "region": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/operations/operation-regions_us-central1_forwardingRules_post",
+  "startTime": "2013-09-03T00:17:25.434-07:00",
+  "status": "DONE",
+  "targetId": "10901665092293158938",
+  "targetLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/forwardingRules/lcforwardingrule",
+  "user": "user@gserviceaccount.com"
+}

--- a/libcloud/test/compute/fixtures/gce/operations_operation_regions_us-central1_targetPools_lctargetpool_addHealthCheck_post.json
+++ b/libcloud/test/compute/fixtures/gce/operations_operation_regions_us-central1_targetPools_lctargetpool_addHealthCheck_post.json
@@ -1,0 +1,16 @@
+{
+  "endTime": "2013-09-03T01:28:49.271-07:00",
+  "id": "17341029456963557514",
+  "insertTime": "2013-09-03T01:28:40.774-07:00",
+  "kind": "compute#operation",
+  "name": "operation-regions_us-central1_targetPools_lctargetpool_addHealthCheck_post",
+  "operationType": "addHealthCheck",
+  "progress": 100,
+  "region": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/operations/operation-regions_us-central1_targetPools_lctargetpool_addHealthCheck_post",
+  "startTime": "2013-09-03T01:28:40.838-07:00",
+  "status": "DONE",
+  "targetId": "16862638289615591831",
+  "targetLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/targetPools/lctargetpool",
+  "user": "user@gserviceaccount.com"
+}

--- a/libcloud/test/compute/fixtures/gce/operations_operation_regions_us-central1_targetPools_lctargetpool_addInstance_post.json
+++ b/libcloud/test/compute/fixtures/gce/operations_operation_regions_us-central1_targetPools_lctargetpool_addInstance_post.json
@@ -1,0 +1,16 @@
+{
+  "endTime": "2013-09-03T01:29:07.021-07:00",
+  "id": "04072826501537092633",
+  "insertTime": "2013-09-03T01:29:03.082-07:00",
+  "kind": "compute#operation",
+  "name": "operation-regions_us-central1_targetPools_lctargetpool_addInstance_post",
+  "operationType": "addInstance",
+  "progress": 100,
+  "region": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/operations/operation-regions_us-central1_targetPools_lctargetpool_addInstance_post",
+  "startTime": "2013-09-03T01:29:03.145-07:00",
+  "status": "DONE",
+  "targetId": "16862638289615591831",
+  "targetLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/targetPools/lctargetpool",
+  "user": "user@gserviceaccount.com"
+}

--- a/libcloud/test/compute/fixtures/gce/operations_operation_regions_us-central1_targetPools_lctargetpool_delete.json
+++ b/libcloud/test/compute/fixtures/gce/operations_operation_regions_us-central1_targetPools_lctargetpool_delete.json
@@ -1,0 +1,15 @@
+{
+  "id": "13500662190763995965",
+  "insertTime": "2013-09-03T00:51:06.799-07:00",
+  "kind": "compute#operation",
+  "name": "operation-regions_us-central1_targetPools_lctargetpool_delete",
+  "operationType": "delete",
+  "progress": 100,
+  "region": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/operations/operation-regions_us-central1_targetPools_lctargetpool_delete",
+  "startTime": "2013-09-03T00:51:06.840-07:00",
+  "status": "DONE",
+  "targetId": "13598380121688918358",
+  "targetLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/targetPools/lctargetpool",
+  "user": "user@gserviceaccount.com"
+}

--- a/libcloud/test/compute/fixtures/gce/operations_operation_regions_us-central1_targetPools_lctargetpool_removeHealthCheck_post.json
+++ b/libcloud/test/compute/fixtures/gce/operations_operation_regions_us-central1_targetPools_lctargetpool_removeHealthCheck_post.json
@@ -1,0 +1,16 @@
+{
+  "endTime": "2013-09-03T01:28:37.095-07:00",
+  "id": "14738174613993796821",
+  "insertTime": "2013-09-03T01:28:32.889-07:00",
+  "kind": "compute#operation",
+  "name": "operation-regions_us-central1_targetPools_lctargetpool_removeHealthCheck_post",
+  "operationType": "removeHealthCheck",
+  "progress": 100,
+  "region": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/operations/operation-regions_us-central1_targetPools_lctargetpool_removeHealthCheck_post",
+  "startTime": "2013-09-03T01:28:32.942-07:00",
+  "status": "DONE",
+  "targetId": "16862638289615591831",
+  "targetLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/targetPools/lctargetpool",
+  "user": "user@gserviceaccount.com"
+}

--- a/libcloud/test/compute/fixtures/gce/operations_operation_regions_us-central1_targetPools_lctargetpool_removeInstance_post.json
+++ b/libcloud/test/compute/fixtures/gce/operations_operation_regions_us-central1_targetPools_lctargetpool_removeInstance_post.json
@@ -1,0 +1,16 @@
+{
+  "endTime": "2013-09-03T01:28:59.247-07:00",
+  "id": "1815686149437875016",
+  "insertTime": "2013-09-03T01:28:53.049-07:00",
+  "kind": "compute#operation",
+  "name": "operation-regions_us-central1_targetPools_lctargetpool_removeInstance_post",
+  "operationType": "removeInstance",
+  "progress": 100,
+  "region": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/operations/operation-regions_us-central1_targetPools_lctargetpool_removeInstance_post",
+  "startTime": "2013-09-03T01:28:53.109-07:00",
+  "status": "DONE",
+  "targetId": "16862638289615591831",
+  "targetLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/targetPools/lctargetpool",
+  "user": "user@gserviceaccount.com"
+}

--- a/libcloud/test/compute/fixtures/gce/operations_operation_regions_us-central1_targetPools_post.json
+++ b/libcloud/test/compute/fixtures/gce/operations_operation_regions_us-central1_targetPools_post.json
@@ -1,0 +1,15 @@
+{
+  "id": "7487852523793007955",
+  "insertTime": "2013-09-03T00:51:05.064-07:00",
+  "kind": "compute#operation",
+  "name": "operation-regions_us-central1_targetPools_post",
+  "operationType": "insert",
+  "progress": 100,
+  "region": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/operations/operation-regions_us-central1_targetPools_post",
+  "startTime": "2013-09-03T00:51:05.115-07:00",
+  "status": "DONE",
+  "targetId": "13598380121688918358",
+  "targetLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/targetPools/lctargetpool",
+  "user": "user@gserviceaccount.com"
+}

--- a/libcloud/test/compute/fixtures/gce/regions.json
+++ b/libcloud/test/compute/fixtures/gce/regions.json
@@ -1,0 +1,45 @@
+{
+  "id": "projects/project_name/regions",
+  "items": [
+    {
+      "creationTimestamp": "2013-04-19T17:58:16.641-07:00",
+      "description": "europe-west1",
+      "id": "0827308347805275727",
+      "kind": "compute#region",
+      "name": "europe-west1",
+      "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/europe-west1",
+      "status": "UP",
+      "zones": [
+        "https://www.googleapis.com/compute/v1beta15/zones/europe-west1-a",
+        "https://www.googleapis.com/compute/v1beta15/zones/europe-west1-b"
+      ]
+    },
+    {
+      "creationTimestamp": "2013-04-19T18:17:05.050-07:00",
+      "description": "us-central1",
+      "id": "06713580496607310378",
+      "kind": "compute#region",
+      "name": "us-central1",
+      "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1",
+      "status": "UP",
+      "zones": [
+        "https://www.googleapis.com/compute/v1beta15/zones/us-central1-a",
+        "https://www.googleapis.com/compute/v1beta15/zones/us-central1-b"
+      ]
+    },
+    {
+      "creationTimestamp": "2013-04-19T18:19:05.482-07:00",
+      "description": "us-central2",
+      "id": "04157375529195793136",
+      "kind": "compute#region",
+      "name": "us-central2",
+      "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central2",
+      "status": "UP",
+      "zones": [
+        "https://www.googleapis.com/compute/v1beta15/zones/us-central2-a"
+      ]
+    }
+  ],
+  "kind": "compute#regionList",
+  "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions"
+}

--- a/libcloud/test/compute/fixtures/gce/regions_us-central1_forwardingRules.json
+++ b/libcloud/test/compute/fixtures/gce/regions_us-central1_forwardingRules.json
@@ -1,0 +1,31 @@
+{
+  "id": "projects/project_name/regions/us-central1/forwardingRules",
+  "items": [
+    {
+      "IPAddress": "173.255.119.224",
+      "IPProtocol": "TCP",
+      "creationTimestamp": "2013-09-03T00:17:25.544-07:00",
+      "id": "10901665092293158938",
+      "kind": "compute#forwardingRule",
+      "name": "lcforwardingrule",
+      "portRange": "8000-8500",
+      "region": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1",
+      "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/forwardingRules/lcforwardingrule",
+      "target": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/targetPools/libcloud-lb-demo-lb-tp"
+    },
+    {
+      "IPAddress": "173.255.119.185",
+      "IPProtocol": "TCP",
+      "creationTimestamp": "2013-09-02T22:25:50.575-07:00",
+      "id": "15826316229163619337",
+      "kind": "compute#forwardingRule",
+      "name": "libcloud-lb-demo-lb",
+      "portRange": "80-80",
+      "region": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1",
+      "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/forwardingRules/libcloud-lb-demo-lb",
+      "target": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/targetPools/libcloud-lb-demo-lb-tp"
+    }
+  ],
+  "kind": "compute#forwardingRuleList",
+  "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/forwardingRules"
+}

--- a/libcloud/test/compute/fixtures/gce/regions_us-central1_forwardingRules_lcforwardingrule.json
+++ b/libcloud/test/compute/fixtures/gce/regions_us-central1_forwardingRules_lcforwardingrule.json
@@ -1,0 +1,12 @@
+{
+  "IPAddress": "173.255.119.224",
+  "IPProtocol": "TCP",
+  "creationTimestamp": "2013-09-03T00:17:25.544-07:00",
+  "id": "10901665092293158938",
+  "kind": "compute#forwardingRule",
+  "name": "lcforwardingrule",
+  "portRange": "8000-8500",
+  "region": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/forwardingRules/lcforwardingrule",
+  "target": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/targetPools/libcloud-lb-demo-lb-tp"
+}

--- a/libcloud/test/compute/fixtures/gce/regions_us-central1_forwardingRules_lcforwardingrule.json
+++ b/libcloud/test/compute/fixtures/gce/regions_us-central1_forwardingRules_lcforwardingrule.json
@@ -8,5 +8,5 @@
   "portRange": "8000-8500",
   "region": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1",
   "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/forwardingRules/lcforwardingrule",
-  "target": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/targetPools/libcloud-lb-demo-lb-tp"
+  "target": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/targetPools/lctargetpool"
 }

--- a/libcloud/test/compute/fixtures/gce/regions_us-central1_forwardingRules_lcforwardingrule_delete.json
+++ b/libcloud/test/compute/fixtures/gce/regions_us-central1_forwardingRules_lcforwardingrule_delete.json
@@ -1,0 +1,15 @@
+{
+  "id": "09064254309855814339",
+  "insertTime": "2013-09-03T00:17:36.062-07:00",
+  "kind": "compute#operation",
+  "name": "operation-regions_us-central1_forwardingRules_lcforwardingrule_delete",
+  "operationType": "delete",
+  "progress": 0,
+  "region": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/operations/operation-regions_us-central1_forwardingRules_lcforwardingrule_delete",
+  "startTime": "2013-09-03T00:17:36.168-07:00",
+  "status": "PENDING",
+  "targetId": "10901665092293158938",
+  "targetLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/forwardingRules/lcforwardingrule",
+  "user": "user@gserviceaccount.com"
+}

--- a/libcloud/test/compute/fixtures/gce/regions_us-central1_forwardingRules_libcloud-lb-demo-lb.json
+++ b/libcloud/test/compute/fixtures/gce/regions_us-central1_forwardingRules_libcloud-lb-demo-lb.json
@@ -1,0 +1,12 @@
+{
+  "IPAddress": "108.59.83.110",
+  "IPProtocol": "TCP",
+  "creationTimestamp": "2013-09-29T13:30:00.702-07:00",
+  "id": "1077550228014866104",
+  "kind": "compute#forwardingRule",
+  "name": "libcloud-lb-demo-lb",
+  "portRange": "80-80",
+  "region": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/forwardingRules/libcloud-lb-demo-lb",
+  "target": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/targetPools/libcloud-lb-demo-lb-tp"
+}

--- a/libcloud/test/compute/fixtures/gce/regions_us-central1_forwardingRules_post.json
+++ b/libcloud/test/compute/fixtures/gce/regions_us-central1_forwardingRules_post.json
@@ -1,0 +1,14 @@
+{
+  "id": "0651769405845333112",
+  "insertTime": "2013-09-03T00:17:25.381-07:00",
+  "kind": "compute#operation",
+  "name": "operation-regions_us-central1_forwardingRules_post",
+  "operationType": "insert",
+  "progress": 0,
+  "region": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/operations/operation-regions_us-central1_forwardingRules_post",
+  "startTime": "2013-09-03T00:17:25.434-07:00",
+  "status": "PENDING",
+  "targetLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/forwardingRules/lcforwardingrule",
+  "user": "user@gserviceaccount.com"
+}

--- a/libcloud/test/compute/fixtures/gce/regions_us-central1_targetPools.json
+++ b/libcloud/test/compute/fixtures/gce/regions_us-central1_targetPools.json
@@ -1,0 +1,38 @@
+{
+  "id": "projects/project_name/regions/us-central1/targetPools",
+  "items": [
+    {
+      "creationTimestamp": "2013-09-03T00:51:05.300-07:00",
+      "healthChecks": [
+        "https://www.googleapis.com/compute/v1beta15/projects/project_name/global/httpHealthChecks/libcloud-lb-demo-healthcheck"
+      ],
+      "id": "13598380121688918358",
+      "instances": [
+        "https://www.googleapis.com/compute/v1beta15/projects/project_name/zones/us-central1-b/instances/libcloud-lb-demo-www-000",
+        "https://www.googleapis.com/compute/v1beta15/projects/project_name/zones/us-central1-b/instances/libcloud-lb-demo-www-001"
+      ],
+      "kind": "compute#targetPool",
+      "name": "lctargetpool",
+      "region": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1",
+      "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/targetPools/lctargetpool"
+    },
+    {
+      "creationTimestamp": "2013-09-02T22:25:45.817-07:00",
+      "healthChecks": [
+        "https://www.googleapis.com/compute/v1beta15/projects/project_name/global/httpHealthChecks/libcloud-lb-demo-healthcheck"
+      ],
+      "id": "16862638289615591831",
+      "instances": [
+        "https://www.googleapis.com/compute/v1beta15/projects/project_name/zones/us-central1-b/instances/libcloud-lb-demo-www-002",
+        "https://www.googleapis.com/compute/v1beta15/projects/project_name/zones/us-central1-b/instances/libcloud-lb-demo-www-001",
+        "https://www.googleapis.com/compute/v1beta15/projects/project_name/zones/us-central1-b/instances/libcloud-lb-demo-www-000"
+      ],
+      "kind": "compute#targetPool",
+      "name": "libcloud-lb-demo-lb-tp",
+      "region": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1",
+      "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/targetPools/libcloud-lb-demo-lb-tp"
+    }
+  ],
+  "kind": "compute#targetPoolList",
+  "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/targetPools"
+}

--- a/libcloud/test/compute/fixtures/gce/regions_us-central1_targetPools_lctargetpool.json
+++ b/libcloud/test/compute/fixtures/gce/regions_us-central1_targetPools_lctargetpool.json
@@ -1,0 +1,15 @@
+{
+  "creationTimestamp": "2013-09-03T00:51:05.300-07:00",
+  "healthChecks": [
+    "https://www.googleapis.com/compute/v1beta15/projects/project_name/global/httpHealthChecks/libcloud-lb-demo-healthcheck"
+  ],
+  "id": "13598380121688918358",
+  "instances": [
+    "https://www.googleapis.com/compute/v1beta15/projects/project_name/zones/us-central1-b/instances/libcloud-lb-demo-www-000",
+    "https://www.googleapis.com/compute/v1beta15/projects/project_name/zones/us-central1-b/instances/libcloud-lb-demo-www-001"
+  ],
+  "kind": "compute#targetPool",
+  "name": "lctargetpool",
+  "region": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/targetPools/lctargetpool"
+}

--- a/libcloud/test/compute/fixtures/gce/regions_us-central1_targetPools_lctargetpool_addHealthCheck_post.json
+++ b/libcloud/test/compute/fixtures/gce/regions_us-central1_targetPools_lctargetpool_addHealthCheck_post.json
@@ -1,0 +1,15 @@
+{
+  "id": "17341029456963557514",
+  "insertTime": "2013-09-03T01:28:40.774-07:00",
+  "kind": "compute#operation",
+  "name": "operation-regions_us-central1_targetPools_lctargetpool_addHealthCheck_post",
+  "operationType": "addHealthCheck",
+  "progress": 0,
+  "region": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/operations/operation-regions_us-central1_targetPools_lctargetpool_addHealthCheck_post",
+  "startTime": "2013-09-03T01:28:40.838-07:00",
+  "status": "PENDING",
+  "targetId": "16862638289615591831",
+  "targetLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/targetPools/lctargetpool",
+  "user": "user@gserviceaccount.com"
+}

--- a/libcloud/test/compute/fixtures/gce/regions_us-central1_targetPools_lctargetpool_addInstance_post.json
+++ b/libcloud/test/compute/fixtures/gce/regions_us-central1_targetPools_lctargetpool_addInstance_post.json
@@ -1,0 +1,15 @@
+{
+  "id": "04072826501537092633",
+  "insertTime": "2013-09-03T01:29:03.082-07:00",
+  "kind": "compute#operation",
+  "name": "operation-regions_us-central1_targetPools_lctargetpool_addInstance_post",
+  "operationType": "addInstance",
+  "progress": 0,
+  "region": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/operations/operation-regions_us-central1_targetPools_lctargetpool_addInstance_post",
+  "startTime": "2013-09-03T01:29:03.145-07:00",
+  "status": "PENDING",
+  "targetId": "16862638289615591831",
+  "targetLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/targetPools/lctargetpool",
+  "user": "user@gserviceaccount.com"
+}

--- a/libcloud/test/compute/fixtures/gce/regions_us-central1_targetPools_lctargetpool_delete.json
+++ b/libcloud/test/compute/fixtures/gce/regions_us-central1_targetPools_lctargetpool_delete.json
@@ -1,0 +1,15 @@
+{
+  "id": "13500662190763995965",
+  "insertTime": "2013-09-03T00:51:06.799-07:00",
+  "kind": "compute#operation",
+  "name": "operation-regions_us-central1_targetPools_lctargetpool_delete",
+  "operationType": "delete",
+  "progress": 0,
+  "region": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/operations/operation-regions_us-central1_targetPools_lctargetpool_delete",
+  "startTime": "2013-09-03T00:51:06.840-07:00",
+  "status": "PENDING",
+  "targetId": "13598380121688918358",
+  "targetLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/targetPools/lctargetpool",
+  "user": "user@gserviceaccount.com"
+}

--- a/libcloud/test/compute/fixtures/gce/regions_us-central1_targetPools_lctargetpool_removeHealthCheck_post.json
+++ b/libcloud/test/compute/fixtures/gce/regions_us-central1_targetPools_lctargetpool_removeHealthCheck_post.json
@@ -1,0 +1,15 @@
+{
+  "id": "14738174613993796821",
+  "insertTime": "2013-09-03T01:28:32.889-07:00",
+  "kind": "compute#operation",
+  "name": "operation-regions_us-central1_targetPools_lctargetpool_removeHealthCheck_post",
+  "operationType": "removeHealthCheck",
+  "progress": 0,
+  "region": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/operations/operation-regions_us-central1_targetPools_lctargetpool_removeHealthCheck_post",
+  "startTime": "2013-09-03T01:28:32.942-07:00",
+  "status": "PENDING",
+  "targetId": "16862638289615591831",
+  "targetLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/targetPools/lctargetpool",
+  "user": "user@gserviceaccount.com"
+}

--- a/libcloud/test/compute/fixtures/gce/regions_us-central1_targetPools_lctargetpool_removeInstance_post.json
+++ b/libcloud/test/compute/fixtures/gce/regions_us-central1_targetPools_lctargetpool_removeInstance_post.json
@@ -1,0 +1,15 @@
+{
+  "id": "1815686149437875016",
+  "insertTime": "2013-09-03T01:28:53.049-07:00",
+  "kind": "compute#operation",
+  "name": "operation-regions_us-central1_targetPools_lctargetpool_removeInstance_post",
+  "operationType": "removeInstance",
+  "progress": 0,
+  "region": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/operations/operation-regions_us-central1_targetPools_lctargetpool_removeInstance_post",
+  "startTime": "2013-09-03T01:28:53.109-07:00",
+  "status": "PENDING",
+  "targetId": "16862638289615591831",
+  "targetLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/targetPools/lctargetpool",
+  "user": "user@gserviceaccount.com"
+}

--- a/libcloud/test/compute/fixtures/gce/regions_us-central1_targetPools_libcloud-lb-demo-lb-tp.json
+++ b/libcloud/test/compute/fixtures/gce/regions_us-central1_targetPools_libcloud-lb-demo-lb-tp.json
@@ -1,0 +1,16 @@
+{
+  "creationTimestamp": "2013-09-02T22:25:45.817-07:00",
+  "healthChecks": [
+    "https://www.googleapis.com/compute/v1beta15/projects/project_name/global/httpHealthChecks/libcloud-lb-demo-healthcheck"
+  ],
+  "id": "16862638289615591831",
+  "instances": [
+    "https://www.googleapis.com/compute/v1beta15/projects/project_name/zones/us-central1-b/instances/libcloud-lb-demo-www-002",
+    "https://www.googleapis.com/compute/v1beta15/projects/project_name/zones/us-central1-b/instances/libcloud-lb-demo-www-001",
+    "https://www.googleapis.com/compute/v1beta15/projects/project_name/zones/us-central1-b/instances/libcloud-lb-demo-www-000"
+  ],
+  "kind": "compute#targetPool",
+  "name": "libcloud-lb-demo-lb-tp",
+  "region": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/targetPools/libcloud-lb-demo-lb-tp"
+}

--- a/libcloud/test/compute/fixtures/gce/regions_us-central1_targetPools_post.json
+++ b/libcloud/test/compute/fixtures/gce/regions_us-central1_targetPools_post.json
@@ -1,0 +1,14 @@
+{
+  "id": "7487852523793007955",
+  "insertTime": "2013-09-03T00:51:05.064-07:00",
+  "kind": "compute#operation",
+  "name": "operation-regions_us-central1_targetPools_post",
+  "operationType": "insert",
+  "progress": 0,
+  "region": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/operations/operation-regions_us-central1_targetPools_post",
+  "startTime": "2013-09-03T00:51:05.115-07:00",
+  "status": "PENDING",
+  "targetLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/targetPools/lctargetpool",
+  "user": "user@gserviceaccount.com"
+}

--- a/libcloud/test/compute/fixtures/gce/regions_us-central1_targetPools_www-pool.json
+++ b/libcloud/test/compute/fixtures/gce/regions_us-central1_targetPools_www-pool.json
@@ -1,0 +1,17 @@
+{
+  "creationTimestamp": "2013-08-19T14:43:25.289-07:00",
+  "description": "",
+  "healthChecks": [
+    "https://www.googleapis.com/compute/v1beta15/projects/project_name/global/httpHealthChecks/basic-check"
+  ],
+  "id": "09965129111508633746",
+  "instances": [
+    "https://www.googleapis.com/compute/v1beta15/projects/project_name/zones/us-central1-b/instances/www1",
+    "https://www.googleapis.com/compute/v1beta15/projects/project_name/zones/us-central1-b/instances/www2",
+    "https://www.googleapis.com/compute/v1beta15/projects/project_name/zones/us-central1-b/instances/www3"
+  ],
+  "kind": "compute#targetPool",
+  "name": "www-pool",
+  "region": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/regions/us-central1/targetPools/www-pool"
+}

--- a/libcloud/test/compute/fixtures/gce/zones_us-central1-b_instances_libcloud-lb-demo-www-000.json
+++ b/libcloud/test/compute/fixtures/gce/zones_us-central1-b_instances_libcloud-lb-demo-www-000.json
@@ -1,0 +1,52 @@
+{
+  "canIpForward": false,
+  "creationTimestamp": "2013-09-02T22:25:15.878-07:00",
+  "disks": [
+    {
+      "index": 0,
+      "kind": "compute#attachedDisk",
+      "mode": "READ_WRITE",
+      "type": "SCRATCH"
+    }
+  ],
+  "id": "16051209904934263688",
+  "image": "https://www.googleapis.com/compute/v1beta15/projects/debian-cloud/global/images/debian-7-wheezy-v20130723",
+  "kernel": "https://www.googleapis.com/compute/v1beta15/projects/google/global/kernels/gce-v20130603",
+  "kind": "compute#instance",
+  "machineType": "https://www.googleapis.com/compute/v1beta15/projects/project_name/zones/us-central1-b/machineTypes/n1-standard-1",
+  "metadata": {
+    "fingerprint": "n9EGknQZPSA=",
+    "items": [
+      {
+        "key": "startup-script",
+        "value": "apt-get -y update && apt-get -y install apache2 && hostname > /var/www/index.html"
+      }
+    ],
+    "kind": "compute#metadata"
+  },
+  "name": "libcloud-lb-demo-www-000",
+  "networkInterfaces": [
+    {
+      "accessConfigs": [
+        {
+          "kind": "compute#accessConfig",
+          "name": "External NAT",
+          "natIP": "173.255.113.234",
+          "type": "ONE_TO_ONE_NAT"
+        }
+      ],
+      "name": "nic0",
+      "network": "https://www.googleapis.com/compute/v1beta15/projects/project_name/global/networks/default",
+      "networkIP": "10.240.138.154"
+    }
+  ],
+  "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/zones/us-central1-b/instances/libcloud-lb-demo-www-000",
+  "status": "RUNNING",
+  "tags": {
+    "fingerprint": "XI0he92M8l8=",
+    "items": [
+      "libcloud-lb-demo-www"
+    ]
+  },
+  "zone": "https://www.googleapis.com/compute/v1beta15/projects/project_name/zones/us-central1-b"
+}

--- a/libcloud/test/compute/fixtures/gce/zones_us-central1-b_instances_libcloud-lb-demo-www-001.json
+++ b/libcloud/test/compute/fixtures/gce/zones_us-central1-b_instances_libcloud-lb-demo-www-001.json
@@ -1,0 +1,52 @@
+{
+  "canIpForward": false,
+  "creationTimestamp": "2013-09-02T22:25:16.253-07:00",
+  "disks": [
+    {
+      "index": 0,
+      "kind": "compute#attachedDisk",
+      "mode": "READ_WRITE",
+      "type": "SCRATCH"
+    }
+  ],
+  "id": "11204787063927654129",
+  "image": "https://www.googleapis.com/compute/v1beta15/projects/debian-cloud/global/images/debian-7-wheezy-v20130723",
+  "kernel": "https://www.googleapis.com/compute/v1beta15/projects/google/global/kernels/gce-v20130603",
+  "kind": "compute#instance",
+  "machineType": "https://www.googleapis.com/compute/v1beta15/projects/project_name/zones/us-central1-b/machineTypes/n1-standard-1",
+  "metadata": {
+    "fingerprint": "n9EGknQZPSA=",
+    "items": [
+      {
+        "key": "startup-script",
+        "value": "apt-get -y update && apt-get -y install apache2 && hostname > /var/www/index.html"
+      }
+    ],
+    "kind": "compute#metadata"
+  },
+  "name": "libcloud-lb-demo-www-001",
+  "networkInterfaces": [
+    {
+      "accessConfigs": [
+        {
+          "kind": "compute#accessConfig",
+          "name": "External NAT",
+          "natIP": "173.255.114.210",
+          "type": "ONE_TO_ONE_NAT"
+        }
+      ],
+      "name": "nic0",
+      "network": "https://www.googleapis.com/compute/v1beta15/projects/project_name/global/networks/default",
+      "networkIP": "10.240.0.123"
+    }
+  ],
+  "selfLink": "https://www.googleapis.com/compute/v1beta15/projects/project_name/zones/us-central1-b/instances/libcloud-lb-demo-www-001",
+  "status": "RUNNING",
+  "tags": {
+    "fingerprint": "XI0he92M8l8=",
+    "items": [
+      "libcloud-lb-demo-www"
+    ]
+  },
+  "zone": "https://www.googleapis.com/compute/v1beta15/projects/project_name/zones/us-central1-b"
+}

--- a/libcloud/test/compute/fixtures/gce/zones_us-central1-b_instances_libcloud-lb-demo-www-002.json
+++ b/libcloud/test/compute/fixtures/gce/zones_us-central1-b_instances_libcloud-lb-demo-www-002.json
@@ -1,0 +1,13 @@
+{
+  "error": {
+    "code": 404,
+    "errors": [
+      {
+        "domain": "global",
+        "message": "The resource 'projects/project-name/zones/us-central1-b/instances/libcloud-lb-demo-www-002' was not found",
+        "reason": "notFound"
+      }
+    ],
+    "message": "The resource 'projects/project-name/zones/us-central1-b/instances/libcloud-lb-demo-www-002' was not found"
+  }
+}

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -25,13 +25,12 @@ from libcloud.compute.drivers.gce import (GCENodeDriver, API_VERSION,
                                           GCEAddress, GCEHealthCheck,
                                           GCEFirewall, GCEForwardingRule,
                                           GCENetwork, GCENodeSize, GCEProject,
-                                          GCERegion, GCETargetPool, GCEZone,
-                                          GCEError, ResourceExistsError,
-                                          QuotaExceededError)
+                                          GCERegion, GCETargetPool, GCEZone)
 from libcloud.common.google import (GoogleBaseAuthConnection,
                                     GoogleInstalledAppAuthConnection,
                                     GoogleBaseConnection,
-                                    ResourceNotFoundError)
+                                    ResourceNotFoundError, ResourceExistsError,
+                                    QuotaExceededError)
 from libcloud.test.common.test_google import GoogleAuthMockHttp
 from libcloud.compute.base import (Node, NodeImage, NodeSize, NodeLocation,
                                    StorageVolume)

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -22,8 +22,10 @@ import datetime
 from libcloud.utils.py3 import httplib
 from libcloud.compute.drivers.gce import (GCENodeDriver, API_VERSION,
                                           timestamp_to_datetime,
-                                          GCEAddress, GCEFirewall, GCENetwork,
-                                          GCENodeSize, GCEProject, GCEZone,
+                                          GCEAddress, GCEHealthCheck,
+                                          GCEFirewall, GCEForwardingRule,
+                                          GCENetwork, GCENodeSize, GCEProject,
+                                          GCERegion, GCETargetPool, GCEZone,
                                           GCEError, ResourceExistsError,
                                           QuotaExceededError)
 from libcloud.common.google import (GoogleBaseAuthConnection,
@@ -71,6 +73,16 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         datetime2 = datetime.datetime(2013, 6, 26, 17, 43, 15)
         self.assertEqual(timestamp_to_datetime(timestamp2), datetime2)
 
+    def test_get_region_from_zone(self):
+        zone1 = self.driver.ex_get_zone('us-central1-a')
+        expected_region1 = 'us-central1'
+        region1 = self.driver._get_region_from_zone(zone1)
+        self.assertEqual(region1.name, expected_region1)
+        zone2 = self.driver.ex_get_zone('europe-west1-b')
+        expected_region2 = 'europe-west1'
+        region2 = self.driver._get_region_from_zone(zone2)
+        self.assertEqual(region2.name, expected_region2)
+
     def test_find_zone(self):
         zone1 = self.driver._find_zone('libcloud-demo-np-node', 'instances')
         self.assertEqual(zone1, 'us-central1-a')
@@ -96,12 +108,26 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         self.assertEqual(len(address_list_all), 4)
         self.assertEqual(address_list[0].name, 'libcloud-demo-address')
         self.assertEqual(address_list_uc1[0].name, 'libcloud-demo-address')
-        #self.assertEqual(address_list_all[0].name, 'lcaddress')
+
+    def test_ex_list_healthchecks(self):
+        healthchecks = self.driver.ex_list_healthchecks()
+        self.assertEqual(len(healthchecks), 2)
+        self.assertEqual(healthchecks[0].name, 'basic-check')
 
     def test_ex_list_firewalls(self):
         firewalls = self.driver.ex_list_firewalls()
         self.assertEqual(len(firewalls), 4)
         self.assertEqual(firewalls[0].name, 'default-allow-internal')
+
+    def test_ex_list_forwarding_rules(self):
+        forwarding_rules = self.driver.ex_list_forwarding_rules()
+        forwarding_rules_all = self.driver.ex_list_forwarding_rules('all')
+        forwarding_rules_uc1 = self.driver.ex_list_forwarding_rules(
+            'us-central1')
+        self.assertEqual(len(forwarding_rules), 2)
+        self.assertEqual(len(forwarding_rules_all), 2)
+        self.assertEqual(forwarding_rules[0].name, 'lcforwardingrule')
+        self.assertEqual(forwarding_rules_uc1[0].name, 'lcforwardingrule')
 
     def test_list_images(self):
         local_images = self.driver.list_images()
@@ -129,7 +155,21 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         self.assertEqual(len(nodes_uc1a), 5)
         self.assertEqual(nodes[0].name, 'node-name')
         self.assertEqual(nodes_uc1a[0].name, 'node-name')
-        #self.assertEqual(nodes_all[0].name, 'libcloud-demo-persist-node')
+
+    def test_ex_list_regions(self):
+        regions = self.driver.ex_list_regions()
+        self.assertEqual(len(regions), 3)
+        self.assertEqual(regions[0].name, 'europe-west1')
+
+    def ex_list_targetpools(self):
+        target_pools = self.driver.ex_list_targetpools()
+        target_pools_all = self.driver.ex_list_targetpools('all')
+        target_pools_uc1 = self.driver.ex_list_targetpools('us-central1')
+        self.assertEqual(len(target_pools), 3)
+        self.assertEqual(len(target_pools_all), 4)
+        self.assertEqual(len(target_pools_uc1), 3)
+        self.assertEqual(target_pools[0].name, 'www-pool')
+        self.assertEqual(target_pools_uc1[0].name, 'www-pool')
 
     def test_list_sizes(self):
         sizes = self.driver.list_sizes()
@@ -138,8 +178,6 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         self.assertEqual(len(sizes_all), 100)
         self.assertEqual(sizes[0].name, 'f1-micro')
         self.assertEqual(sizes[0].extra['zone'].name, 'us-central1-a')
-        #self.assertEqual(sizes_all[0].name, 'n1-highmem-8')
-        #self.assertEqual(sizes_all[0].extra['zone'].name, 'us-central1-a')
 
     def test_list_volumes(self):
         volumes = self.driver.list_volumes()
@@ -149,7 +187,6 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         self.assertEqual(len(volumes_all), 3)
         self.assertEqual(len(volumes_uc1a), 3)
         self.assertEqual(volumes[0].name, 'lcdisk')
-        #self.assertEqual(volumes_all[0].name, 'test-disk')
         self.assertEqual(volumes_uc1a[0].name, 'lcdisk')
 
     def test_ex_list_zones(self):
@@ -163,6 +200,22 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         self.assertTrue(isinstance(address, GCEAddress))
         self.assertEqual(address.name, address_name)
 
+    def test_ex_create_healthcheck(self):
+        healthcheck_name = 'lchealthcheck'
+        kwargs = {'host': 'lchost',
+                  'path': '/lc',
+                  'port': 8000,
+                  'interval': 10,
+                  'timeout': 10,
+                  'unhealthy_threshold': 4,
+                  'healthy_threshold': 3}
+        hc = self.driver.ex_create_healthcheck(healthcheck_name, **kwargs)
+        self.assertTrue(isinstance(hc, GCEHealthCheck))
+        self.assertEqual(hc.name, healthcheck_name)
+        self.assertEqual(hc.path, '/lc')
+        self.assertEqual(hc.port, 8000)
+        self.assertEqual(hc.interval, 10)
+
     def test_ex_create_firewall(self):
         firewall_name = 'lcfirewall'
         allowed = [{'IPProtocol': 'tcp', 'ports': ['4567']}]
@@ -171,6 +224,16 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
                                                   source_tags=source_tags)
         self.assertTrue(isinstance(firewall, GCEFirewall))
         self.assertEqual(firewall.name, firewall_name)
+
+    def test_ex_create_forwarding_rule(self):
+        fwr_name = 'lcforwardingrule'
+        targetpool = 'libcloud-lb-demo-lb-tp'
+        region = 'us-central1'
+        fwr = self.driver.ex_create_forwarding_rule(fwr_name, targetpool,
+                                                    region=region,
+                                                    port_range='8000-8500')
+        self.assertTrue(isinstance(fwr, GCEForwardingRule))
+        self.assertEqual(fwr.name, fwr_name)
 
     def test_ex_create_network(self):
         network_name = 'lcnetwork'
@@ -227,12 +290,35 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         self.assertEqual(nodes[0].name, '%s-000' % base_name)
         self.assertEqual(nodes[1].name, '%s-001' % base_name)
 
+    def test_ex_create_targetpool(self):
+        targetpool_name = 'lctargetpool'
+        region = 'us-central1'
+        healthchecks = ['libcloud-lb-demo-healthcheck']
+        node1 = self.driver.ex_get_node('libcloud-lb-demo-www-000',
+                                        'us-central1-b')
+        node2 = self.driver.ex_get_node('libcloud-lb-demo-www-001',
+                                        'us-central1-b')
+        nodes = [node1, node2]
+        targetpool = self.driver.ex_create_targetpool(
+            targetpool_name, region=region, healthchecks=healthchecks,
+            nodes=nodes)
+        self.assertEqual(targetpool.name, targetpool_name)
+        self.assertEqual(len(targetpool.nodes), len(nodes))
+        self.assertEqual(targetpool.region.name, region)
+
     def test_create_volume(self):
         volume_name = 'lcdisk'
         size = 1
         volume = self.driver.create_volume(size, volume_name)
         self.assertTrue(isinstance(volume, StorageVolume))
         self.assertEqual(volume.name, volume_name)
+
+    def test_ex_update_healthcheck(self):
+        healthcheck_name = 'lchealthcheck'
+        healthcheck = self.driver.ex_get_healthcheck(healthcheck_name)
+        healthcheck.port = 9000
+        healthcheck2 = self.driver.ex_update_healthcheck(healthcheck)
+        self.assertTrue(isinstance(healthcheck2, GCEHealthCheck))
 
     def test_ex_update_firewall(self):
         firewall_name = 'lcfirewall'
@@ -241,6 +327,32 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         firewall.source_tags = ['libcloud', 'test']
         firewall2 = self.driver.ex_update_firewall(firewall)
         self.assertTrue(isinstance(firewall2, GCEFirewall))
+
+    def test_ex_targetpool_remove_add_node(self):
+        targetpool = self.driver.ex_get_targetpool('lctargetpool')
+        node = self.driver.ex_get_node('libcloud-lb-demo-www-001',
+                                       'us-central1-b')
+        remove_node = self.driver.ex_targetpool_remove_node(targetpool, node)
+        self.assertTrue(remove_node)
+        self.assertEqual(len(targetpool.nodes), 1)
+
+        add_node = self.driver.ex_targetpool_add_node(targetpool, node)
+        self.assertTrue(add_node)
+        self.assertEqual(len(targetpool.nodes), 2)
+
+    def test_ex_targetpool_remove_add_healthcheck(self):
+        targetpool = self.driver.ex_get_targetpool('lctargetpool')
+        healthcheck = self.driver.ex_get_healthcheck(
+            'libcloud-lb-demo-healthcheck')
+        remove_healthcheck = self.driver.ex_targetpool_remove_healthcheck(
+            targetpool, healthcheck)
+        self.assertTrue(remove_healthcheck)
+        self.assertEqual(len(targetpool.healthchecks), 0)
+
+        add_healthcheck = self.driver.ex_targetpool_add_healthcheck(
+            targetpool, healthcheck)
+        self.assertTrue(add_healthcheck)
+        self.assertEqual(len(targetpool.healthchecks), 1)
 
     def test_reboot_node(self):
         node = self.driver.ex_get_node('node-name')
@@ -274,9 +386,19 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         destroyed = address.destroy()
         self.assertTrue(destroyed)
 
+    def test_ex_destroy_healthcheck(self):
+        hc = self.driver.ex_get_healthcheck('lchealthcheck')
+        destroyed = hc.destroy()
+        self.assertTrue(destroyed)
+
     def test_ex_destroy_firewall(self):
         firewall = self.driver.ex_get_firewall('lcfirewall')
         destroyed = firewall.destroy()
+        self.assertTrue(destroyed)
+
+    def test_ex_destroy_forwarding_rule(self):
+        fwr = self.driver.ex_get_forwarding_rule('lcforwardingrule')
+        destroyed = fwr.destroy()
         self.assertTrue(destroyed)
 
     def test_ex_destroy_network(self):
@@ -297,9 +419,14 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         for d in destroyed:
             self.assertTrue(d)
 
+    def test_destroy_targetpool(self):
+        targetpool = self.driver.ex_get_targetpool('lctargetpool')
+        destroyed = targetpool.destroy()
+        self.assertTrue(destroyed)
+
     def test_destroy_volume(self):
-        address = self.driver.ex_get_address('lcaddress')
-        destroyed = address.destroy()
+        disk = self.driver.ex_get_volume('lcdisk')
+        destroyed = disk.destroy()
         self.assertTrue(destroyed)
 
     def test_ex_get_address(self):
@@ -307,8 +434,15 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         address = self.driver.ex_get_address(address_name)
         self.assertEqual(address.name, address_name)
         self.assertEqual(address.address, '173.255.113.20')
-        self.assertEqual(address.region, 'us-central1')
+        self.assertEqual(address.region.name, 'us-central1')
         self.assertEqual(address.extra['status'], 'RESERVED')
+
+    def test_ex_get_healthcheck(self):
+        healthcheck_name = 'lchealthcheck'
+        healthcheck = self.driver.ex_get_healthcheck(healthcheck_name)
+        self.assertEqual(healthcheck.name, healthcheck_name)
+        self.assertEqual(healthcheck.port, 8000)
+        self.assertEqual(healthcheck.path, '/lc')
 
     def test_ex_get_firewall(self):
         firewall_name = 'lcfirewall'
@@ -316,6 +450,14 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         self.assertEqual(firewall.name, firewall_name)
         self.assertEqual(firewall.network.name, 'default')
         self.assertEqual(firewall.source_tags, ['libcloud'])
+
+    def test_ex_get_forwarding_rule(self):
+        fwr_name = 'lcforwardingrule'
+        fwr = self.driver.ex_get_forwarding_rule(fwr_name)
+        self.assertEqual(fwr.name, fwr_name)
+        self.assertEqual(fwr.extra['portRange'], '8000-8500')
+        self.assertEqual(fwr.targetpool.name, 'libcloud-lb-demo-lb-tp')
+        self.assertEqual(fwr.protocol, 'TCP')
 
     def test_ex_get_image(self):
         partial_name = 'debian-7'
@@ -343,6 +485,13 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         self.assertEqual(instances_quota['usage'], 7.0)
         self.assertEqual(instances_quota['limit'], 8.0)
 
+    def test_ex_get_region(self):
+        region_name = 'us-central1'
+        region = self.driver.ex_get_region(region_name)
+        self.assertEqual(region.name, region_name)
+        self.assertEqual(region.status, 'UP')
+        self.assertEqual(region.zones[0].name, 'us-central1-a')
+
     def test_ex_get_size(self):
         size_name = 'n1-standard-1'
         size = self.driver.ex_get_size(size_name)
@@ -351,6 +500,13 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         self.assertEqual(size.disk, 10)
         self.assertEqual(size.ram, 3840)
         self.assertEqual(size.extra['guestCpus'], 1)
+
+    def test_ex_get_targetpool(self):
+        targetpool_name = 'lctargetpool'
+        targetpool = self.driver.ex_get_targetpool(targetpool_name)
+        self.assertEqual(targetpool.name, targetpool_name)
+        self.assertEqual(len(targetpool.nodes), 2)
+        self.assertEqual(targetpool.region.name, 'us-central1')
 
     def test_ex_get_volume(self):
         volume_name = 'lcdisk'
@@ -397,12 +553,46 @@ class GCEMockHttp(MockHttpTestCase):
         body = self.fixtures.load('aggregated_disks.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
+    def _aggregated_forwardingRules(self, method, url, body, headers):
+        body = self.fixtures.load('aggregated_forwardingRules.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
     def _aggregated_instances(self, method, url, body, headers):
         body = self.fixtures.load('aggregated_instances.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
     def _aggregated_machineTypes(self, method, url, body, headers):
         body = self.fixtures.load('aggregated_machineTypes.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _global_httpHealthChecks(self, method, url, body, headers):
+        if method == 'POST':
+            body = self.fixtures.load('global_httpHealthChecks_post.json')
+        else:
+            body = self.fixtures.load('global_httpHealthChecks.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _global_httpHealthChecks_basic_check(self, method, url, body, headers):
+        body = self.fixtures.load('global_httpHealthChecks_basic-check.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _global_httpHealthChecks_libcloud_lb_demo_healthcheck(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'global_httpHealthChecks_libcloud-lb-demo-healthcheck.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _global_httpHealthChecks_lchealthcheck(self, method, url, body,
+                                               headers):
+        if method == 'DELETE':
+            body = self.fixtures.load(
+                'global_httpHealthChecks_lchealthcheck_delete.json')
+        elif method == 'PUT':
+            body = self.fixtures.load(
+                'global_httpHealthChecks_lchealthcheck_put.json')
+        else:
+            body = self.fixtures.load(
+                'global_httpHealthChecks_lchealthcheck.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
     def _global_firewalls(self, method, url, body, headers):
@@ -455,6 +645,24 @@ class GCEMockHttp(MockHttpTestCase):
             body = self.fixtures.load('global_networks_lcnetwork.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
+    def _global_operations_operation_global_httpHealthChecks_lchealthcheck_delete(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'operations_operation_global_httpHealthChecks_lchealthcheck_delete.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _global_operations_operation_global_httpHealthChecks_lchealthcheck_put(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'operations_operation_global_httpHealthChecks_lchealthcheck_delete.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _global_operations_operation_global_httpHealthChecks_post(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'operations_operation_global_httpHealthChecks_post.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
     def _global_operations_operation_global_firewalls_lcfirewall_delete(
             self, method, url, body, headers):
         body = self.fixtures.load(
@@ -495,6 +703,54 @@ class GCEMockHttp(MockHttpTestCase):
             self, method, url, body, headers):
         body = self.fixtures.load(
             'operations_operation_regions_us-central1_addresses_post.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _regions_us_central1_operations_operation_regions_us_central1_forwardingRules_post(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'operations_operation_regions_us-central1_forwardingRules_post.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _regions_us_central1_operations_operation_regions_us_central1_forwardingRules_lcforwardingrule_delete(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'operations_operation_regions_us-central1_forwardingRules_lcforwardingrule_delete.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _regions_us_central1_operations_operation_regions_us_central1_targetPools_post(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'operations_operation_regions_us-central1_targetPools_post.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _regions_us_central1_operations_operation_regions_us_central1_targetPools_lctargetpool_delete(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'operations_operation_regions_us-central1_targetPools_lctargetpool_delete.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _regions_us_central1_operations_operation_regions_us_central1_targetPools_lctargetpool_removeHealthCheck_post(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'operations_operation_regions_us-central1_targetPools_lctargetpool_removeHealthCheck_post.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _regions_us_central1_operations_operation_regions_us_central1_targetPools_lctargetpool_addHealthCheck_post(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'operations_operation_regions_us-central1_targetPools_lctargetpool_addHealthCheck_post.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _regions_us_central1_operations_operation_regions_us_central1_targetPools_lctargetpool_removeInstance_post(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'operations_operation_regions_us-central1_targetPools_lctargetpool_removeInstance_post.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _regions_us_central1_operations_operation_regions_us_central1_targetPools_lctargetpool_addInstance_post(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'operations_operation_regions_us-central1_targetPools_lctargetpool_addInstance_post.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
     def _zones_us_central1_a_operations_operation_zones_us_central1_a_disks_lcdisk_delete(
@@ -571,6 +827,11 @@ class GCEMockHttp(MockHttpTestCase):
         body = self.fixtures.load('projects_debian-cloud_global_images.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
+    def _regions(self, method, url, body, headers):
+        body = self.fixtures.load(
+            'regions.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
     def _regions_us_central1_addresses(self, method, url, body, headers):
         if method == 'POST':
             body = self.fixtures.load(
@@ -587,6 +848,73 @@ class GCEMockHttp(MockHttpTestCase):
         else:
             body = self.fixtures.load(
                 'regions_us-central1_addresses_lcaddress.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _regions_us_central1_forwardingRules(self, method, url, body, headers):
+        if method == 'POST':
+            body = self.fixtures.load(
+                'regions_us-central1_forwardingRules_post.json')
+        else:
+            body = self.fixtures.load(
+                'regions_us-central1_forwardingRules.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _regions_us_central1_forwardingRules_lcforwardingrule(
+            self, method, url, body, headers):
+        if method == 'DELETE':
+            body = self.fixtures.load(
+                'regions_us-central1_forwardingRules_lcforwardingrule_delete.json')
+        else:
+            body = self.fixtures.load(
+                'regions_us-central1_forwardingRules_lcforwardingrule.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _regions_us_central1_targetPools(self, method, url, body, headers):
+        if method == 'POST':
+            body = self.fixtures.load(
+                'regions_us-central1_targetPools_post.json')
+        else:
+            body = self.fixtures.load('regions_us-central1_targetPools.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _regions_us_central1_targetPools_lctargetpool(self, method, url,
+                                                      body, headers):
+        if method == 'DELETE':
+            body = self.fixtures.load(
+                'regions_us-central1_targetPools_lctargetpool_delete.json')
+        else:
+            body = self.fixtures.load(
+                'regions_us-central1_targetPools_lctargetpool.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _regions_us_central1_targetPools_libcloud_lb_demo_lb_tp(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'regions_us-central1_targetPools_libcloud-lb-demo-lb-tp.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _regions_us_central1_targetPools_lctargetpool_removeHealthCheck(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'regions_us-central1_targetPools_lctargetpool_removeHealthCheck_post.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _regions_us_central1_targetPools_lctargetpool_addHealthCheck(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'regions_us-central1_targetPools_lctargetpool_addHealthCheck_post.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _regions_us_central1_targetPools_lctargetpool_removeInstance(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'regions_us-central1_targetPools_lctargetpool_removeInstance_post.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _regions_us_central1_targetPools_lctargetpool_addInstance(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'regions_us-central1_targetPools_lctargetpool_addInstance_post.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
     def _zones(self, method, url, body, headers):
@@ -677,6 +1005,25 @@ class GCEMockHttp(MockHttpTestCase):
             body = self.fixtures.load(
                 'zones_us-central1-a_instances_lcnode-001.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _zones_us_central1_b_instances_libcloud_lb_demo_www_000(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'zones_us-central1-b_instances_libcloud-lb-demo-www-000.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _zones_us_central1_b_instances_libcloud_lb_demo_www_001(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'zones_us-central1-b_instances_libcloud-lb-demo-www-001.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _zones_us_central1_b_instances_libcloud_lb_demo_www_002(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'zones_us-central1-b_instances_libcloud-lb-demo-www-002.json')
+        return (httplib.NOT_FOUND, body, self.json_hdr,
+                httplib.responses[httplib.NOT_FOUND])
 
     def _zones_us_central1_a(self, method, url, body, headers):
         body = self.fixtures.load('zones_us-central1-a.json')

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -83,15 +83,16 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         region2 = self.driver._get_region_from_zone(zone2)
         self.assertEqual(region2.name, expected_region2)
 
-    def test_find_zone(self):
-        zone1 = self.driver._find_zone('libcloud-demo-np-node', 'instances')
-        self.assertEqual(zone1, 'us-central1-a')
-        zone2 = self.driver._find_zone('libcloud-demo-europe-np-node',
-                                       'instances')
-        self.assertEqual(zone2, 'europe-west1-a')
-        region = self.driver._find_zone('libcloud-demo-address', 'addresses',
-                                        region=True)
-        self.assertEqual(region, 'us-central1')
+    def test_find_zone_or_region(self):
+        zone1 = self.driver._find_zone_or_region('libcloud-demo-np-node',
+                                                 'instances')
+        self.assertEqual(zone1.name, 'us-central1-a')
+        zone2 = self.driver._find_zone_or_region(
+            'libcloud-demo-europe-np-node', 'instances')
+        self.assertEqual(zone2.name, 'europe-west1-a')
+        region = self.driver._find_zone_or_region('libcloud-demo-address',
+                                                  'addresses', region=True)
+        self.assertEqual(region.name, 'us-central1')
 
     def test_match_images(self):
         project = 'debian-cloud'
@@ -108,6 +109,8 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         self.assertEqual(len(address_list_all), 4)
         self.assertEqual(address_list[0].name, 'libcloud-demo-address')
         self.assertEqual(address_list_uc1[0].name, 'libcloud-demo-address')
+        names = [a.name for a in address_list_all]
+        self.assertTrue('libcloud-demo-address' in names)
 
     def test_ex_list_healthchecks(self):
         healthchecks = self.driver.ex_list_healthchecks()
@@ -128,6 +131,8 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         self.assertEqual(len(forwarding_rules_all), 2)
         self.assertEqual(forwarding_rules[0].name, 'lcforwardingrule')
         self.assertEqual(forwarding_rules_uc1[0].name, 'lcforwardingrule')
+        names = [f.name for f in forwarding_rules_all]
+        self.assertTrue('lcforwardingrule' in names)
 
     def test_list_images(self):
         local_images = self.driver.list_images()
@@ -155,6 +160,8 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         self.assertEqual(len(nodes_uc1a), 5)
         self.assertEqual(nodes[0].name, 'node-name')
         self.assertEqual(nodes_uc1a[0].name, 'node-name')
+        names = [n.name for n in nodes_all]
+        self.assertTrue('node-name' in names)
 
     def test_ex_list_regions(self):
         regions = self.driver.ex_list_regions()
@@ -170,6 +177,8 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         self.assertEqual(len(target_pools_uc1), 3)
         self.assertEqual(target_pools[0].name, 'www-pool')
         self.assertEqual(target_pools_uc1[0].name, 'www-pool')
+        names = [t.name for t in target_pools_all]
+        self.assertTrue('www-pool' in names)
 
     def test_list_sizes(self):
         sizes = self.driver.list_sizes()
@@ -178,6 +187,8 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         self.assertEqual(len(sizes_all), 100)
         self.assertEqual(sizes[0].name, 'f1-micro')
         self.assertEqual(sizes[0].extra['zone'].name, 'us-central1-a')
+        names = [s.name for s in sizes_all]
+        self.assertEqual(names.count('n1-standard-1'), 5)
 
     def test_list_volumes(self):
         volumes = self.driver.list_volumes()
@@ -188,6 +199,8 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         self.assertEqual(len(volumes_uc1a), 3)
         self.assertEqual(volumes[0].name, 'lcdisk')
         self.assertEqual(volumes_uc1a[0].name, 'lcdisk')
+        names = [v.name for v in volumes_all]
+        self.assertTrue('test-disk' in names)
 
     def test_ex_list_zones(self):
         zones = self.driver.ex_list_zones()

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -240,7 +240,7 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
 
     def test_ex_create_forwarding_rule(self):
         fwr_name = 'lcforwardingrule'
-        targetpool = 'libcloud-lb-demo-lb-tp'
+        targetpool = 'lctargetpool'
         region = 'us-central1'
         fwr = self.driver.ex_create_forwarding_rule(fwr_name, targetpool,
                                                     region=region,
@@ -469,7 +469,7 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         fwr = self.driver.ex_get_forwarding_rule(fwr_name)
         self.assertEqual(fwr.name, fwr_name)
         self.assertEqual(fwr.extra['portRange'], '8000-8500')
-        self.assertEqual(fwr.targetpool.name, 'libcloud-lb-demo-lb-tp')
+        self.assertEqual(fwr.targetpool.name, 'lctargetpool')
         self.assertEqual(fwr.protocol, 'TCP')
 
     def test_ex_get_image(self):
@@ -883,6 +883,12 @@ class GCEMockHttp(MockHttpTestCase):
         else:
             body = self.fixtures.load(
                 'regions_us-central1_forwardingRules.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _regions_us_central1_forwardingRules_libcloud_lb_demo_lb(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'regions_us-central1_forwardingRules_libcloud-lb-demo-lb.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
     def _regions_us_central1_forwardingRules_lcforwardingrule(

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -30,7 +30,8 @@ from libcloud.compute.drivers.gce import (GCENodeDriver, API_VERSION,
                                           QuotaExceededError)
 from libcloud.common.google import (GoogleBaseAuthConnection,
                                     GoogleInstalledAppAuthConnection,
-                                    GoogleBaseConnection)
+                                    GoogleBaseConnection,
+                                    ResourceNotFoundError)
 from libcloud.test.common.test_google import GoogleAuthMockHttp
 from libcloud.compute.base import (Node, NodeImage, NodeSize, NodeLocation,
                                    StorageVolume)
@@ -477,6 +478,19 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         self.assertEqual(network.name, network_name)
         self.assertEqual(network.cidr, '10.11.0.0/16')
         self.assertEqual(network.extra['gatewayIPv4'], '10.11.0.1')
+
+    def test_ex_get_node(self):
+        node_name = 'node-name'
+        zone = 'us-central1-a'
+        node = self.driver.ex_get_node(node_name, zone)
+        self.assertEqual(node.name, node_name)
+        self.assertEqual(node.size, 'n1-standard-1')
+        removed_node = 'libcloud-lb-demo-www-002'
+        self.assertRaises(ResourceNotFoundError, self.driver.ex_get_node,
+                          removed_node, 'us-central1-b')
+        missing_node = 'dummy-node'
+        self.assertRaises(ResourceNotFoundError, self.driver.ex_get_node,
+                          missing_node, 'all')
 
     def test_ex_get_project(self):
         project = self.driver.ex_get_project()

--- a/libcloud/test/loadbalancer/test_gce.py
+++ b/libcloud/test/loadbalancer/test_gce.py
@@ -1,0 +1,195 @@
+"""One-line documentation for test_gce module.
+
+A detailed description of test_gce.
+"""
+
+import sys
+import unittest
+
+from libcloud.common.google import (GoogleBaseAuthConnection,
+                                    GoogleInstalledAppAuthConnection,
+                                    GoogleBaseConnection)
+from libcloud.compute.drivers.gce import (GCENodeDriver)
+from libcloud.loadbalancer.drivers.gce import (GCELBDriver)
+from libcloud.test.common.test_google import GoogleAuthMockHttp
+from libcloud.test.compute.test_gce import GCEMockHttp
+
+from libcloud.test import MockHttpTestCase, LibcloudTestCase
+
+from libcloud.test.secrets import GCE_PARAMS, GCE_KEYWORD_PARAMS
+
+
+class GCELoadBalancerTest(LibcloudTestCase):
+    GoogleBaseConnection._get_token_info_from_file = lambda x: None
+    GoogleBaseConnection._write_token_info_to_file = lambda x: None
+    GoogleInstalledAppAuthConnection.get_code = lambda x: '1234'
+    datacenter = 'us-central1-a'
+
+    def setUp(self):
+        GCEMockHttp.test = self
+        GCELBDriver.connectionCls.conn_classes = (GCEMockHttp, GCEMockHttp)
+        GCENodeDriver.connectionCls.conn_classes = (GCEMockHttp, GCEMockHttp)
+        GoogleBaseAuthConnection.conn_classes = (GoogleAuthMockHttp,
+                                                 GoogleAuthMockHttp)
+        GCEMockHttp.type = None
+        kwargs = GCE_KEYWORD_PARAMS.copy()
+        kwargs['auth_type'] = 'IA'
+        kwargs['datacenter'] = self.datacenter
+        self.driver = GCELBDriver(*GCE_PARAMS, **kwargs)
+
+    def test_get_node_from_ip(self):
+        ip = '173.255.115.146'
+        expected_name = 'node-name'
+        node = self.driver._get_node_from_ip(ip)
+        self.assertEqual(node.name, expected_name)
+
+        dummy_ip = '8.8.8.8'
+        node = self.driver._get_node_from_ip(dummy_ip)
+        self.assertTrue(node is None)
+
+    def test_list_protocols(self):
+        expected_protocols = ['TCP', 'UDP']
+        protocols = self.driver.list_protocols()
+        self.assertEqual(protocols, expected_protocols)
+
+    def test_list_balancers(self):
+        balancers = self.driver.list_balancers()
+        balancers_all = self.driver.list_balancers(ex_region='all')
+        balancer_name = 'lcforwardingrule'
+        self.assertEqual(len(balancers), 2)
+        self.assertEqual(len(balancers_all), 2)
+        self.assertEqual(balancers[0].name, balancer_name)
+
+    def test_create_balancer(self):
+        balancer_name = 'libcloud-lb-demo-lb'
+        tp_name = '%s-tp' % (balancer_name)
+        port = '80'
+        protocol = 'tcp'
+        algorithm = None
+        node0 = self.driver.gce.ex_get_node('libcloud-lb-demo-www-000',
+                                            'us-central1-b')
+        node1 = self.driver.gce.ex_get_node('libcloud-lb-demo-www-001',
+                                            'us-central1-b')
+        members = [node0, node1]
+        balancer = self.driver.create_balancer(balancer_name, port, protocol,
+                                               algorithm, members)
+        self.assertEqual(balancer.name, balancer_name)
+        self.assertEqual(balancer.extra['targetpool'].name, tp_name)
+        self.assertEqual(len(balancer.list_members()), 3)
+
+    def test_destory_balancer(self):
+        balancer_name = 'lcforwardingrule'
+        balancer = self.driver.get_balancer(balancer_name)
+        destroyed = balancer.destroy()
+        self.assertTrue(destroyed)
+
+    def test_get_balancer(self):
+        balancer_name = 'lcforwardingrule'
+        tp_name = 'lctargetpool'
+        balancer_ip = '173.255.119.224'
+        balancer = self.driver.get_balancer(balancer_name)
+        self.assertEqual(balancer.name, balancer_name)
+        self.assertEqual(balancer.extra['forwarding_rule'].name, balancer_name)
+        self.assertEqual(balancer.ip, balancer_ip)
+        self.assertEqual(balancer.extra['targetpool'].name, tp_name)
+
+    def test_attach_compute_node(self):
+        node = self.driver.gce.ex_get_node('libcloud-lb-demo-www-001',
+                                           'us-central1-b')
+        balancer = self.driver.get_balancer('lcforwardingrule')
+        member = self.driver._node_to_member(node, balancer)
+        # Detach member first
+        detach_member = balancer.detach_member(member)
+        self.assertEqual(len(balancer.list_members()), 1)
+        # Attach Node
+        attach_node = balancer.attach_compute_node(node)
+        self.assertEqual(len(balancer.list_members()), 2)
+
+    def test_detach_attach_member(self):
+        node = self.driver.gce.ex_get_node('libcloud-lb-demo-www-001',
+                                           'us-central1-b')
+        balancer = self.driver.get_balancer('lcforwardingrule')
+        member = self.driver._node_to_member(node, balancer)
+
+        # Check that balancer has 2 members
+        self.assertEqual(len(balancer.list_members()), 2)
+
+        # Remove a member and check that it now has 1 member
+        detach_member = balancer.detach_member(member)
+        self.assertEqual(len(balancer.list_members()), 1)
+
+        # Reattach member and check that it has 2 members again
+        attach_member = balancer.attach_member(member)
+        self.assertEqual(len(balancer.list_members()), 2)
+
+    def test_balancer_list_members(self):
+        balancer = self.driver.get_balancer('lcforwardingrule')
+        members = balancer.list_members()
+        self.assertEqual(len(members), 2)
+        member_ips = [m.ip for m in members]
+        self.assertTrue('173.255.113.234' in member_ips)
+
+    def test_ex_create_healthcheck(self):
+        healthcheck_name = 'lchealthcheck'
+        kwargs = {'host': 'lchost',
+                  'path': '/lc',
+                  'port': 8000,
+                  'interval': 10,
+                  'timeout': 10,
+                  'unhealthy_threshold': 4,
+                  'healthy_threshold': 3}
+        hc = self.driver.ex_create_healthcheck(healthcheck_name, **kwargs)
+        self.assertEqual(hc.name, healthcheck_name)
+        self.assertEqual(hc.path, '/lc')
+        self.assertEqual(hc.port, 8000)
+        self.assertEqual(hc.interval, 10)
+
+    def test_ex_list_healthchecks(self):
+        healthchecks = self.driver.ex_list_healthchecks()
+        self.assertEqual(len(healthchecks), 2)
+        self.assertEqual(healthchecks[0].name, 'basic-check')
+
+    def test_ex_balancer_detach_attach_healthcheck(self):
+        healthcheck = self.driver.gce.ex_get_healthcheck(
+            'libcloud-lb-demo-healthcheck')
+        balancer = self.driver.get_balancer('lcforwardingrule')
+
+        healthchecks = self.driver.ex_balancer_list_healthchecks(balancer)
+        self.assertEqual(len(healthchecks), 1)
+        # Detach Healthcheck
+        detach_healthcheck = self.driver.ex_balancer_detach_healthcheck(
+            balancer, healthcheck)
+        self.assertTrue(detach_healthcheck)
+        healthchecks = self.driver.ex_balancer_list_healthchecks(balancer)
+        self.assertEqual(len(healthchecks), 0)
+
+        # Reattach Healthcheck
+        attach_healthcheck = self.driver.ex_balancer_attach_healthcheck(
+            balancer, healthcheck)
+        self.assertTrue(attach_healthcheck)
+        healthchecks = self.driver.ex_balancer_list_healthchecks(balancer)
+        self.assertEqual(len(healthchecks), 1)
+
+    def test_ex_balancer_list_healthchecks(self):
+        balancer = self.driver.get_balancer('lcforwardingrule')
+        healthchecks = self.driver.ex_balancer_list_healthchecks(balancer)
+        self.assertEqual(healthchecks[0].name, 'libcloud-lb-demo-healthcheck')
+
+    def test_node_to_member(self):
+        node = self.driver.gce.ex_get_node('libcloud-lb-demo-www-001',
+                                           'us-central1-b')
+        balancer = self.driver.get_balancer('lcforwardingrule')
+        member = self.driver._node_to_member(node, balancer)
+        self.assertEqual(member.ip, node.public_ips[0])
+        self.assertEqual(member.id, node.name)
+        self.assertEqual(member.port, balancer.port)
+
+    def test_forwarding_rule_to_loadbalancer(self):
+        fwr = self.driver.gce.ex_get_forwarding_rule('lcforwardingrule')
+        balancer = self.driver._forwarding_rule_to_loadbalancer(fwr)
+        self.assertEqual(fwr.name, balancer.name)
+        self.assertEqual(fwr.address, balancer.ip)
+        self.assertEqual(fwr.extra['portRange'], balancer.port)
+
+if __name__ == '__main__':
+    sys.exit(unittest.main())

--- a/libcloud/test/loadbalancer/test_gce.py
+++ b/libcloud/test/loadbalancer/test_gce.py
@@ -1,8 +1,20 @@
-"""One-line documentation for test_gce module.
-
-A detailed description of test_gce.
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """
-
+Tests for Google Compute Engine Load Balancer Driver
+"""
 import sys
 import unittest
 


### PR DESCRIPTION
This adds Load Balancing support for Google Compute Engine.

Since Load Balancer support for GCE is directly part of the GCE API, all of the API calls were added to the existing compute driver.  Then, wrapper methods were added to the Load Balancer driver to make it compatible with the Libcloud Load Balancer API.

In addition, there are some bug fixes and minor improvements.

Note that I'm still working on the test for the "wrapper" methods in the LoadBalancer driver, but tests have been added for all of the actual API calls that were added to the Compute driver.
