### PR TITLE
[google] global IP addresses

### DIFF
--- a/libcloud/test/compute/fixtures/gce/aggregated_addresses.json
+++ b/libcloud/test/compute/fixtures/gce/aggregated_addresses.json
@@ -64,6 +64,20 @@
         ],
         "message": "There are no results for scope 'regions/us-central2' on this page."
       }
+    },
+    "global": {
+      "addresses": [
+        {
+          "address": "173.99.99.99",
+          "creationTimestamp": "2013-06-26T12:21:40.625-07:00",
+          "description": "",
+          "id": "01531551729918243104",
+          "kind": "compute#address",
+          "name": "lcaddressglobal",
+          "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/addresses/lcaddressglobal",
+          "status": "RESERVED"
+        }
+      ]
     }
   },
   "kind": "compute#addressAggregatedList",

--- a/libcloud/test/compute/fixtures/gce/global_addresses.json
+++ b/libcloud/test/compute/fixtures/gce/global_addresses.json
@@ -1,0 +1,17 @@
+{
+  "id": "projects/project_name/global/addresses",
+  "items": [
+    {
+      "address": "173.99.99.99",
+      "creationTimestamp": "2013-06-26T09:48:31.184-07:00",
+      "description": "",
+      "id": "17634862894218443422",
+      "kind": "compute#address",
+      "name": "lcaddressglobal",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/addresses/lcaddressglobal",
+      "status": "RESERVED"
+    }
+  ],
+  "kind": "compute#addressList",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/addresses"
+}

--- a/libcloud/test/compute/fixtures/gce/global_addresses_lcaddressglobal.json
+++ b/libcloud/test/compute/fixtures/gce/global_addresses_lcaddressglobal.json
@@ -1,0 +1,10 @@
+{
+  "address": "173.99.99.99",
+  "creationTimestamp": "2013-06-26T12:21:40.625-07:00",
+  "description": "",
+  "id": "01531551729918243104",
+  "kind": "compute#address",
+  "name": "lcaddressglobal",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/addresses/lcaddressglobal",
+  "status": "RESERVED"
+}

--- a/libcloud/test/compute/fixtures/gce/global_addresses_lcaddressglobal_delete.json
+++ b/libcloud/test/compute/fixtures/gce/global_addresses_lcaddressglobal_delete.json
@@ -1,0 +1,14 @@
+{
+  "id": "7128783508312083402",
+  "insertTime": "2013-06-26T12:21:44.075-07:00",
+  "kind": "compute#operation",
+  "name": "operation-global_addresses_lcaddressglobal_delete",
+  "operationType": "delete",
+  "progress": 0,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/operations/operation-global_addresses_lcaddressglobal_delete",
+  "startTime": "2013-06-26T12:21:44.110-07:00",
+  "status": "PENDING",
+  "targetId": "01531551729918243104",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/addresses/lcaddressglobal",
+  "user": "foo@developer.gserviceaccount.com"
+}

--- a/libcloud/test/compute/fixtures/gce/global_addresses_post.json
+++ b/libcloud/test/compute/fixtures/gce/global_addresses_post.json
@@ -1,0 +1,13 @@
+{
+  "id": "16064059851942653139",
+  "insertTime": "2013-06-26T12:21:40.299-07:00",
+  "kind": "compute#operation",
+  "name": "operation-global_addresses_post",
+  "operationType": "insert",
+  "progress": 0,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/operations/operation-global_addresses_post",
+  "startTime": "2013-06-26T12:21:40.358-07:00",
+  "status": "PENDING",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/addresses/lcaddressglobal",
+  "user": "foo@developer.gserviceaccount.com"
+}

--- a/libcloud/test/compute/fixtures/gce/operations_operation_global_addresses_lcaddressglobal_delete.json
+++ b/libcloud/test/compute/fixtures/gce/operations_operation_global_addresses_lcaddressglobal_delete.json
@@ -1,0 +1,14 @@
+{
+  "id": "7128783508312083402",
+  "insertTime": "2013-06-26T12:21:44.075-07:00",
+  "kind": "compute#operation",
+  "name": "operation-global_addresses_lcaddressglobal_delete",
+  "operationType": "delete",
+  "progress": 100,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/operations/operation-global_addresses_lcaddressglobal_delete",
+  "startTime": "2013-06-26T12:21:44.110-07:00",
+  "status": "DONE",
+  "targetId": "01531551729918243104",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/addresses/lcaddressglobal",
+  "user": "foo@developer.gserviceaccount.com"
+}

