### PR TITLE
Add methods ex_add/ex_delete port_forwarding_rule to CloudstackNode (similar to ip_forwarding_rule)

### DIFF
--- a/libcloud/compute/drivers/cloudstack.py
+++ b/libcloud/compute/drivers/cloudstack.py
@@ -42,15 +42,35 @@ class CloudStackNode(Node):
         "Release a public IP that this node holds."
         return self.driver.ex_release_public_ip(self, address)
 
-    def ex_add_ip_forwarding_rule(self, address, protocol, start_port,
-                                  end_port=None):
+    def ex_create_ip_forwarding_rule(self, address, protocol,
+                                     start_port, end_port=None):
         "Add a NAT/firewall forwarding rule for a port or ports."
-        return self.driver.ex_add_ip_forwarding_rule(self, address, protocol,
-                                                     start_port, end_port)
+        return self.driver.ex_create_ip_forwarding_rule(self, address,
+                                                        protocol,
+                                                        start_port, end_port)
+
+    def ex_create_port_forwarding_rule(self, address,
+                                       private_port, public_port,
+                                       protocol,
+                                       public_end_port=None,
+                                       private_end_port=None,
+                                       openfirewall=True):
+        "Add a port forwarding rule for port or ports."
+        return self.driver.ex_create_port_forwarding_rule(self, address,
+                                                          private_port,
+                                                          public_port,
+                                                          protocol,
+                                                          public_end_port,
+                                                          private_end_port,
+                                                          openfirewall)
 
     def ex_delete_ip_forwarding_rule(self, rule):
-        "Delete a NAT/firewall rule."
+        "Delete a port forwarding rule."
         return self.driver.ex_delete_ip_forwarding_rule(self, rule)
+
+    def ex_delete_port_forwarding_rule(self, rule):
+        "Delete a NAT/firewall rule."
+        return self.driver.ex_delete_port_forwarding_rule(self, rule)
 
     def ex_start(self):
         "Starts a stopped virtual machine"
@@ -886,8 +906,9 @@ class CloudStackNodeDriver(CloudStackDriverMixIn, NodeDriver):
 
         return rules
 
-    def ex_create_port_forwarding_rule(self, address, private_port,
-                                       public_port, protocol, node,
+    def ex_create_port_forwarding_rule(self, node, address,
+                                       private_port, public_port,
+                                       protocol,
                                        public_end_port=None,
                                        private_end_port=None,
                                        openfirewall=True):
@@ -960,8 +981,8 @@ class CloudStackNodeDriver(CloudStackDriverMixIn, NodeDriver):
                                   method='GET')
         return res['success']
 
-    def ex_add_ip_forwarding_rule(self, node, address, protocol,
-                                  start_port, end_port=None):
+    def ex_create_ip_forwarding_rule(self, node, address, protocol,
+                                     start_port, end_port=None):
         """
         "Add a NAT/firewall forwarding rule.
 

--- a/libcloud/test/compute/test_cloudstack.py
+++ b/libcloud/test/compute/test_cloudstack.py
@@ -421,11 +421,11 @@ class CloudStackCommonTestCase(TestCaseMixin):
         public_end_port = 34
         openfirewall = True
         protocol = 'TCP'
-        rule = self.driver.ex_create_port_forwarding_rule(address,
+        rule = self.driver.ex_create_port_forwarding_rule(node,
+                                                          address,
                                                           private_port,
                                                           public_port,
                                                           protocol,
-                                                          node,
                                                           public_end_port,
                                                           private_end_port,
                                                           openfirewall)
@@ -453,6 +453,37 @@ class CloudStackCommonTestCase(TestCaseMixin):
         rule = self.driver.ex_list_port_forwarding_rules()[0]
         res = self.driver.ex_delete_port_forwarding_rule(node, rule)
         self.assertTrue(res)
+
+    def test_node_ex_delete_port_forwarding_rule(self):
+        node = self.driver.list_nodes()[0]
+        self.assertEqual(len(node.extra['port_forwarding_rules']), 1)
+        node.extra['port_forwarding_rules'][0].delete()
+        self.assertEqual(len(node.extra['port_forwarding_rules']), 0)
+
+    def test_node_ex_create_port_forwarding_rule(self):
+        node = self.driver.list_nodes()[0]
+        self.assertEqual(len(node.extra['port_forwarding_rules']), 1)
+        address = self.driver.ex_list_public_ips()[0]
+        private_port = 33
+        private_end_port = 34
+        public_port = 33
+        public_end_port = 34
+        openfirewall = True
+        protocol = 'TCP'
+        rule = node.ex_create_port_forwarding_rule(address,
+                                                   private_port,
+                                                   public_port,
+                                                   protocol,
+                                                   public_end_port,
+                                                   private_end_port,
+                                                   openfirewall)
+        self.assertEqual(rule.address, address)
+        self.assertEqual(rule.protocol, protocol)
+        self.assertEqual(rule.public_port, public_port)
+        self.assertEqual(rule.public_end_port, public_end_port)
+        self.assertEqual(rule.private_port, private_port)
+        self.assertEqual(rule.private_end_port, private_end_port)
+        self.assertEqual(len(node.extra['port_forwarding_rules']), 2)
 
 
 class CloudStackTestCase(CloudStackCommonTestCase, unittest.TestCase):


### PR DESCRIPTION
Hi!

I have added port forwarding method to CloudstackNode object because class CloudstackPortForwardingRule has a method delete which doesn't work. And change call signature because node object was not in first place

And want ask about naming of port forwarding methods. We have ex_add_ip_forwarding_rule and ex_create_port_forwarding_rule maybe rename one of this?
