### PR TITLE
[LIBCLOUD-544] Resolve a bug introduced by the original fix of the issue...

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -1211,9 +1211,23 @@ class GCENodeDriver(NodeDriver):
                                               use_existing=use_existing_disk,
                                               ex_disk_type=ex_disk_type)
 
-        if ex_metadata is not None:
-            ex_metadata = {"items": [{"key": k, "value": v}
-                                     for k, v in ex_metadata.items()]}
+        if not ex_metadata:
+            ex_metadata = None
+        elif not isinstance(ex_metadata, dict):
+            raise ValueError('metadata field is not a dictionnary.')
+        else:
+            if 'items' not in ex_metadata:
+                # The expected GCE format is odd:
+                # items: [{'value': '1', 'key': 'one'},
+                #        {'value': '2', 'key': 'two'},
+                #        {'value': 'N', 'key': 'N'}]
+                # So the only real key is items, and the values are tuples
+                # Since arbitrary values are fine, we only check for the key.
+                # If missing, we prefix it to the items.
+                items = []
+                for k, v in ex_metadata.items():
+                    items.append({'key': k, 'value': v})
+                ex_metadata = {'items': items}
 
         request, node_data = self._create_node_req(name, size, image,
                                                    location, ex_network,


### PR DESCRIPTION
This is meant to replace github.com/apache/libcloud/pull/349
With one clean commit.

1- Add separated verifications for "None" and malformed metadata.
   A clear error will be raised upon malformed metadata.
   If undefined or already None, we assume None.
2- Provide comments explaining the odd GCE dictionary format.
3- Perform check on metadata dictionary structure. We expect one "items" key
   and a tuple of arbitrary values.
4- Prefix the keys/values provided by a simple dictionary by "items" if not
   found, enforcing point 3's structure.
