### PR TITLE
[LIBCLOUD-592] Create a generic method for listing AWS EIPs

### DIFF
--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -3322,6 +3322,42 @@ class BaseEC2NodeDriver(NodeDriver):
         response = self.connection.request(self.path, params=params).object
         return self._get_boolean(response)
 
+    def ex_list_addresses(self, public_ips=None,
+                          allocation_ids=None, filters=None):
+        """
+        Return Elastic IP addresses allocated in the current region
+
+        :param   public_ips: Return only EIPs matching the provided IP
+                             addresses.
+        :type    public_ips: ``list``
+
+        :param   allocation_ids: Return only EIPs matching the provided
+                                 allocation ID (when listing EIPs
+                                 allocated for a VPC).
+        :type    allocation_ids: ``list``
+
+        :param   filters: The filters so that the response includes
+                          information for only certain EIPs
+        :type    filters: ``dict``
+
+        :rtype: ``list`` of :class:`.ElasticIP`
+        """
+
+        params = {'Action': 'DescribeAddresses'}
+
+        if public_ips:
+            params.update(self._pathlist('PublicIp', public_ips))
+
+        if allocation_ids:
+            params.update(self._pathlist('AllocationId', allocation_ids))
+
+        if filters:
+            params.update(self._build_filters(filters))
+
+        response = self.connection.request(self.path, params=params).object
+
+        return self._to_addresses(response, only_associated=False)
+
     def ex_describe_all_addresses(self, only_associated=False):
         """
         Return all the Elastic IP addresses for this account


### PR DESCRIPTION
Currently there are three methods in ec2 driver for listing EIPs:
They all satisfy different use cases:
ex_describe_all_addresses() - list all EIPs (vpc and ec2) optionally list only associated EIPs.
ex_describe_addresses() - list only EIPs for the specific nodes.
ex_describe_addresses_for_node() - list only EIPs for specific node.

This PR creates a generic method ex_list_addresses() to give users more flexibility while listing EIPs, by implementing all the functionality from this API call: http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeAddresses.html
