### PR TITLE
Add the Hong Kong (HKG) endpoint for Rackspace

### DIFF
--- a/docs/upgrade_notes.rst
+++ b/docs/upgrade_notes.rst
@@ -93,7 +93,8 @@ And replaced with two new constants:
 * ``RACKSPACE`` - Supported values for ``region`` argument are: ``us``, ``uk``.
   Default value is ``us``.
 * ``RACKSPACE_FIRST_GEN`` - Supported values for the ``region`` argument are:
-  ``dfw``, ``ord``, ``iad``, ``lon``, ``syd``. Default value is ``dfw``.
+  ``dfw``, ``ord``, ``iad``, ``lon``, ``syd``, ``hkg``.
+  Default value is ``dfw``.
 
 Besides that, ``RACKSPACE`` provider constant now defaults to next-generation
 OpenStack based servers. Previously it defaulted to first generation cloud

--- a/libcloud/compute/drivers/rackspace.py
+++ b/libcloud/compute/drivers/rackspace.py
@@ -40,6 +40,10 @@ ENDPOINT_ARGS_MAP = {
     'syd': {'service_type': 'compute',
             'name': 'cloudServersOpenStack',
             'region': 'SYD'},
+    'hkg': {'service_type': 'compute',
+            'name': 'cloudServersOpenStack',
+            'region': 'HKG'},
+
 }
 
 

--- a/libcloud/loadbalancer/drivers/rackspace.py
+++ b/libcloud/loadbalancer/drivers/rackspace.py
@@ -47,6 +47,10 @@ ENDPOINT_ARGS_MAP = {
     'syd': {'service_type': 'rax:load-balancer',
             'name': 'cloudLoadBalancers',
             'region': 'SYD'},
+    'hkg': {'service_type': 'rax:load-balancer',
+            'name': 'cloudLoadBalancers',
+            'region': 'HKG'},
+
 }
 
 

--- a/libcloud/test/compute/fixtures/openstack/_v2_0__auth.json
+++ b/libcloud/test/compute/fixtures/openstack/_v2_0__auth.json
@@ -101,6 +101,14 @@
                         "versionInfo": "https://syd.servers.api.rackspacecloud.com/v2/",
                         "versionList": "https://syd.servers.api.rackspacecloud.com/",
                         "versionId": "2"
+                    },
+                    {
+                        "region": "HKG",
+                        "tenantId": "613469",
+                        "publicURL": "https://hkg.servers.api.rackspacecloud.com/v2/1337",
+                        "versionInfo": "https://hkg.servers.api.rackspacecloud.com/v2/",
+                        "versionList": "https://hkg.servers.api.rackspacecloud.com/",
+                        "versionId": "2"
                     }
 
                 ],

--- a/libcloud/test/compute/fixtures/openstack/_v2_0__auth_deployment.json
+++ b/libcloud/test/compute/fixtures/openstack/_v2_0__auth_deployment.json
@@ -101,7 +101,16 @@
                         "versionInfo": "https://syd.servers.api.rackspacecloud.com/v2/",
                         "versionList": "https://syd.servers.api.rackspacecloud.com/",
                         "versionId": "2"
+                    },
+                    {
+                        "region": "HKG",
+                        "tenantId": "613469",
+                        "publicURL": "https://hkg.servers.api.rackspacecloud.com/v2/slug",
+                        "versionInfo": "https://hkg.servers.api.rackspacecloud.com/v2/",
+                        "versionList": "https://hkg.servers.api.rackspacecloud.com/",
+                        "versionId": "2"
                     }
+
 
                 ],
                 "name": "cloudServersOpenStack",

--- a/libcloud/test/compute/test_rackspace.py
+++ b/libcloud/test/compute/test_rackspace.py
@@ -199,5 +199,15 @@ class RackspaceNovaSydTests(BaseRackspaceNovaTestCase, OpenStack_1_1_Tests):
 
     expected_endpoint = 'https://syd.servers.api.rackspacecloud.com/v2/1337'
 
+
+class RackspaceNovaHkgTests(BaseRackspaceNovaTestCase, OpenStack_1_1_Tests):
+
+    driver_klass = RackspaceNodeDriver
+    driver_type = RackspaceNodeDriver
+    driver_args = RACKSPACE_NOVA_PARAMS
+    driver_kwargs = {'region': 'hkg'}
+
+    expected_endpoint = 'https://hkg.servers.api.rackspacecloud.com/v2/1337'
+
 if __name__ == '__main__':
     sys.exit(unittest.main())


### PR DESCRIPTION
Rackspace has opened a datacenter in Hong Kong with an endpoint name of HKG. This change adds the endpoint to the endpoint mappings for the `compute` and `loadbalancer` packages.
