### PR TITLE
Add `ex_set_volume_auto_delete` to the GCE driver.

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -1838,6 +1838,33 @@ class GCENodeDriver(NodeDriver):
                                       data='ignored')
         return True
 
+    def ex_set_volume_auto_delete(self, volume, node, auto_delete=True):
+        """
+        Sets the auto-delete flag for a volume attached to a node.
+
+        :param  volume: Volume object to auto-delete
+        :type   volume: :class:`StorageVolume`
+
+        :param   ex_node: Node object to auto-delete volume from
+        :type    ex_node: :class:`Node`
+
+        :keyword auto_delete: Flag to set for the auto-delete value
+        :type    auto_delete: ``bool`` (default True)
+
+        :return:  True if successfull
+        :rtype:   ``bool``
+        """
+        request = '/zones/%s/instances/%s/setDiskAutoDelete' % (
+            node.extra['zone'].name, node.name
+        )
+        delete_params = {
+            'deviceName': volume,
+            'autoDelete': auto_delete,
+        }
+        self.connection.async_request(request, method='POST',
+                                      params=delete_params)
+        return True
+
     def ex_destroy_address(self, address):
         """
         Destroy a static address.

--- a/libcloud/test/compute/fixtures/gce/zones_us_central1_a_instances_node_name_setDiskAutoDelete.json
+++ b/libcloud/test/compute/fixtures/gce/zones_us_central1_a_instances_node_name_setDiskAutoDelete.json
@@ -1,0 +1,16 @@
+{
+ "kind": "compute#operation",
+ "id": "14265294323024381703",
+ "name": "operation-volume-auto-delete",
+ "zone": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a",
+ "operationType": "setDiskAutoDelete",
+ "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/instances/dev-test",
+ "targetId": "4313186599918690450",
+ "status": "PENDING",
+ "user": "user@developer.gserviceaccount.com",
+ "progress": 0,
+ "insertTime": "2014-03-13T21:50:57.612-07:00",
+ "startTime": "2014-03-13T21:50:57.717-07:00",
+ "endTime": "2014-03-13T21:50:58.047-07:00",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/operations/operation-volume-auto-delete"
+}

--- a/libcloud/test/compute/fixtures/gce/zones_us_central1_a_operations_operation_volume_auto_delete.json
+++ b/libcloud/test/compute/fixtures/gce/zones_us_central1_a_operations_operation_volume_auto_delete.json
@@ -1,0 +1,16 @@
+{
+ "kind": "compute#operation",
+ "id": "14265294323024381703",
+ "name": "operation-volume-auto-delete",
+ "zone": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a",
+ "operationType": "setDiskAutoDelete",
+ "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/instances/dev-test",
+ "targetId": "4313186599918690450",
+ "status": "DONE",
+ "user": "user@developer.gserviceaccount.com",
+ "progress": 100,
+ "insertTime": "2014-03-13T21:50:57.612-07:00",
+ "startTime": "2014-03-13T21:50:57.717-07:00",
+ "endTime": "2014-03-13T21:50:58.047-07:00",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/operations/operation-volume-auto-delete"
+}

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -454,6 +454,13 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         destroyed = disk.destroy()
         self.assertTrue(destroyed)
 
+    def test_ex_set_volume_auto_delete(self):
+        node = self.driver.ex_get_node('node-name')
+        volume = node.extra['boot_disk']
+        auto_delete = self.driver.ex_set_volume_auto_delete(
+            volume, node)
+        self.assertTrue(auto_delete)
+
     def test_destroy_volume_snapshot(self):
         snapshot = self.driver.ex_get_snapshot('lcsnapshot')
         destroyed = snapshot.destroy()
@@ -831,6 +838,18 @@ class GCEMockHttp(MockHttpTestCase):
             self, method, url, body, headers):
         body = self.fixtures.load(
             'operations_operation_zones_us-central1-a_disks_lcdisk_delete.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _zones_us_central1_a_instances_node_name_setDiskAutoDelete(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'zones_us_central1_a_instances_node_name_setDiskAutoDelete.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _zones_us_central1_a_operations_operation_volume_auto_delete(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'zones_us_central1_a_operations_operation_volume_auto_delete.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
     def _zones_us_central1_a_operations_operation_zones_us_central1_a_disks_lcdisk_createSnapshot_post(


### PR DESCRIPTION
Sets the auto-delete flag for a volume attached to a node.
