### PR TITLE
[LIBCLOUD-554] Add support for providing filters and VPC IDs to EC2: ex_list_networks()

### DIFF
--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -2256,11 +2256,14 @@ class BaseEC2NodeDriver(NodeDriver):
         Return a list of :class:`EC2Network` objects for the
         current region.
 
-        :param      network_ids: One or more VPC IDs
+        :param      network_ids: Return only networks matching the provided
+                                 network IDs. If not specified, a list of all
+                                 the networks in the corresponding region
+                                 is returned.
         :type       network_ids: ``list``
 
         :param      filters: The filters so that the response includes
-                             information for only certain VPCs
+                             information for only certain networks.
         :type       filters: ``dict``
 
         :rtype:     ``list`` of :class:`EC2Network`
@@ -2268,18 +2271,21 @@ class BaseEC2NodeDriver(NodeDriver):
         params = {'Action': 'DescribeVpcs'}
 
         if network_ids is not None:
-            for network_idx, network_id in enumerate(network_ids, 1):
+            for network_idx, network_id in enumerate(network_ids):
+                network_idx += 1 # We want 1-based indexes
                 network_key = 'VpcId.%s' % network_idx
                 params[network_key] = network_id
 
         if filters is not None:
-            for filter_idx, filter_data in enumerate(filters.items(), 1):
+            for filter_idx, filter_data in enumerate(filters.items()):
+                filter_idx += 1 # We want 1-based indexes
                 filter_name, filter_values = filter_data
                 filter_key = 'Filter.%s.Name' % filter_idx
                 params[filter_key] = filter_name
 
                 if isinstance(filter_values, list):
-                    for value_idx, value in enumerate(filter_values, 1):
+                    for value_idx, value in enumerate(filter_values):
+                        value_idx += 1 # We want 1-based indexes
                         value_key = 'Filter.%s.Value.%s' % (filter_idx,
                                                             value_idx)
                         params[value_key] = value

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -919,6 +919,25 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
         self.assertEqual('available', vpcs[1].extra['state'])
         self.assertEqual('dopt-7eded312', vpcs[1].extra['dhcp_options_id'])
 
+    def test_ex_list_networks_network_ids(self):
+        network_ids = ['vpc-532335e1']
+        vpcs = self.driver.ex_list_networks(network_ids=network_ids)
+
+        # result should be one object
+        self.assertEqual(len(vpcs), 1)
+        # object id should match network id we requested
+        self.assertEqual('vpc-532335e1', vpcs[0].id)
+
+    def test_ex_list_networks_network_filters(self):
+        filters = {'dhcp-options-id':'dopt-7eded312', # matches two networks
+                   'cidr': '192.168.51.0/24'} # matches one network
+        vpcs = self.driver.ex_list_networks(filters=filters)
+
+        # result should be one object
+        self.assertEqual(len(vpcs), 1)
+        # object id should match network id with cidr we requested
+        self.assertEqual('vpc-532335e1', vpcs[0].id)
+
     def test_ex_create_network(self):
         vpc = self.driver.ex_create_network('192.168.55.0/24',
                                             name='Test VPC',


### PR DESCRIPTION
EC2 API allows VPC ID and filters to be provided to list only specific VPCs. 
http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeVpcs.html
Add support for specifying filters and vpc ids when listing networks (vpc's) with ec2 driver's method ex_list_networks()
