### PR TITLE
when a request is made to a CDN endpoint there is no internalURL to use,...

### DIFF
--- a/libcloud/storage/drivers/cloudfiles.py
+++ b/libcloud/storage/drivers/cloudfiles.py
@@ -105,6 +105,8 @@ class CloudFilesConnection(OpenStackBaseConnection):
 
     auth_url = AUTH_URL
     _auth_version = '2.0'
+    INTERNAL_URL = 'internalURL'
+    PUBLIC_URL = 'publicURL'
 
     def __init__(self, user_id, key, secure=True,
                  use_internal_url=False, **kwargs):
@@ -113,7 +115,13 @@ class CloudFilesConnection(OpenStackBaseConnection):
         self.api_version = API_VERSION
         self.accept_format = 'application/json'
         self.cdn_request = False
-        self.endpoint_url = 'internalURL' if use_internal_url else 'publicURL'
+        self.use_internal_url = use_internal_url
+
+    def _get_endpoint_url(self):
+        endpoint_url = self.INTERNAL_URL if self.use_internal_url else self.PUBLIC_URL
+        if self.cdn_request:
+            endpoint_url = self.PUBLIC_URL  # cdn endpoints don't have internal urls
+        return endpoint_url
 
     def get_endpoint(self):
         region = self._ex_force_service_region.upper()
@@ -134,12 +142,13 @@ class CloudFilesConnection(OpenStackBaseConnection):
         # if this is a CDN request, return the cdn url instead
         if self.cdn_request:
             ep = cdn_ep
+        endpoint_url = self._get_endpoint_url()
 
         if not ep:
             raise LibcloudError('Could not find specified endpoint')
 
-        if self.endpoint_url in ep:
-            return ep[self.endpoint_url]
+        if endpoint_url in ep:
+            return ep[endpoint_url]
         else:
             raise LibcloudError('Could not find specified endpoint')
 

--- a/libcloud/storage/drivers/cloudfiles.py
+++ b/libcloud/storage/drivers/cloudfiles.py
@@ -52,6 +52,8 @@ from libcloud.common.rackspace import AUTH_URL
 
 CDN_HOST = 'cdn.clouddrive.com'
 API_VERSION = 'v1.0'
+INTERNAL_ENDPOINT_KEY = 'internalURL'
+PUBLIC_ENDPOINT_KEY = 'publicURL'
 
 
 class CloudFilesResponse(Response):
@@ -105,8 +107,6 @@ class CloudFilesConnection(OpenStackBaseConnection):
 
     auth_url = AUTH_URL
     _auth_version = '2.0'
-    INTERNAL_URL = 'internalURL'
-    PUBLIC_URL = 'publicURL'
 
     def __init__(self, user_id, key, secure=True,
                  use_internal_url=False, **kwargs):
@@ -117,11 +117,11 @@ class CloudFilesConnection(OpenStackBaseConnection):
         self.cdn_request = False
         self.use_internal_url = use_internal_url
 
-    def _get_endpoint_url(self):
-        endpoint_url = self.INTERNAL_URL if self.use_internal_url else self.PUBLIC_URL
+    def _get_endpoint_key(self):
+        endpoint_key = INTERNAL_ENDPOINT_KEY if self.use_internal_url else PUBLIC_ENDPOINT_KEY
         if self.cdn_request:
-            endpoint_url = self.PUBLIC_URL  # cdn endpoints don't have internal urls
-        return endpoint_url
+            endpoint_key = PUBLIC_ENDPOINT_KEY  # cdn endpoints don't have internal urls
+        return endpoint_key
 
     def get_endpoint(self):
         region = self._ex_force_service_region.upper()
@@ -142,7 +142,7 @@ class CloudFilesConnection(OpenStackBaseConnection):
         # if this is a CDN request, return the cdn url instead
         if self.cdn_request:
             ep = cdn_ep
-        endpoint_url = self._get_endpoint_url()
+        endpoint_url = self._get_endpoint_key()
 
         if not ep:
             raise LibcloudError('Could not find specified endpoint')

--- a/libcloud/test/storage/test_cloudfiles.py
+++ b/libcloud/test/storage/test_cloudfiles.py
@@ -141,12 +141,12 @@ class CloudFilesTests(unittest.TestCase):
     def test_endpoint_pointer(self):
         kwargs = {'use_internal_url': False}
         driver = CloudFilesStorageDriver('driver', 'dummy', **kwargs)
-        self.assertEquals(driver.connection._get_endpoint_url(), 'publicURL')
+        self.assertEquals(driver.connection._get_endpoint_key(), libcloud.storage.drivers.cloudfiles.PUBLIC_ENDPOINT_KEY)
         kwargs = {'use_internal_url': True}
         driver = CloudFilesStorageDriver('driver', 'dummy', **kwargs)
-        self.assertEquals(driver.connection._get_endpoint_url(), 'internalURL')
+        self.assertEquals(driver.connection._get_endpoint_key(), libcloud.storage.drivers.cloudfiles.INTERNAL_ENDPOINT_KEY)
         driver.connection.cdn_request = True
-        self.assertEquals(driver.connection._get_endpoint_url(), 'publicURL')
+        self.assertEquals(driver.connection._get_endpoint_key(), libcloud.storage.drivers.cloudfiles.PUBLIC_ENDPOINT_KEY)
 
     def test_list_containers(self):
         CloudFilesMockHttp.type = 'EMPTY'

--- a/libcloud/test/storage/test_cloudfiles.py
+++ b/libcloud/test/storage/test_cloudfiles.py
@@ -141,10 +141,12 @@ class CloudFilesTests(unittest.TestCase):
     def test_endpoint_pointer(self):
         kwargs = {'use_internal_url': False}
         driver = CloudFilesStorageDriver('driver', 'dummy', **kwargs)
-        self.assertEquals(driver.connection.endpoint_url, 'publicURL')
+        self.assertEquals(driver.connection._get_endpoint_url(), 'publicURL')
         kwargs = {'use_internal_url': True}
         driver = CloudFilesStorageDriver('driver', 'dummy', **kwargs)
-        self.assertEquals(driver.connection.endpoint_url, 'internalURL')
+        self.assertEquals(driver.connection._get_endpoint_url(), 'internalURL')
+        driver.connection.cdn_request = True
+        self.assertEquals(driver.connection._get_endpoint_url(), 'publicURL')
 
     def test_list_containers(self):
         CloudFilesMockHttp.type = 'EMPTY'


### PR DESCRIPTION
... we have to fall back to the publicURL. This was an oversight on my part with my first pull request  --https://github.com/apache/libcloud/pull/229

And this is the fix
