### PR TITLE
[LIBCLOUD-576] SWIFT: removed superfulous call to upper() on service_region

### DIFF
--- a/libcloud/storage/drivers/cloudfiles.py
+++ b/libcloud/storage/drivers/cloudfiles.py
@@ -124,7 +124,7 @@ class OpenStackSwiftConnection(OpenStackBaseConnection):
         self._service_name = self._ex_force_service_name or 'swift'
 
         if self._ex_force_service_region:
-            self._service_region = self._ex_force_service_region.upper()
+            self._service_region = self._ex_force_service_region
         else:
             self._service_region = None
 


### PR DESCRIPTION
As stated in the jira ticket, OpenStack uses mixed-case regions, but rackspace only has uppercase regions. It seems that as a holdover from supporting cloudfiles all openstack regions were converted to upper, causing endpoint_get to fail.
