### PR TITLE
adds ex_security_group_ids to ec2 in order to be able to launch nodes with security groups on a VPC

### DIFF
--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -2135,6 +2135,10 @@ class BaseEC2NodeDriver(NodeDriver):
                                         assign to the node.
         :type       ex_security_groups:   ``list``
 
+        :keyword    ex_security_group_ids: A list of ids of security groups to
+                                        assign to the node.[for VPC nodes only]
+        :type       ex_security_group_ids:   ``list``
+
         :keyword    ex_metadata: Key/Value metadata to associate with a node
         :type       ex_metadata: ``dict``
 
@@ -2186,6 +2190,20 @@ class BaseEC2NodeDriver(NodeDriver):
             for sig in range(len(security_groups)):
                 params['SecurityGroup.%d' % (sig + 1,)] =\
                     security_groups[sig]
+
+        if 'ex_security_group_ids' in kwargs and not 'ex_subnet' in kwargs:
+            raise ValueError('You can only supply ex_security_group_id'
+                             ' combinated with ex_subnet')
+
+        security_group_id = kwargs.get('ex_security_group_ids', None)
+
+        if security_group_id:
+            if not isinstance(security_group_id, (tuple, list)):
+                security_group_id = [security_group_id]
+
+            for sig in range(len(security_group_id)):
+                params['SecurityGroupId.%d' % (sig + 1,)] =\
+                    security_group_id[sig]
 
         if 'location' in kwargs:
             availability_zone = getattr(kwargs['location'],

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -2191,7 +2191,7 @@ class BaseEC2NodeDriver(NodeDriver):
                 params['SecurityGroup.%d' % (sig + 1,)] =\
                     security_groups[sig]
 
-        if 'ex_security_group_ids' in kwargs and not 'ex_subnet' in kwargs:
+        if 'ex_security_group_ids' in kwargs and 'ex_subnet' not in kwargs:
             raise ValueError('You can only supply ex_security_group_id'
                              ' combinated with ex_subnet')
 

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -2192,18 +2192,18 @@ class BaseEC2NodeDriver(NodeDriver):
                     security_groups[sig]
 
         if 'ex_security_group_ids' in kwargs and 'ex_subnet' not in kwargs:
-            raise ValueError('You can only supply ex_security_group_id'
+            raise ValueError('You can only supply ex_security_group_ids'
                              ' combinated with ex_subnet')
 
-        security_group_id = kwargs.get('ex_security_group_ids', None)
+        security_group_ids = kwargs.get('ex_security_group_ids', None)
 
-        if security_group_id:
-            if not isinstance(security_group_id, (tuple, list)):
-                security_group_id = [security_group_id]
+        if security_group_ids:
+            if not isinstance(security_group_ids, (tuple, list)):
+                security_group_ids = [security_group_ids]
 
-            for sig in range(len(security_group_id)):
+            for sig in range(len(security_group_ids)):
                 params['SecurityGroupId.%d' % (sig + 1,)] =\
-                    security_group_id[sig]
+                    security_group_ids[sig]
 
         if 'location' in kwargs:
             availability_zone = getattr(kwargs['location'],

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -871,6 +871,20 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
                           ex_securitygroup=security_groups,
                           ex_security_groups=security_groups)
 
+    def test_create_node_ex_security_group_id(self):
+        EC2MockHttp.type = 'ex_security_group_ids'
+
+        image = NodeImage(id='ami-be3adfd7',
+                          name=self.image_name,
+                          driver=self.driver)
+        size = NodeSize('m1.small', 'Small Instance', None, None, None, None,
+                        driver=self.driver)
+
+        security_groups = ['sg-1aa11a1a', 'sg-2bb22b2b']
+
+        self.driver.create_node(name='foo', image=image, size=size,
+                                ex_security_group_ids=security_groups)
+
     def test_ex_get_metadata_for_node(self):
         image = NodeImage(id='ami-be3adfd7',
                           name=self.image_name,
@@ -1185,6 +1199,13 @@ class EC2MockHttp(MockHttpTestCase):
     def _ex_security_groups_RunInstances(self, method, url, body, headers):
         self.assertUrlContainsQueryParams(url, {'SecurityGroup.1': 'group1'})
         self.assertUrlContainsQueryParams(url, {'SecurityGroup.2': 'group2'})
+
+        body = self.fixtures.load('run_instances.xml')
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+
+    def _ex_security_group_ids_RunInstances(self, method, url, body, headers):
+        self.assertUrlContainsQueryParams(url, {'SecurityGroupId.1': 'sg-1aa11a1a'})
+        self.assertUrlContainsQueryParams(url, {'SecurityGroupId.2': 'sg-2bb22b2b'})
 
         body = self.fixtures.load('run_instances.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -872,7 +872,7 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
                           ex_securitygroup=security_groups,
                           ex_security_groups=security_groups)
 
-    def test_create_node_ex_security_group_id(self):
+    def test_create_node_ex_security_group_ids(self):
         EC2MockHttp.type = 'ex_security_group_ids'
 
         image = NodeImage(id='ami-be3adfd7',
@@ -881,12 +881,15 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
         size = NodeSize('m1.small', 'Small Instance', None, None, None, None,
                         driver=self.driver)
 
-        subnet = EC2NetworkSubnet(12345, "test_subnet", "waiting")
+        subnet = EC2NetworkSubnet(12345, "test_subnet", "pending")
         security_groups = ['sg-1aa11a1a', 'sg-2bb22b2b']
 
         self.driver.create_node(name='foo', image=image, size=size,
                                 ex_security_group_ids=security_groups,
                                 ex_subnet=subnet)
+        self.assertRaises(ValueError, self.driver.create_node,
+                          name='foo', image=image, size=size,
+                          ex_security_group_ids=security_groups)
 
     def test_ex_get_metadata_for_node(self):
         image = NodeImage(id='ami-be3adfd7',

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -34,6 +34,7 @@ from libcloud.compute.drivers.ec2 import OutscaleSASNodeDriver
 from libcloud.compute.drivers.ec2 import IdempotentParamError
 from libcloud.compute.drivers.ec2 import REGION_DETAILS
 from libcloud.compute.drivers.ec2 import ExEC2AvailabilityZone
+from libcloud.compute.drivers.ec2 import EC2NetworkSubnet
 from libcloud.compute.base import Node, NodeImage, NodeSize, NodeLocation
 from libcloud.compute.base import StorageVolume, VolumeSnapshot
 from libcloud.compute.types import KeyPairDoesNotExistError
@@ -880,10 +881,12 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
         size = NodeSize('m1.small', 'Small Instance', None, None, None, None,
                         driver=self.driver)
 
+        subnet = EC2NetworkSubnet(12345, "test_subnet", "waiting")
         security_groups = ['sg-1aa11a1a', 'sg-2bb22b2b']
 
         self.driver.create_node(name='foo', image=image, size=size,
-                                ex_security_group_ids=security_groups)
+                                ex_security_group_ids=security_groups,
+                                ex_subnet=subnet)
 
     def test_ex_get_metadata_for_node(self):
         image = NodeImage(id='ami-be3adfd7',


### PR DESCRIPTION
Due to amazon having a different param for the security groups on an instance launched on a VPC and libcloud already supports VPCs (ex_subnet) this is the piece is missing to support the security groups on a VPC node
- adds a ex_security_group_ids kwarg which is a list of security group ids
- checks for the existence of ex_subnet if ex_security_group_ids is called, as it depends on it to make sense
- adds a test to see if the params are being constructed correctly

EC2 API page: http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-RunInstances.html

```
SecurityGroupId.n
One or more security group IDs. You can create a security group using CreateSecurityGroup.
Type: String
Default: Amazon EC2 uses the default security group.
Required: No
```

```
SecurityGroup.n
[EC2-Classic, default VPC] One or more security group names. For a nondefault VPC, you must use SecurityGroupId.n.
Type: String
Default: Amazon EC2 uses the default security group.
Required: No
```
