### PR TITLE
[LIBCLOUD-551] Fix Google DNS to use valid record split character

### DIFF
--- a/libcloud/dns/drivers/google.py
+++ b/libcloud/dns/drivers/google.py
@@ -330,7 +330,7 @@ class GoogleDNSDriver(DNSDriver):
         return records
 
     def _to_record(self, r, zone):
-        record_id = '%s-%s' % (r['name'], r['type'])
+        record_id = '%s:%s' % (r['type'], r['name'])
         return Record(id=record_id, name=r['name'],
                       type=r['type'], data=r, zone=zone,
                       driver=self, extra={})

--- a/libcloud/dns/drivers/google.py
+++ b/libcloud/dns/drivers/google.py
@@ -260,7 +260,7 @@ class GoogleDNSDriver(DNSDriver):
                 }
             ]
         }
-        request = '/managedZones/%s/changes' % (record.zone.id)
+        request = '/managedZones/%s/changes' % (record.zone)
         response = self.connection.request(request, method='POST',
                                            data=data)
         return response.success()

--- a/libcloud/dns/drivers/google.py
+++ b/libcloud/dns/drivers/google.py
@@ -124,7 +124,7 @@ class GoogleDNSDriver(DNSDriver):
 
         :rtype: :class:`Record`
         """
-        (record_name, record_type) = record_id.split('-')
+        (record_type, record_name) = record_id.split(':', 1)
 
         params = {
             'name': record_name,

--- a/libcloud/dns/drivers/google.py
+++ b/libcloud/dns/drivers/google.py
@@ -142,7 +142,8 @@ class GoogleDNSDriver(DNSDriver):
                                         zone_id=zone_id)
 
         if len(response['rrsets']) > 0:
-            return self._to_record(response['rrsets'][0], zone_id)
+            zone = self.get_zone(zone_id)
+            return self._to_record(response['rrsets'][0], zone)
 
         raise RecordDoesNotExistError(value='', driver=self.connection.driver,
                                       record_id=record_id)
@@ -260,7 +261,7 @@ class GoogleDNSDriver(DNSDriver):
                 }
             ]
         }
-        request = '/managedZones/%s/changes' % (record.zone)
+        request = '/managedZones/%s/changes' % (record.zone.id)
         response = self.connection.request(request, method='POST',
                                            data=data)
         return response.success()
@@ -319,8 +320,9 @@ class GoogleDNSDriver(DNSDriver):
 
         extra['creationTime'] = r.get('creationTime')
         extra['nameServers'] = r.get('nameServers')
+        extra['id'] = r.get('id')
 
-        return Zone(id=r['id'], domain=r['dnsName'],
+        return Zone(id=r['name'], domain=r['dnsName'],
                     type='master', ttl=0, driver=self, extra=extra)
 
     def _to_records(self, response, zone):

--- a/libcloud/test/dns/fixtures/google/get_zone_does_not_exists.json
+++ b/libcloud/test/dns/fixtures/google/get_zone_does_not_exists.json
@@ -4,10 +4,10 @@
    {
     "domain": "global",
     "reason": "notFound",
-    "message": "The 'parameters.managedZone' resource named '2' does not exist."
+    "message": "The 'parameters.managedZone' resource named 'example-com' does not exist."
    }
   ],
   "code": 404,
-  "message": "The 'parameters.managedZone' resource named '2' does not exist."
+  "message": "The 'parameters.managedZone' resource named 'example-com' does not exist."
  }
 }

--- a/libcloud/test/dns/fixtures/google/zone.json
+++ b/libcloud/test/dns/fixtures/google/zone.json
@@ -1,0 +1,1 @@
+{"kind": "dns#managedZone", "name": "example-com", "nameServers": ["ns-cloud-e1.googledomains.com.", "ns-cloud-e2.googledomains.com.", "ns-cloud-e3.googledomains.com.", "ns-cloud-e4.googledomains.com."], "creationTime": "2014-03-29T22:45:47.618Z", "dnsName": "example.com.", "id": "1", "description": ""}

--- a/libcloud/test/dns/test_google.py
+++ b/libcloud/test/dns/test_google.py
@@ -74,7 +74,7 @@ class GoogleTests(LibcloudTestCase):
     def test_get_record(self):
         GoogleDNSMockHttp.type = 'FILTER_ZONES'
         zone = self.driver.list_zones()[0]
-        record = self.driver.get_record(zone.id, "foo.example.com.-A")
+        record = self.driver.get_record(zone.id, "A:foo.example.com.")
         self.assertEqual(record.name, 'foo.example.com.')
         self.assertEqual(record.type, 'A')
 
@@ -82,7 +82,7 @@ class GoogleTests(LibcloudTestCase):
         GoogleDNSMockHttp.type = 'ZONE_DOES_NOT_EXIST'
 
         try:
-            self.driver.get_record(2, 'a-a')
+            self.driver.get_record(2, 'a:a')
         except ZoneDoesNotExistError:
             e = sys.exc_info()[1]
             self.assertEqual(e.zone_id, 2)
@@ -92,10 +92,10 @@ class GoogleTests(LibcloudTestCase):
     def test_get_record_record_does_not_exist(self):
         GoogleDNSMockHttp.type = 'RECORD_DOES_NOT_EXIST'
         try:
-            self.driver.get_record(1, "foo-A")
+            self.driver.get_record(1, "A:foo")
         except RecordDoesNotExistError:
             e = sys.exc_info()[1]
-            self.assertEqual(e.record_id, 'foo-A')
+            self.assertEqual(e.record_id, 'A:foo')
         else:
             self.fail('Exception not thrown')
 

--- a/libcloud/test/dns/test_google.py
+++ b/libcloud/test/dns/test_google.py
@@ -56,18 +56,18 @@ class GoogleTests(LibcloudTestCase):
         self.assertEqual(len(records), 3)
 
     def test_get_zone(self):
-        zone = self.driver.get_zone(1)
-        self.assertEqual(zone.id, '1')
+        zone = self.driver.get_zone('example-com')
+        self.assertEqual(zone.id, 'example-com')
         self.assertEqual(zone.domain, 'example.com.')
 
     def test_get_zone_does_not_exist(self):
         GoogleDNSMockHttp.type = 'ZONE_DOES_NOT_EXIST'
 
         try:
-            self.driver.get_zone(2)
+            self.driver.get_zone('example-com')
         except ZoneDoesNotExistError:
             e = sys.exc_info()[1]
-            self.assertEqual(e.zone_id, 2)
+            self.assertEqual(e.zone_id, 'example-com')
         else:
             self.fail('Exception not thrown')
 
@@ -75,24 +75,26 @@ class GoogleTests(LibcloudTestCase):
         GoogleDNSMockHttp.type = 'FILTER_ZONES'
         zone = self.driver.list_zones()[0]
         record = self.driver.get_record(zone.id, "A:foo.example.com.")
+        self.assertEqual(record.id, 'A:foo.example.com.')
         self.assertEqual(record.name, 'foo.example.com.')
         self.assertEqual(record.type, 'A')
+        self.assertEqual(record.zone.id, 'example-com')
 
     def test_get_record_zone_does_not_exist(self):
         GoogleDNSMockHttp.type = 'ZONE_DOES_NOT_EXIST'
 
         try:
-            self.driver.get_record(2, 'a:a')
+            self.driver.get_record('example-com', 'a:a')
         except ZoneDoesNotExistError:
             e = sys.exc_info()[1]
-            self.assertEqual(e.zone_id, 2)
+            self.assertEqual(e.zone_id, 'example-com')
         else:
             self.fail('Exception not thrown')
 
     def test_get_record_record_does_not_exist(self):
         GoogleDNSMockHttp.type = 'RECORD_DOES_NOT_EXIST'
         try:
-            self.driver.get_record(1, "A:foo")
+            self.driver.get_record('example-com', "A:foo")
         except RecordDoesNotExistError:
             e = sys.exc_info()[1]
             self.assertEqual(e.record_id, 'A:foo')
@@ -107,7 +109,7 @@ class GoogleTests(LibcloudTestCase):
         self.assertEqual(len(zone.extra['nameServers']), 4)
 
     def test_delete_zone(self):
-        zone = self.driver.get_zone(1)
+        zone = self.driver.get_zone('example-com')
         res = self.driver.delete_zone(zone)
         self.assertTrue(res)
 
@@ -128,17 +130,17 @@ class GoogleDNSMockHttp(MockHttpTestCase):
         body = self.fixtures.load('zone_list.json')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
-    def _dns_v1beta1_projects_project_name_managedZones_1_rrsets_FILTER_ZONES(
+    def _dns_v1beta1_projects_project_name_managedZones_example_com_rrsets_FILTER_ZONES(
             self, method, url, body, headers):
         body = self.fixtures.load('record.json')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
-    def _dns_v1beta1_projects_project_name_managedZones_1_rrsets(
+    def _dns_v1beta1_projects_project_name_managedZones_example_com_rrsets(
             self, method, url, body, headers):
         body = self.fixtures.load('records_list.json')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
-    def _dns_v1beta1_projects_project_name_managedZones_1(self, method,
+    def _dns_v1beta1_projects_project_name_managedZones_example_com(self, method,
                                                           url, body,
                                                           headers):
         if method == 'GET':
@@ -147,33 +149,38 @@ class GoogleDNSMockHttp(MockHttpTestCase):
             body = None
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
-    def _dns_v1beta1_projects_project_name_managedZones_2_ZONE_DOES_NOT_EXIST(
+    def _dns_v1beta1_projects_project_name_managedZones_example_com_ZONE_DOES_NOT_EXIST(
             self, method, url, body, headers):
         body = self.fixtures.load('get_zone_does_not_exists.json')
         return (httplib.NOT_FOUND, body, {},
                 httplib.responses[httplib.NOT_FOUND])
 
-    def _dns_v1beta1_projects_project_name_managedZones_3_ZONE_DOES_NOT_EXIST(
+    def _dns_v1beta1_projects_project_name_managedZones_example_com_ZONE_DOES_NOT_EXIST(
             self, method, url, body, headers):
         body = self.fixtures.load('get_zone_does_not_exists.json')
         return (httplib.NOT_FOUND, body, {},
                 httplib.responses[httplib.NOT_FOUND])
 
-    def _dns_v1beta1_projects_project_name_managedZones_1_RECORD_DOES_NOT_EXIST(
+    def _dns_v1beta1_projects_project_name_managedZones_example_com_RECORD_DOES_NOT_EXIST(
             self, method, url, body, headers):
         body = self.fixtures.load('managed_zones_1.json')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
-    def _dns_v1beta1_projects_project_name_managedZones_1_rrsets_RECORD_DOES_NOT_EXIST(
+    def _dns_v1beta1_projects_project_name_managedZones_example_com_rrsets_RECORD_DOES_NOT_EXIST(
             self, method, url, body, headers):
         body = self.fixtures.load('no_record.json')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
-    def _dns_v1beta1_projects_project_name_managedZones_2_rrsets_ZONE_DOES_NOT_EXIST(
+    def _dns_v1beta1_projects_project_name_managedZones_example_com_rrsets_ZONE_DOES_NOT_EXIST(
             self, method, url, body, headers):
         body = self.fixtures.load('get_zone_does_not_exists.json')
         return (httplib.NOT_FOUND, body, {},
                 httplib.responses[httplib.NOT_FOUND])
+
+    def _dns_v1beta1_projects_project_name_managedZones_example_com_FILTER_ZONES(
+            self, method, url, body, headers):
+        body = self.fixtures.load('zone.json')
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
 if __name__ == '__main__':
     sys.exit(unittest.main())

--- a/libcloud/test/dns/test_google.py
+++ b/libcloud/test/dns/test_google.py
@@ -140,20 +140,13 @@ class GoogleDNSMockHttp(MockHttpTestCase):
         body = self.fixtures.load('records_list.json')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
-    def _dns_v1beta1_projects_project_name_managedZones_example_com(self, method,
-                                                          url, body,
-                                                          headers):
+    def _dns_v1beta1_projects_project_name_managedZones_example_com(
+            self, method, url, body, headers):
         if method == 'GET':
             body = self.fixtures.load('managed_zones_1.json')
         elif method == 'DELETE':
             body = None
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
-
-    def _dns_v1beta1_projects_project_name_managedZones_example_com_ZONE_DOES_NOT_EXIST(
-            self, method, url, body, headers):
-        body = self.fixtures.load('get_zone_does_not_exists.json')
-        return (httplib.NOT_FOUND, body, {},
-                httplib.responses[httplib.NOT_FOUND])
 
     def _dns_v1beta1_projects_project_name_managedZones_example_com_ZONE_DOES_NOT_EXIST(
             self, method, url, body, headers):


### PR DESCRIPTION
@franckcuny - mind looking this over?

I ran into this because one of my testing domains was foo-bar.com.  When trying to look up a record with get_record(), I formed "foo-bar.com-A" and the get_records()'s split() call failed on unpacking the string.

Looking over other providers, it seems they've all settled on using ':'.  I also swapped the record type / name ordering for unpacking to make it more compatible with the other providers.
