### PR TITLE
[LIBCLOUD-612] Customize HTTP vendor prefix for Google Storage

### DIFF
--- a/libcloud/storage/drivers/google_storage.py
+++ b/libcloud/storage/drivers/google_storage.py
@@ -134,3 +134,4 @@ class GoogleStorageDriver(BaseS3StorageDriver):
     namespace = NAMESPACE
     supports_chunked_encoding = False
     supports_s3_multipart_upload = False
+    http_vendor_prefix = 'x-goog'

--- a/libcloud/storage/drivers/s3.py
+++ b/libcloud/storage/drivers/s3.py
@@ -227,6 +227,7 @@ class BaseS3StorageDriver(StorageDriver):
     supports_s3_multipart_upload = True
     ex_location_name = ''
     namespace = NAMESPACE
+    http_vendor_prefix = 'x-amz'
 
     def iterate_containers(self):
         response = self.connection.request('/')
@@ -796,7 +797,8 @@ class BaseS3StorageDriver(StorageDriver):
             raise ValueError(
                 'Invalid storage class value: %s' % (storage_class))
 
-        headers['x-amz-storage-class'] = storage_class.upper()
+        key = self.http_vendor_prefix + '-storage-class'
+        headers[key] = storage_class.upper()
 
         content_type = extra.get('content_type', None)
         meta_data = extra.get('meta_data', None)
@@ -804,11 +806,11 @@ class BaseS3StorageDriver(StorageDriver):
 
         if meta_data:
             for key, value in list(meta_data.items()):
-                key = 'x-amz-meta-%s' % (key)
+                key = self.http_vendor_prefix + '-meta-%s' % (key)
                 headers[key] = value
 
         if acl:
-            headers['x-amz-acl'] = acl
+            headers[self.http_vendor_prefix + '-acl'] = acl
 
         request_path = self._get_object_path(container, object_name)
 
@@ -880,10 +882,10 @@ class BaseS3StorageDriver(StorageDriver):
             extra['last_modified'] = headers['last-modified']
 
         for key, value in headers.items():
-            if not key.lower().startswith('x-amz-meta-'):
+            if not key.lower().startswith(self.http_vendor_prefix + '-meta-'):
                 continue
 
-            key = key.replace('x-amz-meta-', '')
+            key = key.replace(self.http_vendor_prefix + '-meta-', '')
             meta_data[key] = value
 
         obj = Object(name=object_name, size=headers['content-length'],

--- a/libcloud/test/storage/test_google_storage.py
+++ b/libcloud/test/storage/test_google_storage.py
@@ -16,6 +16,8 @@
 import sys
 import unittest
 
+from libcloud.utils.py3 import httplib
+
 from libcloud.storage.drivers.google_storage import GoogleStorageDriver
 from libcloud.test.storage.test_s3 import S3Tests, S3MockHttp
 
@@ -25,6 +27,22 @@ from libcloud.test.secrets import STORAGE_GOOGLE_STORAGE_PARAMS
 
 class GoogleStorageMockHttp(S3MockHttp):
     fixtures = StorageFileFixtures('google_storage')
+
+    def _test2_test_get_object(self, method, url, body, headers):
+        # test_get_object
+        # Google uses a different HTTP header prefix for meta data
+        body = self.fixtures.load('list_containers.xml')
+        headers = {'content-type': 'application/zip',
+                   'etag': '"e31208wqsdoj329jd"',
+                   'x-goog-meta-rabbits': 'monkeys',
+                   'content-length': 12345,
+                   'last-modified': 'Thu, 13 Sep 2012 07:13:22 GMT'
+                   }
+
+        return (httplib.OK,
+                body,
+                headers,
+                httplib.responses[httplib.OK])
 
 
 class GoogleStorageTests(S3Tests):


### PR DESCRIPTION
https://issues.apache.org/jira/browse/LIBCLOUD-612

Google storage uses/expects custom headers like meta data
and storage class to be prefixed with "x-goog" instead of
"x-amz". This enables use of object tagging in the Google
Storage provider.
