### PR TITLE
[LIBCLOUD-568] Fixing cross service OAuth scopes for Google Compute Engine / DNS / Storage

### DIFF
--- a/libcloud/common/google.py
+++ b/libcloud/common/google.py
@@ -506,10 +506,21 @@ class GoogleBaseConnection(ConnectionUserAndKey, PollingConnection):
                 auth_type = 'SA'
             else:
                 auth_type = 'IA'
-        if 'scope' in kwargs:
-            self.scope = kwargs['scope']
+
+        # Default scopes to read/write for compute, storage, and dns.  Can
+        # override this when calling get_driver() or setting in secrets.py
+        self.scope = None
+        if kwargs and type(kwargs) is dict:
+            self.scope = kwargs.get('scope', None)
             kwargs.pop('scope', None)
+        if not self.scope:
+            self.scope = [
+                'https://www.googleapis.com/auth/compute',
+                'https://www.googleapis.com/auth/devstorage.full_control',
+                'https://www.googleapis.com/auth/ndev.clouddns.readwrite',
+            ]
         self.token_info = self._get_token_info_from_file()
+
         if auth_type == 'SA':
             self.auth_conn = GoogleServiceAcctAuthConnection(
                 user_id, key, self.scope, **kwargs)

--- a/libcloud/common/google.py
+++ b/libcloud/common/google.py
@@ -253,7 +253,7 @@ class GoogleBaseAuthConnection(ConnectionUserAndKey):
     host = 'accounts.google.com'
     auth_path = '/o/oauth2/auth'
 
-    def __init__(self, user_id, key, scope,
+    def __init__(self, user_id, key, scopes=[],
                  redirect_uri='urn:ietf:wg:oauth:2.0:oob',
                  login_hint=None, **kwargs):
         """
@@ -266,9 +266,9 @@ class GoogleBaseAuthConnection(ConnectionUserAndKey):
                      authentication.
         :type   key: ``str``
 
-        :param  scope: A list of urls defining the scope of authentication
+        :param  scopes: A list of urls defining the scope of authentication
                        to grant.
-        :type   scope: ``list``
+        :type   scopes: ``list``
 
         :keyword  redirect_uri: The Redirect URI for the authentication
                                 request.  See Google OAUTH2 documentation for
@@ -280,7 +280,7 @@ class GoogleBaseAuthConnection(ConnectionUserAndKey):
         :type     login_hint: ``str``
         """
 
-        self.scope = " ".join(scope)
+        self.scopes = " ".join(scopes)
         self.redirect_uri = redirect_uri
         self.login_hint = login_hint
 
@@ -329,7 +329,7 @@ class GoogleInstalledAppAuthConnection(GoogleBaseAuthConnection):
         auth_params = {'response_type': 'code',
                        'client_id': self.user_id,
                        'redirect_uri': self.redirect_uri,
-                       'scope': self.scope,
+                       'scope': self.scopes,
                        'state': 'Libcloud Request'}
         if self.login_hint:
             auth_params['login_hint'] = self.login_hint
@@ -426,7 +426,7 @@ class GoogleServiceAcctAuthConnection(GoogleBaseAuthConnection):
 
         # Construct a claim set
         claim_set = {'iss': self.user_id,
-                     'scope': self.scope,
+                     'scope': self.scopes,
                      'aud': 'https://accounts.google.com/o/oauth2/token',
                      'exp': int(time.time()) + 3600,
                      'iat': int(time.time())}
@@ -473,7 +473,7 @@ class GoogleBaseConnection(ConnectionUserAndKey, PollingConnection):
     timeout = 180
 
     def __init__(self, user_id, key, auth_type=None,
-                 credential_file=None, **kwargs):
+                 credential_file=None, scopes=None, **kwargs):
         """
         Determine authentication type, set up appropriate authentication
         connection and get initial authentication information.
@@ -496,6 +496,10 @@ class GoogleBaseConnection(ConnectionUserAndKey, PollingConnection):
         :keyword  credential_file: Path to file for caching authentication
                                    information.
         :type     credential_file: ``str``
+
+        :keyword  scopes: List of OAuth2 scope URLs. The empty default sets
+                          read/write access to Compute, Storage, and DNS.
+        :type     scopes: ``list``
         """
         self.credential_file = credential_file or '~/.gce_libcloud_auth'
 
@@ -509,12 +513,9 @@ class GoogleBaseConnection(ConnectionUserAndKey, PollingConnection):
 
         # Default scopes to read/write for compute, storage, and dns.  Can
         # override this when calling get_driver() or setting in secrets.py
