### PR TITLE
LIBCLOUD-509: Add extra dictionary to the NodeSize object within the bas...

### DIFF
--- a/libcloud/compute/base.py
+++ b/libcloud/compute/base.py
@@ -276,28 +276,28 @@ class NodeSize(UuidMixin):
                  driver, extra=None):
         """
         :param id: Size ID.
-        :type id: ``str``
+        :type  id: ``str``
 
         :param name: Size name.
-        :type name: ``str``
+        :type  name: ``str``
 
         :param ram: Amount of memory (in MB) provided by this size.
-        :type ram: ``int``
+        :type  ram: ``int``
 
         :param disk: Amount of disk storage (in GB) provided by this image.
-        :type disk: ``int``
+        :type  disk: ``int``
 
         :param bandwidth: Amount of bandiwdth included with this size.
-        :type bandwidth: ``int``
+        :type  bandwidth: ``int``
 
         :param price: Price (in US dollars) of running this node for an hour.
-        :type price: ``float``
+        :type  price: ``float``
 
-        :param driver: Driver this image belongs to.
-        :type driver: :class:`.NodeDriver`
+        :param driver: Driver this size belongs to.
+        :type  driver: :class:`.NodeDriver`
 
         :param extra: Optional provider specific attributes associated with
-                      this node.
+                      this size.
         :type  extra: ``dict``
         """
         self.id = str(id)

--- a/libcloud/compute/base.py
+++ b/libcloud/compute/base.py
@@ -272,7 +272,8 @@ class NodeSize(UuidMixin):
     4
     """
 
-    def __init__(self, id, name, ram, disk, bandwidth, price, driver):
+    def __init__(self, id, name, ram, disk, bandwidth, price,
+                 driver, extra=None):
         """
         :param id: Size ID.
         :type id: ``str``
@@ -294,6 +295,10 @@ class NodeSize(UuidMixin):
 
         :param driver: Driver this image belongs to.
         :type driver: :class:`.NodeDriver`
+
+        :param extra: Optional provider specific attributes associated with
+                      this node.
+        :type  extra: ``dict``
         """
         self.id = str(id)
         self.name = name
@@ -302,6 +307,7 @@ class NodeSize(UuidMixin):
         self.bandwidth = bandwidth
         self.price = price
         self.driver = driver
+        self.extra = extra or {}
         UuidMixin.__init__(self)
 
     def __repr__(self):

--- a/libcloud/compute/drivers/cloudstack.py
+++ b/libcloud/compute/drivers/cloudstack.py
@@ -589,8 +589,9 @@ class CloudStackNodeDriver(CloudStackDriverMixIn, NodeDriver):
                                  method='GET')
         sizes = []
         for sz in szs['serviceoffering']:
+            extra = {'cpu': sz['cpunumber']}
             sizes.append(NodeSize(sz['id'], sz['name'], sz['memory'], 0, 0,
-                                  0, self))
+                                  0, self, extra=extra))
         return sizes
 
     def create_node(self, **kwargs):

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -259,7 +259,7 @@ class GCENodeSize(NodeSize):
                  extra=None):
         self.extra = extra
         super(GCENodeSize, self).__init__(id, name, ram, disk, bandwidth,
-                                          price, driver)
+                                          price, driver, extra=extra)
 
 
 class GCEProject(UuidMixin):


### PR DESCRIPTION
...e compute API. This will allow additional properties specific to providers to be stored within the object. The GCE driver was updated and the addition of the # of CPUs was added into the CloudStack driver.
