### PR TITLE
NodeState.STOPPED fix for VCloud driver

### DIFF
--- a/libcloud/compute/drivers/vcloud.py
+++ b/libcloud/compute/drivers/vcloud.py
@@ -947,7 +947,7 @@ class VCloud_1_5_NodeDriver(VCloudNodeDriver):
                       '5': NodeState.RUNNING,
                       '6': NodeState.UNKNOWN,
                       '7': NodeState.UNKNOWN,
-                      '8': NodeState.TERMINATED,
+                      '8': NodeState.STOPPED,
                       '9': NodeState.UNKNOWN,
                       '10': NodeState.UNKNOWN}
 

--- a/libcloud/test/compute/test_vcloud.py
+++ b/libcloud/test/compute/test_vcloud.py
@@ -208,13 +208,13 @@ class VCloud_1_5_Tests(unittest.TestCase, TestCaseMixin):
         node = self.driver.ex_undeploy_node(
             Node('https://test/api/vApp/undeployTest', 'testNode', state=0,
                  public_ips=[], private_ips=[], driver=self.driver))
-        self.assertEqual(node.state, NodeState.TERMINATED)
+        self.assertEqual(node.state, NodeState.STOPPED)
 
     def test_ex_undeploy_with_error(self):
         node = self.driver.ex_undeploy_node(
             Node('https://test/api/vApp/undeployErrorTest', 'testNode',
                  state=0, public_ips=[], private_ips=[], driver=self.driver))
-        self.assertEqual(node.state, NodeState.TERMINATED)
+        self.assertEqual(node.state, NodeState.STOPPED)
 
     def test_ex_find_node(self):
         node = self.driver.ex_find_node('testNode')


### PR DESCRIPTION
This fixes up the vCloud drivers to correctly update the Node state to be
STOPPED rather than TERMINATED - a node can be restarted from this state
