### PR TITLE
LIBCLOUD-439

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -892,7 +892,7 @@ Changes with Apache Libcloud 0.12.1:
 
    - Add missing 'deletd' -> terminated mapping to OpenStack driver.
      (LIBCLOUD-276)
-     [Jayyy V]
+     [Jayy Vis]
 
    - Fix create_node in OpenStack driver to work correctly if 'adminPass'
      attribute is not present in the response. (LIBCLOUD-292)

--- a/CHANGES
+++ b/CHANGES
@@ -1894,208 +1894,209 @@ Changes with Apache Libcloud 0.5.2
 
 Changes with Apache Libcloud 0.5.0
 
-    *) Existing APIs directly on the libcloud.* module have been
-       deprecated and will be removed in version 0.6.0.  Most methods
-       were moved to the libcloud.compute.* module.
+    - Existing APIs directly on the libcloud.* module have been
+      deprecated and will be removed in version 0.6.0.  Most methods
+      were moved to the libcloud.compute.* module.
 
-    *) Add new libcloud.loadbalancers API, with initial support for:
-        - GoGrid Load Balancers
-        - Rackspace Load Balancers
+    - Add new libcloud.loadbalancers API, with initial support for:
+       - GoGrid Load Balancers
+       - Rackspace Load Balancers
+     [Roman Bogorodskiy]
+
+    - Add new libcloud.storage API, with initial support for:
+       - Amazon S3
+       - Rackspace CloudFiles
+      [Tomaz Muraus]
+
+    - Add new libcloud.compute drivers for:
+       - Bluebox [Christian Paredes]
+       - Gandi.net [Aymeric Barantal]
+       - Nimbus [David LaBissoniere]
+       - OpenStack [Roman Bogorodskiy]
+       - Opsource.net [Joe Miller]
+
+    - Added "pricing" module and improved pricing handling.
+      [Tomaz Muraus]
+
+    - Updates to the GoGrid compute driver:
+       - Use API version 1.0.
+       - Remove sandbox flag.
+       - Add ex_list_ips() to list IP addresses assigned to the account.
+       - Implement ex_edit_image method which allows changing image attributes
+         like name, description and make image public or private.
       [Roman Bogorodskiy]
 
-    *) Add new libcloud.storage API, with initial support for:
-        - Amazon S3
-        - Rackspace CloudFiles
-       [Tomaz Muraus]
+    - Updates to the Amazon EC2 compute driver:
+       - When creating a Node, use the name argument to set a Tag with the
+         value.  [Tomaz Muraus]
+       - Add extension method for modifying node attributes and changing the
+         node size. [Tomaz Muraus]
+       - Add support for the new Amazon Region (Tokyo). [Tomaz Muraus]
+       - Added ex_create_tags and ex_delete_tags. [Brandon Rhodes]
+       - Include node Elastic IP addresses in the node public_ip attribute
+         for the EC2 nodes. [Tomaz Muraus]
+       - Use ipAddress and privateIpAddress attribute for the EC 2node public
+         and private ip. [Tomaz Muraus]
+       - Add ex_describe_addresses method to the EC2 driver. [Tomaz Muraus]
 
-    *) Add new libcloud.compute drivers for:
-        - Bluebox [Christian Paredes]
-        - Gandi.net [Aymeric Barantal]
-        - Nimbus [David LaBissoniere]
-        - OpenStack [Roman Bogorodskiy]
-        - Opsource.net [Joe Miller]
+    - Updates to the Rackspace CloudServers compute driver:
+       - Add ex_rebuild() and ex_get_node_details() [Andrew Klochkov]
+       - Expose URI of a Rackspace node to the node meta data. [Paul Querna]
 
