### PR TITLE
Add 'name' argument to key pair importing examples

### DIFF
--- a/docs/examples/compute/import_key_pair_from_file.py
+++ b/docs/examples/compute/import_key_pair_from_file.py
@@ -10,4 +10,4 @@ Driver = get_driver(Provider.EC2)
 conn = Driver(EC2_ACCESS_ID, EC2_SECRET_KEY)
 
 key_file_path = os.path.expanduser('~/.ssh/id_rsa_my_key_pair_1.pub')
-key_pair = conn.import_key_pair_from_file(key_file_path=key_file_path)
+key_pair = conn.import_key_pair_from_file(name='my_key', key_file_path=key_file_path)

--- a/docs/examples/compute/import_key_pair_from_string.py
+++ b/docs/examples/compute/import_key_pair_from_string.py
@@ -15,4 +15,4 @@ key_file_path = os.path.expanduser('~/.ssh/id_rsa_my_key_pair_1.pub')
 with open(key_file_path, 'r') as fp:
     key_material = fp.read()
 
-key_pair = conn.import_key_pair_from_string(key_material=key_material)
+key_pair = conn.import_key_pair_from_string(name='my_key', key_material=key_material)


### PR DESCRIPTION
The [key pair management](https://libcloud.readthedocs.org/en/latest/compute/key_pair_management.html) examples show two importing methods, from file and string, but leave out the `name` argument.
