### PR TITLE
Made optional Google token file writing

### DIFF
--- a/libcloud/common/google.py
+++ b/libcloud/common/google.py
@@ -698,10 +698,14 @@ class GoogleBaseConnection(ConnectionUserAndKey, PollingConnection):
         """
         Write token_info to credential file.
         """
-        filename = os.path.realpath(os.path.expanduser(self.credential_file))
-        data = json.dumps(self.token_info)
-        with open(filename, 'w') as f:
-            f.write(data)
+        try:
+            filename = os.path.realpath(os.path.expanduser(
+                self.credential_file))
+            data = json.dumps(self.token_info)
+            with open(filename, 'w') as f:
+                f.write(data)
+        except IOError:
+            pass
 
     def has_completed(self, response):
         """


### PR DESCRIPTION
I had an issue where I can't write the token file in home directory.

File reading is made as optional by a try/except IOError.
So I made the same with file writing by change GoogleBaseConnection._write_token_info_to_file() with try/except IOError.

I use this patch in production without trouble.
