### PR TITLE
Fixes Deprecation warning for AssertEquals in tests

### DIFF
--- a/libcloud/test/common/test_openstack.py
+++ b/libcloud/test/common/test_openstack.py
@@ -35,7 +35,7 @@ class OpenStackBaseConnectionTest(unittest.TestCase):
 
     def test_base_connection_timeout(self):
         self.connection.connect()
-        self.assertEquals(self.connection.timeout, self.timeout)
+        self.assertEqual(self.connection.timeout, self.timeout)
         if PY25:
             self.connection.conn_classes[1].assert_called_with(host='127.0.0.1',
                                                                port=443)

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -12,6 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import with_statement
+
 import os
 import sys
 import unittest
@@ -337,9 +339,8 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
 
     def test_ex_import_keypair_from_string(self):
         path = os.path.join(os.path.dirname(__file__), "fixtures", "misc", "dummy_rsa.pub")
-        fh = open(path)
-        key = self.driver.ex_import_keypair_from_string('keypair', fh.read())
-        fh.close()
+        with open(path,'r') as fh:
+            key = self.driver.ex_import_keypair_from_string('keypair', fh.read())
         self.assertEqual(key['keyName'], 'keypair')
         self.assertEqual(key['keyFingerprint'], null_fingerprint)
 

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -337,7 +337,9 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
 
     def test_ex_import_keypair_from_string(self):
         path = os.path.join(os.path.dirname(__file__), "fixtures", "misc", "dummy_rsa.pub")
-        key = self.driver.ex_import_keypair_from_string('keypair', open(path).read())
+        fh = open(path)
+        key = self.driver.ex_import_keypair_from_string('keypair', fh.read())
+        fh.close()
         self.assertEqual(key['keyName'], 'keypair')
         self.assertEqual(key['keyFingerprint'], null_fingerprint)
 
@@ -426,8 +428,8 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
         location = self.driver.list_locations()[0]
         vol = self.driver.create_volume(10, 'vol', location)
 
-        self.assertEquals(10, vol.size)
-        self.assertEquals('vol', vol.name)
+        self.assertEqual(10, vol.size)
+        self.assertEqual('vol', vol.name)
 
     def test_destroy_volume(self):
         vol = StorageVolume(

--- a/libcloud/test/compute/test_ibm_sce.py
+++ b/libcloud/test/compute/test_ibm_sce.py
@@ -42,29 +42,29 @@ class IBMTests(unittest.TestCase, TestCaseMixin):
         except InvalidCredsError:
             e = sys.exc_info()[1]
             self.assertTrue(isinstance(e, InvalidCredsError))
-            self.assertEquals(e.value, '401: Unauthorized')
+            self.assertEqual(e.value, '401: Unauthorized')
         else:
             self.fail('test should have thrown')
 
     def test_list_nodes(self):
         ret = self.driver.list_nodes()
-        self.assertEquals(len(ret), 3)
-        self.assertEquals(ret[0].id, '26557')
-        self.assertEquals(ret[0].name, 'Insight Instance')
-        self.assertEquals(ret[0].public_ips, ['129.33.196.128'])
-        self.assertEquals(ret[0].private_ips, [])  # Private IPs not supported
-        self.assertEquals(ret[1].public_ips, [])   # Node is non-active (no IP)
-        self.assertEquals(ret[1].private_ips, [])
-        self.assertEquals(ret[1].id, '28193')
+        self.assertEqual(len(ret), 3)
+        self.assertEqual(ret[0].id, '26557')
+        self.assertEqual(ret[0].name, 'Insight Instance')
+        self.assertEqual(ret[0].public_ips, ['129.33.196.128'])
+        self.assertEqual(ret[0].private_ips, [])  # Private IPs not supported
+        self.assertEqual(ret[1].public_ips, [])   # Node is non-active (no IP)
+        self.assertEqual(ret[1].private_ips, [])
+        self.assertEqual(ret[1].id, '28193')
 
     def test_list_sizes(self):
         ret = self.driver.list_sizes()
-        self.assertEquals(len(ret), 9) # 9 instance configurations supported
-        self.assertEquals(ret[0].id, 'BRZ32.1/2048/60*175')
-        self.assertEquals(ret[1].id, 'BRZ64.2/4096/60*500*350')
-        self.assertEquals(ret[2].id, 'COP32.1/2048/60')
-        self.assertEquals(ret[0].name, 'Bronze 32 bit')
-        self.assertEquals(ret[0].disk, None)
+        self.assertEqual(len(ret), 9) # 9 instance configurations supported
+        self.assertEqual(ret[0].id, 'BRZ32.1/2048/60*175')
+        self.assertEqual(ret[1].id, 'BRZ64.2/4096/60*500*350')
+        self.assertEqual(ret[2].id, 'COP32.1/2048/60')
+        self.assertEqual(ret[0].name, 'Bronze 32 bit')
+        self.assertEqual(ret[0].disk, None)
 
     def test_list_images(self):
         ret = self.driver.list_images()
@@ -74,10 +74,10 @@ class IBMTests(unittest.TestCase, TestCaseMixin):
 
     def test_list_locations(self):
         ret = self.driver.list_locations()
-        self.assertEquals(len(ret), 6)
-        self.assertEquals(ret[0].id, '41')
-        self.assertEquals(ret[0].name, 'Raleigh')
-        self.assertEquals(ret[0].country, 'U.S.A')
+        self.assertEqual(len(ret), 6)
+        self.assertEqual(ret[0].id, '41')
+        self.assertEqual(ret[0].name, 'Raleigh')
+        self.assertEqual(ret[0].country, 'U.S.A')
 
     def test_create_node(self):
         # Test creation of node
@@ -95,7 +95,7 @@ class IBMTests(unittest.TestCase, TestCaseMixin):
                                            'db2_admin_password': 'myPassword2',
                                            'report_user_password': 'myPassword3'})
         self.assertTrue(isinstance(ret, Node))
-        self.assertEquals(ret.name, 'RationalInsight4')
+        self.assertEqual(ret.name, 'RationalInsight4')
 
         # Test creation attempt with invalid location
         IBMMockHttp.type = 'CREATE_INVALID'
@@ -112,14 +112,14 @@ class IBMTests(unittest.TestCase, TestCaseMixin):
                                                'report_user_password': 'myPassword3'})
         except Exception:
             e = sys.exc_info()[1]
-            self.assertEquals(e.args[0], 'Error 412: No DataCenter with id: 3')
+            self.assertEqual(e.args[0], 'Error 412: No DataCenter with id: 3')
         else:
             self.fail('test should have thrown')
 
     def test_destroy_node(self):
         # Delete existent node
         nodes = self.driver.list_nodes()            # retrieves 3 nodes
-        self.assertEquals(len(nodes), 3)
+        self.assertEqual(len(nodes), 3)
         IBMMockHttp.type = 'DELETE'
         toDelete = nodes[1]
         ret = self.driver.destroy_node(toDelete)
@@ -128,12 +128,12 @@ class IBMTests(unittest.TestCase, TestCaseMixin):
         # Delete non-existant node
         IBMMockHttp.type = 'DELETED'
         nodes = self.driver.list_nodes()            # retrieves 2 nodes
-        self.assertEquals(len(nodes), 2)
+        self.assertEqual(len(nodes), 2)
         try:
             self.driver.destroy_node(toDelete)      # delete non-existent node
         except Exception:
             e = sys.exc_info()[1]
-            self.assertEquals(e.args[0], 'Error 404: Invalid Instance ID 28193')
+            self.assertEqual(e.args[0], 'Error 404: Invalid Instance ID 28193')
         else:
             self.fail('test should have thrown')
 
@@ -142,7 +142,7 @@ class IBMTests(unittest.TestCase, TestCaseMixin):
         IBMMockHttp.type = 'REBOOT'
 
         # Reboot active node
-        self.assertEquals(len(nodes), 3)
+        self.assertEqual(len(nodes), 3)
         ret = self.driver.reboot_node(nodes[0])
         self.assertTrue(ret)
 
@@ -151,7 +151,7 @@ class IBMTests(unittest.TestCase, TestCaseMixin):
             ret = self.driver.reboot_node(nodes[1])
         except Exception:
             e = sys.exc_info()[1]
-            self.assertEquals(e.args[0], 'Error 412: Instance must be in the Active state')
+            self.assertEqual(e.args[0], 'Error 412: Instance must be in the Active state')
         else:
             self.fail('test should have thrown')
 

--- a/libcloud/test/compute/test_ktucloud.py
+++ b/libcloud/test/compute/test_ktucloud.py
@@ -69,7 +69,7 @@ class KTUCloudNodeDriverTest(unittest.TestCase, TestCaseMixin):
         KTUCloudStackMockHttp.fixture_tag = 'notemplates'
 
         images = self.driver.list_images()
