### PR TITLE
GCE don't send field description in image if it doesn't exist or blank

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -2470,7 +2470,7 @@ class GCENodeDriver(NodeDriver):
         """
         extra = {}
         extra['preferredKernel'] = image['preferredKernel']
-        extra['description'] = image['description']
+        extra['description'] = image.get('description', None)
         extra['creationTimestamp'] = image['creationTimestamp']
         extra['selfLink'] = image['selfLink']
         return NodeImage(id=image['id'], name=image['name'], driver=self,

--- a/libcloud/test/compute/fixtures/gce/global_images.json
+++ b/libcloud/test/compute/fixtures/gce/global_images.json
@@ -15,6 +15,20 @@
       "selfLink": "https://www.googleapis.com/compute/v1beta16/projects/debian-cloud/global/images/debian-7-wheezy-v20130617",
       "sourceType": "RAW",
       "status": "READY"
+    },
+    {
+      "creationTimestamp": "2013-11-18T12:24:21.560-07:00",
+      "id": "1539141992335368259",
+      "kind": "compute#image",
+      "name": "centos-6-v20131118",
+      "preferredKernel": "https://www.googleapis.com/compute/v1beta16/projects/google/global/kernels/gce-v20130603",
+      "rawDisk": {
+        "containerType": "TAR",
+        "source": ""
+      },
+      "selfLink": "https://www.googleapis.com/compute/v1beta16/projects/debian-cloud/global/images/centos-6-v20131118",
+      "sourceType": "RAW",
+      "status": "READY"
     }
   ],
   "kind": "compute#imageList",

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -136,9 +136,10 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
     def test_list_images(self):
         local_images = self.driver.list_images()
         debian_images = self.driver.list_images(ex_project='debian-cloud')
-        self.assertEqual(len(local_images), 1)
+        self.assertEqual(len(local_images), 2)
         self.assertEqual(len(debian_images), 17)
         self.assertEqual(local_images[0].name, 'debian-7-wheezy-v20130617')
+        self.assertEqual(local_images[1].name, 'centos-6-v20131118')
 
     def test_list_locations(self):
         locations = self.driver.list_locations()


### PR DESCRIPTION
Hello

In GCE we can set description for image, but this's not required and we set this field blank. But if this field blank GCE return response without this field. I fix this with tests
