### PR TITLE
[google compute] Adding GCE DiskTypes resource - part 1

### DIFF
--- a/libcloud/test/compute/fixtures/gce/aggregated_disktypes.json
+++ b/libcloud/test/compute/fixtures/gce/aggregated_disktypes.json
@@ -1,0 +1,112 @@
+{
+ "kind": "compute#diskTypeAggregatedList",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/aggregated/diskTypes",
+ "items": {
+  "zones/us-central1-a": {
+   "diskTypes": [
+    {
+     "kind": "compute#diskType",
+     "creationTimestamp": "2014-06-02T11:07:28.529-07:00",
+     "name": "pd-ssd",
+     "description": "SSD Persistent Disk",
+     "validDiskSize": "10GB-10240GB",
+     "zone": "https://content.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a",
+     "selfLink": "https://content.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/diskTypes/pd-ssd",
+     "defaultDiskSizeGb": "100"
+    },
+    {
+     "kind": "compute#diskType",
+     "creationTimestamp": "2014-06-02T11:07:28.529-07:00",
+     "name": "local-ssd",
+     "description": "Local SSD",
+     "validDiskSize": "375GB-375",
+     "zone": "https://content.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a",
+     "selfLink": "https://content.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/diskTypes/local-ssd",
+     "defaultDiskSizeGb": "375"
+    },
+    {
+     "kind": "compute#diskType",
+     "creationTimestamp": "2014-06-02T11:07:28.530-07:00",
+     "name": "pd-standard",
+     "description": "Standard Persistent Disk",
+     "validDiskSize": "10GB-10240GB",
+     "zone": "https://content.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a",
+     "selfLink": "https://content.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/diskTypes/pd-standard",
+     "defaultDiskSizeGb": "500"
+    }
+   ]
+  },
+  "zones/us-central1-b": {
+   "diskTypes": [
+    {
+     "kind": "compute#diskType",
+     "creationTimestamp": "2014-06-02T11:07:28.529-07:00",
+     "name": "pd-ssd",
+     "description": "SSD Persistent Disk",
+     "validDiskSize": "10GB-10240GB",
+     "zone": "https://content.googleapis.com/compute/v1/projects/project_name/zones/us-central1-b",
+     "selfLink": "https://content.googleapis.com/compute/v1/projects/project_name/zones/us-central1-b/diskTypes/pd-ssd",
+     "defaultDiskSizeGb": "100"
+    },
+    {
+     "kind": "compute#diskType",
+     "creationTimestamp": "2014-06-02T11:07:28.530-07:00",
+     "name": "pd-standard",
+     "description": "Standard Persistent Disk",
+     "validDiskSize": "10GB-10240GB",
+     "zone": "https://content.googleapis.com/compute/v1/projects/project_name/zones/us-central1-b",
+     "selfLink": "https://content.googleapis.com/compute/v1/projects/project_name/zones/us-central1-b/diskTypes/pd-standard",
+     "defaultDiskSizeGb": "500"
+    }
+   ]
+  },
+  "zones/europe-west1-a": {
+   "diskTypes": [
+    {
+     "kind": "compute#diskType",
+     "creationTimestamp": "2014-06-02T11:07:28.529-07:00",
+     "name": "pd-ssd",
+     "description": "SSD Persistent Disk",
+     "validDiskSize": "10GB-10240GB",
+     "zone": "https://content.googleapis.com/compute/v1/projects/project_name/zones/europe-west1-a",
+     "selfLink": "https://content.googleapis.com/compute/v1/projects/project_name/zones/europe-west1-a/diskTypes/pd-ssd",
+     "defaultDiskSizeGb": "100"
+    },
+    {
+     "kind": "compute#diskType",
+     "creationTimestamp": "2014-06-02T11:07:28.530-07:00",
+     "name": "pd-standard",
+     "description": "Standard Persistent Disk",
+     "validDiskSize": "10GB-10240GB",
+     "zone": "https://content.googleapis.com/compute/v1/projects/project_name/zones/europe-west1-a",
+     "selfLink": "https://content.googleapis.com/compute/v1/projects/project_name/zones/europe-west1-a/diskTypes/pd-standard",
+     "defaultDiskSizeGb": "500"
+    }
+   ]
+  },
+  "zones/europe-west1-b": {
+   "diskTypes": [
+    {
+     "kind": "compute#diskType",
+     "creationTimestamp": "2014-06-02T11:07:28.529-07:00",
+     "name": "pd-ssd",
+     "description": "SSD Persistent Disk",
+     "validDiskSize": "10GB-10240GB",
+     "zone": "https://content.googleapis.com/compute/v1/projects/project_name/zones/europe-west1-b",
+     "selfLink": "https://content.googleapis.com/compute/v1/projects/project_name/zones/europe-west1-b/diskTypes/pd-ssd",
+     "defaultDiskSizeGb": "100"
+    },
+    {
+     "kind": "compute#diskType",
+     "creationTimestamp": "2014-06-02T11:07:28.530-07:00",
+     "name": "pd-standard",
+     "description": "Standard Persistent Disk",
+     "validDiskSize": "10GB-10240GB",
+     "zone": "https://content.googleapis.com/compute/v1/projects/project_name/zones/europe-west1-b",
+     "selfLink": "https://content.googleapis.com/compute/v1/projects/project_name/zones/europe-west1-b/diskTypes/pd-standard",
+     "defaultDiskSizeGb": "500"
+    }
+   ]
+  }
+ }
+}

