### PR TITLE
Adding/Removing instances from targetpool requires a list.

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -1517,7 +1517,7 @@ class GCENodeDriver(NodeDriver):
         if not hasattr(node, 'name'):
             node = self.ex_get_node(node, 'all')
 
-        targetpool_data = {'instance': node.extra['selfLink']}
+        targetpool_data = {'instances': [{'instance': node.extra['selfLink']}]}
 
         request = '/regions/%s/targetPools/%s/addInstance' % (
             targetpool.region.name, targetpool.name)
@@ -1571,7 +1571,7 @@ class GCENodeDriver(NodeDriver):
         if not hasattr(node, 'name'):
             node = self.ex_get_node(node, 'all')
 
-        targetpool_data = {'instance': node.extra['selfLink']}
+        targetpool_data = {'instances': [{'instance': node.extra['selfLink']}]}
 
         request = '/regions/%s/targetPools/%s/removeInstance' % (
             targetpool.region.name, targetpool.name)


### PR DESCRIPTION
This fixes a bug with attaching/detaching nodes from loadbalancers.
(Attach/Detach wasn't working)

This may have changed in the API at some point after I wrote the initial load balancing implementation, but I'm not sure when.  If so, I missed the change previously.