-        self.scope = None
-        if kwargs and type(kwargs) is dict:
-            self.scope = kwargs.get('scope', None)
-            kwargs.pop('scope', None)
-        if not self.scope:
-            self.scope = [
+        self.scopes = scopes
+        if self.scopes is None or not self.scopes:
+            self.scopes = [
                 'https://www.googleapis.com/auth/compute',
                 'https://www.googleapis.com/auth/devstorage.full_control',
                 'https://www.googleapis.com/auth/ndev.clouddns.readwrite',
@@ -523,10 +524,10 @@ class GoogleBaseConnection(ConnectionUserAndKey, PollingConnection):
 
         if auth_type == 'SA':
             self.auth_conn = GoogleServiceAcctAuthConnection(
-                user_id, key, self.scope, **kwargs)
+                user_id, key, self.scopes, **kwargs)
         elif auth_type == 'IA':
             self.auth_conn = GoogleInstalledAppAuthConnection(
-                user_id, key, self.scope, **kwargs)
+                user_id, key, self.scopes, **kwargs)
         else:
             raise GoogleAuthError('auth_type should be \'SA\' or \'IA\'')
 

--- a/libcloud/common/google.py
+++ b/libcloud/common/google.py
@@ -514,7 +514,7 @@ class GoogleBaseConnection(ConnectionUserAndKey, PollingConnection):
         # Default scopes to read/write for compute, storage, and dns.  Can
         # override this when calling get_driver() or setting in secrets.py
         self.scopes = scopes
-        if self.scopes is None or not self.scopes:
+        if not self.scopes:
             self.scopes = [
                 'https://www.googleapis.com/auth/compute',
                 'https://www.googleapis.com/auth/devstorage.full_control',

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -535,7 +535,7 @@ class GCENodeDriver(NodeDriver):
     }
 
     def __init__(self, user_id, key, datacenter=None, project=None,
-                 auth_type=None, **kwargs):
+                 auth_type=None, scopes=None, **kwargs):
         """
         :param  user_id: The email address (for service accounts) or Client ID
                          (for installed apps) to be used for authentication.
@@ -558,12 +558,14 @@ class GCENodeDriver(NodeDriver):
                              If not supplied, auth_type will be guessed based
                              on value of user_id.
         :type     auth_type: ``str``
+
+        :keyword  scopes: List of authorization URLs. Default is empty and
+                          grants read/write to Compute, Storage, DNS.
+        :type     scopes: ``list``
         """
         self.auth_type = auth_type
         self.project = project
-        self.scope = None
-        if kwargs and type(kwargs) is dict:
-            self.scope = kwargs.get('scope', None)
+        self.scopes = scopes
         if not self.project:
             raise ValueError('Project name must be specified using '
                              '"project" keyword.')
@@ -2521,7 +2523,7 @@ class GCENodeDriver(NodeDriver):
     def _ex_connection_class_kwargs(self):
         return {'auth_type': self.auth_type,
                 'project': self.project,
-                'scope': self.scope}
+                'scopes': self.scopes}
 
     def _catch_error(self, ignore_errors=False):
         """

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -68,7 +68,6 @@ class GCEConnection(GoogleBaseConnection):
 
     def __init__(self, user_id, key, secure, auth_type=None,
                  credential_file=None, project=None, **kwargs):
-        self.scope = ['https://www.googleapis.com/auth/compute']
         super(GCEConnection, self).__init__(user_id, key, secure=secure,
                                             auth_type=auth_type,
                                             credential_file=credential_file,
@@ -562,6 +561,9 @@ class GCENodeDriver(NodeDriver):
         """
         self.auth_type = auth_type
         self.project = project
+        self.scope = None
+        if kwargs and type(kwargs) is dict:
+            self.scope = kwargs.get('scope', None)
         if not self.project:
             raise ValueError('Project name must be specified using '
                              '"project" keyword.')
