### PR TITLE
Use string for RecordType enum value

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -114,6 +114,12 @@ Changes with Apache Libcloud in development
      the provided key is not set.
      [Tomaz Muraus]
 
+   - Use string instead of integer for RecordType ENUM value.
+     Note: If you directly use an integer instead of RecordType ENUM class you
+     need to update your code to use the RecordType ENUM otherwise the code
+     won't work.
+     [Tomaz Muraus]
+
 Changes with Apache Libcloud 0.13.1
 
  *) General

--- a/libcloud/dns/base.py
+++ b/libcloud/dns/base.py
@@ -120,8 +120,8 @@ class Record(object):
     def __repr__(self):
         return ('<Record: zone=%s, name=%s, type=%s, data=%s, provider=%s '
                 '...>' %
-                (self.zone.id, self.name, RecordType.__repr__(self.type),
-                 self.data, self.driver.name))
+                (self.zone.id, self.name, self.type, self.data,
+                 self.driver.name))
 
 
 class DNSDriver(BaseDriver):

--- a/libcloud/dns/drivers/dummy.py
+++ b/libcloud/dns/drivers/dummy.py
@@ -49,7 +49,7 @@ class DummyDNSDriver(DNSDriver):
         """
         >>> driver = DummyDNSDriver('key', 'secret')
         >>> driver.list_record_types()
-        [0]
+        ['A']
 
         @inherits: L{DNSDriver.list_record_types}
         """

--- a/libcloud/dns/types.py
+++ b/libcloud/dns/types.py
@@ -42,29 +42,6 @@ class RecordType(object):
     """
     DNS record type.
     """
-    A = 0
-    AAAA = 1
-    MX = 2
-    NS = 3
-    CNAME = 4
-    DNAME = 5
-    TXT = 6
-    PTR = 7
-    SOA = 8
-    SPF = 9
-    SRV = 10
-    PTR = 11
-    NAPTR = 12
-    REDIRECT = 13
-    GEO = 14
-    URL = 15
-    WKS = 16
-    LOC = 17
-
-class RecordType(object):
-    """
-    DNS record type.
-    """
     A = 'A'
     AAAA = 'AAAA'
     MX = 'MX'

--- a/libcloud/dns/types.py
+++ b/libcloud/dns/types.py
@@ -61,10 +61,28 @@ class RecordType(object):
     WKS = 16
     LOC = 17
 
-    @classmethod
-    def __repr__(self, value):
-        reverse = dict((v, k) for k, v in list(RecordType.__dict__.items()))
-        return reverse[value]
+class RecordType(object):
+    """
+    DNS record type.
+    """
+    A = 'A'
+    AAAA = 'AAAA'
+    MX = 'MX'
+    NS = 'NS'
+    CNAME = 'CNAME'
+    DNAME = 'DNAME'
+    TXT = 'TXT'
+    PTR = 'PTR'
+    SOA = 'SOA'
+    SPF = 'SPF'
+    SRV = 'SRV'
+    PTR = 'PTR'
+    NAPTR = 'NAPTR'
+    REDIRECT = 'REDIRECT'
+    GEO = 'GEO'
+    URL = 'URL'
+    WKS = 'WKS'
+    LOC = 'LOC'
 
 
 class ZoneError(LibcloudError):

--- a/libcloud/test/test_connection.py
+++ b/libcloud/test/test_connection.py
@@ -15,10 +15,10 @@
 # limitations under the License.
 
 import sys
-import unittest
 
 from mock import Mock, call
 
+from libcloud.test import unittest
 from libcloud.common.base import Connection
 
 


### PR DESCRIPTION
@Jc2k mentioned this "issue" on the IRC yesterday.

Using integer value for enums is a common practice in Python, but I believe that using a string value is better in this case. It makes debugging and everything else easier.

With this approach, user can also directly pass a string value for `type` argument and it makes getting rid of `RecordType` type in the future easier, if we ever want to do that.
