### PR TITLE
[LIBCLOUD-615]: add optional project param for ex_list_networks() to CloudStack provider.

### DIFF
--- a/libcloud/compute/drivers/cloudstack.py
+++ b/libcloud/compute/drivers/cloudstack.py
@@ -964,14 +964,23 @@ class CloudStackNodeDriver(CloudStackDriverMixIn, NodeDriver):
 
         return diskOfferings
 
-    def ex_list_networks(self):
+    def ex_list_networks(self, project=None):
         """
         List the available networks
+
+        :param  project: Optional project the networks belongs to.
+        :type   project: :class:`.CloudStackProject`
 
         :rtype ``list`` of :class:`CloudStackNetwork`
         """
 
+        args = {}
+
+        if project is not None:
+            args['projectid'] = project.id
+
         res = self._sync_request(command='listNetworks',
+                                 params=args,
                                  method='GET')
         nets = res.get('network', [])
 


### PR DESCRIPTION
Signed-off-by: René Moser mail@renemoser.net
