### PR TITLE
Support deletion and deprecation of GCE's images.

### DIFF
--- a/libcloud/test/compute/fixtures/gce/global_images_debian_6_squeeze_v20130926_deprecate.json
+++ b/libcloud/test/compute/fixtures/gce/global_images_debian_6_squeeze_v20130926_deprecate.json
@@ -1,0 +1,14 @@
+{
+    "status": "PENDING",
+    "kind": "compute#operation",
+    "name": "operation-1394594316110-4f4604ad0e708-2e4622ab",
+    "startTime": "2014-03-11T20:18:36.194-07:00",
+    "insertTime": "2014-03-11T20:18:36.110-07:00",
+    "targetId": "10034929421075729520",
+    "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/images/debian_6_squeeze_v20130926",
+    "operationType": "setDeprecation",
+    "progress": 0,
+    "id": "11223768474922166090",
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/operations/operation-1394594316110-4f4604ad0e708-2e4622ab",
+    "user": "user@developer.gserviceaccount.com"
+}

--- a/libcloud/test/compute/fixtures/gce/global_images_debian_7_wheezy_v20130617_delete.json
+++ b/libcloud/test/compute/fixtures/gce/global_images_debian_7_wheezy_v20130617_delete.json
@@ -1,0 +1,15 @@
+{
+ "kind": "compute#operation",
+ "id": "10762099380229198553",
+ "name": "operation-global_images_debian7_delete",
+ "operationType": "delete",
+ "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/images/debian-7-wheezy-v20130617",
+ "targetId": "14881612020726561163",
+ "status": "PENDING",
+ "user": "user@developer.gserviceaccount.com",
+ "progress": 0,
+ "insertTime": "2014-03-11T14:37:48.075-07:00",
+ "startTime": "2014-03-11T14:37:48.158-07:00",
+ "endTime": "2014-03-11T14:37:48.634-07:00",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/operations/operation-global_images_debian7_delete"
+}

--- a/libcloud/test/compute/fixtures/gce/operations_operation_global_images_debian7_delete.json
+++ b/libcloud/test/compute/fixtures/gce/operations_operation_global_images_debian7_delete.json
@@ -1,0 +1,15 @@
+{
+ "kind": "compute#operation",
+ "id": "10762099380229198553",
+ "name": "operation-global_images_debian7_delete",
+ "operationType": "delete",
+ "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/images/debian-7-wheezy-v20130617",
+ "targetId": "14881612020726561163",
+ "status": "DONE",
+ "user": "user@developer.gserviceaccount.com",
+ "progress": 100,
+ "insertTime": "2014-03-11T14:37:48.075-07:00",
+ "startTime": "2014-03-11T14:37:48.158-07:00",
+ "endTime": "2014-03-11T14:37:48.634-07:00",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/operations/operation-global_images_debian7_delete"
+}

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -416,6 +416,16 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         destroyed = hc.destroy()
         self.assertTrue(destroyed)
 
+    def test_ex_delete_image(self):
+        image = self.driver.ex_get_image('debian-7')
+        deleted = self.driver.ex_delete_image(image)
+        self.assertTrue(deleted)
+
+    def test_ex_deprecate_image(self):
+        image = self.driver.ex_get_image('debian-6')
+        deprecated = image.deprecate('debian-7', 'DEPRECATED')
+        self.assertTrue(deprecated)
+
     def test_ex_destroy_firewall(self):
         firewall = self.driver.ex_get_firewall('lcfirewall')
         destroyed = firewall.destroy()
@@ -672,6 +682,16 @@ class GCEMockHttp(MockHttpTestCase):
         body = self.fixtures.load('global_images.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
+    def _global_images_debian_7_wheezy_v20130617(
+            self, method, url, body, headers):
+        body = self.fixtures.load('global_images_debian_7_wheezy_v20130617_delete.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _global_images_debian_6_squeeze_v20130926_deprecate(
+            self, method, url, body, headers):
+        body = self.fixtures.load('global_images_debian_6_squeeze_v20130926_deprecate.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
     def _global_networks(self, method, url, body, headers):
         if method == 'POST':
             body = self.fixtures.load('global_networks_post.json')
@@ -717,6 +737,12 @@ class GCEMockHttp(MockHttpTestCase):
             self, method, url, body, headers):
         body = self.fixtures.load(
             'operations_operation_global_httpHealthChecks_lchealthcheck_delete.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _global_operations_operation_global_images_debian7_delete(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'operations_operation_global_images_debian7_delete.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
     def _global_operations_operation_global_httpHealthChecks_lchealthcheck_put(


### PR DESCRIPTION
Add a new class GCENodeImage to represent GCE's images, and support the
`delete` and `deprecated` functions.

Added a new extra field to the image object to specify the deprecation
status.
