### PR TITLE
openstack: put floating ips in public_ips

### DIFF
--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -2009,13 +2009,15 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
             if label in public_networks_labels:
                 public_ips.extend(ips)
             else:
-                for ip in ips:
-                    # is_private_subnet does not check for ipv6
+                for v in values:
+                    ip = v['addr']
+                    ip_type = v.get('OS-EXT-IPS:type')  # added in grizzly
                     try:
-                        if is_private_subnet(ip):
-                            private_ips.append(ip)
-                        else:
+                        # is_private_subnet does not check for ipv6
+                        if ip_type == 'floating' or not is_private_subnet(ip):
                             public_ips.append(ip)
+                        else:
+                            private_ips.append(ip)
                     except:
                         private_ips.append(ip)
 


### PR DESCRIPTION
This patch use OS-EXT-IPS:type introduced in Nova 2013.1 ("Grizzly") but stay compatible with older version.

This is useful in testing environment where floating ips can be private but we want see them as public.
I'm not sure that you want that merged but I think it could be nice so I propose ...
