### PR TITLE
Some bugfixes

### DIFF
--- a/contrib/generate_provider_feature_matrix_table.py
+++ b/contrib/generate_provider_feature_matrix_table.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import with_statement
 
 import os
 import sys

--- a/libcloud/compute/drivers/abiquo.py
+++ b/libcloud/compute/drivers/abiquo.py
@@ -274,8 +274,8 @@ class AbiquoNodeDriver(NodeDriver):
 
         You can specify the location as well.
 
-        :param     name:     name of the group (required)
-        :type      name:     ``str``
+        :param     group:     name of the group (required)
+        :type      group:     ``str``
 
         :param     location: location were to create the group
         :type      location: :class:`NodeLocation`

--- a/libcloud/compute/drivers/brightbox.py
+++ b/libcloud/compute/drivers/brightbox.py
@@ -121,12 +121,15 @@ class BrightboxNodeDriver(NodeDriver):
         )
 
     def _to_location(self, data):
-        return NodeLocation(
-            id=data['id'],
-            name=data['handle'],
-            country='GB',
-            driver=self
-        )
+        if data:
+            return NodeLocation(
+                id=data['id'],
+                name=data['handle'],
+                country='GB',
+                driver=self
+            )
+        else:
+            return None
 
     def _post(self, path, data={}):
         headers = {'Content-Type': 'application/json'}
@@ -183,7 +186,7 @@ class BrightboxNodeDriver(NodeDriver):
         data = self.connection.request('/%s/servers' % self.api_version).object
         return list(map(self._to_node, data))
 
-    def list_images(self):
+    def list_images(self, location=None):
         data = self.connection.request('/%s/images' % self.api_version).object
         return list(map(self._to_image, data))
 

--- a/libcloud/compute/drivers/cloudsigma.py
+++ b/libcloud/compute/drivers/cloudsigma.py
@@ -1611,8 +1611,8 @@ class CloudSigma_2_0_NodeDriver(CloudSigmaNodeDriver):
         """
         Retrieve a single tag.
 
-        :param id: ID of the tag to retrieve.
-        :type id: ``str``
+        :param tag_id: ID of the tag to retrieve.
+        :type tag_id: ``str``
 
         :rtype: ``list`` of :class:`.CloudSigmaTag` objects
         """
@@ -1674,8 +1674,8 @@ class CloudSigma_2_0_NodeDriver(CloudSigmaNodeDriver):
         """
         Associate tag with the provided resources.
 
-        :param resource: Resources to associate a tag with.
-        :type resource: ``list`` of :class:`libcloud.compute.base.Node` or
+        :param resources: Resources to associate a tag with.
+        :type resources: ``list`` of :class:`libcloud.compute.base.Node` or
                         :class:`.CloudSigmaDrive`
 
         :param tag: Tag to associate with the resources.

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -3327,8 +3327,8 @@ class BaseEC2NodeDriver(NodeDriver):
         """
         Create a network interface within a VPC subnet.
 
-        :param      node: EC2NetworkSubnet instance
-        :type       node: :class:`EC2NetworkSubnet`
+        :param      subnet: EC2NetworkSubnet instance
+        :type       subnet: :class:`EC2NetworkSubnet`
 
         :param      name:  Optional name of the interface
         :type       name:  ``str``
@@ -3473,8 +3473,8 @@ class BaseEC2NodeDriver(NodeDriver):
         """
         Modify image attributes.
 
-        :param      node: Node instance
-        :type       node: :class:`Node`
+        :param      image: NodeImage instance
+        :type       image: :class:`NodeImage`
 
         :param      attributes: Dictionary with node attributes
         :type       attributes: ``dict``

--- a/libcloud/compute/drivers/gogrid.py
+++ b/libcloud/compute/drivers/gogrid.py
@@ -403,7 +403,7 @@ class GoGridNodeDriver(BaseGoGridDriver, NodeDriver):
         :type       ex_description: ``str``
 
         :keyword    name: name of the image
-        :type       name ``str``
+        :type       name: ``str``
 
         :rtype: :class:`NodeImage`
         """

--- a/libcloud/compute/drivers/libvirt_driver.py
+++ b/libcloud/compute/drivers/libvirt_driver.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import with_statement
 
 import re
 import os

--- a/libcloud/compute/drivers/opennebula.py
+++ b/libcloud/compute/drivers/opennebula.py
@@ -415,9 +415,9 @@ class OpenNebulaNodeDriver(NodeDriver):
         """
         List virtual networks on a provider.
 
-        :type  location: :class:`NodeLocation`
         :param location: Location from which to request a list of virtual
                          networks. (optional)
+        :type  location: :class:`NodeLocation`
 
         :return: List of virtual networks available to be connected to a
                  compute node.

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -1072,7 +1072,7 @@ class OpenStackSecurityGroup(object):
         :type       description: ``str``
 
         :keyword    rules: Rules associated with this group.
-        :type       description: ``list`` of
+        :type       rules: ``list`` of
                     :class:`OpenStackSecurityGroupRule`
 
         :keyword    extra: Extra attributes associated with this group.
@@ -1248,6 +1248,9 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
                                     Can be either ``AUTO`` or ``MANUAL``.
         :type       ex_disk_config: ``str``
 
+        :keyword    ex_admin_pass: The root password for the node
+        :type       ex_admin_pass: ``str``
+
         :keyword    ex_availability_zone: Nova availability zone for the node
         :type       ex_availability_zone: ``str``
         """
@@ -1333,6 +1336,9 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
 
         if 'ex_disk_config' in kwargs:
             server_params['OS-DCF:diskConfig'] = kwargs['ex_disk_config']
+
+        if 'ex_admin_pass' in kwargs:
+            server_params['adminPass'] = kwargs['ex_admin_pass']
 
         if 'networks' in kwargs:
             networks = kwargs['networks']
@@ -1642,8 +1648,8 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
         """
         Create a snapshot based off of a volume.
 
-        :param      node: volume
-        :type       node: :class:`StorageVolume`
+        :param      volume: volume
+        :type       volume: :class:`StorageVolume`
 
         :keyword    name: New name for the volume snapshot
         :type       name: ``str``
@@ -1669,8 +1675,8 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
         """
         Delete a VolumeSnapshot
 
-        :param      node: snapshot
-        :type       node: :class:`VolumeSnapshot`
+        :param      snapshot: snapshot
+        :type       snapshot: :class:`VolumeSnapshot`
 
         :rtype:     ``bool``
         """


### PR DESCRIPTION
-Mainly fixes wrong names in docstrings.
-Added admin_pass parameter to the create_node() function of OpenStack_1_1_NodeDriver.
 This allows to set the root password that is assigned to a node when creating an instance with Rackspace. 
-Added some imports of with_statement to be compatible to Python 2.5.
-Fixed exception when calling list_nodes() with Brightbox.
-Added locations arguments to Brightboxs list_images() to avoid exceptions when providing a location argument.
