### PR TITLE
Removing ex_ from the front of vps_parameters to avoid overwrites of ser...

### DIFF
--- a/libcloud/compute/drivers/rimuhosting.py
+++ b/libcloud/compute/drivers/rimuhosting.py
@@ -307,7 +307,7 @@ class RimuHostingNodeDriver(NodeDriver):
             data['vps_parameters']['memory_mb'] = kwargs['ex_memory_mb']
 
         if 'ex_disk_space_mb' in kwargs:
-            if 'ex_vps_parameters' not in data:
+            if 'vps_parameters' not in data:
                 data['vps_parameters'] = {}
             data['vps_parameters']['disk_space_mb'] = \
                 kwargs['ex_disk_space_mb']


### PR DESCRIPTION
The base rimu compute class has options in the create function that can set custom memory and disk values for a VPS. The problem is in the logic that looks to see if vps_parameters is in the data structure sent in the create api call. In the first block it looks to see if vps_parameters exists which is the correct naming. In the second one it looks for ex_vps_parameters, which will never exist. And then it re initializes vps_parameters which wipes the values set for memory in the previous block. This change fixes that.
