### PR TITLE
Import LockTimeout before trying to catch it.

### DIFF
--- a/libcloud/storage/drivers/local.py
+++ b/libcloud/storage/drivers/local.py
@@ -25,7 +25,7 @@ import shutil
 import sys
 
 try:
-    from lockfile import mkdirlockfile
+    from lockfile import LockTimeout, mkdirlockfile
 except ImportError:
     raise ImportError('Missing lockfile dependency, you can install it ' \
                       'using pip: pip install lockfile')
@@ -57,7 +57,7 @@ class LockLocalStorage(object):
     def __enter__(self):
         try:
             self.lock.acquire(timeout=0.1)
-        except lockfile.LockTimeout:
+        except LockTimeout:
             raise LibcloudError('Lock timeout')
 
     def __exit__(self, type, value, traceback):

--- a/libcloud/test/storage/test_local.py
+++ b/libcloud/test/storage/test_local.py
@@ -21,6 +21,8 @@ import shutil
 import unittest
 import tempfile
 
+import mock
+
 from libcloud.utils.py3 import httplib
 
 from libcloud.common.types import InvalidCredsError
@@ -35,9 +37,12 @@ from libcloud.storage.types import ObjectHashMismatchError
 
 try:
     from libcloud.storage.drivers.local import LocalStorageDriver
+    from libcloud.storage.drivers.local import LockLocalStorage
+    from lockfile import LockTimeout
 except ImportError:
     print('lockfile library is not available, skipping local_storage tests...')
     LocalStorageDriver = None
+    LockTimeout = None
 
 from libcloud.storage.drivers.dummy import DummyIterator
 
@@ -317,6 +322,14 @@ class LocalTests(unittest.TestCase):
         obj.delete()
         container.delete()
         self.remove_tmp_file(tmppath)
+
+    @mock.patch("lockfile.mkdirlockfile.MkdirLockFile.acquire",
+                mock.MagicMock(side_effect=LockTimeout))
+    def test_proper_lockfile_imports(self):
+        # LockLocalStorage was previously using an un-imported exception
+        # in its __enter__ method, so the following would raise a NameError.
+        lls = LockLocalStorage("blah")
+        self.assertRaises(LibcloudError, lls.__enter__)
 
 
 if not LocalStorageDriver:


### PR DESCRIPTION
If `lock.acquire` raised any sort of exception, a `NameError` would trump it because the `__enter__` method was trying to catch `lockfile.LockTimeout`, which wasn't imported.
