### PR TITLE
[LIBCLOUD-619] Add extra data from openstack volume to object

### DIFF
--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -2018,6 +2018,11 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
             extra={
                 'description': api_node['displayDescription'],
                 'attachments': [att for att in api_node['attachments'] if att],
+                'state': api_node['status'],
+                'location': api_node['availabilityZone'],
+                'volume_type': api_node['volumeType'],
+                'metadata': api_node['metadata'],
+                'created_at': api_node['createdAt'],
             }
         )
 

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -794,18 +794,34 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
         self.assertEqual('cd76a3a1-c4ce-40f6-9b9f-07a61508938d', volume.id)
         self.assertEqual('test_volume_2', volume.name)
         self.assertEqual(2, volume.size)
-
-        self.assertEqual(volume.extra['description'], '')
-        self.assertEqual(volume.extra['attachments'][0][
-                         'id'], 'cd76a3a1-c4ce-40f6-9b9f-07a61508938d')
+        self.assertEqual(volume.extra, {
+            'description': '',
+            'attachments': [{
+                'id': 'cd76a3a1-c4ce-40f6-9b9f-07a61508938d',
+                "device": "/dev/vdb",
+                "serverId": "12065",
+                "volumeId": "cd76a3a1-c4ce-40f6-9b9f-07a61508938d",
+            }],
+            'state': 'available',
+            'location': 'nova',
+            'volume_type': 'None',
+            'metadata': {},
+            'created_at': '2013-06-24T11:20:13.000000',
+        })
 
         volume = volumes[1]
         self.assertEqual('cfcec3bc-b736-4db5-9535-4c24112691b5', volume.id)
         self.assertEqual('test_volume', volume.name)
         self.assertEqual(50, volume.size)
-
-        self.assertEqual(volume.extra['description'], 'some description')
-        self.assertEqual(volume.extra['attachments'], [])
+        self.assertEqual(volume.extra, {
+            'description': 'some description',
+            'attachments': [],
+            'state': 'available',
+            'location': 'nova',
+            'volume_type': 'None',
+            'metadata': {},
+            'created_at': '2013-06-21T12:39:02.000000',
+        })
 
     def test_list_sizes(self):
         sizes = self.driver.list_sizes()


### PR DESCRIPTION
OpenStack Volumes have a state, but libcloud has no way to retrieve it. This PR adds all available data from the Openstack volume to the `extra`-dict on the `StorageVolume`.
