### PR TITLE
LIBCLOUD-578: GCE adding Service Accounts to create_node

### DIFF
--- a/docs/compute/drivers/gce.rst
+++ b/docs/compute/drivers/gce.rst
@@ -15,6 +15,7 @@ Google Compute Engine features:
 * High-performance virtual machines
 * Minute-level billing (10-minute minimum)
 * Fast VM provisioning
+* Persistent block storage (SSD and standard)
 * Native Load Balancing
 
 Connecting to Google Compute Engine
@@ -68,6 +69,14 @@ To set up Installed Account authentication:
 7. You will also need your "Project ID" which can be found by clicking on the
    "Overview" link on the left sidebar.
 
+Accessing Google Cloud services from your Libcloud nodes
+--------------------------------------------------------
+In order for nodes created with libcloud to be able to access or manage other
+Google Cloud Platform services, you will need to specify a list of Service
+Account Scopes.  By default libcloud will create nodes that only allow
+read-only access to Google Cloud Storage. A few of the examples below
+illustrate how to use Service Account Scopes.
+
 Examples
 --------
 
@@ -88,6 +97,11 @@ https://github.com/apache/libcloud/blob/trunk/demos/gce_demo.py
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. literalinclude:: /examples/compute/gce/gce_datacenter.py
+
+4. Specifying Service Account Scopes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. literalinclude:: /examples/compute/gce/gce_service_account_scopes.py
 
 API Docs
 --------

--- a/docs/examples/compute/gce/gce_service_account_scopes.py
+++ b/docs/examples/compute/gce/gce_service_account_scopes.py
@@ -1,0 +1,29 @@
+# See previous examples for connecting and creating the driver
+# ...
+
+# Define common example attributes
+s = 'n1-standard-1'
+i = 'debian-7'
+z = 'us-central1-a'
+
+# Service Account Scopes require a list of dictionaries. Each dictionary
+# can have an optional 'email' address specifying the Service Account
+# address, and list of 'scopes'. The default Service Account Scopes for
+# new nodes will effectively use:
+
+sa_scopes = [
+  {'email': 'default',
+   'scopes': ['storage-ro']
+  }
+]
+
+# The expected scenario will likely use the default Service Account email
+# address, but allow users to override the default list of scopes.
+# For example, create a new node with full access to Google Cloud Storage
+# and Google Compute Engine:
+sa_scopes = [{'scopes': ['compute', 'storage-full']}]
+node_1 = driver.create_node("n1", s, i, z, ex_service_accounts=sa_scopes)
+
+# See Google's documentation for Accessing other Google Cloud services from
+# your Google Compute Engine instances at,
+# https://cloud.google.com/compute/docs/authentication

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -324,16 +324,18 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         # ex_service_accounts with specific scopes, default 'email'
         ex_sa = [{'scopes': ['compute-ro', 'pubsub', 'storage-ro']}]
         node_request, node_data = self.driver._create_node_req('lcnode', size,
-                image, location, network, ex_service_accounts=ex_sa)
+                                                               image, location,
+                                                               network,
+                                                               ex_service_accounts=ex_sa)
         self.assertIsInstance(node_data['serviceAccounts'], list)
         self.assertIsInstance(node_data['serviceAccounts'][0], dict)
         self.assertTrue(node_data['serviceAccounts'][0]['email'], 'default')
         self.assertIsInstance(node_data['serviceAccounts'][0]['scopes'], list)
         self.assertTrue(len(node_data['serviceAccounts'][0]['scopes']), 3)
         self.assertTrue('https://www.googleapis.com/auth/devstorage.read_only'
-                in node_data['serviceAccounts'][0]['scopes'])
+                        in node_data['serviceAccounts'][0]['scopes'])
         self.assertTrue('https://www.googleapis.com/auth/compute.readonly'
-                in node_data['serviceAccounts'][0]['scopes'])
+                        in node_data['serviceAccounts'][0]['scopes'])
 
     def test_create_node_with_metadata(self):
         node_name = 'node-name'


### PR DESCRIPTION
Adding support for user-defined Service Account scopes when creating nodes in the GCE driver.  The default for this new paramter is modeled after both the Google Developers Console and Cloud SDK and sets an instance's (node's) default serviceAccount to,

```
[{'email': 'default',
'scopes': ['https://www.googleapis.com/auth/devstorage.read_only']
}]
```

To better match Google tools, short-name aliases as documented in Cloud SDK's `gcloud compute instances create --help` are supported.

Typical usage would likely just use the 'default' email for the Service Account but allow overriding the list of scopes.  For example,

```
ex_service_accounts = [{'scopes': ['bigquery','compute-ro', 'pubsub']}]
```

Will map to,

```
[{'email': 'default',
'scopes': [
  'https://www.googleapis.com/auth/bigquery',
  'https://www.googleapis.com/auth/compute.readonly',
  'https://www.googleapis.com/auth/pubsub'
  ]
}]
```

GCE public docs on this capability are,
https://cloud.google.com/compute/docs/authentication
https://cloud.google.com/compute/docs/reference/latest/instances#resource

/cc @ross-p
