### PR TITLE
[LIBCLOUD-618] Make openstack create_volume return a StorageVolume

### DIFF
--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -152,7 +152,7 @@ class OpenStackNodeDriver(NodeDriver, OpenStackDriverMixin):
         if snapshot:
             raise NotImplementedError(
                 "create_volume does not yet support create from snapshot")
-        return self.connection.request('/os-volumes',
+        resp = self.connection.request('/os-volumes',
                                        method='POST',
                                        data={
                                            'volume': {
@@ -165,7 +165,8 @@ class OpenStackNodeDriver(NodeDriver, OpenStackDriverMixin):
                                                },
                                                'availability_zone': location,
                                            }
-                                       }).success()
+                                       })
+        return self._to_volume(resp.object)
 
     def destroy_volume(self, volume):
         return self.connection.request('/os-volumes/%s' % volume.id,

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -907,7 +907,9 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
         self.assertTrue(self.node.reboot())
 
     def test_create_volume(self):
-        self.assertEqual(self.driver.create_volume(1, 'test'), True)
+        volume = self.driver.create_volume(1, 'test')
+        self.assertEqual(volume.name, 'test')
+        self.assertEqual(volume.size, 1)
 
     def test_destroy_volume(self):
         volume = self.driver.ex_get_volume(


### PR DESCRIPTION
The create_volume call in the OpenStack driver returns a bool to signify whether the call succeeded. This call should return a StorageVolume object, as other drivers already do (ec2, cloudstack, gce, etc).