-        self.assertEquals(0, len(images))
+        self.assertEqual(0, len(images))
 
 
 class KTUCloudStackMockHttp(MockHttpTestCase):

--- a/libcloud/test/compute/test_opennebula.py
+++ b/libcloud/test/compute/test_opennebula.py
@@ -647,9 +647,9 @@ class OpenNebula_3_6_Tests(unittest.TestCase, OpenNebulaCaseMixin):
     def test_create_volume(self):
         new_volume = self.driver.create_volume(1000, 'test-volume')
 
-        self.assertEquals(new_volume.id, '5')
-        self.assertEquals(new_volume.size, 1000)
-        self.assertEquals(new_volume.name, 'test-volume')
+        self.assertEqual(new_volume.id, '5')
+        self.assertEqual(new_volume.size, 1000)
+        self.assertEqual(new_volume.name, 'test-volume')
 
     def test_destroy_volume(self):
         images = self.driver.list_images()

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -256,13 +256,13 @@ class OpenStack_1_0_Tests(unittest.TestCase, TestCaseMixin):
 
     def test_auth_token_is_set(self):
         self.driver.connection._populate_hosts_and_request_paths()
-        self.assertEquals(self.driver.connection.auth_token, "603d2bd9-f45c-4583-b91c-2c8eac0b5654")
+        self.assertEqual(self.driver.connection.auth_token, "603d2bd9-f45c-4583-b91c-2c8eac0b5654")
 
     def test_auth_token_expires_is_set(self):
         self.driver.connection._populate_hosts_and_request_paths()
 
         expires = self.driver.connection.auth_token_expires
-        self.assertEquals(expires.isoformat(), "2011-09-18T02:44:17-05:00")
+        self.assertEqual(expires.isoformat(), "2011-09-18T02:44:17-05:00")
 
     def test_auth(self):
         OpenStackMockHttp.type = 'UNAUTHORIZED'
@@ -429,57 +429,57 @@ class OpenStack_1_0_Tests(unittest.TestCase, TestCaseMixin):
 
     def test_ex_list_ip_addresses(self):
         ret = self.driver.ex_list_ip_addresses(node_id=72258)
-        self.assertEquals(2, len(ret.public_addresses))
+        self.assertEqual(2, len(ret.public_addresses))
         self.assertTrue('67.23.10.131' in ret.public_addresses)
         self.assertTrue('67.23.10.132' in ret.public_addresses)
-        self.assertEquals(1, len(ret.private_addresses))
+        self.assertEqual(1, len(ret.private_addresses))
         self.assertTrue('10.176.42.16' in ret.private_addresses)
 
     def test_ex_list_ip_groups(self):
         ret = self.driver.ex_list_ip_groups()
-        self.assertEquals(2, len(ret))
-        self.assertEquals('1234', ret[0].id)
-        self.assertEquals('Shared IP Group 1', ret[0].name)
-        self.assertEquals('5678', ret[1].id)
-        self.assertEquals('Shared IP Group 2', ret[1].name)
+        self.assertEqual(2, len(ret))
+        self.assertEqual('1234', ret[0].id)
+        self.assertEqual('Shared IP Group 1', ret[0].name)
+        self.assertEqual('5678', ret[1].id)
+        self.assertEqual('Shared IP Group 2', ret[1].name)
         self.assertTrue(ret[0].servers is None)
 
     def test_ex_list_ip_groups_detail(self):
         ret = self.driver.ex_list_ip_groups(details=True)
 
-        self.assertEquals(2, len(ret))
+        self.assertEqual(2, len(ret))
 
-        self.assertEquals('1234', ret[0].id)
-        self.assertEquals('Shared IP Group 1', ret[0].name)
-        self.assertEquals(2, len(ret[0].servers))
-        self.assertEquals('422', ret[0].servers[0])
-        self.assertEquals('3445', ret[0].servers[1])
+        self.assertEqual('1234', ret[0].id)
+        self.assertEqual('Shared IP Group 1', ret[0].name)
+        self.assertEqual(2, len(ret[0].servers))
+        self.assertEqual('422', ret[0].servers[0])
+        self.assertEqual('3445', ret[0].servers[1])
 
-        self.assertEquals('5678', ret[1].id)
-        self.assertEquals('Shared IP Group 2', ret[1].name)
-        self.assertEquals(3, len(ret[1].servers))
-        self.assertEquals('23203', ret[1].servers[0])
-        self.assertEquals('2456', ret[1].servers[1])
-        self.assertEquals('9891', ret[1].servers[2])
+        self.assertEqual('5678', ret[1].id)
+        self.assertEqual('Shared IP Group 2', ret[1].name)
+        self.assertEqual(3, len(ret[1].servers))
+        self.assertEqual('23203', ret[1].servers[0])
+        self.assertEqual('2456', ret[1].servers[1])
+        self.assertEqual('9891', ret[1].servers[2])
 
     def test_ex_create_ip_group(self):
         ret = self.driver.ex_create_ip_group('Shared IP Group 1', '5467')
-        self.assertEquals('1234', ret.id)
-        self.assertEquals('Shared IP Group 1', ret.name)
-        self.assertEquals(1, len(ret.servers))
-        self.assertEquals('422', ret.servers[0])
+        self.assertEqual('1234', ret.id)
+        self.assertEqual('Shared IP Group 1', ret.name)
+        self.assertEqual(1, len(ret.servers))
+        self.assertEqual('422', ret.servers[0])
 
     def test_ex_delete_ip_group(self):
         ret = self.driver.ex_delete_ip_group('5467')
-        self.assertEquals(True, ret)
+        self.assertEqual(True, ret)
 
     def test_ex_share_ip(self):
         ret = self.driver.ex_share_ip('1234', '3445', '67.23.21.133')
-        self.assertEquals(True, ret)
+        self.assertEqual(True, ret)
 
     def test_ex_unshare_ip(self):
         ret = self.driver.ex_unshare_ip('3445', '67.23.21.133')
