### PR TITLE
Better support for permissions-restricted (IAM) environments on AWS

### DIFF
--- a/libcloud/common/aws.py
+++ b/libcloud/common/aws.py
@@ -110,7 +110,8 @@ class AWSTokenConnection(ConnectionUserAndKey):
                  host=None, port=None, url=None, timeout=None, token=None):
         self.token = token
         super(AWSTokenConnection, self).__init__(user_id, key, secure=secure,
-            host=host, port=port, url=url, timeout=timeout)
+                                                 host=host, port=port, url=url,
+                                                 timeout=timeout)
 
     def add_default_params(self, params):
         # Even though we are adding it to the headers, we need it here too
@@ -178,8 +179,9 @@ class AWSDriver(BaseDriver):
                  api_version=None, region=None, token=None, **kwargs):
         self.token = token
         super(AWSDriver, self).__init__(key, secret=secret, secure=secure,
-            host=host, port=port, api_version=api_version, region=region,
-            token=token, **kwargs)
+                                        host=host, port=port,
+                                        api_version=api_version, region=region,
+                                        token=token, **kwargs)
 
     def _ex_connection_class_kwargs(self):
         kwargs = super(AWSDriver, self)._ex_connection_class_kwargs()

--- a/libcloud/storage/base.py
+++ b/libcloud/storage/base.py
@@ -55,7 +55,7 @@ class Object(object):
     """
 
     def __init__(self, name, size, hash, extra, meta_data, container,
-                 driver):
+                 driver, acl=None):
         """
         :param name: Object name (must be unique per container).
         :type  name: ``str``
@@ -77,6 +77,9 @@ class Object(object):
 
         :param driver: StorageDriver instance.
         :type  driver: :class:`StorageDriver`
+
+        :param acl: ACL information.
+        :type  acl: ``str``
         """
 
         self.name = name
@@ -86,6 +89,7 @@ class Object(object):
         self.extra = extra or {}
         self.meta_data = meta_data or {}
         self.driver = driver
+        self.acl = acl
 
     def get_cdn_url(self):
         return self.driver.get_object_cdn_url(obj=self)

--- a/libcloud/storage/base.py
+++ b/libcloud/storage/base.py
@@ -55,7 +55,7 @@ class Object(object):
     """
 
     def __init__(self, name, size, hash, extra, meta_data, container,
-                 driver, acl=None):
+                 driver):
         """
         :param name: Object name (must be unique per container).
         :type  name: ``str``
@@ -77,9 +77,6 @@ class Object(object):
 
         :param driver: StorageDriver instance.
         :type  driver: :class:`StorageDriver`
-
-        :param acl: ACL information.
-        :type  acl: ``str``
         """
 
         self.name = name
@@ -89,7 +86,6 @@ class Object(object):
         self.extra = extra or {}
         self.meta_data = meta_data or {}
         self.driver = driver
-        self.acl = acl
 
     def get_cdn_url(self):
         return self.driver.get_object_cdn_url(obj=self)

--- a/libcloud/storage/drivers/google_storage.py
+++ b/libcloud/storage/drivers/google_storage.py
@@ -24,7 +24,7 @@ from libcloud.utils.py3 import b
 
 from libcloud.common.base import ConnectionUserAndKey
 
-from libcloud.storage.drivers.s3 import S3StorageDriver, S3Response
+from libcloud.storage.drivers.s3 import BaseS3StorageDriver, S3Response
 from libcloud.storage.drivers.s3 import S3RawResponse
 
 SIGNATURE_IDENTIFIER = 'GOOG1'
@@ -126,7 +126,7 @@ class GoogleStorageConnection(ConnectionUserAndKey):
         return b64_hmac.decode('utf-8')
 
 
-class GoogleStorageDriver(S3StorageDriver):
+class GoogleStorageDriver(BaseS3StorageDriver):
     name = 'Google Storage'
     website = 'http://cloud.google.com/'
     connectionCls = GoogleStorageConnection
@@ -134,9 +134,3 @@ class GoogleStorageDriver(S3StorageDriver):
     namespace = NAMESPACE
     supports_chunked_encoding = False
     supports_s3_multipart_upload = False
-
-    # Security tokens are not actually a feature of Google Storage
-    def _ex_connection_class_kwargs(self):
-        kwargs = super(GoogleStorageDriver, self)._ex_connection_class_kwargs()
-        kwargs.pop('token', None)
-        return kwargs

--- a/libcloud/storage/drivers/google_storage.py
+++ b/libcloud/storage/drivers/google_storage.py
@@ -134,3 +134,9 @@ class GoogleStorageDriver(S3StorageDriver):
     namespace = NAMESPACE
     supports_chunked_encoding = False
     supports_s3_multipart_upload = False
+
+    # Security tokens are not actually a feature of Google Storage
+    def _ex_connection_class_kwargs(self):
+        kwargs = super(GoogleStorageDriver, self)._ex_connection_class_kwargs()
+        kwargs.pop('token', None)
+        return kwargs

