### PR TITLE
#issue-421 supporting kt ucloud storage driver

### DIFF
--- a/libcloud/storage/drivers/ktucloud.py
+++ b/libcloud/storage/drivers/ktucloud.py
@@ -1,0 +1,53 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from libcloud.common.types import MalformedResponseError, LibcloudError
+from libcloud.storage.providers import Provider
+
+from libcloud.storage.drivers.cloudfiles import CloudFilesConnection
+from libcloud.storage.drivers.cloudfiles import CloudFilesStorageDriver
+
+KTUCLOUDSTORAGE_AUTH_URL = "https://ssproxy.ucloudbiz.olleh.com/"
+KTUCLOUDSTORAGE_API_VERSION = "1.0"
+KTUCLOUDSTORAGE_AUTH_URI = '/auth/v1.0'
+
+class KTUCloudStorageConnection(CloudFilesConnection):
+    """
+    Connection class for the KT UCloud Storage endpoint.
+    """
+
+    auth_url = KTUCLOUDSTORAGE_AUTH_URL
+    _auth_version = KTUCLOUDSTORAGE_API_VERSION
+    auth_uri = KTUCLOUDSTORAGE_AUTH_URI
+
+    def get_endpoint(self):
+        eps = self.service_catalog.get_endpoints(name='cloudFiles')
+        if len(eps) == 0:
+            raise LibcloudError('Could not find specified endpoint')
+        ep = eps[0]
+        if 'publicURL' in ep:
+            return ep['publicURL']
+        else:
+            raise LibcloudError('Could not find specified endpoint')
+
+class KTUCloudStorageDriver(CloudFilesStorageDriver):
+    """
+    Cloudfiles storage driver for the UK endpoint.
+    """
+
+    type = Provider.KTUCLOUD
+    name = 'KTUCloud Storage'
+    connectionCls = KTUCloudStorageConnection
+

--- a/libcloud/storage/providers.py
+++ b/libcloud/storage/providers.py
@@ -46,6 +46,8 @@ DRIVERS = {
     ('libcloud.storage.drivers.local', 'LocalStorageDriver'),
     Provider.AZURE_BLOBS:
     ('libcloud.storage.drivers.azure_blobs', 'AzureBlobsStorageDriver'),
+    Provider.KTUCLOUD:
+    ('libcloud.storage.drivers.ktucloud', 'KTUCloudStorageDriver'),
 
     # Deprecated
     Provider.CLOUDFILES_US:

--- a/libcloud/storage/types.py
+++ b/libcloud/storage/types.py
@@ -57,6 +57,7 @@ class Provider(object):
     LOCAL = 'local'
     CLOUDFILES = 'cloudfiles'
     AZURE_BLOBS = 'azure_blobs'
+    KTUCLOUD = 'ktucloud'
 
     # Deperecated
     CLOUDFILES_US = 'cloudfiles_us'


### PR DESCRIPTION
kt ucloud storage is based on swift.
but kt customized it.
so default cloudfiles driver doesn't work for it.

so I patched 2 thigns.
1. using auth_uri variable to change auth url address.
 for example:
  currently cloudfiles driver's auth entry point is fixed. so we can't change it.
  to set auth_uri, now we can change it.
1. add ktucloud storage driver.
   It is inherited cloudfiles.py and set some parameters. 
   so it is very easy  to read.
