### PR TITLE
LIBCLOUD-390: fix missing Content-Length header

### DIFF
--- a/libcloud/storage/drivers/azure_blobs.py
+++ b/libcloud/storage/drivers/azure_blobs.py
@@ -493,8 +493,9 @@ class AzureBlobsStorageDriver(StorageDriver):
         params = {'restype': 'container'}
 
         container_path = '/%s' % (container_name)
+        headers = {'Content-Length': 0}
         response = self.connection.request(container_path, params=params,
-                                           method='PUT')
+                                           method='PUT', headers=headers)
 
         if response.status == httplib.CREATED:
             return self._response_to_container(container_name, response)

--- a/libcloud/test/storage/test_azure_blobs.py
+++ b/libcloud/test/storage/test_azure_blobs.py
@@ -198,23 +198,28 @@ class AzureBlobsMockHttp(StorageMockHttp, MockHttpTestCase):
     def _new_container(self, method, url, body, headers):
         # test_create_container, test_delete_container
 
-        headers = {}
+        response_headers = {}
 
         if method == 'PUT':
-            status = httplib.CREATED
+            if not 'Content-Length' in headers:
+                status = httplib.LENGTH_REQUIRED
+                body = ''
+            else:
+                status = httplib.CREATED
 
-            headers['etag'] = '0x8CFB877BB56A6FB'
-            headers['last-modified'] = 'Fri, 04 Jan 2013 09:48:06 GMT'
-            headers['x-ms-lease-status'] = 'unlocked'
-            headers['x-ms-lease-state'] = 'available'
-            headers['x-ms-meta-meta1'] = 'value1'
+                response_headers['etag'] = '0x8CFB877BB56A6FB'
+                response_headers['last-modified'] = ('Fri, 04 Jan 2013'
+                                                     ' 09:48:06 GMT')
+                response_headers['x-ms-lease-status'] = 'unlocked'
+                response_headers['x-ms-lease-state'] = 'available'
+                response_headers['x-ms-meta-meta1'] = 'value1'
 
         elif method == 'DELETE':
             status = httplib.NO_CONTENT
 
         return (status,
                 body,
-                headers,
+                response_headers,
                 httplib.responses[status])
 
     def _new_container_DOESNT_EXIST(self, method, url, body, headers):


### PR DESCRIPTION
On the Storage API for create_container method on the Azure Storage Service.
