### PR TITLE
[LIBCLOUD-544] GCE: fix adding node metadata at node creation

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -1196,6 +1196,10 @@ class GCENodeDriver(NodeDriver):
                                               image=image,
                                               use_existing=use_existing_disk)
 
+        if ex_metadata is not None:
+            ex_metadata = {"items": [{"key": k, "value": v}
+                                     for k, v in ex_metadata.items()]}
+
         request, node_data = self._create_node_req(name, size, image,
                                                    location, ex_network,
                                                    ex_tags, ex_metadata,

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -1196,6 +1196,10 @@ class GCENodeDriver(NodeDriver):
                                               image=image,
                                               use_existing=use_existing_disk)
 
+        if ex_metadata != None:
+            ex_metadata = {"items": [{"key": k, "value": v}
+                                     for k, v in ex_metadata.items()]}
+
         request, node_data = self._create_node_req(name, size, image,
                                                    location, ex_network,
                                                    ex_tags, ex_metadata,

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -1196,7 +1196,7 @@ class GCENodeDriver(NodeDriver):
                                               image=image,
                                               use_existing=use_existing_disk)
 
-        if ex_metadata != None:
+        if ex_metadata is not None:
             ex_metadata = {"items": [{"key": k, "value": v}
                                      for k, v in ex_metadata.items()]}
 


### PR DESCRIPTION
Passing a simple metadata dict to create_node GCE driver method doesn't work.
GCE api requires the following structure for metadata:
metadata = {"items": [{"value": "val1", "key": "key1"}, {"value": "val2", "key": "key2"}]}

This fix converts simple dict to what the API wants.
