### PR TITLE
Support for internal endpoints in cloudfiles

### DIFF
--- a/libcloud/test/storage/test_cloudfiles.py
+++ b/libcloud/test/storage/test_cloudfiles.py
@@ -138,6 +138,14 @@ class CloudFilesTests(unittest.TestCase):
             self.driver.connection.get_endpoint())
         self.driver.connection.cdn_request = False
 
+    def test_endpoint_pointer(self):
+        kwargs = {'use_internal_url': False}
+        driver = CloudFilesStorageDriver('driver', 'dummy', **kwargs)
+        self.assertEquals(driver.connection.endpoint_url, 'publicURL')
+        kwargs = {'use_internal_url': True}
+        driver = CloudFilesStorageDriver('driver', 'dummy', **kwargs)
+        self.assertEquals(driver.connection.endpoint_url, 'internalURL')
+
     def test_list_containers(self):
         CloudFilesMockHttp.type = 'EMPTY'
         containers = self.driver.list_containers()


### PR DESCRIPTION
Sorry for the ugliness of the commit history. I didn't do this cleanly from the start. The diff is clean, however.

Being able to use the internal network endpoint gives significant speed improvements (upwards of a whole second from my brief benchmarking) when your application server and cloudfiles are in the same region/datacenter.

RE: https://github.com/apache/libcloud/pull/186#issuecomment-33209925
