### PR TITLE
[LIBCLOUD-595] Support GCE LB session affinity

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -212,8 +212,8 @@ Bad (please avoid):
         description = kwargs.get('description', None)
         public_ips = kwargs.get('public_ips', None)
 
-5. When returning a dictionary, document it's structure
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+5. When returning a dictionary, document its structure
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Dynamic nature of Python can be very nice and useful, but if (ab)use it in a
 wrong way it can also make it hard for the API consumer to understand what is

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -1350,7 +1350,7 @@ class GCENodeDriver(NodeDriver):
         return node_list
 
     def ex_create_targetpool(self, name, region=None, healthchecks=None,
-                             nodes=None):
+                             nodes=None, session_affinity=None):
         """
         Create a target pool.
 
@@ -1366,6 +1366,10 @@ class GCENodeDriver(NodeDriver):
 
         :keyword  nodes:  Optional list of nodes to attach to the pool
         :type     nodes:  ``list`` of ``str`` or :class:`Node`
+
+        :keyword  session_affinity:  Optional algorithm to use for session
+                                     affinity.
+        :type     session_affinity:  ``str``
 
         :return:  Target Pool object
         :rtype:   :class:`GCETargetPool`
@@ -1391,6 +1395,8 @@ class GCENodeDriver(NodeDriver):
             else:
                 node_list = [n.extra['selfLink'] for n in nodes]
             targetpool_data['instances'] = node_list
+        if session_affinity:
+            targetpool_data['sessionAffinity'] = session_affinity
 
         request = '/regions/%s/targetPools' % (region.name)
 
@@ -3312,6 +3318,7 @@ class GCENodeDriver(NodeDriver):
         extra = {}
         extra['selfLink'] = targetpool.get('selfLink')
         extra['description'] = targetpool.get('description')
+        extra['sessionAffinity'] = targetpool.get('sessionAffinity')
         region = self.ex_get_region(targetpool['region'])
         healthcheck_list = [self.ex_get_healthcheck(h.split('/')[-1]) for h
                             in targetpool.get('healthChecks', [])]

--- a/libcloud/loadbalancer/drivers/gce.py
+++ b/libcloud/loadbalancer/drivers/gce.py
@@ -89,7 +89,8 @@ class GCELBDriver(Driver):
         return balancers
 
     def create_balancer(self, name, port, protocol, algorithm, members,
-                        ex_region=None, ex_healthchecks=None, ex_address=None):
+                        ex_region=None, ex_healthchecks=None, ex_address=None,
+                        ex_session_affinity=None):
         """
         Create a new load balancer instance.
 
@@ -126,11 +127,17 @@ class GCELBDriver(Driver):
         :keyword  ex_healthchecks: Optional list of healthcheck objects or
                                    names to add to the load balancer.
         :type     ex_healthchecks: ``list`` of :class:`GCEHealthCheck` or
-                                   ``str``
+                                   ``list`` of ``str``
 
         :keyword  ex_address: Optional static address object to be assigned to
                               the load balancer.
         :type     ex_address: C{GCEAddress}
+
+        :keyword  ex_session_affinity: Optional algorithm to use for session
+                                       affinity.  This will modify the hashing
+                                       algorithm such that a client will tend
+                                       to stick to a particular Member.
+        :type     ex_session_affinity: ``str``
 
         :return:  LoadBalancer object
         :rtype:   :class:`LoadBalancer`
@@ -154,7 +161,7 @@ class GCELBDriver(Driver):
         tp_name = '%s-tp' % name
         targetpool = self.gce.ex_create_targetpool(
             tp_name, region=ex_region, healthchecks=ex_healthchecks,
-            nodes=node_list)
+            nodes=node_list, session_affinity=ex_session_affinity)
 
         # Create the Forwarding rule, but if it fails, delete the target pool.
         try:

--- a/libcloud/test/compute/fixtures/gce/regions_us-central1_targetPools_lctargetpool_sticky.json
+++ b/libcloud/test/compute/fixtures/gce/regions_us-central1_targetPools_lctargetpool_sticky.json
@@ -1,0 +1,9 @@
+{
+  "creationTimestamp": "2014-07-11T15:52:43.720-07:00",
+  "id": "13598380121688918358",
+  "kind": "compute#targetPool",
+  "name": "lctargetpool-sticky",
+  "region": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1/targetPools/lctargetpool-sticky",
+  "sessionAffinity": "CLIENT_IP_PROTO"
+}

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -327,6 +327,17 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         self.assertEqual(len(targetpool.nodes), len(nodes))
         self.assertEqual(targetpool.region.name, region)
 
+    def test_ex_create_targetpool_session_affinity(self):
+        targetpool_name = 'lctargetpool-sticky'
+        region = 'us-central1'
+        session_affinity = 'CLIENT_IP_PROTO'
+        targetpool = self.driver.ex_create_targetpool(
+            targetpool_name, region=region,
+            session_affinity=session_affinity)
+        self.assertEqual(targetpool.name, targetpool_name)
+        self.assertEqual(targetpool.extra.get('sessionAffinity'),
+                         session_affinity)
+
     def test_ex_create_volume_snapshot(self):
         snapshot_name = 'lcsnapshot'
         volume = self.driver.ex_get_volume('lcdisk')
@@ -1036,6 +1047,12 @@ class GCEMockHttp(MockHttpTestCase):
         else:
             body = self.fixtures.load(
                 'regions_us-central1_targetPools_lctargetpool.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _regions_us_central1_targetPools_lctargetpool_sticky(self, method, url,
+                                                             body, headers):
+        body = self.fixtures.load(
+            'regions_us-central1_targetPools_lctargetpool_sticky.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
     def _regions_us_central1_targetPools_libcloud_lb_demo_lb_tp(


### PR DESCRIPTION
Add support for sessionAffinity to the GCE Load Balancer driver.
sessionAffinity has the effect of causing clients to "stick" to a
particular backend server.

Also, trivial documentation fixes:
- resolve ambiguous type specification in create_balancer
- fix typo in development doc

https://issues.apache.org/jira/browse/LIBCLOUD-595