-    *) Added "pricing" module and improved pricing handling.
-       [Tomaz Muraus]
-
-    *) Updates to the GoGrid compute driver:
-        - Use API version 1.0.
-        - Remove sandbox flag.
-        - Add ex_list_ips() to list IP addresses assigned to the account.
-        - Implement ex_edit_image method which allows changing image attributes
-          like name, description and make image public or private.
-       [Roman Bogorodskiy]
-
-    *) Updates to the Amazon EC2 compute driver:
-        - When creating a Node, use the name argument to set a Tag with the
-          value.  [Tomaz Muraus]
-        - Add extension method for modifying node attributes and changing the
-          node size. [Tomaz Muraus]
-        - Add support for the new Amazon Region (Tokyo). [Tomaz Muraus]
-        - Added ex_create_tags and ex_delete_tags. [Brandon Rhodes]
-        - Include node Elastic IP addresses in the node public_ip attribute
-          for the EC2 nodes. [Tomaz Muraus]
-        - Use ipAddress and privateIpAddress attribute for the EC 2node public
-          and private ip. [Tomaz Muraus]
-        - Add ex_describe_addresses method to the EC2 driver. [Tomaz Muraus]
-
-    *) Updates to the Rackspace CloudServers compute driver:
-        - Add ex_rebuild() and ex_get_node_details() [Andrew Klochkov]
-        - Expose URI of a Rackspace node to the node meta data. [Paul Querna]
-
-    *) Minor fixes to get the library and tests working on Python 2.7 and PyPy.
-       [Tomaz Muraus]
+    - Minor fixes to get the library and tests working on Python 2.7 and PyPy.
+      [Tomaz Muraus]
 
 Changes with Apache Libcloud 0.4.2 (Released January 18, 2011)
 
-    *) Fix EC2 create_node to become backward compatible for
-       NodeLocation.
-       [Tomaž Muraus]
+    - Fix EC2 create_node to become backward compatible for
+      NodeLocation.
+      [Tomaz Muraus]
 
-    *) Update code for compatibility with CPython 2.5
-       [Jerry Chen]
+    - Update code for compatibility with CPython 2.5
+      [Jerry Chen]
 
-    *) Implement ex_edit_node method for GoGrid driver which allows
-       changing node attributes like amount of RAM or description.
-       [Roman Bogorodskiy]
+    - Implement ex_edit_node method for GoGrid driver which allows
+      changing node attributes like amount of RAM or description.
+      [Roman Bogorodskiy]
 
-    *) Add ex_set_password and ex_set_server_name to Rackspace driver.
-       [Peter Herndon, Paul Querna]
+    - Add ex_set_password and ex_set_server_name to Rackspace driver.
+      [Peter Herndon, Paul Querna]
 
-    *) Add Hard and Soft reboot methods to Rackspace driver.
-       [Peter Herndon]
+    - Add Hard and Soft reboot methods to Rackspace driver.
+      [Peter Herndon]
 
-    *) EC2 Driver availability zones, via ex_list_availability_zones;
-       list_locations rewrite to include availablity zones
-       [Tomaž Muraus]
+    - EC2 Driver availability zones, via ex_list_availability_zones;
+      list_locations rewrite to include availablity zones
+      [Tomaz Muraus]
 
-    *) EC2 Driver Idempotency capability in create_node; LIBCLOUD-69
-       [David LaBissoniere]
+    - EC2 Driver Idempotency capability in create_node; LIBCLOUD-69
+      [David LaBissoniere]
 
-    *) SSL Certificate Name Verification:
-       - libcloud.security module
-       - LibcloudHTTPSConnection, LibcloudHTTPConnection (alias)
-       - Emits warning when not verifying, or CA certs not found
+    - SSL Certificate Name Verification:
+      - libcloud.security module
+      - LibcloudHTTPSConnection, LibcloudHTTPConnection (alias)
+      - Emits warning when not verifying, or CA certs not found
 
-    *) Append ORD1 to available Rackspace location, but keep in the
-       same node as DFW1, because it's not readable or writeable from
-       the API.
-       [Per suggestion of Grig Gheorghiu]
+    - Append ORD1 to available Rackspace location, but keep in the
+      same node as DFW1, because it's not readable or writeable from
+      the API.
+      [Per suggestion of Grig Gheorghiu]
 
-    *) ex_create_ip_group, ex_list_ip_groups, ex_delete_ip_group,
-       ex_share_ip, ex_unshare_ip, ex_list_ip_addresses additions
-       to Rackspace driver
-       [Andrew Klochkov]
+    - ex_create_ip_group, ex_list_ip_groups, ex_delete_ip_group,
+      ex_share_ip, ex_unshare_ip, ex_list_ip_addresses additions
+      to Rackspace driver
+      [Andrew Klochkov]
 
