### PR TITLE
Fix ex_unpause_node in openstack

### DIFF
--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -2311,7 +2311,7 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
 
     def ex_unpause_node(self, node):
         uri = '/servers/%s/action' % (node.id)
-        data = {'pause': None}
+        data = {'unpause': None}
         resp = self.connection.request(uri, method='POST', data=data)
         return resp.status == httplib.ACCEPTED
 


### PR DESCRIPTION
ex_unpause_node in the OpenStack driver was calling the 'pause' action instead of the 'unpause' action.
