### PR TITLE
LIBCLOUD-571 subnet-filters for ec2 driver

### DIFF
--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -2459,14 +2459,33 @@ class BaseEC2NodeDriver(NodeDriver):
 
         return element == 'true'
 
-    def ex_list_subnets(self):
+    def ex_list_subnets(self, subnet_ids=None, filters=None):
         """
         Return a list of :class:`EC2NetworkSubnet` objects for the
         current region.
 
+        :param      subnet_ids: Return only subnets matching the provided
+                                subnet IDs. If not specified, a list of all
+                                the subnets in the corresponding region
+                                is returned.
+        :type       subnet_ids: ``list``
+
+        :param      filters: The filters so that the response includes
+                             information for only certain subnets.
+        :type       filters: ``dict``
+
         :rtype:     ``list`` of :class:`EC2NetworkSubnet`
         """
         params = {'Action': 'DescribeSubnets'}
+
+        if subnet_ids:
+            for subnet_idx, subnet_id in enumerate(subnet_ids):
+                subnet_idx += 1  # We want 1-based indexes
+                subnet_key = 'SubnetId.%s' % subnet_idx
+                params[subnet_key] = subnet_id
+
+        if filters:
+            params.update(self._build_filters(filters))
 
         return self._to_subnets(
             self.connection.request(self.path, params=params).object


### PR DESCRIPTION
Extend EC2 driver ex_list_subnets() method with ability to provide subnet ID and filters to list only specific subnets.