--- a/libcloud/test/compute/fixtures/gce/zones_us-central1-a_diskTypes.json
+++ b/libcloud/test/compute/fixtures/gce/zones_us-central1-a_diskTypes.json
@@ -1,0 +1,27 @@
+{
+ "kind": "compute#diskTypeList",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/diskTypes",
+ "id": "projects/project_name/zones/us-central1-a/diskTypes",
+ "items": [
+  {
+   "kind": "compute#diskType",
+   "creationTimestamp": "2014-06-02T11:07:28.529-07:00",
+   "name": "pd-ssd",
+   "description": "SSD Persistent Disk",
+   "validDiskSize": "10GB-10240GB",
+   "zone": "https://content.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a",
+   "selfLink": "https://content.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/diskTypes/pd-ssd",
+   "defaultDiskSizeGb": "100"
+  },
+  {
+   "kind": "compute#diskType",
+   "creationTimestamp": "2014-06-02T11:07:28.530-07:00",
+   "name": "pd-standard",
+   "description": "Standard Persistent Disk",
+   "validDiskSize": "10GB-10240GB",
+   "zone": "https://content.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a",
+   "selfLink": "https://content.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/diskTypes/pd-standard",
+   "defaultDiskSizeGb": "500"
+  }
+ ]
+}

--- a/libcloud/test/compute/fixtures/gce/zones_us-central1-a_diskTypes_pd_ssd.json
+++ b/libcloud/test/compute/fixtures/gce/zones_us-central1-a_diskTypes_pd_ssd.json
@@ -1,0 +1,10 @@
+{
+ "kind": "compute#diskType",
+ "creationTimestamp": "2014-06-02T11:07:28.529-07:00",
+ "name": "pd-ssd",
+ "description": "SSD Persistent Disk",
+ "validDiskSize": "10GB-10240GB",
+ "zone": "https://content.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a",
+ "selfLink": "https://content.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/diskTypes/pd-ssd",
+ "defaultDiskSizeGb": "100"
+}

--- a/libcloud/test/compute/fixtures/gce/zones_us-central1-a_disktypes_pd-ssd.json
+++ b/libcloud/test/compute/fixtures/gce/zones_us-central1-a_disktypes_pd-ssd.json
@@ -1,0 +1,10 @@
+{
+ "kind": "compute#diskType",
+ "creationTimestamp": "2014-06-02T11:07:28.529-07:00",
+ "name": "pd-ssd",
+ "description": "SSD Persistent Disk",
+ "validDiskSize": "10GB-10240GB",
+ "zone": "https://content.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a",
+ "selfLink": "https://content.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/diskTypes/pd-ssd",
+ "defaultDiskSizeGb": "100"
+}


### PR DESCRIPTION
Adding GCE DiskTypes[1] support - part 1.

The GCE driver fakes support for DiskTypes at the moment and relies on a string `pd-ssd` or `pd-standard` for users to select the disktype. This PR sets the ground work to add GCE native DiskTypes that will be easier to expand in the future. For instance, Google has already introduced a `local-ssd` option.

I opted to split this up into two PRs so that this one only introduces a new libcloud object and does not tinker with existing "fake" disk-types.  Part 2 will be a follow-up to this one to update existing use of the string-version option and also allow using the new GCEDiskType object.

[1] https://cloud.google.com/compute/docs/reference/latest/diskTypes
