### PR TITLE
Issue LIBCLOUD-417: Add support for more EC2 Elastic IP Address operations

### DIFF
--- a/docs/compute/drivers/ec2.rst
+++ b/docs/compute/drivers/ec2.rst
@@ -1,6 +1,16 @@
 Amazon EC2 Driver Documentation
 ===============================
 
+Examples
+--------
+
+Allocate, Associate, Disassociate, and Release an Elastic IP
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. literalinclude:: /examples/compute/create_ec2_node_and_associate_elastic_ip.py
+   :language: python
+
+
 API Docs
 --------
 

--- a/docs/examples/compute/create_ec2_node_and_associate_elastic_ip.py
+++ b/docs/examples/compute/create_ec2_node_and_associate_elastic_ip.py
@@ -1,0 +1,28 @@
+from libcloud.compute.types import Provider
+from libcloud.compute.providers import get_driver
+
+ACCESS_ID = 'your access id'
+SECRET_KEY = 'your secret key'
+
+IMAGE_ID = 'ami-c8052d8d'
+SIZE_ID = 't1.micro'
+
+cls = get_driver(Provider.EC2_US_WEST)
+driver = cls(ACCESS_ID, SECRET_KEY)
+
+sizes = driver.list_sizes()
+images = driver.list_images()
+
+size = [s for s in sizes if s.id == SIZE_ID][0]
+image = [i for i in images if i.id == IMAGE_ID][0]
+
+node = driver.create_node(name='test-node', image=image, size=size)
+
+# Here we allocate and associate an elastic IP
+elastic_ip = driver.ex_allocate_address()
+driver.ex_associate_addresses(node, elastic_ip)
+
+# When we are done with our elastic IP, we can disassociate from our
+# node, and release it
+driver.ex_disassociate_address(elastic_ip)
+driver.ex_release_address(elastic_ip)

--- a/libcloud/test/compute/fixtures/ec2/allocate_address.xml
+++ b/libcloud/test/compute/fixtures/ec2/allocate_address.xml
@@ -1,0 +1,5 @@
+<AllocateAddressResponse xmlns="http://ec2.amazonaws.com/doc/2010-08-31/">
+    <requestId>56926e0e-5fa3-41f3-927c-17212def59df</requestId>
+    <publicIp>192.0.2.1</publicIp>
+    <domain>standard</domain>
+</AllocateAddressResponse>

--- a/libcloud/test/compute/fixtures/ec2/disassociate_address.xml
+++ b/libcloud/test/compute/fixtures/ec2/disassociate_address.xml
@@ -1,0 +1,4 @@
+<DisassociateAddressResponse xmlns="http://ec2.amazonaws.com/doc/2010-08-31/">
+    <requestId>dfb841f8-cc26-4f45-a3ac-dc08589eec1d</requestId>
+    <return>true</return>
+</DisassociateAddressResponse>

--- a/libcloud/test/compute/fixtures/ec2/release_address.xml
+++ b/libcloud/test/compute/fixtures/ec2/release_address.xml
@@ -1,0 +1,4 @@
+<ReleaseAddressResponse xmlns="http://ec2.amazonaws.com/doc/2010-08-31/">
+    <requestId>23ec1390-8c1d-4a3e-8042-b1ad84933f57</requestId>
+    <return>true</return>
+</ReleaseAddressResponse>

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -459,9 +459,21 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
         self.assertEqual(len(elastic_ips2), 2)
         self.assertTrue('1.2.3.5' not in elastic_ips2)
 
+    def test_ex_allocate_address(self):
+        ret = self.driver.ex_allocate_address()
+        self.assertTrue(ret)
+
+    def test_ex_release_address(self):
+        ret = self.driver.ex_release_address('1.2.3.4')
+        self.assertTrue(ret)
+
     def test_ex_associate_addresses(self):
         node = Node('i-4382922a', None, None, None, None, self.driver)
         ret = self.driver.ex_associate_addresses(node, '1.2.3.4')
+        self.assertTrue(ret)
+
+    def test_ex_disassociate_address(self):
+        ret = self.driver.ex_disassociate_address('1.2.3.4')
         self.assertTrue(ret)
 
     def test_ex_change_node_size_same_size(self):
@@ -777,8 +789,20 @@ class EC2MockHttp(MockHttpTestCase):
         body = self.fixtures.load('describe_addresses_multi.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
+    def _AllocateAddress(self, method, url, body, headers):
+        body = self.fixtures.load('allocate_address.xml')
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+
     def _AssociateAddress(self, method, url, body, headers):
         body = self.fixtures.load('associate_address.xml')
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+
+    def _DisassociateAddress(self, method, url, body, headers):
+        body = self.fixtures.load('disassociate_address.xml')
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+
+    def _ReleaseAddress(self, method, url, body, headers):
+        body = self.fixtures.load('release_address.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
     def _all_addresses_DescribeAddresses(self, method, url, body, headers):


### PR DESCRIPTION
Add support for:

DisassociateAddress
ReleaseAddress
AllocateAddress

Also fix AssociateAddress
