### PR TITLE
Issue LIBCLOUD-499: Add support for ssh_config and proxycommand

### DIFF
--- a/libcloud/compute/ssh.py
+++ b/libcloud/compute/ssh.py
@@ -22,7 +22,7 @@ paramiko_1_10 = False
 try:
     import paramiko
     have_paramiko = True
-    if tuple([ int(d) for d in paramiko.__version__.split(".") ]) > (1,10):
+    if tuple([int(d) for d in paramiko.__version__.split(".")]) > (1, 10):
         paramiko_1_10 = True
 except ImportError:
     pass
@@ -47,6 +47,7 @@ from libcloud.utils.py3 import StringIO
 CHUNK_SIZE = 1024
 
 SSH_CONFIG_FILES = ['/etc/ssh/ssh_config', '~/.ssh/config']
+
 
 class BaseSSHClient(object):
     """

--- a/libcloud/test/compute/fixtures/ssh/ssh_config
+++ b/libcloud/test/compute/fixtures/ssh/ssh_config
@@ -1,0 +1,7 @@
+Host *.host.org
+	IdentityFile /dir/host_org_rsa
+	User root
+	Proxycommand ssh -q -W ssh -q -W %h:%p
+
+Host dummy.host.org
+	Hostname realname.dummy.host.org

--- a/libcloud/test/compute/test_ssh_client.py
+++ b/libcloud/test/compute/test_ssh_client.py
@@ -23,9 +23,12 @@ import tempfile
 import unittest
 
 from libcloud import _init_once
+from libcloud.compute import ssh
+ssh.SSH_CONFIG_FILES = []
 from libcloud.compute.ssh import ParamikoSSHClient
 from libcloud.compute.ssh import ShellOutSSHClient
 from libcloud.compute.ssh import have_paramiko
+from libcloud.test.file_fixtures import ComputeFileFixtures
 
 from mock import patch, Mock
 
@@ -34,6 +37,7 @@ if not have_paramiko:
 
 
 class ParamikoSSHClientTests(unittest.TestCase):
+    fixtures = ComputeFileFixtures('ssh')
 
     @patch('paramiko.SSHClient', Mock)
     def setUp(self):
@@ -183,6 +187,49 @@ class ParamikoSSHClientTests(unittest.TestCase):
 
         self.assertTrue(content.find(expected_msg) != -1)
 
+    @patch('paramiko.SSHClient', Mock)
+    @patch('paramiko.ProxyCommand', Mock)
+    def test_create_with_ssh_config(self):
+        filename = os.path.join(self.fixtures.root,'ssh_config')
+        ssh.SSH_CONFIG_FILES = [filename]
+
+        conn_params = {'hostname': 'dummy.host.org'}
+        mock = ParamikoSSHClient(**conn_params)
+        mock.connect()
+        ssh.SSH_CONFIG_FILES = []
+
+        expected_conn = {'username': 'root',
+                         'allow_agent': True,
+                         'hostname': 'realname.dummy.host.org',
+                         'look_for_keys': True,
+                         'key_filename': ['/dir/host_org_rsa'],
+                         'sock': mock.sock,
+                         'port': 22}
+        mock.client.connect.assert_called_once_with(**expected_conn)
+        self.assertLogMsg('Connecting to server')
+
+    @patch('paramiko.SSHClient', Mock)
+    @patch('paramiko.ProxyCommand', Mock)
+    def test_create_with_ssh_config_and_forced_cred(self):
+        filename = os.path.join(self.fixtures.root,'ssh_config')
+        ssh.SSH_CONFIG_FILES = [filename]
+
+        conn_params = {'hostname': 'dummy.host.org',
+                       'username': 'ubuntu',
+                       'password': 'ubuntu'}
+        mock = ParamikoSSHClient(**conn_params)
+        mock.connect()
+        ssh.SSH_CONFIG_FILES = []
+
+        expected_conn = {'username': 'ubuntu',
+                         'password': 'ubuntu',
+                         'allow_agent': False,
+                         'hostname': 'realname.dummy.host.org',
+                         'look_for_keys': False,
+                         'sock': mock.sock,
+                         'port': 22}
+        mock.client.connect.assert_called_once_with(**expected_conn)
+        self.assertLogMsg('Connecting to server')
 
 if not ParamikoSSHClient:
     class ParamikoSSHClientTests(unittest.TestCase):  # NOQA

--- a/libcloud/test/compute/test_ssh_client.py
+++ b/libcloud/test/compute/test_ssh_client.py
@@ -190,7 +190,7 @@ class ParamikoSSHClientTests(unittest.TestCase):
     @patch('paramiko.SSHClient', Mock)
     @patch('paramiko.ProxyCommand', Mock)
     def test_create_with_ssh_config(self):
-        filename = os.path.join(self.fixtures.root,'ssh_config')
+        filename = os.path.join(self.fixtures.root, 'ssh_config')
         ssh.SSH_CONFIG_FILES = [filename]
 
         conn_params = {'hostname': 'dummy.host.org'}
@@ -211,7 +211,7 @@ class ParamikoSSHClientTests(unittest.TestCase):
     @patch('paramiko.SSHClient', Mock)
     @patch('paramiko.ProxyCommand', Mock)
     def test_create_with_ssh_config_and_forced_cred(self):
-        filename = os.path.join(self.fixtures.root,'ssh_config')
+        filename = os.path.join(self.fixtures.root, 'ssh_config')
         ssh.SSH_CONFIG_FILES = [filename]
 
         conn_params = {'hostname': 'dummy.host.org',


### PR DESCRIPTION
since 1.10 paramiko supports ssh_config parsing and proxycommand.

Proxycommand is essential if you have a ssh gateway between you and your computes. Some big infrastructures does.
