### PR TITLE
If you know the name of the container, you shouldn't need to make a call...

### DIFF
--- a/libcloud/storage/drivers/cloudfiles.py
+++ b/libcloud/storage/drivers/cloudfiles.py
@@ -263,6 +263,9 @@ class CloudFilesStorageDriver(StorageDriver, OpenStackDriverMixin):
 
     def get_container_cdn_url(self, container):
         container_name = container.name
+        return self.get_container_cdn_url_from_name(container_name)
+
+    def get_container_cdn_url_from_name(self, container_name):
         response = self.connection.request('/%s' % (container_name),
                                            method='HEAD',
                                            cdn_request=True)


### PR DESCRIPTION
... to get a container obj/dict first, and then another for the cdn url.
