### PR TITLE
Fix F401 errors from flake8

### DIFF
--- a/libcloud/common/azure.py
+++ b/libcloud/common/azure.py
@@ -20,10 +20,9 @@ import hmac
 
 from hashlib import sha256
 
-from libcloud.utils.py3 import PY3
 from libcloud.utils.py3 import httplib
 from libcloud.utils.py3 import b
-from libcloud.utils.xml import fixxpath, findtext
+from libcloud.utils.xml import fixxpath
 from xml.etree          import ElementTree
 
 from libcloud.common.types import InvalidCredsError

--- a/libcloud/common/google.py
+++ b/libcloud/common/google.py
@@ -65,7 +65,6 @@ except ImportError:
     import json
 
 import base64
-import calendar
 import errno
 import time
 import datetime
@@ -76,9 +75,7 @@ import sys
 from libcloud.utils.py3 import httplib, urlencode, urlparse, PY3
 from libcloud.common.base import (ConnectionUserAndKey, JsonResponse,
                                   PollingConnection)
-from libcloud.common.types import (InvalidCredsError,
-                                   MalformedResponseError,
-                                   ProviderError,
+from libcloud.common.types import (ProviderError,
                                    LibcloudError)
 
 try:

--- a/libcloud/compute/drivers/ecp.py
+++ b/libcloud/compute/drivers/ecp.py
@@ -24,7 +24,6 @@ import binascii
 
 from libcloud.utils.py3 import httplib
 from libcloud.utils.py3 import b
-from libcloud.utils.py3 import u
 
 # JSON is included in the standard library starting with Python 2.6.  For 2.5
 # and 2.4, there's a simplejson egg at: http://pypi.python.org/pypi/simplejson

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -20,18 +20,15 @@ from __future__ import with_statement
 import datetime
 import time
 import sys
-import os
-import getpass
 
 from libcloud.common.google import GoogleResponse
 from libcloud.common.google import GoogleBaseConnection
 from libcloud.common.google import ResourceNotFoundError
 
-from libcloud.common.types import MalformedResponseError
 from libcloud.compute.base import Node, NodeDriver, NodeImage, NodeLocation
 from libcloud.compute.base import NodeSize, StorageVolume, UuidMixin
 from libcloud.compute.providers import Provider
-from libcloud.compute.types import NodeState, LibcloudError
+from libcloud.compute.types import NodeState
 
 API_VERSION = 'v1beta15'
 DEFAULT_TASK_COMPLETION_TIMEOUT = 180

--- a/libcloud/compute/drivers/ktucloud.py
+++ b/libcloud/compute/drivers/ktucloud.py
@@ -14,9 +14,7 @@
 # limitations under the License.
 
 from libcloud.compute.providers import Provider
-from libcloud.compute.base import Node, NodeDriver, NodeImage, NodeLocation, \
-    NodeSize
-from libcloud.compute.types import NodeState
+from libcloud.compute.base import Node, NodeImage, NodeSize
 from libcloud.compute.drivers.cloudstack import CloudStackNodeDriver
 
 

--- a/libcloud/compute/drivers/opennebula.py
+++ b/libcloud/compute/drivers/opennebula.py
@@ -220,7 +220,7 @@ class OpenNebulaNetwork(object):
     You don't normally create a network object yourself; instead you use
     a driver and then have that create the network for you.
 
-    >>> from libcloud.compute.drivers.dummy import DummyNodeDriver
+    >>> from libcloud.compute.drivers.dummy import DummyNetworkDriver
     >>> driver = DummyNetworkDriver()
     >>> network = driver.create_network()
     >>> network = driver.list_networks()[0]

--- a/libcloud/compute/drivers/opsource.py
+++ b/libcloud/compute/drivers/opsource.py
@@ -21,7 +21,7 @@ from base64 import b64encode
 from libcloud.utils.py3 import httplib
 from libcloud.utils.py3 import b
 
-from libcloud.compute.base import NodeDriver, Node, NodeAuthPassword
+from libcloud.compute.base import NodeDriver, Node
 from libcloud.compute.base import NodeSize, NodeImage, NodeLocation
 from libcloud.common.types import LibcloudError, InvalidCredsError
 from libcloud.common.base import ConnectionUserAndKey, XmlResponse

--- a/libcloud/compute/drivers/rimuhosting.py
+++ b/libcloud/compute/drivers/rimuhosting.py
@@ -24,7 +24,7 @@ from libcloud.common.base import ConnectionKey, JsonResponse
 from libcloud.common.types import InvalidCredsError
 from libcloud.compute.types import Provider, NodeState
 from libcloud.compute.base import NodeDriver, NodeSize, Node, NodeLocation
-from libcloud.compute.base import NodeImage, NodeAuthPassword
+from libcloud.compute.base import NodeImage
 
 API_CONTEXT = '/r'
 API_HOST = 'rimuhosting.com'

--- a/libcloud/compute/drivers/softlayer.py
+++ b/libcloud/compute/drivers/softlayer.py
@@ -16,12 +16,7 @@
 Softlayer driver
 """
 
-import sys
 import time
-
-import libcloud
-
-from libcloud.utils.py3 import xmlrpclib
 
 from libcloud.common.base import ConnectionUserAndKey
 from libcloud.common.xmlrpc import XMLRPCResponse, XMLRPCConnection

--- a/libcloud/compute/drivers/vcloud.py
+++ b/libcloud/compute/drivers/vcloud.py
@@ -38,7 +38,7 @@ from libcloud.common.types import InvalidCredsError, LibcloudError
 from libcloud.compute.providers import Provider
 from libcloud.compute.types import NodeState
 from libcloud.compute.base import Node, NodeDriver, NodeLocation
-from libcloud.compute.base import NodeSize, NodeImage, NodeAuthPassword
+from libcloud.compute.base import NodeSize, NodeImage
 
 """
 From vcloud api "The VirtualQuantity element defines the number of MB

--- a/libcloud/loadbalancer/drivers/gce.py
+++ b/libcloud/loadbalancer/drivers/gce.py
@@ -13,11 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import simplejson as json
-except ImportError:
-    import json
-
 from libcloud.loadbalancer.base import LoadBalancer, Member, Driver, Algorithm
 from libcloud.compute.drivers.gce import GCEConnection, GCENodeDriver
 

--- a/libcloud/storage/drivers/azure_blobs.py
+++ b/libcloud/storage/drivers/azure_blobs.py
@@ -15,14 +15,10 @@
 
 from __future__ import with_statement
 
-import time
 import base64
-import hmac
-import re
 import os
 import binascii
 
-from hashlib import sha256
 from xml.etree.ElementTree import Element, SubElement
 
 from libcloud.utils.py3 import PY3
@@ -31,7 +27,7 @@ from libcloud.utils.py3 import urlquote
 from libcloud.utils.py3 import tostring
 from libcloud.utils.py3 import b
 
-from libcloud.utils.xml import fixxpath, findtext
+from libcloud.utils.xml import fixxpath
 from libcloud.utils.files import read_in_chunks
 from libcloud.common.types import LibcloudError
 from libcloud.common.azure import AzureConnection

--- a/libcloud/storage/drivers/nimbus.py
+++ b/libcloud/storage/drivers/nimbus.py
@@ -17,11 +17,6 @@ import time
 import hashlib
 import hmac
 
-try:
-    import simplejson as json
-except ImportError:
-    import json
-
 from libcloud.utils.py3 import httplib
 from libcloud.utils.py3 import urlencode
 

--- a/libcloud/storage/drivers/s3.py
+++ b/libcloud/storage/drivers/s3.py
@@ -22,7 +22,6 @@ import sys
 from hashlib import sha1
 from xml.etree.ElementTree import Element, SubElement
 
-from libcloud.utils.py3 import PY3
 from libcloud.utils.py3 import httplib
 from libcloud.utils.py3 import urlquote
 from libcloud.utils.py3 import urlencode

--- a/libcloud/utils/py3.py
+++ b/libcloud/utils/py3.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Skip flake8 for this file as it raises many warnings about unused imports.
+# flake8: noqa
+
 # Libcloud Python 2.x and 3.x compatibility layer
 # Some methods bellow are taken from Django PYK3 port which is licensed under 3
 # clause BSD license


### PR DESCRIPTION
`flake8` emits warnings for names that are imported but not used. In most cases, these either look like copy/pasted import blocks, or names left in from debugging or after refactoring. Common unused names are the `sys` or `time` modules, and base classes. Some modules were doing an import dance to get `simplejson` or standard `json`, but those modules no longer parse json directly, likely as the result of refactoring it to a lower level.

The `libcloud.utils.py3` module contains a lot of these unused imports, but that's intentional. Because of that, it includes a `flake8: noqa` comment near the top of the file to tell `flake8` to ignore it.
