### PR TITLE
[LIBCLOUD-591] Updating Compute Engine image project list

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -2305,10 +2305,17 @@ class GCENodeDriver(NodeDriver):
             return self._to_node_image(response.object)
         image = self._match_images(None, partial_name)
         if not image:
-            if partial_name.startswith('debian'):
+            if (partial_name.startswith('debian') or
+                    partial_name.startswith('backports')):
                 image = self._match_images('debian-cloud', partial_name)
             elif partial_name.startswith('centos'):
                 image = self._match_images('centos-cloud', partial_name)
+            elif partial_name.startswith('sles'):
+                image = self._match_images('suse-cloud', partial_name)
+            elif partial_name.startswith('rhel'):
+                image = self._match_images('rhel-cloud', partial_name)
+            elif partial_name.startswith('windows'):
+                image = self._match_images('windows-cloud', partial_name)
             elif partial_name.startswith('container-vm'):
                 image = self._match_images('google-containers', partial_name)
 

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -100,8 +100,8 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         project = 'debian-cloud'
         image = self.driver._match_images(project, 'debian-7')
         self.assertEqual(image.name, 'debian-7-wheezy-v20131120')
-        image = self.driver._match_images(project, 'debian-6')
-        self.assertEqual(image.name, 'debian-6-squeeze-v20130926')
+        image = self.driver._match_images(project, 'backports')
+        self.assertEqual(image.name, 'backports-debian-7-wheezy-v20131127')
 
     def test_ex_list_addresses(self):
         address_list = self.driver.ex_list_addresses()


### PR DESCRIPTION
Google Compute Engine is expanding operating system images.  This minor change will make RHEL, SLES, and other vendor images available to libcloud users.
