### PR TITLE
Rackspace pagination

### DIFF
--- a/libcloud/dns/drivers/rackspace.py
+++ b/libcloud/dns/drivers/rackspace.py
@@ -167,11 +167,20 @@ class RackspaceDNSDriver(DNSDriver, OpenStackDriverMixin):
             }
             response = self.connection.request(
                 action='/domains/%s' % (zone.id), params=params).object
-            response_data = response['recordsList']['records']
-            for item in response_data:
+            records_list = response['recordsList']
+            for item in records_list['records']:
                 record = self._to_record(data=item, zone=zone)
                 yield record
-            if len(response_data) < limit:
+
+            more = False
+            # Paginated results return links to the previous and next
+            # sets of data, but 'next' only exists when there is more to get.
+            if 'links' in records_list:
+                for item in records_list['links']:
+                    if item['rel'] == 'next':
+                        more = True
+
+            if not more:
                 break
             else:
                 offset += limit

--- a/libcloud/dns/drivers/rackspace.py
+++ b/libcloud/dns/drivers/rackspace.py
@@ -157,7 +157,6 @@ class RackspaceDNSDriver(DNSDriver, OpenStackDriverMixin):
 
     def iterate_records(self, zone):
         self.connection.set_context({'resource': 'zone', 'id': zone.id})
-        records = []
         offset = 0
         limit = 100
         while True:

--- a/libcloud/dns/drivers/rackspace.py
+++ b/libcloud/dns/drivers/rackspace.py
@@ -179,6 +179,7 @@ class RackspaceDNSDriver(DNSDriver, OpenStackDriverMixin):
                 for item in records_list['links']:
                     if item['rel'] == 'next':
                         more = True
+                        break
 
             if not more:
                 break

--- a/libcloud/dns/drivers/rackspace.py
+++ b/libcloud/dns/drivers/rackspace.py
@@ -150,10 +150,24 @@ class RackspaceDNSDriver(DNSDriver, OpenStackDriverMixin):
         RecordType.PTR: 'PTR',
     }
 
-    def list_zones(self):
-        response = self.connection.request(action='/domains')
-        zones = self._to_zones(data=response.object['domains'])
-        return zones
+    def iterate_zones(self):
+        offset = 0
+        limit = 100
+        while True:
+            params = {
+                'limit': limit,
+                'offset': offset,
+            }
+            response = self.connection.request(
+                action='/domains', params=params).object
+            zones_list = response['domains']
+            for item in zones_list:
+                yield self._to_zone(item)
+
+            if _rackspace_result_has_more(response):
+                offset += limit
+            else:
+                break
 
     def iterate_records(self, zone):
         self.connection.set_context({'resource': 'zone', 'id': zone.id})
@@ -318,14 +332,6 @@ class RackspaceDNSDriver(DNSDriver, OpenStackDriverMixin):
                                       (record.zone.id, record.id),
                                       method='DELETE')
         return True
-
-    def _to_zones(self, data):
-        zones = []
-        for item in data:
-            zone = self._to_zone(data=item)
-            zones.append(zone)
-
-        return zones
 
     def _to_zone(self, data):
         id = data['id']


### PR DESCRIPTION
A set of commits to handle Rackspace's pagination of results in their DNS API in the Rackspace driver.

Originally in pull request #190, but moved here to clean it up.
