### PR TITLE
Issue LIBCLOUD-407: Better name for Node drivers

### DIFF
--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -1540,6 +1540,7 @@ class EC2EUNodeDriver(EC2NodeDriver):
     """
     Driver class for EC2 in the Western Europe Region.
     """
+    name = 'Amazon EC2 (eu-west-1)'
     _region = 'eu-west-1'
 
 
@@ -1547,6 +1548,7 @@ class EC2USWestNodeDriver(EC2NodeDriver):
     """
     Driver class for EC2 in the Western US Region
     """
+    name = 'Amazon EC2 (us-west-1)'
     _region = 'us-west-1'
 
 
@@ -1554,6 +1556,7 @@ class EC2USWestOregonNodeDriver(EC2NodeDriver):
     """
     Driver class for EC2 in the US West Oregon region.
     """
+    name = 'Amazon EC2 (us-west-2)'
     _region = 'us-west-2'
 
 
@@ -1561,6 +1564,7 @@ class EC2APSENodeDriver(EC2NodeDriver):
     """
     Driver class for EC2 in the Southeast Asia Pacific Region.
     """
+    name = 'Amazon EC2 (ap-southeast-1)'
     _region = 'ap-southeast-1'
 
 
@@ -1568,6 +1572,7 @@ class EC2APNENodeDriver(EC2NodeDriver):
     """
     Driver class for EC2 in the Northeast Asia Pacific Region.
     """
+    name = 'Amazon EC2 (ap-northeast-1)'
     _region = 'ap-northeast-1'
 
 
@@ -1575,6 +1580,7 @@ class EC2SAEastNodeDriver(EC2NodeDriver):
     """
     Driver class for EC2 in the South America (Sao Paulo) Region.
     """
+    name = 'Amazon EC2 (sa-east-1)'
     _region = 'sa-east-1'
 
 
@@ -1582,6 +1588,7 @@ class EC2APSESydneyNodeDriver(EC2NodeDriver):
     """
     Driver class for EC2 in the Southeast Asia Pacific (Sydney) Region.
     """
+    name = 'Amazon EC2 (ap-southeast-1)'
     _region = 'ap-southeast-2'
 
 

--- a/libcloud/compute/drivers/elastichosts.py
+++ b/libcloud/compute/drivers/elastichosts.py
@@ -156,6 +156,7 @@ class ElasticHostsUK1NodeDriver(ElasticHostsBaseNodeDriver):
     ElasticHosts node driver for the London Peer 1 end-point
     """
     connectionCls = ElasticHostsUK1Connection
+    name = 'ElasticHosts (uk-1)'
 
 
 class ElasticHostsUK2Connection(ElasticStackBaseConnection):
@@ -171,6 +172,7 @@ class ElasticHostsUK2NodeDriver(ElasticHostsBaseNodeDriver):
     ElasticHosts node driver for the London Bluesquare end-point
     """
     connectionCls = ElasticHostsUK2Connection
+    name = 'ElasticHosts (uk-2)'
 
 
 class ElasticHostsUS1Connection(ElasticStackBaseConnection):
@@ -186,6 +188,7 @@ class ElasticHostsUS1NodeDriver(ElasticHostsBaseNodeDriver):
     ElasticHosts node driver for the San Antonio Peer 1 end-point
     """
     connectionCls = ElasticHostsUS1Connection
+    name = 'ElasticHosts (us-1)'
 
 
 class ElasticHostsUS2Connection(ElasticStackBaseConnection):
@@ -201,6 +204,7 @@ class ElasticHostsUS2NodeDriver(ElasticHostsBaseNodeDriver):
     ElasticHosts node driver for the Los Angeles Peer 1 end-point
     """
     connectionCls = ElasticHostsUS2Connection
+    name = 'ElasticHosts (us-2)'
 
 
 class ElasticHostsCA1Connection(ElasticStackBaseConnection):
@@ -216,3 +220,4 @@ class ElasticHostsCA1NodeDriver(ElasticHostsBaseNodeDriver):
     ElasticHosts node driver for the Toronto Peer 1 end-point
     """
     connectionCls = ElasticHostsCA1Connection
+    name = 'ElasticHosts (ca-1)'

--- a/libcloud/compute/drivers/rackspace.py
+++ b/libcloud/compute/drivers/rackspace.py
@@ -67,7 +67,7 @@ class RackspaceFirstGenConnection(OpenStack_1_0_Connection):
 
 
 class RackspaceFirstGenNodeDriver(OpenStack_1_0_NodeDriver):
-    name = 'Rackspace Cloud'
+    name = 'Rackspace Cloud (First Gen)'
     website = 'http://www.rackspace.com'
     connectionCls = RackspaceFirstGenConnection
     type = Provider.RACKSPACE_FIRST_GEN
@@ -141,7 +141,7 @@ class RackspaceConnection(OpenStack_1_1_Connection):
 
 
 class RackspaceNodeDriver(OpenStack_1_1_NodeDriver):
-    name = 'Rackspace Cloud'
+    name = 'Rackspace Cloud (Next Gen)'
     website = 'http://www.rackspace.com'
     connectionCls = RackspaceConnection
     type = Provider.RACKSPACE


### PR DESCRIPTION
Some classes in `libcloud.compute.drivers` aren't easily identifiable in the supported provider matrix due to their `name` attributes being generic. This change adds detail to `NodeDriver` classes where there are multiple per provider, e.g., Amazon EC2.
