### PR TITLE
restore the connection request_path in case of failed request. 

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -708,10 +708,10 @@ class GCENodeDriver(NodeDriver):
             try:
                 response = self.connection.request(request, method='GET').object
             except:
-                self.connection.request_path = save_request_path
-                raise
+                response = {}
             # Restore the connection request_path
-            self.connection.request_path = save_request_path
+            finally:
+                self.connection.request_path = save_request_path
         list_images = [self._to_node_image(i) for i in
                        response.get('items', [])]
         return list_images

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -705,7 +705,11 @@ class GCENodeDriver(NodeDriver):
             new_request_path = save_request_path.replace(self.project,
                                                          ex_project)
             self.connection.request_path = new_request_path
-            response = self.connection.request(request, method='GET').object
+            try:
+                response = self.connection.request(request, method='GET').object
+            except:
+                self.connection.request_path = save_request_path
+                raise
             # Restore the connection request_path
             self.connection.request_path = save_request_path
         list_images = [self._to_node_image(i) for i in


### PR DESCRIPTION
This could happen if ex_project is specified and request gets ResourceNotFoundError, then request_path will be wrong for all other requests (eg on a script)