-    *) New driver for CloudSigma.
-       [Tomaž Muraus]
+    - New driver for CloudSigma.
+      [Tomaz Muraus]
 
-    *) New driver for Brightbox Cloud. (LIBCLOUD-63)
-       [Tim Fletcher]
+    - New driver for Brightbox Cloud. (LIBCLOUD-63)
+      [Tim Fletcher]
 
-    *) Deployment capability to ElasticHosts
-       [Tomaž Muraus]
+    - Deployment capability to ElasticHosts
+      [Tomaz Muraus]
 
-    *) Allow deploy_node to use non-standard SSH username and port
-       [Tomaž Muraus]
+    - Allow deploy_node to use non-standard SSH username and port
+      [Tomaz Muraus]
 
-    *) Added Rackspace UK (London) support
-       [Chmouel Boudjnah]
+    - Added Rackspace UK (London) support
+      [Chmouel Boudjnah]
 
-    *) GoGrid driver: add support for locations, i.e. listing
-       of locations and creation of a node in specified
-       location
-       [Roman Bogorodskiy]
+    - GoGrid driver: add support for locations, i.e. listing
+      of locations and creation of a node in specified
+      location
+      [Roman Bogorodskiy]
 
-    *) GoGrid and Rackspace drivers: add ex_save_image() extra
-       call to convert running node to an image
-       [Roman Bogorodskiy]
+    - GoGrid and Rackspace drivers: add ex_save_image() extra
+      call to convert running node to an image
+      [Roman Bogorodskiy]
 
-    *) GoGrid driver: add support for creating 'sandbox' server
-       and populate isSandbox flag in node's extra information.
-       [Roman Bogorodskiy]
+    - GoGrid driver: add support for creating 'sandbox' server
+      and populate isSandbox flag in node's extra information.
+      [Roman Bogorodskiy]
 
-    *) Add ImportKeyPair and DescribeKeyPair to EC2. (LIBCLOUD-62)
-       [Philip Schwartz]
+    - Add ImportKeyPair and DescribeKeyPair to EC2. (LIBCLOUD-62)
+      [Philip Schwartz]
 
-    *) Update EC2 driver and test fixtures for new API.
-       [Philip Schwartz]
+    - Update EC2 driver and test fixtures for new API.
+      [Philip Schwartz]
 
 Changes with Apache Libcloud 0.4.0 [Released October 6, 2010]
 
-    *) Add create keypair functionality to EC2 Drivers. (LIBCLOUD-57)
-       [Grig Gheorghiu]
+    - Add create keypair functionality to EC2 Drivers. (LIBCLOUD-57)
+      [Grig Gheorghiu]
 
-    *) Improve handling of GoGrid accounts with limited access
-       API keys. [Paul Querna]
+    - Improve handling of GoGrid accounts with limited access
+      API keys.
+      [Paul Querna]
 
-    *) New Driver for ElasticHosts. (LIBCLOUD-45)
-       [Tomaz Muraus]
+    - New Driver for ElasticHosts. (LIBCLOUD-45)
+      [Tomaz Muraus]
 
-    *) Use more consistent name for GoGrid driver and use http
-       POST method for 'unsafe' operations
-       [Russell Haering]
+    - Use more consistent name for GoGrid driver and use http
+      POST method for 'unsafe' operations
+      [Russell Haering]
 
-    *) Implement password handling and add deployment support
-       for GoGrid nodes.
-       [Roman Bogorodskiy]
+    - Implement password handling and add deployment support
+      for GoGrid nodes.
+      [Roman Bogorodskiy]
 
-    *) Fix behavior of GoGrid's create_node to wait for a Node ID.
-       [Roman Bogorodskiy]
+    - Fix behavior of GoGrid's create_node to wait for a Node ID.
+      [Roman Bogorodskiy]
 
-    *) Add ex_create_node_nowait to GoGrid driver if you don't need to
-       wait for a Node ID when creating a node.
-       [Roman Bogorodskiy]
+    - Add ex_create_node_nowait to GoGrid driver if you don't need to
+      wait for a Node ID when creating a node.
+      [Roman Bogorodskiy]
 
-    *) Removed libcloud.interfaces module.
-       [Paul Querna]
+    - Removed libcloud.interfaces module.
+      [Paul Querna]
 
