### PR TITLE
Support for Google-Containers

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -2305,6 +2305,8 @@ class GCENodeDriver(NodeDriver):
                 image = self._match_images('debian-cloud', partial_name)
             elif partial_name.startswith('centos'):
                 image = self._match_images('centos-cloud', partial_name)
+            elif partial_name.startswith('container-vm'):
+                image = self._match_images('google-containers', partial_name)
 
         return image
 


### PR DESCRIPTION
Recently Google have released a google VM Image that comes with docker preinstalled and supports docker provisioning via metadata.

See the documentation here: https://developers.google.com/compute/docs/containers

Toady in libcloud both debian and centos images are supported by matching against the VM name and then injecting the appropiate project name (`debian-cloud` and `centos-cloud`).

This adds support for `google-containers` as well.