--- a/libcloud/test/compute/fixtures/gce/operations_operation_global_addresses_post.json
+++ b/libcloud/test/compute/fixtures/gce/operations_operation_global_addresses_post.json
@@ -1,0 +1,14 @@
+{
+  "id": "16064059851942653139",
+  "insertTime": "2013-06-26T12:21:40.299-07:00",
+  "kind": "compute#operation",
+  "name": "operation-global_addresses_post",
+  "operationType": "insert",
+  "progress": 100,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/operations/operation-global_addresses_post",
+  "startTime": "2013-06-26T12:21:40.358-07:00",
+  "status": "DONE",
+  "targetId": "01531551729918243104",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/addresses/lcaddressglobal",
+  "user": "foo@developer.gserviceaccount.com"
+}

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -110,10 +110,13 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         address_list = self.driver.ex_list_addresses()
         address_list_all = self.driver.ex_list_addresses('all')
         address_list_uc1 = self.driver.ex_list_addresses('us-central1')
+        address_list_global = self.driver.ex_list_addresses('global')
         self.assertEqual(len(address_list), 2)
-        self.assertEqual(len(address_list_all), 4)
+        self.assertEqual(len(address_list_all), 5)
+        self.assertEqual(len(address_list_global), 1)
         self.assertEqual(address_list[0].name, 'libcloud-demo-address')
         self.assertEqual(address_list_uc1[0].name, 'libcloud-demo-address')
+        self.assertEqual(address_list_global[0].name, 'lcaddressglobal')
         names = [a.name for a in address_list_all]
         self.assertTrue('libcloud-demo-address' in names)
 
@@ -217,6 +220,13 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         zones = self.driver.ex_list_zones()
         self.assertEqual(len(zones), 5)
         self.assertEqual(zones[0].name, 'europe-west1-a')
+
+    def test_ex_create_address_global(self):
+        address_name = 'lcaddressglobal'
+        address = self.driver.ex_create_address(address_name, 'global')
+        self.assertTrue(isinstance(address, GCEAddress))
+        self.assertEqual(address.name, address_name)
+        self.assertEqual(address.region, 'global')
 
     def test_ex_create_address(self):
         address_name = 'lcaddress'
@@ -515,6 +525,13 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         detach = self.driver.detach_volume(volume, node)
         self.assertTrue(detach)
 
+    def test_ex_destroy_address_global(self):
+        address = self.driver.ex_get_address('lcaddressglobal', 'global')
+        self.assertTrue(address.name, 'lcaddressglobal')
+        self.assertTrue(address.region, 'global')
+        destroyed = address.destroy()
+        self.assertTrue(destroyed)
+
     def test_ex_destroy_address(self):
         address = self.driver.ex_get_address('lcaddress')
         destroyed = address.destroy()
@@ -584,6 +601,14 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         snapshot = self.driver.ex_get_snapshot('lcsnapshot')
         destroyed = snapshot.destroy()
         self.assertTrue(destroyed)
+
+    def test_ex_get_address_global(self):
+        address_name = 'lcaddressglobal'
+        address = self.driver.ex_get_address(address_name, 'global')
+        self.assertEqual(address.name, address_name)
+        self.assertEqual(address.address, '173.99.99.99')
+        self.assertEqual(address.region, 'global')
+        self.assertEqual(address.extra['status'], 'RESERVED')
 
     def test_ex_get_address(self):
         address_name = 'lcaddress'
@@ -927,10 +952,22 @@ class GCEMockHttp(MockHttpTestCase):
             'operations_operation_global_image_post.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
+    def _global_operations_operation_global_addresses_lcaddressglobal_delete(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'operations_operation_global_addresses_lcaddressglobal_delete.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
     def _regions_us_central1_operations_operation_regions_us_central1_addresses_lcaddress_delete(
             self, method, url, body, headers):
         body = self.fixtures.load(
             'operations_operation_regions_us-central1_addresses_lcaddress_delete.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _global_operations_operation_global_addresses_post(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'operations_operation_global_addresses_post.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
     def _regions_us_central1_operations_operation_regions_us_central1_addresses_post(
@@ -1084,12 +1121,28 @@ class GCEMockHttp(MockHttpTestCase):
             'regions.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
+    def _global_addresses(self, method, url, body, headers):
+        if method == 'POST':
+            body = self.fixtures.load(
+                'global_addresses_post.json')
+        else:
+            body = self.fixtures.load('global_addresses.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
     def _regions_us_central1_addresses(self, method, url, body, headers):
         if method == 'POST':
             body = self.fixtures.load(
                 'regions_us-central1_addresses_post.json')
         else:
             body = self.fixtures.load('regions_us-central1_addresses.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _global_addresses_lcaddressglobal(self, method, url, body, headers):
+        if method == 'DELETE':
+            body = self.fixtures.load(
+                'global_addresses_lcaddressglobal_delete.json')
+        else:
+            body = self.fixtures.load('global_addresses_lcaddressglobal.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
     def _regions_us_central1_addresses_lcaddress(self, method, url, body,


### PR DESCRIPTION
I should've really added this as part of #390 but didn't catch it until after it had been merged.

Google Compute Engine typically has region-based IP addresses, but with the introduction of HTTP load-balancing, a `global` static IP addresses have been introduced.  This PR is a small change to allow the `GCEAddress` class to allow for 'global' to be specified as the region.

New tests added to ensure both the original 'region-only' and new 'global' addresses are supported.
