### PR TITLE
LIBCLOUD-433: Make storage backend send content-type of "application/octet-stream" if none is supplied and none can be guessed.

### DIFF
--- a/libcloud/storage/base.py
+++ b/libcloud/storage/base.py
@@ -598,9 +598,9 @@ class StorageDriver(BaseDriver):
             content_type, _ = libcloud.utils.files.guess_file_mime_type(name)
 
             if not content_type:
-                raise AttributeError(
-                    'File content-type could not be guessed and' +
-                    ' no content_type value provided')
+                # Fallback to a content-type that will cause most browsers to
+                # download it again as a binary file.
+                content_type = 'application/octet-stream'
 
         file_size = None
 

--- a/libcloud/test/storage/test_atmos.py
+++ b/libcloud/test/storage/test_atmos.py
@@ -316,17 +316,14 @@ class AtmosTests(unittest.TestCase):
         file_path = os.path.abspath(__file__)
         container = Container(name='fbc', extra={}, driver=self)
         object_name = 'ftu'
-        try:
-            self.driver.upload_object(file_path=file_path, container=container,
-                                      object_name=object_name)
-        except AttributeError:
-            pass
-        else:
-            self.fail(
-                'File content type not provided'
-                ' but an exception was not thrown')
-        finally:
-            libcloud.utils.files.guess_file_mime_type = old_func
+        obj = self.driver.upload_object(file_path=file_path,
+                                        container=container,
+                                        object_name=object_name)
+
+        # Just check that the file was uploaded OK, as the fallback
+        # Content-Type header should be set (application/octet-stream).
+        self.assertEqual(obj.name, object_name)
+        libcloud.utils.files.guess_file_mime_type = old_func
 
     def test_upload_object_error(self):
         def dummy_content_type(name):

--- a/libcloud/test/storage/test_cloudfiles.py
+++ b/libcloud/test/storage/test_cloudfiles.py
@@ -439,17 +439,13 @@ class CloudFilesTests(unittest.TestCase):
         file_path = os.path.abspath(__file__)
         container = Container(name='foo_bar_container', extra={}, driver=self)
         object_name = 'foo_test_upload'
-        try:
-            self.driver.upload_object(file_path=file_path, container=container,
-                                      object_name=object_name)
-        except AttributeError:
-            pass
-        else:
-            self.fail(
-                'File content type not provided'
-                ' but an exception was not thrown')
-        finally:
-            libcloud.utils.files.guess_file_mime_type = old_func
+
+        obj = self.driver.upload_object(file_path=file_path, verify_hash=False,
+                                        container=container,
+                                        object_name=object_name)
+
+        self.assertEqual(obj.name, object_name)
+        libcloud.utils.files.guess_file_mime_type = old_func
 
     def test_upload_object_error(self):
         def dummy_content_type(name):


### PR DESCRIPTION
https://issues.apache.org/jira/browse/LIBCLOUD-433