-    *) Removed dependency on zope.interfaces.
-       [Paul Querna]
+    - Removed dependency on zope.interfaces.
+      [Paul Querna]
 
-    *) RimuHosting moved API endpoint address.
-       [Paul Querna]
+    - RimuHosting moved API endpoint address.
+      [Paul Querna]
 
-    *) Fix regression and error in GoGrid driver for parsing node objects.
-       [Roman Bogorodskiy]
+    - Fix regression and error in GoGrid driver for parsing node objects.
+      [Roman Bogorodskiy]
 
-    *) Added more test cases for GoGrid driver. (LIBCLOUD-34)
-       [Roman Bogorodskiy, Jerry Chen]
+    - Added more test cases for GoGrid driver. (LIBCLOUD-34)
+      [Roman Bogorodskiy, Jerry Chen]
 
-    *) Fix parsing of Slicehost nodes with multiple Public IP addresses.
-       [Paul Querna]
+    - Fix parsing of Slicehost nodes with multiple Public IP addresses.
+      [Paul Querna]
 
-    *) Add exit_status to ScriptDeployment. (LIBCLOUD-36)
-       [Paul Querna]
+    - Add exit_status to ScriptDeployment. (LIBCLOUD-36)
+      [Paul Querna]
 
-    *) Update prices for several drivers.
+    - Update prices for several drivers.
        [Brad Morgan, Paul Querna]
 
-    *) Update Linode driver to reflect new plan sizes.
-       [Jed Smith]
+    - Update Linode driver to reflect new plan sizes.
+      [Jed Smith]
 
-    *) Change default of 'location' in Linode create_node. (LIBCLOUD-41)
+    - Change default of 'location' in Linode create_node. (LIBCLOUD-41)
        [Jed Smith, Steve Steiner]
 
-    *) Document the Linode driver.
-       [Jed Smith]
+    - Document the Linode driver.
+      [Jed Smith]
 
-    *) Request a private, LAN IP address at Linode creation.
-       [Jed Smith]
+    - Request a private, LAN IP address at Linode creation.
+      [Jed Smith]
 
 Changes with Apache Libcloud 0.3.1 [Released May 11, 2010]
 
-    *) Updates to Apache License blocks to correctly reflect status as an
+    - Updates to Apache License blocks to correctly reflect status as an
        Apache Project.
 
-    *) Fix NOTICE file to use 2010 copyright date.
+    - Fix NOTICE file to use 2010 copyright date.
 
-    *) Improve error messages for when running the test cases without
+    - Improve error messages for when running the test cases without
        first setting up a secrets.py
 
 Changes with Apache Libcloud 0.3.0 [Tagged May 6, 2010, not released]
 
-    *) New Drivers for:
+    - New Drivers for:
       - Dreamhost
       - Eucalyptus
       - Enomaly ECP
@@ -2103,22 +2104,22 @@ Changes with Apache Libcloud 0.3.0 [Tagged May 6, 2010, not released]
       - OpenNebula
       - SoftLayer
 
-    *) Added new deployment and bootstrap API.
+    - Added new deployment and bootstrap API.
 
-    *) Improved Voxel driver.
+    - Improved Voxel driver.
 
-    *) Added support for Amazon EC2 Asia Pacific (Singapore) Region.
+    - Added support for Amazon EC2 Asia Pacific (Singapore) Region.
 
-    *) Improved test coverage for all drivers.
+    - Improved test coverage for all drivers.
 
-    *) Add support for multiple security groups in EC2.
+    - Add support for multiple security groups in EC2.
 
-    *) Fixed bug in Rackspace and RimuHosting when using multiple threads.
+    - Fixed bug in Rackspace and RimuHosting when using multiple threads.
 
-    *) Improved debugging and logging of HTTP requests.
+    - Improved debugging and logging of HTTP requests.
 
-    *) Improved documentation for all classes and methods.
+    - Improved documentation for all classes and methods.
 
 Changes with Apache Libcloud 0.2.0 [Tagged February 2, 2010]
 
-    *) First public release.
+    - First public release.

--- a/CHANGES
+++ b/CHANGES
@@ -71,13 +71,15 @@ Changes with Apache Libcloud in development
      [Tomaz Muraus]
 
    - Bump API version used in the EC2 driver from 2010-08-21 to 2013-10-15.