--- a/libcloud/storage/drivers/s3.py
+++ b/libcloud/storage/drivers/s3.py
@@ -89,7 +89,7 @@ class S3RawResponse(S3Response, RawResponse):
 
 class BaseS3Connection(ConnectionUserAndKey):
     """
-    Repersents a single connection to the S3 Endpoint
+    Represents a single connection to the S3 Endpoint
     """
 
     host = 's3.amazonaws.com'

--- a/libcloud/storage/drivers/s3.py
+++ b/libcloud/storage/drivers/s3.py
@@ -787,11 +787,15 @@ class S3StorageDriver(StorageDriver):
 
         content_type = extra.get('content_type', None)
         meta_data = extra.get('meta_data', None)
+        acl = extra.get('acl', None)
 
         if meta_data:
             for key, value in list(meta_data.items()):
                 key = 'x-amz-meta-%s' % (key)
                 headers[key] = value
+
+        if acl:
+            headers['x-amz-acl'] = acl
 
         request_path = self._get_object_path(container, object_name)
 
@@ -822,7 +826,7 @@ class S3StorageDriver(StorageDriver):
             obj = Object(
                 name=object_name, size=bytes_transferred, hash=server_hash,
                 extra=None, meta_data=meta_data, container=container,
-                driver=self)
+                driver=self, acl=acl)
 
             return obj
         else:

--- a/libcloud/storage/drivers/s3.py
+++ b/libcloud/storage/drivers/s3.py
@@ -295,13 +295,14 @@ class BaseS3StorageDriver(StorageDriver):
 
     def get_container(self, container_name):
         try:
-            response = self.connection.request('/%s'%container_name, method='HEAD')
+            response = self.connection.request('/%s' % container_name,
+                                               method='HEAD')
             if response.status == httplib.NOT_FOUND:
                 raise ContainerDoesNotExistError(value=None, driver=self,
                                                  container_name=container_name)
         except InvalidCredsError:
-            # This just means the user doesn't have IAM permissions to do a HEAD
-            # but other requests might work.
+            # This just means the user doesn't have IAM permissions to do a
+            # HEAD request but other requests might work.
             pass
         return Container(name=container_name, extra=None, driver=self)
 

--- a/libcloud/storage/drivers/s3.py
+++ b/libcloud/storage/drivers/s3.py
@@ -217,7 +217,7 @@ class S3MultipartUpload(object):
 class BaseS3StorageDriver(StorageDriver):
     name = 'Amazon S3 (standard)'
     website = 'http://aws.amazon.com/s3/'
-    connectionCls = S3Connection
+    connectionCls = BaseS3Connection
     hash_type = 'md5'
     supports_chunked_encoding = False
     supports_s3_multipart_upload = True
@@ -917,7 +917,7 @@ class BaseS3StorageDriver(StorageDriver):
 
 
 class S3StorageDriver(AWSDriver, BaseS3StorageDriver):
-    pass
+    connectionCls = S3Connection
 
 
 class S3USWestConnection(S3Connection):

--- a/libcloud/storage/drivers/s3.py
+++ b/libcloud/storage/drivers/s3.py
@@ -831,8 +831,8 @@ class S3StorageDriver(AWSDriver, StorageDriver):
         elif response.status == httplib.OK:
             obj = Object(
                 name=object_name, size=bytes_transferred, hash=server_hash,
-                extra=None, meta_data=meta_data, container=container,
-                driver=self, acl=acl)
+                extra={'acl': acl}, meta_data=meta_data, container=container,
+                driver=self)
 
             return obj
         else:

--- a/libcloud/test/storage/test_google_storage.py
+++ b/libcloud/test/storage/test_google_storage.py
@@ -36,6 +36,10 @@ class GoogleStorageTests(S3Tests):
         # TODO
         pass
 
+    def test_token(self):
+        # Not supported on Google Storage
+        pass
+
 
 if __name__ == '__main__':
     sys.exit(unittest.main())

--- a/libcloud/test/storage/test_s3.py
+++ b/libcloud/test/storage/test_s3.py
@@ -775,7 +775,7 @@ class S3Tests(unittest.TestCase):
                                         verify_hash=True)
         self.assertEqual(obj.name, 'foo_test_upload')
         self.assertEqual(obj.size, 1000)
-        self.assertEqual(obj.acl, 'public-read')
+        self.assertEqual(obj.extra['acl'], 'public-read')
         self.driver_type._upload_file = old_func
 
     def test_upload_empty_object_via_stream(self):

--- a/libcloud/test/storage/test_s3.py
+++ b/libcloud/test/storage/test_s3.py
@@ -67,6 +67,14 @@ class S3MockHttp(StorageMockHttp, MockHttpTestCase):
                 self.base_headers,
                 httplib.responses[httplib.OK])
 
