### PR TITLE
allow specifying standard as a domain in ex_associate_address_with_node

### DIFF
--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -3352,7 +3352,7 @@ class BaseEC2NodeDriver(NodeDriver):
         :param      elastic_ip: Elastic IP instance
         :type       elastic_ip: :class:`ElasticIP`
 
-        :param      domain: The domain where the IP resides (vpc only)
+        :param      domain: The domain where the IP resides (standard/vpc)
         :type       domain: ``str``
 
         :return:    A string representation of the association ID which is
@@ -3362,10 +3362,10 @@ class BaseEC2NodeDriver(NodeDriver):
         """
         params = {'Action': 'AssociateAddress', 'InstanceId': node.id}
 
-        if domain is not None and domain != 'vpc':
-            raise AttributeError('Domain can only be set to vpc')
+        if domain is not None and domain not in ['standard', 'vpc']:
+            raise AttributeError('Domain can only be set to standard or vpc')
 
-        if domain is None:
+        if domain is None or domain == 'standard':
             params.update({'PublicIp': elastic_ip.ip})
         else:
             params.update({'AllocationId': elastic_ip.extra['allocation_id']})


### PR DESCRIPTION
AWS uses "domain" field to distinguish between EIPs allocated for Classic EC2 ('standard') and EIPs allocated for VPC (value 'vpc')

domain
    Indicates whether this Elastic IP address is for use with instances in EC2-Classic (standard) or instances in a VPC (vpc).
    Type: xsd:string
    Valid values: standard | vpc

http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-ItemType-DescribeAddressesResponseItemType.html

The method ex_allocate_address() also uses 'standard' and 'vpc' as allowed parameters.

This patch adds 'standard' as a value to domain parameter.
None is left for backward compatibility.