+     (LIBCLOUD-454)
      [Tomaz Muraus]
 
    - Add ex_get_limits method for retrieving account resource limits to the
      EC2 driver.
      [Tomaz Muraus]
 
-   - Add c3 instance types to the us-west-1 region in the EC2 driver.
+   - Update us-west-1 region in the EC2 driver to include c3 instance types.
+     Also include pricing information.
      [Tomaz Muraus]
 
   *) Storage

--- a/contrib/generate_contributor_list.py
+++ b/contrib/generate_contributor_list.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python
+#
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+#
+# Script which generates markdown formatted list of contributors. It generates
+# this list by parsing the "CHANGES" file.
+
+from __future__ import with_statement
+
+import re
+import argparse
+from collections import defaultdict
+
+JIRA_URL = 'https://issues.apache.org/jira/browse/LIBCLOUD-%s'
+GITHUB_URL = 'https://github.com/apache/libcloud/pull/%s'
+
+
+def parse_changes_file(file_path):
+    """
+    Parse CHANGES file and return a dictionary with contributors.
+
+    Dictionary maps contributor name to the JIRA tickets or Github pull
+    requests the user has worked on.
+    """
+    # Maps contributor name to a list of JIRA tickets
+    contributors_map = defaultdict(set)
+
+    in_entry = False
+    active_tickets = []
+
+    with open(file_path, 'r') as fp:
+        for line in fp:
+            line = line.strip()
+
+            if line.startswith('-') or line.startswith('*)'):
+                in_entry = True
+                active_tickets = []
+
+            if in_entry and line == '':
+                in_entry = False
+
+            if in_entry:
+                match = re.search(r'\((.+?)\)$', line)
+
+                if match:
+                    active_tickets = match.groups()[0]
+                    active_tickets = active_tickets.split(', ')
+                    active_tickets = [ticket for ticket in active_tickets if
+                                      ticket.startswith('LIBCLOUD-') or
+                                      ticket.startswith('GITHUB-')]
+
+                match = re.search(r'^\[(.+?)\]$', line)
+
+                if match:
+                    contributors = match.groups()[0]
+                    contributors = contributors.split(',')
+                    contributors = [name.strip() for name in contributors]
+
+                    for name in contributors:
+                        contributors_map[name].update(set(active_tickets))
+
+    return contributors_map
+
+
+def convert_to_markdown(contributors_map):
+
+    # Contributors are sorted in ascending lexiographical order based on their
+    # last name
+    def compare(item1, item2):
+        lastname1 = item1.split(' ')[-1].lower()
+        lastname2 = item2.split(' ')[-1].lower()
+        return cmp(lastname1, lastname2)
+
+    names = contributors_map.keys()
+    names = sorted(names, cmp=compare)
+
+    result = []
+    for name in names:
+        tickets = contributors_map[name]
+
+        tickets_string = []
+
+        for ticket in tickets:
+            if '-' not in ticket:
+                # Invalid ticket number
+                continue
+
+            number = ticket.split('-')[1]
+
+            if ticket.startswith('LIBCLOUD-'):
+                url = JIRA_URL % (number)
+            elif ticket.startswith('GITHUB-') or ticket.startswith('GH-'):
+                url = GITHUB_URL % (number)
+
+            values = {'ticket': ticket, 'url': url}
+            tickets_string.append('[%(ticket)s](%(url)s)' % values)
+
+        tickets_string = ', '.join(tickets_string)
+        line = '* %(name)s: %(tickets)s' % {'name': name,
+                                            'tickets': tickets_string}
+        result.append(line)
+
+    result = '\n'.join(result)
+    return result
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Assemble provider logos '
+                                                 ' in a single image')
+    parser.add_argument('--changes-path', action='store',
+                        help='Path to the changes file')
+    args = parser.parse_args()
+
+    contributors_map = parse_changes_file(file_path=args.changes_path)
+    markdown = convert_to_markdown(contributors_map=contributors_map)
+
+    print(markdown)

