### PR TITLE
[LIBCLOUD-569] Removing the overloaded constructor from the rimuhosting ...

### DIFF
--- a/libcloud/compute/drivers/rimuhosting.py
+++ b/libcloud/compute/drivers/rimuhosting.py
@@ -43,16 +43,9 @@ class RimuHostingException(Exception):
 
 
 class RimuHostingResponse(JsonResponse):
-    def __init__(self, response, connection):
-        self.body = response.read()
-        self.status = response.status
-        self.headers = dict(response.getheaders())
-        self.error = response.reason
-        self.connection = connection
-
-        if self.success():
-            self.object = self.parse_body()
-
+    """
+    Response Class for RimuHosting driver
+    """
     def success(self):
         if self.status == 403:
             raise InvalidCredsError()

--- a/libcloud/compute/drivers/rimuhosting.py
+++ b/libcloud/compute/drivers/rimuhosting.py
@@ -307,7 +307,7 @@ class RimuHostingNodeDriver(NodeDriver):
             data['vps_parameters']['memory_mb'] = kwargs['ex_memory_mb']
 
         if 'ex_disk_space_mb' in kwargs:
-            if 'ex_vps_parameters' not in data:
+            if 'vps_parameters' not in data:
                 data['vps_parameters'] = {}
             data['vps_parameters']['disk_space_mb'] = \
                 kwargs['ex_disk_space_mb']


### PR DESCRIPTION
...base class.

Rimu uses gzip'ed responses but the overloaded constructor was not calling the decompress function resuuulting in a MalformedResponseError. All functionality in overloaded constructor already existed in the base clase.
