### PR TITLE
[LIBCLOUD-573] Update 'CA_CERTS_PATH' to look for updated MacOS X Homebrew location

### DIFF
--- a/libcloud/security.py
+++ b/libcloud/security.py
@@ -42,7 +42,10 @@ CA_CERTS_PATH = [
     # macports: curl-ca-bundle
     '/opt/local/share/curl/curl-ca-bundle.crt',
 
-    # homebrew: curl-ca-bundle
+    # homebrew: openssl
+    '/usr/local/etc/openssl/cert.pem',
+
+    # homebrew: curl-ca-bundle (backward compatibility)
     '/usr/local/opt/curl-ca-bundle/share/ca-bundle.crt',
 ]
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/LIBCLOUD-573
