### PR TITLE
Fix for various PEP8 errors.

### DIFF
--- a/docs/examples/compute/cloudstack/security_groups_management.py
+++ b/docs/examples/compute/cloudstack/security_groups_management.py
@@ -17,11 +17,11 @@ pprint(security_group)
 # Authorize an ingress rule on a security group
 # If `startport` is used alone, this will be the only port open
 # If `endport` is also used then the entire range will be authorized
-sg = driver.ex_authorize_security_group_ingress(securitygroupname=
-                                                'test-security-group',
-                                                protocol='tcp',
-                                                startport='22',
-                                                cidrlist='0.0.0.0/0')
+sg = driver.ex_authorize_security_group_ingress(
+    securitygroupname='test-security-group', protocol='tcp', startport='22',
+    cidrlist='0.0.0.0/0'
+)
+
 pprint(sg)
 
 # Delete a security group we have previously created

--- a/libcloud/common/cloudstack.py
+++ b/libcloud/common/cloudstack.py
@@ -107,14 +107,9 @@ class CloudStackConnection(ConnectionUserAndKey, PollingConnection):
 
         # Command is specified as part of GET call
         context['command'] = command
-        result = super(CloudStackConnection, self).async_request(action=action,
-                                                                 params=params,
-                                                                 data=data,
-                                                                 headers=
-                                                                 headers,
-                                                                 method=method,
-                                                                 context=
-                                                                 context)
+        result = super(CloudStackConnection, self).async_request(
+            action=action, params=params, data=data, headers=headers,
+            method=method, context=context)
         return result['jobresult']
 
     def get_request_kwargs(self, action, params=None, data='', headers=None,

--- a/libcloud/common/openstack.py
+++ b/libcloud/common/openstack.py
@@ -604,8 +604,8 @@ class OpenStackBaseConnection(ConnectionUserAndKey):
             self.auth_user_info = osa.auth_user_info
 
             # Pull out and parse the service catalog
-            osc = OpenStackServiceCatalog(osa.urls, ex_force_auth_version=
-                                          self._auth_version)
+            osc = OpenStackServiceCatalog(
+                osa.urls, ex_force_auth_version=self._auth_version)
             self.service_catalog = osc
 
         url = self._ex_force_base_url or self.get_endpoint()

--- a/libcloud/compute/drivers/cloudstack.py
+++ b/libcloud/compute/drivers/cloudstack.py
@@ -289,20 +289,11 @@ class CloudStackNode(Node):
         """
         Add a port forwarding rule for port or ports.
         """
-        return self.driver.ex_create_port_forwarding_rule(node=self,
-                                                          address=
-                                                          address,
-                                                          private_port=
-                                                          private_port,
-                                                          public_port=
-                                                          public_port,
-                                                          protocol=protocol,
-                                                          public_end_port=
-                                                          public_end_port,
-                                                          private_end_port=
-                                                          private_end_port,
-                                                          openfirewall=
-                                                          openfirewall)
+        return self.driver.ex_create_port_forwarding_rule(
+            node=self, address=address, private_port=private_port,
+            public_port=public_port, protocol=protocol,
+            public_end_port=public_end_port, private_end_port=private_end_port,
+            openfirewall=openfirewall)
 
     def ex_delete_ip_forwarding_rule(self, rule):
         """

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -1662,16 +1662,11 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
             group = obj['group'].get('name', None)
             tenant_id = obj['group'].get('tenant_id', None)
 
-        return OpenStackSecurityGroupRule(id=obj['id'],
-                                          parent_group_id=
-                                          obj['parent_group_id'],
-                                          ip_protocol=obj['ip_protocol'],
-                                          from_port=obj['from_port'],
-                                          to_port=obj['to_port'],
-                                          driver=self,
-                                          ip_range=ip_range,
-                                          group=group,
-                                          tenant_id=tenant_id)
+        return OpenStackSecurityGroupRule(
+            id=obj['id'], parent_group_id=obj['parent_group_id'],
+            ip_protocol=obj['ip_protocol'], from_port=obj['from_port'],
+            to_port=obj['to_port'], driver=self, ip_range=ip_range,
+            group=group, tenant_id=tenant_id)
 
     def _to_security_groups(self, obj):
         security_groups = obj['security_groups']

--- a/libcloud/test/compute/test_cloudsigma_v2_0.py
+++ b/libcloud/test/compute/test_cloudsigma_v2_0.py
@@ -388,8 +388,8 @@ class CloudSigmaAPI20BaseTestCase(object):
 
     def test_ex_toggle_subscription_auto_renew(self):
         subscription = self.driver.ex_list_subscriptions()[0]
-        status = self.driver.ex_toggle_subscription_auto_renew(subscription=
-                                                               subscription)
+        status = self.driver.ex_toggle_subscription_auto_renew(
+            subscription=subscription)
         self.assertTrue(status)
 
     def test_ex_list_capabilities(self):

--- a/libcloud/utils/misc.py
+++ b/libcloud/utils/misc.py
@@ -166,7 +166,7 @@ def str2dicts(data):
         value = line[whitespace + 1:]
         d.update({key: value})
 
-    list_data = [value for value in list_data if value != {}]
+    list_data = [val for val in list_data if val != {}]
     return list_data
 
 


### PR DESCRIPTION
pep8 1.5.2 started to report errors when a new line follows the
parameter equal, and when a variable is redefined in a list
comprehension.
