### PR TITLE
GCE: fix GCE internal auth

### DIFF
--- a/libcloud/common/google.py
+++ b/libcloud/common/google.py
@@ -111,7 +111,7 @@ def _get_gce_metadata(path=''):
     try:
         url = "http://metadata/computeMetadata/v1/" + path.lstrip('/')
         headers = {'Metadata-Flavor': 'Google'}
-        response = get_response_object(url, headers)
+        response = get_response_object(url, headers=headers)
         return response.status, "", response.body
     except Exception as e:
         return -1, str(e), None


### PR DESCRIPTION
@Kami - Very sorry, but I think with the merge trouble we were having on LIBCLOUD-625[1], I must have goofed on one of conflicts.  This minor change fixes LIBCLOUD-625.

[1] https://github.com/apache/libcloud/commit/20d977075117f05a0d8cd8ceb91c4dfcd93a7766
