### PR TITLE
LIBCLOUD-590 - Reduce redundant API calls of CloudStack compute driver's...

### DIFF
--- a/libcloud/compute/drivers/cloudstack.py
+++ b/libcloud/compute/drivers/cloudstack.py
@@ -1364,11 +1364,7 @@ class CloudStackNodeDriver(CloudStackDriverMixIn, NodeDriver):
         vms = self._sync_request('listVirtualMachines', params=args)
         addrs = self._sync_request('listPublicIpAddresses', params=args)
         port_forwarding_rules = self._sync_request('listPortForwardingRules')
-
-        try:
-            ip_forwarding_rules = self._sync_request('listIpForwardingRules')
-        except:
-            ip_forwarding_rules = {}
+        ip_forwarding_rules = self._sync_request('listIpForwardingRules')
 
         public_ips_map = {}
         for addr in addrs.get('publicipaddress', []):

--- a/libcloud/compute/drivers/cloudstack.py
+++ b/libcloud/compute/drivers/cloudstack.py
@@ -1363,6 +1363,12 @@ class CloudStackNodeDriver(CloudStackDriverMixIn, NodeDriver):
             args['projectid'] = project.id
         vms = self._sync_request('listVirtualMachines', params=args)
         addrs = self._sync_request('listPublicIpAddresses', params=args)
+        port_forwarding_rules = self._sync_request('listPortForwardingRules')
+
+        try:
+            ip_forwarding_rules = self._sync_request('listIpForwardingRules')
+        except:
+            ip_forwarding_rules = {}
 
         public_ips_map = {}
         for addr in addrs.get('publicipaddress', []):
@@ -1380,14 +1386,14 @@ class CloudStackNodeDriver(CloudStackDriverMixIn, NodeDriver):
             public_ips = list(public_ips)
             node = self._to_node(data=vm, public_ips=public_ips)
 
-            addresses = public_ips_map.get(vm['id'], {}).items()
-            addresses = [CloudStackAddress(node, v, k) for k, v in addresses]
+            addresses = public_ips_map.get(str(vm['id']), {}).items()
+            addresses = [CloudStackAddress(address_id, address, node.driver)
+                         for address, address_id in addresses]
             node.extra['ip_addresses'] = addresses
 
             rules = []
             for addr in addresses:
