### PR TITLE
LIBCLOUD-434: route53 replace list_* with iterate_*

### DIFF
--- a/libcloud/dns/drivers/route53.py
+++ b/libcloud/dns/drivers/route53.py
@@ -111,17 +111,11 @@ class Route53DNSDriver(DNSDriver):
         RecordType.TXT: 'TXT'
     }
 
-    def list_zones(self):
-        data = self.connection.request(API_ROOT + 'hostedzone').object
-        zones = self._to_zones(data=data)
-        return zones
+    def iterate_zones(self):
+        return self._get_more('zones')
 
-    def list_records(self, zone):
-        self.connection.set_context({'zone_id': zone.id})
-        uri = API_ROOT + 'hostedzone/' + zone.id + '/rrset'
-        data = self.connection.request(uri).object
-        records = self._to_records(data=data, zone=zone)
-        return records
+    def iterate_records(self, zone):
+        return self._get_more('records', zone=zone)
 
     def get_zone(self, zone_id):
         self.connection.set_context({'zone_id': zone_id})
@@ -308,3 +302,40 @@ class Route53DNSDriver(DNSDriver):
         record = Record(id=id, name=name, type=type, data=data, zone=zone,
                         driver=self, extra=extra)
         return record
+
+    def _get_more(self, rtype, **kwargs):
+        exhausted = False
+        last_key = None
+        while not exhausted:
+            items, last_key, exhausted = self._get_data(rtype, last_key,
+                                                        **kwargs)
+            for item in items:
+                yield item
+
+    def _get_data(self, rtype, last_key, **kwargs):
+        params = {}
+        if last_key:
+            params['name'] = last_key
+        path = API_ROOT + 'hostedzone'
+        
+        if rtype == 'zones':
+            response = self.connection.request(path, params=params)
+            transform_func = self._to_zones
+        elif rtype == 'records':
+            zone = kwargs['zone']
+            path += '/{}/rrset'.format(zone.id)
+            response = self.connection.request(path, params=params)
+            transform_func = self._to_records
+
+        if response.status == httplib.OK:
+            is_truncated = findtext(element=response.object,
+                                    xpath='IsTruncated',
+                                    namespace=NAMESPACE)
+            exhausted = is_truncated != 'true'
+            last_key = findtext(element=response.object,
+                                xpath='NextRecordName',
+                                namespace=NAMESPACE)
+            items = transform_func(data=response.object, **kwargs)
+            return items, last_key, exhausted
+        else:
+            return [], None, True

--- a/libcloud/dns/drivers/route53.py
+++ b/libcloud/dns/drivers/route53.py
@@ -317,13 +317,13 @@ class Route53DNSDriver(DNSDriver):
         if last_key:
             params['name'] = last_key
         path = API_ROOT + 'hostedzone'
-        
+
         if rtype == 'zones':
             response = self.connection.request(path, params=params)
             transform_func = self._to_zones
         elif rtype == 'records':
             zone = kwargs['zone']
-            path += '/{}/rrset'.format(zone.id)
+            path += '/%s/rrset' % zone.id
             response = self.connection.request(path, params=params)
             transform_func = self._to_records
 

--- a/libcloud/dns/drivers/route53.py
+++ b/libcloud/dns/drivers/route53.py
@@ -324,6 +324,7 @@ class Route53DNSDriver(DNSDriver):
         elif rtype == 'records':
             zone = kwargs['zone']
             path += '/%s/rrset' % zone.id
+            self.connection.set_context({'zone_id': zone.id})
             response = self.connection.request(path, params=params)
             transform_func = self._to_records
 


### PR DESCRIPTION
The Route53 API returns a maximum of 100 records per request. This change implements iterate_zones and iterate_records methods.