-        self.assertEquals(True, ret)
+        self.assertEqual(True, ret)
 
     def test_ex_resize(self):
         node = Node(id=444222, name=None, state=None, public_ips=None,
@@ -731,7 +731,7 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
         self.driver.connection.auth_token_expires = None
         self.driver.connection._populate_hosts_and_request_paths()
 
-        self.assertEquals(self.driver.connection.auth_token, "aaaaaaaaaaaa-bbb-cccccccccccccc")
+        self.assertEqual(self.driver.connection.auth_token, "aaaaaaaaaaaa-bbb-cccccccccccccc")
 
     def test_auth_token_expires_is_set(self):
         # change base url and trash the current auth token so we can re-authenticate
@@ -741,7 +741,7 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
         self.driver.connection._populate_hosts_and_request_paths()
 
         expires = self.driver.connection.auth_token_expires
-        self.assertEquals(expires.isoformat(), "2011-11-23T21:00:14-06:00")
+        self.assertEqual(expires.isoformat(), "2011-11-23T21:00:14-06:00")
 
     def test_ex_force_base_url(self):
         # change base url and trash the current auth token so we can re-authenticate
@@ -801,12 +801,12 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
         driver = self.driver_type(*self.driver_args, **kwargs)
         driver.list_nodes()
 
-        self.assertEquals(kwargs['ex_force_auth_token'],
+        self.assertEqual(kwargs['ex_force_auth_token'],
                           driver.connection.auth_token)
-        self.assertEquals('servers.api.rackspacecloud.com',
+        self.assertEqual('servers.api.rackspacecloud.com',
                           driver.connection.host)
-        self.assertEquals('/v1.1/slug', driver.connection.request_path)
-        self.assertEquals(443, driver.connection.port)
+        self.assertEqual('/v1.1/slug', driver.connection.request_path)
+        self.assertEqual(443, driver.connection.port)
 
     def test_list_nodes(self):
         nodes = self.driver.list_nodes()
@@ -1404,7 +1404,7 @@ class OpenStack_1_1_Auth_2_0_Tests(OpenStack_1_1_Tests):
 
     def test_auth_user_info_is_set(self):
         self.driver.connection._populate_hosts_and_request_paths()
-        self.assertEquals(self.driver.connection.auth_user_info, {
+        self.assertEqual(self.driver.connection.auth_user_info, {
             'id': '7',
             'name': 'testuser',
             'roles': [{'description': 'Default Role.',

--- a/libcloud/test/compute/test_ssh_client.py
+++ b/libcloud/test/compute/test_ssh_client.py
@@ -191,10 +191,10 @@ class ShellOutSSHClientTests(unittest.TestCase):
         cmd2 = client2._get_base_ssh_command()
         cmd3 = client3._get_base_ssh_command()
 
-        self.assertEquals(cmd1, ['ssh', 'root@localhost'])
-        self.assertEquals(cmd2, ['ssh', '-i', '/home/my.key',
+        self.assertEqual(cmd1, ['ssh', 'root@localhost'])
+        self.assertEqual(cmd2, ['ssh', '-i', '/home/my.key',
                                  'root@localhost'])
-        self.assertEquals(cmd3, ['ssh', '-i', '/home/my.key',
+        self.assertEqual(cmd3, ['ssh', '-i', '/home/my.key',
                                  '-oConnectTimeout=5', 'root@localhost'])
 
 

--- a/libcloud/test/dns/test_rackspace.py
+++ b/libcloud/test/dns/test_rackspace.py
@@ -48,9 +48,9 @@ class RackspaceUSTests(unittest.TestCase):
         driver = self.klass(*DNS_PARAMS_RACKSPACE, **kwargs)
         driver.list_zones()
 
-        self.assertEquals(kwargs['ex_force_auth_token'],
+        self.assertEqual(kwargs['ex_force_auth_token'],
             driver.connection.auth_token)
-        self.assertEquals('/v1.0/11111',
+        self.assertEqual('/v1.0/11111',
             driver.connection.request_path)
 
     def test_force_auth_url_kwargs(self):
@@ -60,9 +60,9 @@ class RackspaceUSTests(unittest.TestCase):
         }
         driver = self.klass(*DNS_PARAMS_RACKSPACE, **kwargs)
 
-        self.assertEquals(kwargs['ex_force_auth_url'],
+        self.assertEqual(kwargs['ex_force_auth_url'],
             driver.connection._ex_force_auth_url)
-        self.assertEquals(kwargs['ex_force_auth_version'],
+        self.assertEqual(kwargs['ex_force_auth_version'],
             driver.connection._auth_version)
 
     def test_gets_auth_2_0_endpoint(self):
@@ -70,7 +70,7 @@ class RackspaceUSTests(unittest.TestCase):
         driver = self.klass(*DNS_PARAMS_RACKSPACE, **kwargs)
         driver.connection._populate_hosts_and_request_paths()
 
-        self.assertEquals('https://dns.api.rackspacecloud.com/v1.0/11111',
+        self.assertEqual('https://dns.api.rackspacecloud.com/v1.0/11111',
             driver.connection.get_endpoint())
 
     def test_list_record_types(self):
@@ -300,13 +300,13 @@ class RackspaceUSTests(unittest.TestCase):
     def test_to_full_record_name_name_provided(self):
         domain = 'foo.bar'
         name = 'test'
-        self.assertEquals(self.driver._to_full_record_name(domain, name),
+        self.assertEqual(self.driver._to_full_record_name(domain, name),
                           'test.foo.bar')
 
     def test_to_full_record_name_name_not_provided(self):
         domain = 'foo.bar'
         name = None
-        self.assertEquals(self.driver._to_full_record_name(domain, name),
+        self.assertEqual(self.driver._to_full_record_name(domain, name),
                           'foo.bar')
 
 

--- a/libcloud/test/loadbalancer/test_brightbox.py
+++ b/libcloud/test/loadbalancer/test_brightbox.py
@@ -43,16 +43,16 @@ class BrightboxLBTests(unittest.TestCase):
     def test_list_balancers(self):
         balancers = self.driver.list_balancers()
 
-        self.assertEquals(len(balancers), 1)
-        self.assertEquals(balancers[0].id, 'lba-1235f')
-        self.assertEquals(balancers[0].name, 'lb1')
+        self.assertEqual(len(balancers), 1)
+        self.assertEqual(balancers[0].id, 'lba-1235f')
+        self.assertEqual(balancers[0].name, 'lb1')
 
     def test_get_balancer(self):
         balancer = self.driver.get_balancer(balancer_id='lba-1235f')
 
-        self.assertEquals(balancer.id, 'lba-1235f')
-        self.assertEquals(balancer.name, 'lb1')
-        self.assertEquals(balancer.state, State.RUNNING)
+        self.assertEqual(balancer.id, 'lba-1235f')
+        self.assertEqual(balancer.name, 'lb1')
+        self.assertEqual(balancer.state, State.RUNNING)
 
     def test_destroy_balancer(self):
         balancer = self.driver.get_balancer(balancer_id='lba-1235f')
@@ -65,24 +65,24 @@ class BrightboxLBTests(unittest.TestCase):
         balancer = self.driver.create_balancer(name='lb2', port=80,
             protocol='http', algorithm=Algorithm.ROUND_ROBIN, members=members)
 
-        self.assertEquals(balancer.name, 'lb2')
-        self.assertEquals(balancer.port, 80)
-        self.assertEquals(balancer.state, State.PENDING)
+        self.assertEqual(balancer.name, 'lb2')
+        self.assertEqual(balancer.port, 80)
+        self.assertEqual(balancer.state, State.PENDING)
 
     def test_balancer_list_members(self):
         balancer = self.driver.get_balancer(balancer_id='lba-1235f')
         members = balancer.list_members()
 
-        self.assertEquals(len(members), 1)
-        self.assertEquals(members[0].balancer, balancer)
-        self.assertEquals('srv-lv426', members[0].id)
+        self.assertEqual(len(members), 1)
+        self.assertEqual(members[0].balancer, balancer)
+        self.assertEqual('srv-lv426', members[0].id)
 
     def test_balancer_attach_member(self):
         balancer = self.driver.get_balancer(balancer_id='lba-1235f')
         member = balancer.attach_member(Member('srv-kg983', ip=None,
                                                port=None))
 
-        self.assertEquals(member.id, 'srv-kg983')
+        self.assertEqual(member.id, 'srv-kg983')
 
     def test_balancer_detach_member(self):
         balancer = self.driver.get_balancer(balancer_id='lba-1235f')

--- a/libcloud/test/loadbalancer/test_cloudstack.py
+++ b/libcloud/test/loadbalancer/test_cloudstack.py
@@ -82,7 +82,7 @@ class CloudStackLBTests(unittest.TestCase):
         members = balancer.list_members()
         for member in members:
             self.assertTrue(isinstance(member, Member))
-            self.assertEquals(member.balancer, balancer)
+            self.assertEqual(member.balancer, balancer)
 
 class CloudStackMockHttp(MockHttpTestCase):
     fixtures = LoadBalancerFileFixtures('cloudstack')

--- a/libcloud/test/loadbalancer/test_elb.py
+++ b/libcloud/test/loadbalancer/test_elb.py
@@ -46,16 +46,16 @@ class ElasticLBTests(unittest.TestCase):
     def test_list_balancers(self):
         balancers = self.driver.list_balancers()
 
-        self.assertEquals(len(balancers), 1)
-        self.assertEquals(balancers[0].id, 'tests')
-        self.assertEquals(balancers[0].name, 'tests')
+        self.assertEqual(len(balancers), 1)
+        self.assertEqual(balancers[0].id, 'tests')
+        self.assertEqual(balancers[0].name, 'tests')
 
     def test_get_balancer(self):
         balancer = self.driver.get_balancer(balancer_id='tests')
 
-        self.assertEquals(balancer.id, 'tests')
-        self.assertEquals(balancer.name, 'tests')
-        self.assertEquals(balancer.state, State.UNKNOWN)
+        self.assertEqual(balancer.id, 'tests')
+        self.assertEqual(balancer.name, 'tests')
+        self.assertEqual(balancer.state, State.UNKNOWN)
 
     def test_destroy_balancer(self):
         balancer = self.driver.get_balancer(balancer_id='tests')
@@ -69,17 +69,17 @@ class ElasticLBTests(unittest.TestCase):
             protocol='http', algorithm=Algorithm.ROUND_ROBIN,
             members=members)
 
-        self.assertEquals(balancer.name, 'lb2')
-        self.assertEquals(balancer.port, 80)
-        self.assertEquals(balancer.state, State.PENDING)
+        self.assertEqual(balancer.name, 'lb2')
+        self.assertEqual(balancer.port, 80)
+        self.assertEqual(balancer.state, State.PENDING)
 
     def test_balancer_list_members(self):
         balancer = self.driver.get_balancer(balancer_id='tests')
         members = balancer.list_members()
 
-        self.assertEquals(len(members), 1)
-        self.assertEquals(members[0].balancer, balancer)
-        self.assertEquals('i-64bd081c', members[0].id)
+        self.assertEqual(len(members), 1)
+        self.assertEqual(members[0].balancer, balancer)
+        self.assertEqual('i-64bd081c', members[0].id)
 
     def test_balancer_detach_member(self):
         balancer = self.driver.get_balancer(balancer_id='lba-1235f')

--- a/libcloud/test/loadbalancer/test_gogrid.py
+++ b/libcloud/test/loadbalancer/test_gogrid.py
@@ -51,11 +51,11 @@ class GoGridTests(unittest.TestCase):
     def test_list_balancers(self):
         balancers = self.driver.list_balancers()
 
-        self.assertEquals(len(balancers), 2)
-        self.assertEquals(balancers[0].name, "foo")
-        self.assertEquals(balancers[0].id, "23517")
-        self.assertEquals(balancers[1].name, "bar")
-        self.assertEquals(balancers[1].id, "23526")
+        self.assertEqual(len(balancers), 2)
+        self.assertEqual(balancers[0].name, "foo")
+        self.assertEqual(balancers[0].id, "23517")
+        self.assertEqual(balancers[1].name, "bar")
+        self.assertEqual(balancers[1].id, "23526")
 
     def test_create_balancer(self):
         balancer = self.driver.create_balancer(name='test2',
@@ -66,8 +66,8 @@ class GoGridTests(unittest.TestCase):
                     Member(None, '10.1.0.11', 80))
                 )
 
-        self.assertEquals(balancer.name, 'test2')
-        self.assertEquals(balancer.id, '123')
+        self.assertEqual(balancer.name, 'test2')
+        self.assertEqual(balancer.id, '123')
 
     def test_create_balancer_UNEXPECTED_ERROR(self):
         # Try to create new balancer and attach members with an IP address which
@@ -100,8 +100,8 @@ class GoGridTests(unittest.TestCase):
     def test_get_balancer(self):
         balancer = self.driver.get_balancer(balancer_id='23530')
 
-        self.assertEquals(balancer.name, 'test2')
-        self.assertEquals(balancer.id, '23530')
+        self.assertEqual(balancer.name, 'test2')
+        self.assertEqual(balancer.id, '23530')
 
     def test_balancer_list_members(self):
         balancer = self.driver.get_balancer(balancer_id='23530')
@@ -111,9 +111,9 @@ class GoGridTests(unittest.TestCase):
         expected_members = set(['10.0.0.78:80', '10.0.0.77:80',
                                 '10.0.0.76:80'])
 
-        self.assertEquals(len(members1), 3)
-        self.assertEquals(len(members2), 3)
-        self.assertEquals(expected_members,
+        self.assertEqual(len(members1), 3)
+        self.assertEqual(len(members2), 3)
+        self.assertEqual(expected_members,
                 set(["%s:%s" % (member.ip, member.port) for member in members1]))
         self.assertEquals(members1[0].balancer, balancer)
 
@@ -124,10 +124,10 @@ class GoGridTests(unittest.TestCase):
         member1 = self.driver.balancer_attach_compute_node(balancer, node)
         member2 = balancer.attach_compute_node(node)
 
-        self.assertEquals(member1.ip, '10.0.0.75')
-        self.assertEquals(member1.port, 80)
-        self.assertEquals(member2.ip, '10.0.0.75')
-        self.assertEquals(member2.port, 80)
+        self.assertEqual(member1.ip, '10.0.0.75')
+        self.assertEqual(member1.port, 80)
+        self.assertEqual(member2.ip, '10.0.0.75')
+        self.assertEqual(member2.port, 80)
 
     def test_balancer_attach_member(self):
         balancer = LoadBalancer(23530, None, None, None, None, self.driver)
@@ -135,10 +135,10 @@ class GoGridTests(unittest.TestCase):
         member1 = self.driver.balancer_attach_member(balancer, member=member)
         member2 = balancer.attach_member(member=member)
 
-        self.assertEquals(member1.ip, '10.0.0.75')
-        self.assertEquals(member1.port, 80)
-        self.assertEquals(member2.ip, '10.0.0.75')
-        self.assertEquals(member2.port, 80)
+        self.assertEqual(member1.ip, '10.0.0.75')
+        self.assertEqual(member1.port, 80)
+        self.assertEqual(member2.ip, '10.0.0.75')
+        self.assertEqual(member2.port, 80)
 
     def test_balancer_detach_member(self):
         balancer = LoadBalancer(23530, None, None, None, None, self.driver)

--- a/libcloud/test/loadbalancer/test_rackspace.py
+++ b/libcloud/test/loadbalancer/test_rackspace.py
@@ -56,9 +56,9 @@ class RackspaceLBTests(unittest.TestCase):
         driver = RackspaceLBDriver('user', 'key', **kwargs)
         driver.list_balancers()
 
-        self.assertEquals(kwargs['ex_force_auth_token'],
+        self.assertEqual(kwargs['ex_force_auth_token'],
             driver.connection.auth_token)
-        self.assertEquals('/v1.0/slug',
+        self.assertEqual('/v1.0/slug',
             driver.connection.request_path)
 
     def test_force_auth_url_kwargs(self):
@@ -68,9 +68,9 @@ class RackspaceLBTests(unittest.TestCase):
         }
         driver = RackspaceLBDriver('user', 'key', **kwargs)
 
-        self.assertEquals(kwargs['ex_force_auth_url'],
+        self.assertEqual(kwargs['ex_force_auth_url'],
             driver.connection._ex_force_auth_url)
-        self.assertEquals(kwargs['ex_force_auth_version'],
+        self.assertEqual(kwargs['ex_force_auth_version'],
             driver.connection._auth_version)
 
     def test_gets_auth_2_0_endpoint_defaults_to_ord_region(self):
@@ -79,7 +79,7 @@ class RackspaceLBTests(unittest.TestCase):
         )
         driver.connection._populate_hosts_and_request_paths()
 
-        self.assertEquals('https://ord.loadbalancers.api.rackspacecloud.com/v1.0/11111',
+        self.assertEqual('https://ord.loadbalancers.api.rackspacecloud.com/v1.0/11111',
             driver.connection.get_endpoint())
 
     def test_gets_auth_2_0_endpoint_for_dfw(self):
@@ -89,7 +89,7 @@ class RackspaceLBTests(unittest.TestCase):
         )
         driver.connection._populate_hosts_and_request_paths()
 
-        self.assertEquals('https://dfw.loadbalancers.api.rackspacecloud.com/v1.0/11111',
+        self.assertEqual('https://dfw.loadbalancers.api.rackspacecloud.com/v1.0/11111',
             driver.connection.get_endpoint())
 
     def test_list_protocols(self):
@@ -125,25 +125,25 @@ class RackspaceLBTests(unittest.TestCase):
     def test_list_balancers(self):
         balancers = self.driver.list_balancers()
 
-        self.assertEquals(len(balancers), 2)
-        self.assertEquals(balancers[0].name, "test0")
-        self.assertEquals(balancers[0].id, "8155")
-        self.assertEquals(balancers[0].port, 80)
-        self.assertEquals(balancers[0].ip, "1.1.1.25")
-        self.assertEquals(balancers[1].name, "test1")
-        self.assertEquals(balancers[1].id, "8156")
+        self.assertEqual(len(balancers), 2)
+        self.assertEqual(balancers[0].name, "test0")
+        self.assertEqual(balancers[0].id, "8155")
+        self.assertEqual(balancers[0].port, 80)
+        self.assertEqual(balancers[0].ip, "1.1.1.25")
+        self.assertEqual(balancers[1].name, "test1")
+        self.assertEqual(balancers[1].id, "8156")
 
     def test_list_balancers_ex_member_address(self):
         RackspaceLBMockHttp.type = 'EX_MEMBER_ADDRESS'
         balancers = self.driver.list_balancers(ex_member_address='127.0.0.1')
 
-        self.assertEquals(len(balancers), 3)
-        self.assertEquals(balancers[0].name, "First Loadbalancer")
-        self.assertEquals(balancers[0].id, "1")
-        self.assertEquals(balancers[1].name, "Second Loadbalancer")
-        self.assertEquals(balancers[1].id, "2")
-        self.assertEquals(balancers[2].name, "Third Loadbalancer")
-        self.assertEquals(balancers[2].id, "8")
+        self.assertEqual(len(balancers), 3)
+        self.assertEqual(balancers[0].name, "First Loadbalancer")
+        self.assertEqual(balancers[0].id, "1")
+        self.assertEqual(balancers[1].name, "Second Loadbalancer")
+        self.assertEqual(balancers[1].id, "2")
+        self.assertEqual(balancers[2].name, "Third Loadbalancer")
+        self.assertEqual(balancers[2].id, "8")
 
     def test_create_balancer(self):
         balancer = self.driver.create_balancer(name='test2',
@@ -154,8 +154,8 @@ class RackspaceLBTests(unittest.TestCase):
                          Member(None, '10.1.0.11', 80))
                 )
 
-        self.assertEquals(balancer.name, 'test2')
-        self.assertEquals(balancer.id, '8290')
+        self.assertEqual(balancer.name, 'test2')
+        self.assertEqual(balancer.id, '8290')
 
     def test_ex_create_balancer(self):
         RackspaceLBDriver.connectionCls.conn_classes = (None,
@@ -169,8 +169,8 @@ class RackspaceLBTests(unittest.TestCase):
                 vip='12af'
         )
 
-        self.assertEquals(balancer.name, 'test2')
-        self.assertEquals(balancer.id, '8290')
+        self.assertEqual(balancer.name, 'test2')
+        self.assertEqual(balancer.id, '8290')
 
     def test_destroy_balancer(self):
         balancer = self.driver.list_balancers()[0]
@@ -186,12 +186,12 @@ class RackspaceLBTests(unittest.TestCase):
     def test_get_balancer(self):
         balancer = self.driver.get_balancer(balancer_id='8290')
 
-        self.assertEquals(balancer.name, 'test2')
-        self.assertEquals(balancer.id, '8290')
+        self.assertEqual(balancer.name, 'test2')
+        self.assertEqual(balancer.id, '8290')
 
     def test_get_balancer_extra_vips(self):
         balancer = self.driver.get_balancer(balancer_id='18940')
-        self.assertEquals(balancer.extra["virtualIps"],
+        self.assertEqual(balancer.extra["virtualIps"],
             [{"address":"50.56.49.149",
               "id":2359,
               "type":"PUBLIC",
@@ -199,75 +199,75 @@ class RackspaceLBTests(unittest.TestCase):
 
     def test_get_balancer_extra_public_source_ipv4(self):
         balancer = self.driver.get_balancer(balancer_id='18940')
-        self.assertEquals(balancer.extra["ipv4PublicSource"], '184.106.100.25')
+        self.assertEqual(balancer.extra["ipv4PublicSource"], '184.106.100.25')
 
     def test_get_balancer_extra_public_source_ipv6(self):
         balancer = self.driver.get_balancer(balancer_id='18940')
-        self.assertEquals(balancer.extra["ipv6PublicSource"],
+        self.assertEqual(balancer.extra["ipv6PublicSource"],
                           '2001:4801:7901::6/64')
 
     def test_get_balancer_extra_private_source_ipv4(self):
         balancer = self.driver.get_balancer(balancer_id='18940')
-        self.assertEquals(balancer.extra["ipv4PrivateSource"], '10.183.252.25')
+        self.assertEqual(balancer.extra["ipv4PrivateSource"], '10.183.252.25')
 
     def test_get_balancer_extra_members(self):
         balancer = self.driver.get_balancer(balancer_id='8290')
         members = balancer.extra['members']
-        self.assertEquals(3, len(members))
-        self.assertEquals('10.1.0.11', members[0].ip)
-        self.assertEquals('10.1.0.10', members[1].ip)
-        self.assertEquals('10.1.0.9', members[2].ip)
+        self.assertEqual(3, len(members))
+        self.assertEqual('10.1.0.11', members[0].ip)
+        self.assertEqual('10.1.0.10', members[1].ip)
+        self.assertEqual('10.1.0.9', members[2].ip)
 
     def test_get_balancer_extra_created(self):
         balancer = self.driver.get_balancer(balancer_id='8290')
 
         created_8290 = datetime.datetime(2011, 4, 7, 16, 27, 50)
-        self.assertEquals(created_8290, balancer.extra['created'])
+        self.assertEqual(created_8290, balancer.extra['created'])
 
     def test_get_balancer_extra_updated(self):
         balancer = self.driver.get_balancer(balancer_id='8290')
 
         updated_8290 = datetime.datetime(2011, 4, 7, 16, 28, 12)
-        self.assertEquals(updated_8290, balancer.extra['updated'])
+        self.assertEqual(updated_8290, balancer.extra['updated'])
 
     def test_get_balancer_extra_access_list(self):
         balancer = self.driver.get_balancer(balancer_id='94698')
 
         access_list = balancer.extra['accessList']
 
-        self.assertEquals(3, len(access_list))
-        self.assertEquals(2883, access_list[0].id)
-        self.assertEquals("0.0.0.0/0", access_list[0].address)
-        self.assertEquals(RackspaceAccessRuleType.DENY,
+        self.assertEqual(3, len(access_list))
+        self.assertEqual(2883, access_list[0].id)
+        self.assertEqual("0.0.0.0/0", access_list[0].address)
+        self.assertEqual(RackspaceAccessRuleType.DENY,
             access_list[0].rule_type)
 
-        self.assertEquals(2884, access_list[1].id)
-        self.assertEquals("2001:4801:7901::6/64",
+        self.assertEqual(2884, access_list[1].id)
+        self.assertEqual("2001:4801:7901::6/64",
             access_list[1].address)
-        self.assertEquals(RackspaceAccessRuleType.ALLOW,
+        self.assertEqual(RackspaceAccessRuleType.ALLOW,
             access_list[1].rule_type)
 
-        self.assertEquals(3006, access_list[2].id)
-        self.assertEquals("8.8.8.8/0", access_list[2].address)
-        self.assertEquals(RackspaceAccessRuleType.DENY,
+        self.assertEqual(3006, access_list[2].id)
+        self.assertEqual("8.8.8.8/0", access_list[2].address)
+        self.assertEqual(RackspaceAccessRuleType.DENY,
             access_list[2].rule_type)
 
     def test_get_balancer_algorithm(self):
         balancer = self.driver.get_balancer(balancer_id='8290')
-        self.assertEquals(balancer.extra["algorithm"], Algorithm.RANDOM)
+        self.assertEqual(balancer.extra["algorithm"], Algorithm.RANDOM)
 
     def test_get_balancer_protocol(self):
         balancer = self.driver.get_balancer(balancer_id='94695')
-        self.assertEquals(balancer.extra['protocol'], 'HTTP')
+        self.assertEqual(balancer.extra['protocol'], 'HTTP')
 
     def test_get_balancer_weighted_round_robin_algorithm(self):
         balancer = self.driver.get_balancer(balancer_id='94692')
-        self.assertEquals(balancer.extra["algorithm"],
+        self.assertEqual(balancer.extra["algorithm"],
                            Algorithm.WEIGHTED_ROUND_ROBIN)
 
     def test_get_balancer_weighted_least_connections_algorithm(self):
         balancer = self.driver.get_balancer(balancer_id='94693')
-        self.assertEquals(balancer.extra["algorithm"],
+        self.assertEqual(balancer.extra["algorithm"],
                            Algorithm.WEIGHTED_LEAST_CONNECTIONS)
 
     def test_get_balancer_unknown_algorithm(self):
@@ -278,59 +278,59 @@ class RackspaceLBTests(unittest.TestCase):
         balancer = self.driver.get_balancer(balancer_id='94695')
         balancer_health_monitor = balancer.extra["healthMonitor"]
 
-        self.assertEquals(balancer_health_monitor.type, "CONNECT")
-        self.assertEquals(balancer_health_monitor.delay, 10)
-        self.assertEquals(balancer_health_monitor.timeout, 5)
-        self.assertEquals(balancer_health_monitor.attempts_before_deactivation,
+        self.assertEqual(balancer_health_monitor.type, "CONNECT")
+        self.assertEqual(balancer_health_monitor.delay, 10)
+        self.assertEqual(balancer_health_monitor.timeout, 5)
+        self.assertEqual(balancer_health_monitor.attempts_before_deactivation,
                           2)
 
     def test_get_balancer_http_health_monitor(self):
         balancer = self.driver.get_balancer(balancer_id='94696')
         balancer_health_monitor = balancer.extra["healthMonitor"]
 
-        self.assertEquals(balancer_health_monitor.type, "HTTP")
-        self.assertEquals(balancer_health_monitor.delay, 10)
-        self.assertEquals(balancer_health_monitor.timeout, 5)
-        self.assertEquals(balancer_health_monitor.attempts_before_deactivation,
+        self.assertEqual(balancer_health_monitor.type, "HTTP")
+        self.assertEqual(balancer_health_monitor.delay, 10)
+        self.assertEqual(balancer_health_monitor.timeout, 5)
+        self.assertEqual(balancer_health_monitor.attempts_before_deactivation,
                           2)
-        self.assertEquals(balancer_health_monitor.path, "/")
-        self.assertEquals(balancer_health_monitor.status_regex,
+        self.assertEqual(balancer_health_monitor.path, "/")
+        self.assertEqual(balancer_health_monitor.status_regex,
                            "^[234][0-9][0-9]$")
-        self.assertEquals(balancer_health_monitor.body_regex,
+        self.assertEqual(balancer_health_monitor.body_regex,
                            "Hello World!")
 
     def test_get_balancer_https_health_monitor(self):
         balancer = self.driver.get_balancer(balancer_id='94697')
         balancer_health_monitor = balancer.extra["healthMonitor"]
 
-        self.assertEquals(balancer_health_monitor.type, "HTTPS")
-        self.assertEquals(balancer_health_monitor.delay, 15)
-        self.assertEquals(balancer_health_monitor.timeout, 12)
-        self.assertEquals(balancer_health_monitor.attempts_before_deactivation,
+        self.assertEqual(balancer_health_monitor.type, "HTTPS")
+        self.assertEqual(balancer_health_monitor.delay, 15)
+        self.assertEqual(balancer_health_monitor.timeout, 12)
+        self.assertEqual(balancer_health_monitor.attempts_before_deactivation,
                           5)
-        self.assertEquals(balancer_health_monitor.path, "/test")
-        self.assertEquals(balancer_health_monitor.status_regex,
+        self.assertEqual(balancer_health_monitor.path, "/test")
+        self.assertEqual(balancer_health_monitor.status_regex,
                            "^[234][0-9][0-9]$")
-        self.assertEquals(balancer_health_monitor.body_regex, "abcdef")
+        self.assertEqual(balancer_health_monitor.body_regex, "abcdef")
 
     def test_get_balancer_connection_throttle(self):
         balancer = self.driver.get_balancer(balancer_id='94695')
         balancer_connection_throttle = balancer.extra["connectionThrottle"]
 
-        self.assertEquals(balancer_connection_throttle.min_connections, 50)
-        self.assertEquals(balancer_connection_throttle.max_connections, 200)
-        self.assertEquals(balancer_connection_throttle.max_connection_rate, 50)
-        self.assertEquals(balancer_connection_throttle.rate_interval_seconds,
+        self.assertEqual(balancer_connection_throttle.min_connections, 50)
+        self.assertEqual(balancer_connection_throttle.max_connections, 200)
+        self.assertEqual(balancer_connection_throttle.max_connection_rate, 50)
+        self.assertEqual(balancer_connection_throttle.rate_interval_seconds,
                            10)
 
     def test_get_session_persistence(self):
         balancer = self.driver.get_balancer(balancer_id='94695')
-        self.assertEquals(balancer.extra["sessionPersistenceType"],
+        self.assertEqual(balancer.extra["sessionPersistenceType"],
                            "HTTP_COOKIE")
 
     def test_get_connection_logging(self):
         balancer = self.driver.get_balancer(balancer_id='94695')
-        self.assertEquals(balancer.extra["connectionLoggingEnabled"], True)
+        self.assertEqual(balancer.extra["connectionLoggingEnabled"], True)
 
     def test_get_error_page(self):
         balancer = self.driver.get_balancer(balancer_id='18940')
@@ -341,13 +341,13 @@ class RackspaceLBTests(unittest.TestCase):
         balancer = self.driver.get_balancer(balancer_id='18940')
         deny_rule, allow_rule = self.driver.ex_balancer_access_list(balancer)
 
-        self.assertEquals(deny_rule.id, 2883)
-        self.assertEquals(deny_rule.rule_type, RackspaceAccessRuleType.DENY)
-        self.assertEquals(deny_rule.address, "0.0.0.0/0")
+        self.assertEqual(deny_rule.id, 2883)
+        self.assertEqual(deny_rule.rule_type, RackspaceAccessRuleType.DENY)
+        self.assertEqual(deny_rule.address, "0.0.0.0/0")
 
-        self.assertEquals(allow_rule.id, 2884)
-        self.assertEquals(allow_rule.address, "2001:4801:7901::6/64")
-        self.assertEquals(allow_rule.rule_type, RackspaceAccessRuleType.ALLOW)
+        self.assertEqual(allow_rule.id, 2884)
+        self.assertEqual(allow_rule.address, "2001:4801:7901::6/64")
+        self.assertEqual(allow_rule.rule_type, RackspaceAccessRuleType.ALLOW)
 
     def test_ex_create_balancer_access_rule(self):
         balancer = self.driver.get_balancer(balancer_id='94698')
@@ -357,7 +357,7 @@ class RackspaceLBTests(unittest.TestCase):
 
         rule = self.driver.ex_create_balancer_access_rule(balancer, rule)
 
-        self.assertEquals(2883, rule.id)
+        self.assertEqual(2883, rule.id)
 
     def test_ex_create_balancer_access_rule_no_poll(self):
         balancer = self.driver.get_balancer(balancer_id='94698')
@@ -380,9 +380,9 @@ class RackspaceLBTests(unittest.TestCase):
 
         rules = self.driver.ex_create_balancer_access_rules(balancer, rules)
 
-        self.assertEquals(2, len(rules))
-        self.assertEquals(2884, rules[0].id)
-        self.assertEquals(3006, rules[1].id)
+        self.assertEqual(2, len(rules))
+        self.assertEqual(2884, rules[0].id)
+        self.assertEqual(3006, rules[1].id)
 
     def test_ex_create_balancer_access_rules_no_poll(self):
         balancer = self.driver.get_balancer(balancer_id='94699')
@@ -429,7 +429,7 @@ class RackspaceLBTests(unittest.TestCase):
         balancer = self.driver.ex_destroy_balancer_access_rules(balancer,
             balancer.extra['accessList'])
 
-        self.assertEquals('94699', balancer.id)
+        self.assertEqual('94699', balancer.id)
 
     def test_ex_destroy_balancer_access_rules_no_poll(self):
         balancer = self.driver.get_balancer(balancer_id='94699')
@@ -447,10 +447,10 @@ class RackspaceLBTests(unittest.TestCase):
         balancer = self.driver.ex_update_balancer_health_monitor(balancer, monitor)
         updated_monitor = balancer.extra['healthMonitor']
 
-        self.assertEquals('CONNECT', updated_monitor.type)
-        self.assertEquals(10, updated_monitor.delay)
-        self.assertEquals(5, updated_monitor.timeout)
-        self.assertEquals(2, updated_monitor.attempts_before_deactivation)
+        self.assertEqual('CONNECT', updated_monitor.type)
+        self.assertEqual(10, updated_monitor.delay)
+        self.assertEqual(5, updated_monitor.timeout)
+        self.assertEqual(2, updated_monitor.attempts_before_deactivation)
 
     def test_ex_update_balancer_http_health_monitor(self):
         balancer = self.driver.get_balancer(balancer_id='94696')
@@ -463,13 +463,13 @@ class RackspaceLBTests(unittest.TestCase):
         balancer = self.driver.ex_update_balancer_health_monitor(balancer, monitor)
         updated_monitor = balancer.extra['healthMonitor']
 
-        self.assertEquals('HTTP', updated_monitor.type)
-        self.assertEquals(10, updated_monitor.delay)
-        self.assertEquals(5, updated_monitor.timeout)
-        self.assertEquals(2, updated_monitor.attempts_before_deactivation)
-        self.assertEquals('/', updated_monitor.path)
-        self.assertEquals('^[234][0-9][0-9]$', updated_monitor.status_regex)
-        self.assertEquals('Hello World!', updated_monitor.body_regex)
+        self.assertEqual('HTTP', updated_monitor.type)
+        self.assertEqual(10, updated_monitor.delay)
+        self.assertEqual(5, updated_monitor.timeout)
+        self.assertEqual(2, updated_monitor.attempts_before_deactivation)
+        self.assertEqual('/', updated_monitor.path)
+        self.assertEqual('^[234][0-9][0-9]$', updated_monitor.status_regex)
+        self.assertEqual('Hello World!', updated_monitor.body_regex)
 
     def test_ex_update_balancer_health_monitor_no_poll(self):
         balancer = self.driver.get_balancer(balancer_id='94695')
@@ -505,13 +505,13 @@ class RackspaceLBTests(unittest.TestCase):
         balancer = self.driver.ex_update_balancer_health_monitor(balancer, monitor)
         updated_monitor = balancer.extra['healthMonitor']
 
-        self.assertEquals('HTTP', updated_monitor.type)
-        self.assertEquals(10, updated_monitor.delay)
-        self.assertEquals(5, updated_monitor.timeout)
-        self.assertEquals(2, updated_monitor.attempts_before_deactivation)
-        self.assertEquals('/', updated_monitor.path)
-        self.assertEquals('^[234][0-9][0-9]$', updated_monitor.status_regex)
-        self.assertEquals('', updated_monitor.body_regex)
+        self.assertEqual('HTTP', updated_monitor.type)
+        self.assertEqual(10, updated_monitor.delay)
+        self.assertEqual(5, updated_monitor.timeout)
+        self.assertEqual(2, updated_monitor.attempts_before_deactivation)
+        self.assertEqual('/', updated_monitor.path)
+        self.assertEqual('^[234][0-9][0-9]$', updated_monitor.status_regex)
+        self.assertEqual('', updated_monitor.body_regex)
 
     def test_ex_disable_balancer_health_monitor(self):
         balancer = self.driver.get_balancer(balancer_id='8290')
@@ -536,10 +536,10 @@ class RackspaceLBTests(unittest.TestCase):
             connection_throttle)
         updated_throttle = balancer.extra['connectionThrottle']
 
-        self.assertEquals(200, updated_throttle.max_connections)
-        self.assertEquals(50, updated_throttle.min_connections)
-        self.assertEquals(50, updated_throttle.max_connection_rate)
-        self.assertEquals(10, updated_throttle.rate_interval_seconds)
+        self.assertEqual(200, updated_throttle.max_connections)
+        self.assertEqual(50, updated_throttle.min_connections)
+        self.assertEqual(50, updated_throttle.max_connection_rate)
+        self.assertEqual(10, updated_throttle.rate_interval_seconds)
 
     def test_ex_update_balancer_connection_throttle_no_poll(self):
         balancer = self.driver.get_balancer(balancer_id='94695')
@@ -602,7 +602,7 @@ class RackspaceLBTests(unittest.TestCase):
         balancer = self.driver.ex_enable_balancer_session_persistence(balancer)
 
         persistence_type = balancer.extra['sessionPersistenceType']
-        self.assertEquals('HTTP_COOKIE', persistence_type)
+        self.assertEqual('HTTP_COOKIE', persistence_type)
 
     def test_ex_enable_balancer_session_persistence_no_poll(self):
         balancer = self.driver.get_balancer(balancer_id='94695')
@@ -632,7 +632,7 @@ class RackspaceLBTests(unittest.TestCase):
             balancer, content)
 
         error_page_content = self.driver.ex_get_balancer_error_page(balancer)
-        self.assertEquals(content, error_page_content)
+        self.assertEqual(content, error_page_content)
 
     def test_ex_update_balancer_error_page_no_poll(self):
         balancer = self.driver.get_balancer(balancer_id='8290')
@@ -659,43 +659,43 @@ class RackspaceLBTests(unittest.TestCase):
         balancer = self.driver.ex_disable_balancer_custom_error_page(balancer)
 
         error_page_content = self.driver.ex_get_balancer_error_page(balancer)
-        self.assertEquals(default_error_page, error_page_content)
+        self.assertEqual(default_error_page, error_page_content)
 
     def test_balancer_list_members(self):
         expected = set(['10.1.0.10:80', '10.1.0.11:80', '10.1.0.9:8080'])
         balancer = self.driver.get_balancer(balancer_id='8290')
         members = balancer.list_members()
 
-        self.assertEquals(len(members), 3)
-        self.assertEquals(members[0].balancer, balancer)
-        self.assertEquals(expected, set(["%s:%s" % (member.ip, member.port) for
+        self.assertEqual(len(members), 3)
+        self.assertEqual(members[0].balancer, balancer)
+        self.assertEqual(expected, set(["%s:%s" % (member.ip, member.port) for
                                          member in members]))
 
     def test_balancer_members_extra_weight(self):
         balancer = self.driver.get_balancer(balancer_id='8290')
         members = balancer.list_members()
 
-        self.assertEquals(12, members[0].extra['weight'])
-        self.assertEquals(8, members[1].extra['weight'])
+        self.assertEqual(12, members[0].extra['weight'])
+        self.assertEqual(8, members[1].extra['weight'])
 
     def test_balancer_members_extra_condition(self):
         balancer = self.driver.get_balancer(balancer_id='8290')
         members = balancer.list_members()
 
-        self.assertEquals(MemberCondition.ENABLED,
+        self.assertEqual(MemberCondition.ENABLED,
                           members[0].extra['condition'])
-        self.assertEquals(MemberCondition.DISABLED,
+        self.assertEqual(MemberCondition.DISABLED,
                           members[1].extra['condition'])
-        self.assertEquals(MemberCondition.DRAINING,
+        self.assertEqual(MemberCondition.DRAINING,
                           members[2].extra['condition'])
 
     def test_balancer_members_extra_status(self):
         balancer = self.driver.get_balancer(balancer_id='8290')
         members = balancer.list_members()
 
-        self.assertEquals('ONLINE', members[0].extra['status'])
-        self.assertEquals('OFFLINE', members[1].extra['status'])
-        self.assertEquals('DRAINING', members[2].extra['status'])
+        self.assertEqual('ONLINE', members[0].extra['status'])
+        self.assertEqual('OFFLINE', members[1].extra['status'])
+        self.assertEqual('DRAINING', members[2].extra['status'])
 
     def test_balancer_attach_member(self):
         balancer = self.driver.get_balancer(balancer_id='8290')
@@ -704,16 +704,16 @@ class RackspaceLBTests(unittest.TestCase):
         member = balancer.attach_member(Member(None, ip='10.1.0.12',
                                                port='80', extra=extra))
 
-        self.assertEquals(member.ip, '10.1.0.12')
-        self.assertEquals(member.port, 80)
+        self.assertEqual(member.ip, '10.1.0.12')
+        self.assertEqual(member.port, 80)
 
     def test_balancer_attach_member_with_no_condition_specified(self):
         balancer = self.driver.get_balancer(balancer_id='8291')
         member = balancer.attach_member(Member(None, ip='10.1.0.12',
                                                port='80'))
 
-        self.assertEquals(member.ip, '10.1.0.12')
-        self.assertEquals(member.port, 80)
+        self.assertEqual(member.ip, '10.1.0.12')
+        self.assertEqual(member.port, 80)
 
     def test_balancer_attach_members(self):
         balancer = self.driver.get_balancer(balancer_id='8292')
@@ -725,10 +725,10 @@ class RackspaceLBTests(unittest.TestCase):
 
         first_member = attached_members[0]
         second_member = attached_members[1]
-        self.assertEquals(first_member.ip, '10.1.0.12')
-        self.assertEquals(first_member.port, 80)
-        self.assertEquals(second_member.ip, '10.1.0.13')
-        self.assertEquals(second_member.port, 80)
+        self.assertEqual(first_member.ip, '10.1.0.12')
+        self.assertEqual(first_member.port, 80)
+        self.assertEqual(second_member.ip, '10.1.0.13')
+        self.assertEqual(second_member.port, 80)
 
     def test_balancer_detach_member(self):
         balancer = self.driver.get_balancer(balancer_id='8290')
@@ -743,7 +743,7 @@ class RackspaceLBTests(unittest.TestCase):
 
         balancer = self.driver.ex_balancer_detach_members(balancer, members)
 
-        self.assertEquals('8290', balancer.id)
+        self.assertEqual('8290', balancer.id)
 
     def test_ex_detach_members_no_poll(self):
         balancer = self.driver.get_balancer(balancer_id='8290')
@@ -871,8 +871,8 @@ class RackspaceLBTests(unittest.TestCase):
         member = self.driver.ex_balancer_update_member(balancer, first_member,
             condition=MemberCondition.ENABLED, weight=12)
 
-        self.assertEquals(MemberCondition.ENABLED, member.extra['condition'])
-        self.assertEquals(12, member.extra['weight'])
+        self.assertEqual(MemberCondition.ENABLED, member.extra['condition'])
+        self.assertEqual(12, member.extra['weight'])
 
     def test_ex_update_balancer_member_no_poll_extra_attributes(self):
         balancer = self.driver.get_balancer(balancer_id='8290')
@@ -1087,7 +1087,7 @@ class RackspaceLBMockHttp(MockHttpTestCase):
         elif method == 'PUT':
             json_body = json.loads(body)
 
-            self.assertEquals('<html>Generic Error Page</html>',
+            self.assertEqual('<html>Generic Error Page</html>',
                 json_body['errorpage']['content'])
             return (httplib.ACCEPTED, '', {}, httplib.responses[httplib.ACCEPTED])
 
@@ -1160,10 +1160,10 @@ class RackspaceLBMockHttp(MockHttpTestCase):
         if method == 'PUT':
             json_body = json.loads(body)
 
-            self.assertEquals('CONNECT', json_body['type'])
-            self.assertEquals(10, json_body['delay'])
-            self.assertEquals(5, json_body['timeout'])
-            self.assertEquals(2, json_body['attemptsBeforeDeactivation'])
+            self.assertEqual('CONNECT', json_body['type'])
+            self.assertEqual(10, json_body['delay'])
+            self.assertEqual(5, json_body['timeout'])
+            self.assertEqual(2, json_body['attemptsBeforeDeactivation'])
 
             return (httplib.ACCEPTED, '', {}, httplib.responses[httplib.ACCEPTED])
 
@@ -1173,10 +1173,10 @@ class RackspaceLBMockHttp(MockHttpTestCase):
         if method == 'PUT':
             json_body = json.loads(body)
 
-            self.assertEquals(50, json_body['minConnections'])
-            self.assertEquals(200, json_body['maxConnections'])
-            self.assertEquals(50, json_body['maxConnectionRate'])
-            self.assertEquals(10, json_body['rateInterval'])
+            self.assertEqual(50, json_body['minConnections'])
+            self.assertEqual(200, json_body['maxConnections'])
+            self.assertEqual(50, json_body['maxConnectionRate'])
+            self.assertEqual(10, json_body['rateInterval'])
 
             return (httplib.ACCEPTED, '', {}, httplib.responses[httplib.ACCEPTED])
 
@@ -1197,7 +1197,7 @@ class RackspaceLBMockHttp(MockHttpTestCase):
             json_body = json.loads(body)
 
             persistence_type = json_body['sessionPersistence']['persistenceType']
-            self.assertEquals('HTTP_COOKIE', persistence_type)
+            self.assertEqual('HTTP_COOKIE', persistence_type)
 
             return (httplib.ACCEPTED, '', {}, httplib.responses[httplib.ACCEPTED])
 
@@ -1223,13 +1223,13 @@ class RackspaceLBMockHttp(MockHttpTestCase):
         if method == 'PUT':
             json_body = json.loads(body)
 
-            self.assertEquals('HTTP', json_body['type'])
-            self.assertEquals(10, json_body['delay'])
-            self.assertEquals(5, json_body['timeout'])
-            self.assertEquals(2, json_body['attemptsBeforeDeactivation'])
-            self.assertEquals('/', json_body['path'])
-            self.assertEquals('^[234][0-9][0-9]$', json_body['statusRegex'])
-            self.assertEquals('Hello World!', json_body['bodyRegex'])
+            self.assertEqual('HTTP', json_body['type'])
+            self.assertEqual(10, json_body['delay'])
+            self.assertEqual(5, json_body['timeout'])
+            self.assertEqual(2, json_body['attemptsBeforeDeactivation'])
+            self.assertEqual('/', json_body['path'])
+            self.assertEqual('^[234][0-9][0-9]$', json_body['statusRegex'])
+            self.assertEqual('Hello World!', json_body['bodyRegex'])
 
             return (httplib.ACCEPTED, '', {}, httplib.responses[httplib.ACCEPTED])
 
@@ -1256,8 +1256,8 @@ class RackspaceLBMockHttp(MockHttpTestCase):
         elif method == 'POST':
             json_body = json.loads(body)
 
-            self.assertEquals('0.0.0.0/0', json_body['networkItem']['address'])
-            self.assertEquals('DENY', json_body['networkItem']['type'])
+            self.assertEqual('0.0.0.0/0', json_body['networkItem']['address'])
+            self.assertEqual('DENY', json_body['networkItem']['type'])
 
             return (httplib.ACCEPTED, '', {}, httplib.responses[httplib.ACCEPTED])
 
@@ -1291,10 +1291,10 @@ class RackspaceLBMockHttp(MockHttpTestCase):
 
             json_body = json.loads(body)
             access_list = json_body['accessList']
-            self.assertEquals('ALLOW', access_list[0]['type'])
-            self.assertEquals('2001:4801:7901::6/64', access_list[0]['address'])
-            self.assertEquals('DENY', access_list[1]['type'])
-            self.assertEquals('8.8.8.8/0', access_list[1]['address'])
+            self.assertEqual('ALLOW', access_list[0]['type'])
+            self.assertEqual('2001:4801:7901::6/64', access_list[0]['address'])
+            self.assertEqual('DENY', access_list[1]['type'])
+            self.assertEqual('8.8.8.8/0', access_list[1]['address'])
 
             return (httplib.ACCEPTED, '', {}, httplib.responses[httplib.ACCEPTED])
 
@@ -1317,12 +1317,12 @@ class RackspaceLBMockHttp(MockHttpTestCase):
         if method == 'PUT':
             json_body = json.loads(body)
 
-            self.assertEquals('HTTP', json_body['type'])
-            self.assertEquals(10, json_body['delay'])
-            self.assertEquals(5, json_body['timeout'])
-            self.assertEquals(2, json_body['attemptsBeforeDeactivation'])
-            self.assertEquals('/', json_body['path'])
-            self.assertEquals('^[234][0-9][0-9]$', json_body['statusRegex'])
+            self.assertEqual('HTTP', json_body['type'])
+            self.assertEqual(10, json_body['delay'])
+            self.assertEqual(5, json_body['timeout'])
+            self.assertEqual(2, json_body['attemptsBeforeDeactivation'])
+            self.assertEqual('/', json_body['path'])
+            self.assertEqual('^[234][0-9][0-9]$', json_body['statusRegex'])
             self.assertFalse('bodyRegex' in json_body)
 
             return (httplib.ACCEPTED, '', {}, httplib.responses[httplib.ACCEPTED])

--- a/libcloud/test/storage/test_cloudfiles.py
+++ b/libcloud/test/storage/test_cloudfiles.py
@@ -671,7 +671,7 @@ class CloudFilesTests(unittest.TestCase):
         self.assertEqual(func_args[0], "/" + container.name + "/" + object_name)
         self.assertEqual(func_kwargs["headers"]["X-Object-Manifest"],
                 container.name + "/" + object_name + "/")
-        self.assertEqualEqual(func_kwargs["method"], "PUT")
+        self.assertEqual(func_kwargs["method"], "PUT")
 
     def test__upload_object_manifest_wrong_hash(self):
         fake_response = type('CloudFilesResponse', (), {'headers':

--- a/libcloud/test/storage/test_cloudfiles.py
+++ b/libcloud/test/storage/test_cloudfiles.py
@@ -83,7 +83,7 @@ class CloudFilesTests(unittest.TestCase):
             driver.list_containers()
         except:
             e = sys.exc_info()[1]
-            self.assertEquals(e.value, 'Could not find specified endpoint')
+            self.assertEqual(e.value, 'Could not find specified endpoint')
         else:
             self.fail('Exception was not thrown')
 
@@ -101,11 +101,11 @@ class CloudFilesTests(unittest.TestCase):
         driver = CloudFilesStorageDriver('driver', 'dummy', **kwargs)
         driver.list_containers()
 
-        self.assertEquals(kwargs['ex_force_auth_token'],
+        self.assertEqual(kwargs['ex_force_auth_token'],
             driver.connection.auth_token)
-        self.assertEquals('cdn2.clouddrive.com',
+        self.assertEqual('cdn2.clouddrive.com',
             driver.connection.host)
-        self.assertEquals('/v1/MossoCloudFS',
+        self.assertEqual('/v1/MossoCloudFS',
             driver.connection.request_path)
 
     def test_invalid_ex_force_service_region(self):
@@ -116,7 +116,7 @@ class CloudFilesTests(unittest.TestCase):
             driver.list_containers()
         except:
             e = sys.exc_info()[1]
-            self.assertEquals(e.value, 'Could not find specified endpoint')
+            self.assertEqual(e.value, 'Could not find specified endpoint')
         else:
             self.fail('Exception was not thrown')
 
@@ -132,9 +132,9 @@ class CloudFilesTests(unittest.TestCase):
         }
         driver = CloudFilesStorageDriver('driver', 'dummy', **kwargs)
 
-        self.assertEquals(kwargs['ex_force_auth_url'],
+        self.assertEqual(kwargs['ex_force_auth_url'],
             driver.connection._ex_force_auth_url)
-        self.assertEquals(kwargs['ex_force_auth_version'],
+        self.assertEqual(kwargs['ex_force_auth_version'],
             driver.connection._auth_version)
 
     def test_invalid_json_throws_exception(self):
@@ -643,8 +643,8 @@ class CloudFilesTests(unittest.TestCase):
         CloudFilesStorageDriver._put_object = _put_object
 
         func_kwargs = tuple(mocked__put_object.call_args)[1]
-        self.assertEquals(func_kwargs['object_name'], expected_name)
-        self.assertEquals(func_kwargs['container'], container)
+        self.assertEqual(func_kwargs['object_name'], expected_name)
+        self.assertEqual(func_kwargs['container'], container)
 
     def test__upload_object_manifest(self):
         hash_function = self.driver._get_hash_function()
@@ -668,10 +668,10 @@ class CloudFilesTests(unittest.TestCase):
 
         self.driver.connection.request = _request
 
-        self.assertEquals(func_args[0], "/" + container.name + "/" + object_name)
-        self.assertEquals(func_kwargs["headers"]["X-Object-Manifest"],
+        self.assertEqual(func_args[0], "/" + container.name + "/" + object_name)
+        self.assertEqual(func_kwargs["headers"]["X-Object-Manifest"],
                 container.name + "/" + object_name + "/")
-        self.assertEquals(func_kwargs["method"], "PUT")
+        self.assertEqualEqual(func_kwargs["method"], "PUT")
 
     def test__upload_object_manifest_wrong_hash(self):
         fake_response = type('CloudFilesResponse', (), {'headers':
@@ -748,7 +748,7 @@ class CloudFilesTests(unittest.TestCase):
         ret = self.driver.ex_get_object_temp_url(obj, 'GET')
         temp_url = 'https://storage101.%s1.clouddrive.com/v1/MossoCloudFS/foo_bar_container/foo_bar_object?temp_url_expires=60&temp_url_sig=%s' % (self.region, sig)
 
-        self.assertEquals(''.join(sorted(ret)), ''.join(sorted(temp_url)))
+        self.assertEqual(''.join(sorted(ret)), ''.join(sorted(temp_url)))
 
     def test_ex_get_object_temp_url_no_key_raises_key_error(self):
         self.driver.ex_get_meta_data = mock.Mock()


### PR DESCRIPTION
The CloudStack fixes are left to a patch I submitted on jira for libcloud-391

Note that the github trunk does not pass tox, but the apache trunk does...