@@ -2518,7 +2520,8 @@ class GCENodeDriver(NodeDriver):
 
     def _ex_connection_class_kwargs(self):
         return {'auth_type': self.auth_type,
-                'project': self.project}
+                'project': self.project,
+                'scope': self.scope}
 
     def _catch_error(self, ignore_errors=False):
         """

--- a/libcloud/dns/drivers/google.py
+++ b/libcloud/dns/drivers/google.py
@@ -36,13 +36,10 @@ class GoogleDNSConnection(GoogleBaseConnection):
     responseCls = GoogleDNSResponse
 
     def __init__(self, user_id, key, secure, auth_type=None,
-                 credential_file=None, project=None):
-        self.scope = [
-            'https://www.googleapis.com/auth/ndev.clouddns.readwrite'
-        ]
+                 credential_file=None, project=None, **kwargs):
         super(GoogleDNSConnection, self).\
             __init__(user_id, key, secure=secure, auth_type=auth_type,
-                     credential_file=credential_file)
+                     credential_file=credential_file, **kwargs)
         self.request_path = '/dns/%s/projects/%s' % (API_VERSION, project)
 
 
@@ -65,13 +62,16 @@ class GoogleDNSDriver(DNSDriver):
         RecordType.TXT: 'TXT',
     }
 
-    def __init__(self, user_id, key, project=None, auth_type=None):
+    def __init__(self, user_id, key, project=None, auth_type=None, **kwargs):
         self.auth_type = auth_type
         self.project = project
+        self.scope = None
+        if kwargs and type(kwargs) is dict:
+            self.scope = kwargs.get('scope', None)
         if not self.project:
             raise ValueError('Project name must be specified using '
                              '"project" keyword.')
-        super(GoogleDNSDriver, self).__init__(user_id, key)
+        super(GoogleDNSDriver, self).__init__(user_id, key, **kwargs)
 
     def iterate_zones(self):
         """
@@ -304,7 +304,8 @@ class GoogleDNSDriver(DNSDriver):
 
     def _ex_connection_class_kwargs(self):
         return {'auth_type': self.auth_type,
-                'project': self.project}
+                'project': self.project,
+                'scope': self.scope}
 
     def _to_zones(self, response):
         zones = []

--- a/libcloud/dns/drivers/google.py
+++ b/libcloud/dns/drivers/google.py
@@ -62,16 +62,15 @@ class GoogleDNSDriver(DNSDriver):
         RecordType.TXT: 'TXT',
     }
 
-    def __init__(self, user_id, key, project=None, auth_type=None, **kwargs):
+    def __init__(self, user_id, key, project=None, auth_type=None, scopes=None,
+                 **kwargs):
         self.auth_type = auth_type
         self.project = project
-        self.scope = None
-        if kwargs and type(kwargs) is dict:
-            self.scope = kwargs.get('scope', None)
+        self.scopes = scopes
         if not self.project:
             raise ValueError('Project name must be specified using '
                              '"project" keyword.')