-                result = self._sync_request('listIpForwardingRules')
-                for r in result.get('ipforwardingrule', []):
+                for r in ip_forwarding_rules.get('ipforwardingrule', []):
                     if str(r['virtualmachineid']) == node.id:
                         rule = CloudStackIPForwardingRule(node, r['id'],
                                                           addr,
@@ -1400,11 +1406,13 @@ class CloudStackNodeDriver(CloudStackDriverMixIn, NodeDriver):
 
             rules = []
             public_ips = self.ex_list_public_ips()
-            result = self._sync_request('listPortForwardingRules')
-            for r in result.get('portforwardingrule', []):
+            for r in port_forwarding_rules.get('portforwardingrule', []):
                 if str(r['virtualmachineid']) == node.id:
-                    addr = [a for a in public_ips if
-                            a.address == r['ipaddress']]
+                    addr = [
+                        CloudStackAddress(a['id'], a['ipaddress'], node.driver)
+                        for a in addrs.get('publicipaddress', [])
+                        if a['ipaddress'] == r['ipaddress']
+                    ]
                     rule = CloudStackPortForwardingRule(node, r['id'],
                                                         addr[0],
                                                         r['protocol'].upper(),

--- a/libcloud/compute/drivers/cloudstack.py
+++ b/libcloud/compute/drivers/cloudstack.py
@@ -1405,7 +1405,6 @@ class CloudStackNodeDriver(CloudStackDriverMixIn, NodeDriver):
             node.extra['ip_forwarding_rules'] = rules
 
             rules = []
-            public_ips = self.ex_list_public_ips()
             for r in port_forwarding_rules.get('portforwardingrule', []):
                 if str(r['virtualmachineid']) == node.id:
                     addr = [

--- a/libcloud/compute/drivers/cloudstack.py
+++ b/libcloud/compute/drivers/cloudstack.py
@@ -1383,8 +1383,9 @@ class CloudStackNodeDriver(CloudStackDriverMixIn, NodeDriver):
             node = self._to_node(data=vm, public_ips=public_ips)
 
             addresses = public_ips_map.get(str(vm['id']), {}).items()
-            addresses = [CloudStackAddress(address_id, address, node.driver)
-                         for address, address_id in addresses]
+            addresses = [CloudStackAddress(id=address_id, address=address,
+                                           driver=node.driver) for
+                         address, address_id in addresses]
             node.extra['ip_addresses'] = addresses
 
             rules = []
@@ -1403,10 +1404,11 @@ class CloudStackNodeDriver(CloudStackDriverMixIn, NodeDriver):
             rules = []
             for r in port_forwarding_rules.get('portforwardingrule', []):
                 if str(r['virtualmachineid']) == node.id:
-                    addr = [
-                        CloudStackAddress(a['id'], a['ipaddress'], node.driver)
-                        for a in addrs.get('publicipaddress', [])
-                        if a['ipaddress'] == r['ipaddress']
+                    addr = [CloudStackAddress(id=a['id'],
+                                              address=a['ipaddress'],
+                                              driver=node.driver)
+                            for a in addrs.get('publicipaddress', [])
+                            if a['ipaddress'] == r['ipaddress']
                     ]
                     rule = CloudStackPortForwardingRule(node, r['id'],
                                                         addr[0],

--- a/libcloud/compute/drivers/cloudstack.py
+++ b/libcloud/compute/drivers/cloudstack.py
@@ -1408,8 +1408,7 @@ class CloudStackNodeDriver(CloudStackDriverMixIn, NodeDriver):
                                               address=a['ipaddress'],
                                               driver=node.driver)
                             for a in addrs.get('publicipaddress', [])
-                            if a['ipaddress'] == r['ipaddress']
-                    ]
+                            if a['ipaddress'] == r['ipaddress']]
                     rule = CloudStackPortForwardingRule(node, r['id'],
                                                         addr[0],
                                                         r['protocol'].upper(),

--- a/libcloud/test/compute/fixtures/ktucloud/listIpForwardingRules_default.json
+++ b/libcloud/test/compute/fixtures/ktucloud/listIpForwardingRules_default.json
@@ -1,0 +1,1 @@
+{ "listipforwardingrulesresponse" : { "count":1 ,"ipforwardingrule" : [  {"id":"772fd410-6649-43ed-befa-77be986b8906","protocol":"tcp","virtualmachineid":"2600","virtualmachinename":"test","virtualmachinedisplayname":"test","ipaddressid":34000,"ipaddress":"1.1.1.116","startport":33,"endport":34,"state":"Active"} ] } }

--- a/libcloud/test/compute/test_cloudstack.py
+++ b/libcloud/test/compute/test_cloudstack.py
@@ -581,10 +581,19 @@ class CloudStackCommonTestCase(TestCaseMixin):
         self.assertEqual(2, len(nodes))
         self.assertEqual('test', nodes[0].name)
         self.assertEqual('2600', nodes[0].id)
+        self.assertEqual(0, len(nodes[0].private_ips))
         self.assertEqual([], nodes[0].extra['security_group'])
         self.assertEqual(None, nodes[0].extra['key_name'])
         self.assertEqual(1, len(nodes[0].public_ips))
         self.assertEqual('1.1.1.116', nodes[0].public_ips[0])
+        self.assertEqual(1, len(nodes[0].extra['ip_addresses']))
+        self.assertEqual(34000, nodes[0].extra['ip_addresses'][0].id)
+        self.assertEqual(1, len(nodes[0].extra['ip_forwarding_rules']))
+        self.assertEqual('772fd410-6649-43ed-befa-77be986b8906',
+                         nodes[0].extra['ip_forwarding_rules'][0].id)
+        self.assertEqual(1, len(nodes[0].extra['port_forwarding_rules']))
+        self.assertEqual('bc7ea3ee-a2c3-4b86-a53f-01bdaa1b2e32',
+                         nodes[0].extra['port_forwarding_rules'][0].id)
 
     def test_ex_get_node(self):
         node = self.driver.ex_get_node(2600)


### PR DESCRIPTION
CloudStack compute driver's list_nodes method executes too many API calls and it slows down this method.
The patch reduces redundant API calls and speed up list_nodes method.

https://issues.apache.org/jira/browse/LIBCLOUD-590
