### PR TITLE
Add a deprecated flag to a size for GCE nodes.

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -3125,6 +3125,9 @@ class GCENodeDriver(NodeDriver):
         extra['tags_fingerprint'] = node['tags']['fingerprint']
         extra['scheduling'] = node.get('scheduling', {})
 
+        if (machine_type.get('deprecated')):
+            extra['deprecated'] = True
+
         extra['boot_disk'] = None
         for disk in extra['disks']:
             if disk.get('boot') and disk.get('type') == 'PERSISTENT':


### PR DESCRIPTION
Currently sizes are flagged as deprecated in the Google GCE API

```
'deprecated': {'state': 'OBSOLETE', 'replacement': 'https://www.googleapis.com/compute/v1/projects/clever-span-499/zones/us-central1-a/machineTypes/n1-highmem-4'}
```

But there is no field to indicate this on the returned size.

The code below attaches a 'deprecated' value to 'extra' so it's possible to identify deprecated sizes.