+    def _list_containers_TOKEN(self, method, url, body, headers):
+        self.assertEqual(headers['x-amz-security-token'], 'asdf')
+        body = self.fixtures.load('list_containers_empty.xml')
+        return (httplib.OK,
+                body,
+                self.base_headers,
+                httplib.responses[httplib.OK])
+
     def _list_containers(self, method, url, body, headers):
         body = self.fixtures.load('list_containers.xml')
         return (httplib.OK,
@@ -416,10 +424,9 @@ class S3Tests(unittest.TestCase):
             self.fail('Exception was not thrown')
 
     def test_token(self):
-        self.mock_response_klass.type = 'list_containers'
+        self.mock_response_klass.type = 'list_containers_TOKEN'
         self.driver = self.driver_type(*self.driver_args, token='asdf')
         self.driver.list_containers()
-        # Something here to confirm the header was sent correctly
 
     def test_bucket_is_located_in_different_region(self):
         self.mock_response_klass.type = 'DIFFERENT_REGION'

--- a/libcloud/test/storage/test_s3.py
+++ b/libcloud/test/storage/test_s3.py
@@ -415,6 +415,12 @@ class S3Tests(unittest.TestCase):
         else:
             self.fail('Exception was not thrown')
 
+    def test_token(self):
+        self.mock_response_klass.type = 'list_containers'
+        self.driver = self.driver_type(*self.driver_args, token='asdf')
+        self.driver.list_containers()
+        # Something here to confirm the header was sent correctly
+
     def test_bucket_is_located_in_different_region(self):
         self.mock_response_klass.type = 'DIFFERENT_REGION'
         try:

--- a/libcloud/test/storage/test_s3.py
+++ b/libcloud/test/storage/test_s3.py
@@ -109,7 +109,14 @@ class S3MockHttp(StorageMockHttp, MockHttpTestCase):
                 self.base_headers,
                 httplib.responses[httplib.OK])
 
-    def _test2_test_list_containers(self, method, url, body, headers):
+    def _test2_get_object(self, method, url, body, headers):
+        body = self.fixtures.load('list_container_objects.xml')
+        return (httplib.OK,
+                body,
+                self.base_headers,
+                httplib.responses[httplib.OK])
+
+    def _test2_test_get_object(self, method, url, body, headers):
         # test_get_object
         body = self.fixtures.load('list_containers.xml')
         headers = {'content-type': 'application/zip',
@@ -164,6 +171,25 @@ class S3MockHttp(StorageMockHttp, MockHttpTestCase):
                 body,
                 headers,
                 httplib.responses[httplib.OK])
+
+    def _test1_get_container(self, method, url, body, headers):
+        body = self.fixtures.load('list_container_objects.xml')
+        return (httplib.OK,
+                body,
+                self.base_headers,
+                httplib.responses[httplib.OK])
+
+    def _container1_get_container(self, method, url, body, headers):
+        return (httplib.NOT_FOUND,
+                '',
+                self.base_headers,
+                httplib.responses[httplib.NOT_FOUND])
+
+    def _test_inexistent_get_object(self, method, url, body, headers):
+        return (httplib.NOT_FOUND,
+                '',
+                self.base_headers,
+                httplib.responses[httplib.NOT_FOUND])
 
     def _foo_bar_container(self, method, url, body, headers):
         # test_delete_container
@@ -500,7 +526,7 @@ class S3Tests(unittest.TestCase):
         self.assertTrue('owner' in obj.meta_data)
 
     def test_get_container_doesnt_exist(self):
-        self.mock_response_klass.type = 'list_containers'
+        self.mock_response_klass.type = 'get_container'
         try:
             self.driver.get_container(container_name='container1')
         except ContainerDoesNotExistError:
@@ -509,14 +535,14 @@ class S3Tests(unittest.TestCase):
             self.fail('Exception was not thrown')
 
     def test_get_container_success(self):
-        self.mock_response_klass.type = 'list_containers'
+        self.mock_response_klass.type = 'get_container'
         container = self.driver.get_container(container_name='test1')
         self.assertTrue(container.name, 'test1')
 
     def test_get_object_container_doesnt_exist(self):
         # This method makes two requests which makes mocking the response a bit
         # trickier
-        self.mock_response_klass.type = 'list_containers'
+        self.mock_response_klass.type = 'get_object'
         try:
             self.driver.get_object(container_name='test-inexistent',
                                    object_name='test')
@@ -528,7 +554,7 @@ class S3Tests(unittest.TestCase):
     def test_get_object_success(self):
         # This method makes two requests which makes mocking the response a bit
         # trickier
-        self.mock_response_klass.type = 'list_containers'
+        self.mock_response_klass.type = 'get_object'
         obj = self.driver.get_object(container_name='test2',
                                      object_name='test')
 


### PR DESCRIPTION
This addresses two issues I filed ([LIBCLOUD-497](https://issues.apache.org/jira/browse/LIBCLOUD-497), [LIBCLOUD-498](https://issues.apache.org/jira/browse/LIBCLOUD-498)).

It adds:
- ACL override support for S3 via `extra={'acl': '...'}`
- Support for a `token=` keyword argument on S3 driver (and can be easily added to other AWS drivers) to include the AWS Security Token param/header, which is required when using IAM role-provider credentials or other temporary AS credentials.
- Makes `get_container` on S3 no longer call `list_containers` and otherwise work correctly in an environment with highly restricted permissions. This is a (minorly) backwards incompatible change as `get_container will no longer load the creation time of the bucket. This is not of huge importance, but should be mentioned in the release notes.
