### PR TITLE
Add a delay to SSH connection to fix the deploy_node race condition

### DIFF
--- a/libcloud/compute/base.py
+++ b/libcloud/compute/base.py
@@ -1397,9 +1397,18 @@ class NodeDriver(BaseDriver):
                                key_files=ssh_key_file,
                                timeout=ssh_timeout)
 
-        # Connect to the SSH server running on the node
-        ssh_client = self._ssh_client_connect(ssh_client=ssh_client,
-                                              timeout=timeout)
+        connect_tries = 6
+        connect_delay = 10
+
+        while connect_tries > 0:
+            try:
+                # Connect to the SSH server running on the node
+                ssh_client = self._ssh_client_connect(ssh_client=ssh_client,
+                                                      timeout=timeout)
+                break
+            except:
+                time.sleep(connect_delay)
+                connect_tries -= 1
 
         # Execute the deployment task
         node = self._run_deployment_script(task=task, node=node,


### PR DESCRIPTION
This patch might look a little "hackish", but it has solved the terrible `deploy_node` race condition for me 100%. I've been using libcloud with this patch for a few days with a 100% success rate. It seems that the `timeout` argument for `_ssh_client_connect` is insufficient. In fact, it's set to 300 seconds by default, but the entire operation doesn't take nearly that long to fail, so that timeout must not be the proper thing to fix the `deploy_node` race condition. _This_ fix, however, resolves the issue. 60 seconds is more than enough time to get the SSH key installed onto the node, even with the recent addition of `ssh_alternate_usernames`, which we suspect to be the culprit of this new race condition.

Please, let me know if there's anything I can do to improve upon this patch and get it merged in. This is really a critical bug that needs to be resolved quickly.