-        super(GoogleDNSDriver, self).__init__(user_id, key, **kwargs)
+        super(GoogleDNSDriver, self).__init__(user_id, key, scopes, **kwargs)
 
     def iterate_zones(self):
         """
@@ -305,7 +304,7 @@ class GoogleDNSDriver(DNSDriver):
     def _ex_connection_class_kwargs(self):
         return {'auth_type': self.auth_type,
                 'project': self.project,
-                'scope': self.scope}
+                'scopes': self.scopes}
 
     def _to_zones(self, response):
         zones = []

--- a/libcloud/test/common/test_google.py
+++ b/libcloud/test/common/test_google.py
@@ -56,10 +56,13 @@ class GoogleBaseAuthConnectionTest(LibcloudTestCase):
     def setUp(self):
         GoogleBaseAuthConnection.conn_classes = (GoogleAuthMockHttp,
                                                  GoogleAuthMockHttp)
-        self.mock_scope = ['https://www.googleapis.com/auth/foo']
-        kwargs = {'scope': self.mock_scope}
+        self.mock_scopes = ['foo', 'bar']
+        kwargs = {'scopes': self.mock_scopes}
         self.conn = GoogleInstalledAppAuthConnection(*GCE_PARAMS,
                                                      **kwargs)
+
+    def test_scopes(self):
+        self.assertEqual(self.conn.scopes, 'foo bar')
 
     def test_add_default_headers(self):
         old_headers = {}
@@ -88,8 +91,8 @@ class GoogleInstalledAppAuthConnectionTest(LibcloudTestCase):
     def setUp(self):
         GoogleInstalledAppAuthConnection.conn_classes = (GoogleAuthMockHttp,
                                                          GoogleAuthMockHttp)
-        self.mock_scope = ['https://www.googleapis.com/auth/foo']
-        kwargs = {'scope': self.mock_scope}
+        self.mock_scopes = ['https://www.googleapis.com/auth/foo']
+        kwargs = {'scopes': self.mock_scopes}
         self.conn = GoogleInstalledAppAuthConnection(*GCE_PARAMS,
                                                      **kwargs)
 
@@ -128,15 +131,15 @@ class GoogleBaseConnectionTest(LibcloudTestCase):
     def setUp(self):
         GoogleBaseAuthConnection.conn_classes = (GoogleAuthMockHttp,
                                                  GoogleAuthMockHttp)
-        self.mock_scope = ['https://www.googleapis.com/auth/foo']
-        kwargs = {'scope': self.mock_scope, 'auth_type': 'IA'}
+        self.mock_scopes = ['https://www.googleapis.com/auth/foo']
+        kwargs = {'scopes': self.mock_scopes, 'auth_type': 'IA'}
         self.conn = GoogleBaseConnection(*GCE_PARAMS, **kwargs)
 
     def test_auth_type(self):
         self.assertRaises(GoogleAuthError, GoogleBaseConnection, *GCE_PARAMS,
                           **{'auth_type': 'XX'})
 
-        kwargs = {'scope': self.mock_scope}
+        kwargs = {'scopes': self.mock_scopes}
 
         if SHA256:
             kwargs['auth_type'] = 'SA'

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -64,6 +64,9 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         kwargs['datacenter'] = self.datacenter
         self.driver = GCENodeDriver(*GCE_PARAMS, **kwargs)
 
+    def test_default_scopes(self):
+        self.assertEqual(self.driver.scopes, None)
+
     def test_timestamp_to_datetime(self):
         timestamp1 = '2013-06-26T10:05:19.340-07:00'
         datetime1 = datetime.datetime(2013, 6, 26, 17, 5, 19)
@@ -71,10 +74,6 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         timestamp2 = '2013-06-26T17:43:15.000-00:00'
         datetime2 = datetime.datetime(2013, 6, 26, 17, 43, 15)
         self.assertEqual(timestamp_to_datetime(timestamp2), datetime2)
-
-    def test_scope(self):
-        # 'scope' is set in the test/secrets.py file
-        self.assertEqual(self.driver.scope, ['comp', 'blob'])
 
     def test_get_region_from_zone(self):
         zone1 = self.driver.ex_get_zone('us-central1-a')

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -72,6 +72,10 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         datetime2 = datetime.datetime(2013, 6, 26, 17, 43, 15)
         self.assertEqual(timestamp_to_datetime(timestamp2), datetime2)
 
+    def test_scope(self):
+        # 'scope' is set in the test/secrets.py file
+        self.assertEqual(self.driver.scope, ['comp', 'blob'])
+
     def test_get_region_from_zone(self):
         zone1 = self.driver.ex_get_zone('us-central1-a')
         expected_region1 = 'us-central1'

--- a/libcloud/test/dns/test_google.py
+++ b/libcloud/test/dns/test_google.py
@@ -46,9 +46,8 @@ class GoogleTests(LibcloudTestCase):
         kwargs['auth_type'] = 'IA'
         self.driver = GoogleDNSDriver(*DNS_PARAMS_GOOGLE, **kwargs)
 
-    def test_scope(self):
-        # 'scope' set in test/secrets.py file
-        self.assertEqual(self.driver.scope, ['dns'])
+    def test_default_scopes(self):
+        self.assertEqual(self.driver.scopes, None)
 
     def test_list_zones(self):
         zones = self.driver.list_zones()

--- a/libcloud/test/dns/test_google.py
+++ b/libcloud/test/dns/test_google.py
@@ -46,6 +46,10 @@ class GoogleTests(LibcloudTestCase):
         kwargs['auth_type'] = 'IA'
         self.driver = GoogleDNSDriver(*DNS_PARAMS_GOOGLE, **kwargs)
 
+    def test_scope(self):
+        # 'scope' set in test/secrets.py file
+        self.assertEqual(self.driver.scope, ['dns'])
+
     def test_list_zones(self):
         zones = self.driver.list_zones()
         self.assertEqual(len(zones), 2)


### PR DESCRIPTION
Prior to this fix, a user could call "get_driver()" for GCE but authorization was only allowed for the "compute" scope.  With the addition of the DNS module, users calling its "get_driver()" would only be authorized to the DNS service.

This change allows scopes to be set as keyword params in get_driver() (or via secrets.py) that get propagated down to the authorization connection class.  The default behavior is to grant authorization via scopes to all supported google services (compute, storage, dns).

It should be noted that the storage authorization via oauth scopes is bogus, but sets the stage for future enhancements we expect to contribute over the summer.

@wrigri, @franckcuny - A review would be much appreciated!
