### PR TITLE
[LIBCLOUD-428] Fix auth token caching and re-use in the OpenStack based drivers

### DIFF
--- a/docs/compute/drivers/openstack.rst
+++ b/docs/compute/drivers/openstack.rst
@@ -78,6 +78,16 @@ component of the URL (``12345`` in the example bellow).
 4. Skipping normal authentication flow and hitting the API endpoint directly using the ``ex_force_auth_token`` argument
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+This is an advanced use cases which assumes you manage authentication and token
+retrieval yourself.
+
+If you use this argument, the driver won't hit authentication service and as
+such, won't be aware of the token expiration time.
+
+This means auth token will be considered valid for the whole life time of the
+driver instance and you will need to manually re-instantiate a driver with a new
+token before the currently used one is about to expire.
+
 .. literalinclude:: /examples/compute/openstack/force_auth_token.py
    :language: python
 
@@ -108,6 +118,9 @@ between different requests.
 
 This means that driver will only hit authentication service and obtain auth
 token on the first request or if the auth token is about to expire.
+
+As noted in the example 4 above, this doesn't hold true if you use
+``ex_force_auth_token`` argument.
 
 Troubleshooting
 ---------------

--- a/libcloud/test/compute/fixtures/openstack/_v1_1__auth.json
+++ b/libcloud/test/compute/fixtures/openstack/_v1_1__auth.json
@@ -2,7 +2,7 @@
     "auth": {
         "token": {
             "id": "aaaaaaaaaaaa-bbb-cccccccccccccc",
-            "expires": "2011-11-23T21:00:14-06:00"
+            "expires": "2031-11-23T21:00:14-06:00"
         },
         "serviceCatalog": {
             "cloudFilesCDN": [

--- a/libcloud/test/compute/fixtures/openstack/_v2_0__auth.json
+++ b/libcloud/test/compute/fixtures/openstack/_v2_0__auth.json
@@ -2,7 +2,7 @@
     "access": {
         "token": {
             "id": "aaaaaaaaaaaa-bbb-cccccccccccccc",
-            "expires": "2011-11-23T21:00:14.000-06:00"
+            "expires": "2031-11-23T21:00:14.000-06:00"
         },
         "serviceCatalog": [
             {

--- a/libcloud/test/compute/fixtures/openstack/_v2_0__auth_deployment.json
+++ b/libcloud/test/compute/fixtures/openstack/_v2_0__auth_deployment.json
@@ -2,7 +2,7 @@
     "access": {
         "token": {
             "id": "aaaaaaaaaaaa-bbb-cccccccccccccc",
-            "expires": "2011-11-23T21:00:14.000-06:00"
+            "expires": "2031-11-23T21:00:14.000-06:00"
         },
         "serviceCatalog": [
             {

--- a/libcloud/test/compute/fixtures/openstack/_v2_0__auth_lon.json
+++ b/libcloud/test/compute/fixtures/openstack/_v2_0__auth_lon.json
@@ -2,7 +2,7 @@
     "access": {
         "token": {
             "id": "aaaaaaaaaaaa-bbb-cccccccccccccc",
-            "expires": "2011-11-23T21:00:14.000-06:00"
+            "expires": "2031-11-23T21:00:14.000-06:00"
         },
         "serviceCatalog": [
             {

--- a/libcloud/test/dns/fixtures/rackspace/auth_1_1.json
+++ b/libcloud/test/dns/fixtures/rackspace/auth_1_1.json
@@ -2,7 +2,7 @@
    "auth":{
       "token":{
          "id":"fooo-bar-fooo-bar-fooo-bar",
-         "expires":"2011-10-29T17:39:28.000-05:00"
+         "expires":"2031-10-29T17:39:28.000-05:00"
       },
       "serviceCatalog":{
          "cloudFilesCDN":[

--- a/libcloud/test/dns/fixtures/rackspace/auth_2_0.json
+++ b/libcloud/test/dns/fixtures/rackspace/auth_2_0.json
@@ -2,7 +2,7 @@
     "access": {
         "token": {
             "id": "aaaaaaaaaaaa-bbb-cccccccccccccc",
-            "expires": "2011-11-23T21:00:14.000-06:00"
+            "expires": "2031-11-23T21:00:14.000-06:00"
         },
         "serviceCatalog": [
             {

--- a/libcloud/test/loadbalancer/fixtures/rackspace/_v2_0__auth.json
+++ b/libcloud/test/loadbalancer/fixtures/rackspace/_v2_0__auth.json
@@ -2,7 +2,7 @@
     "access": {
         "token": {
             "id": "aaaaaaaaaaaa-bbb-cccccccccccccc",
-            "expires": "2011-11-23T21:00:14.000-06:00"
+            "expires": "2031-11-23T21:00:14.000-06:00"
         },
         "serviceCatalog": [
             {

--- a/libcloud/test/loadbalancer/fixtures/rackspace/auth_2_0.json
+++ b/libcloud/test/loadbalancer/fixtures/rackspace/auth_2_0.json
@@ -2,7 +2,7 @@
     "access": {
         "token": {
             "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-            "expires": "2012-03-14T08:10:14.000-05:00"
+            "expires": "2031-03-14T08:10:14.000-05:00"
         },
         "serviceCatalog": [
             {

--- a/libcloud/test/storage/fixtures/cloudfiles/_v2_0__auth.json
+++ b/libcloud/test/storage/fixtures/cloudfiles/_v2_0__auth.json
@@ -2,7 +2,7 @@
     "access": {
         "token": {
             "id": "aaaaaaaaaaaa-bbb-cccccccccccccc",
-            "expires": "2011-11-23T21:00:14.000-06:00"
+            "expires": "2031-11-23T21:00:14.000-06:00"
         },
         "serviceCatalog": [
             {


### PR DESCRIPTION
This branch fixes an issue described in LIBCLOUD-436 (https://issues.apache.org/jira/browse/LIBCLOUD-428).

As noted in the ticket description, the problem is that current version of code doesn't properly check if the token has expired before using it. This causes `InvalidCredsError` exception to be thrown if the token has expired. 

This is usually a non-issue for short running scripts, but if you are using a driver in a long running process, there is a bigger chance that the token will expire during the life-time of the process and as such, the exception will be thrown. 

While working on this bug, I also discovered an issue with `ex_force_auth_token` argument. Currently we support skipping the authentication process by passing a valid auth token to the driver constructor using `ex_force_auth_token` argument.

The problem is that we don't know about the token expiration time when this argument is used. Ss such, we can't invalidate the token when it's about to expire. My solution to this problem was documenting this behavior better in the documentation.

As you can see in the diff, I also needed to update the fixtures for tests to pass. The approach that I used is not ideal since it's basically a ticking time bomb, but I opted for a simple and less time-consuming solution at this point and hopefully we will figure a better one by 2031 :P