--- a/libcloud/compute/drivers/cloudstack.py
+++ b/libcloud/compute/drivers/cloudstack.py
@@ -1472,18 +1472,18 @@ class CloudStackNodeDriver(CloudStackDriverMixIn, NodeDriver):
         created = data.get('created', False)
         
         extra = {
-            'zoneid': zone_id,
+            'zone_id': zone_id,
             'ip_addresses': [],
             'ip_forwarding_rules': [],
             'port_forwarding_rules': [],
             'password': password,
             'keyname': keypair,
-            'securitygroup': security_groups,
+            'security_group': security_groups,
             'created': created,
-            'imageid': data.get('templateid', None),
-            'imagename': data.get('templatename', None),
-            'sizeid': data.get('serviceofferingid', None),
-            'sizename': data.get('serviceofferingname', None)
+            'image_id': data.get('templateid', None),
+            'image_name': data.get('templatename', None),
+            'size_id': data.get('serviceofferingid', None),
+            'size_name': data.get('serviceofferingname', None)
         }
 
         node = CloudStackNode(id=id, name=name, state=state,

--- a/libcloud/compute/drivers/cloudstack.py
+++ b/libcloud/compute/drivers/cloudstack.py
@@ -1470,7 +1470,7 @@ class CloudStackNodeDriver(CloudStackDriverMixIn, NodeDriver):
             security_groups = [sg['name'] for sg in security_groups]
 
         created = data.get('created', False)
-
+        
         extra = {
             'zoneid': zone_id,
             'ip_addresses': [],
@@ -1479,7 +1479,11 @@ class CloudStackNodeDriver(CloudStackDriverMixIn, NodeDriver):
             'password': password,
             'keyname': keypair,
             'securitygroup': security_groups,
-            'created': created
+            'created': created,
+            'imageid': data.get('templateid', None),
+            'imagename': data.get('templatename', None),
+            'sizeid': data.get('serviceofferingid', None),
+            'sizename': data.get('serviceofferingname', None)
         }
 
         node = CloudStackNode(id=id, name=name, state=state,

--- a/libcloud/compute/drivers/cloudstack.py
+++ b/libcloud/compute/drivers/cloudstack.py
@@ -1470,7 +1470,7 @@ class CloudStackNodeDriver(CloudStackDriverMixIn, NodeDriver):
             security_groups = [sg['name'] for sg in security_groups]
 
         created = data.get('created', False)
-        
+
         extra = {
             'zone_id': zone_id,
             'ip_addresses': [],

--- a/libcloud/test/compute/test_cloudstack.py
+++ b/libcloud/test/compute/test_cloudstack.py
@@ -105,7 +105,7 @@ class CloudStackCommonTestCase(TestCaseMixin):
         self.assertEqual(node.name, 'fred')
         self.assertEqual(node.public_ips, [])
         self.assertEqual(node.private_ips, ['192.168.1.2'])
-        self.assertEqual(node.extra['zoneid'], default_location.id)
+        self.assertEqual(node.extra['zone_id'], default_location.id)
 
     def test_create_node_ex_security_groups(self):
         size = self.driver.list_sizes()[0]
@@ -119,7 +119,7 @@ class CloudStackCommonTestCase(TestCaseMixin):
                                        size=size,
                                        ex_security_groups=sg)
         self.assertEqual(node.name, 'test')
-        self.assertEqual(node.extra['securitygroup'], sg)
+        self.assertEqual(node.extra['security_group'], sg)
         self.assertEqual(node.id, 'fc4fd31a-16d3-49db-814a-56b39b9ef986')
 
     def test_create_node_ex_keyname(self):
@@ -247,7 +247,7 @@ class CloudStackCommonTestCase(TestCaseMixin):
         self.assertEqual(2, len(nodes))
         self.assertEqual('test', nodes[0].name)
         self.assertEqual('2600', nodes[0].id)
-        self.assertEqual([], nodes[0].extra['securitygroup'])
+        self.assertEqual([], nodes[0].extra['security_group'])
         self.assertEqual(None, nodes[0].extra['keyname'])
 
     def test_list_locations(self):


### PR DESCRIPTION
Adds extra attributes to the node instance. Namely image_id, image_name, size_id, size_name and changes zoneid to zone_id and securitygroup to security_group.

Note that ec2 and openstack driver seem to use camelcase for extra attributes...

Updated tests to reflect these changes
