### PR TITLE
[google compute] improved Images coverage

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -243,7 +243,8 @@ class GCENodeImage(NodeImage):
         """
         return self.driver.ex_delete_image(image=self)
 
-    def deprecate(self, replacement, state):
+    def deprecate(self, replacement, state, deprecated=None, obsolete=None,
+                  deleted=None):
         """
         Deprecate this image
 
@@ -254,10 +255,20 @@ class GCENodeImage(NodeImage):
                        \'DELETED\', \'DEPRECATED\' or \'OBSOLETE\'.
         :type   state: ``str``
 
+        :param  deprecated: RFC3339 timestamp to mark DEPRECATED
+        :type   deprecated: ``str`` or ``None``
+
+        :param  obsolete: RFC3339 timestamp to mark OBSOLETE
+        :type   obsolete: ``str`` or ``None``
+
+        :param  deleted: RFC3339 timestamp to mark DELETED
+        :type   deleted: ``str`` or ``None``
+
         :return: True if successful
         :rtype:  ``bool``
         """
-        return self.driver.ex_deprecate_image(self, replacement, state)
+        return self.driver.ex_deprecate_image(self, replacement, state,
+                                              deprecated, obsolete, deleted)
 
 
 class GCENetwork(UuidMixin):
@@ -722,7 +733,7 @@ class GCENodeDriver(NodeDriver):
         Return a list of image objects for a project.
 
         :keyword  ex_project: Optional alternate project name.
-        :type     ex_project: ``str`` or ``None``
+        :type     ex_project: ``str``, ``list`` of ``str``, or ``None``
 
         :return:  List of GCENodeImage objects
         :rtype:   ``list`` of :class:`GCENodeImage`
@@ -730,18 +741,25 @@ class GCENodeDriver(NodeDriver):
         request = '/global/images'
         if ex_project is None:
             response = self.connection.request(request, method='GET').object
+            list_images = [self._to_node_image(i) for i in
+                           response.get('items', [])]
         else:
+            list_images = []
             # Save the connection request_path
             save_request_path = self.connection.request_path
-            # Override the connection request path
-            new_request_path = save_request_path.replace(self.project,
-                                                         ex_project)
-            self.connection.request_path = new_request_path
-            response = self.connection.request(request, method='GET').object
+            if isinstance(ex_project, str):
+                ex_project = [ex_project]
+            for proj in ex_project:
+                # Override the connection request path
+                new_request_path = save_request_path.replace(self.project,
+                                                             proj)
+                self.connection.request_path = new_request_path
+                response = self.connection.request(request,
+                                                   method='GET').object
+                list_images.extend([self._to_node_image(i) for i in
+                                    response.get('items', [])])
             # Restore the connection request_path
             self.connection.request_path = save_request_path
-        list_images = [self._to_node_image(i) for i in
-                       response.get('items', [])]
         return list_images
 
     def list_locations(self):
@@ -2182,7 +2200,8 @@ class GCENodeDriver(NodeDriver):
         self.connection.async_request(request, method='DELETE')
         return True
 
-    def ex_deprecate_image(self, image, replacement, state=None):
+    def ex_deprecate_image(self, image, replacement, state=None,
+                           deprecated=None, obsolete=None, deleted=None):
         """
         Deprecate a specific image resource.
 
@@ -2194,6 +2213,15 @@ class GCENodeDriver(NodeDriver):
 
         :param  state: State of the image
         :type   state: ``str``
+
+        :param  deprecated: RFC3339 timestamp to mark DEPRECATED
+        :type   deprecated: ``str`` or ``None``
+
+        :param  obsolete: RFC3339 timestamp to mark OBSOLETE
+        :type   obsolete: ``str`` or ``None``
+
+        :param  deleted: RFC3339 timestamp to mark DELETED
+        :type   deleted: ``str`` or ``None``
 
         :return: True if successful
         :rtype:  ``bool``
@@ -2217,6 +2245,27 @@ class GCENodeDriver(NodeDriver):
             'state': state,
             'replacement': replacement.extra['selfLink'],
         }
+
+        if deprecated is not None:
+            try:
+                _ = timestamp_to_datetime(deprecated)    # NOQA
+            except:
+                raise ValueError('deprecated must be an RFC3339 timestamp')
+            image_data['deprecated'] = deprecated
+
+        if obsolete is not None:
+            try:
+                _ = timestamp_to_datetime(obsolete)      # NOQA
+            except:
+                raise ValueError('obsolete must be an RFC3339 timestamp')
+            image_data['obsolete'] = obsolete
+
+        if deleted is not None:
+            try:
+                _ = timestamp_to_datetime(deleted)       # NOQA
+            except:
+                raise ValueError('deleted must be an RFC3339 timestamp')
+            image_data['deleted'] = deleted
 
         request = '/global/images/%s/deprecate' % (image.name)
 
@@ -2523,7 +2572,7 @@ class GCENodeDriver(NodeDriver):
         response = self.connection.request(request, method='GET').object
         return self._to_forwarding_rule(response)
 
-    def ex_get_image(self, partial_name):
+    def ex_get_image(self, partial_name, ex_project_list=None):
         """
         Return an GCENodeImage object based on the name or link provided.
 
@@ -2538,10 +2587,11 @@ class GCENodeDriver(NodeDriver):
         if partial_name.startswith('https://'):
             response = self.connection.request(partial_name, method='GET')
             return self._to_node_image(response.object)
-        image = self._match_images(None, partial_name)
+        image = self._match_images(ex_project_list, partial_name)
         if not image:
             if (partial_name.startswith('debian') or
-                    partial_name.startswith('backports')):
+                    partial_name.startswith('backports') or
+                    partial_name.startswith('nvme-backports')):
                 image = self._match_images('debian-cloud', partial_name)
             elif partial_name.startswith('centos'):
                 image = self._match_images('centos-cloud', partial_name)
@@ -3416,11 +3466,24 @@ class GCENodeDriver(NodeDriver):
         :rtype: :class:`GCENodeImage`
         """
         extra = {}
-        extra['preferredKernel'] = image.get('preferredKernel', None)
+        if 'preferredKernel' in image:
+            extra['preferredKernel'] = image.get('preferredKernel', None)
         extra['description'] = image.get('description', None)
         extra['creationTimestamp'] = image.get('creationTimestamp')
         extra['selfLink'] = image.get('selfLink')
-        extra['deprecated'] = image.get('deprecated', None)
+        if 'deprecated' in image:
+            extra['deprecated'] = image.get('deprecated', None)
+        extra['sourceType'] = image.get('sourceType', None)
+        extra['rawDisk'] = image.get('rawDisk', None)
+        extra['status'] = image.get('status', None)
+        extra['archiveSizeBytes'] = image.get('archiveSizeBytes', None)
+        extra['diskSizeGb'] = image.get('diskSizeGb', None)
+        if 'sourceDisk' in image:
+            extra['sourceDisk'] = image.get('sourceDisk', None)
+        if 'sourceDiskId' in image:
+            extra['sourceDiskId'] = image.get('sourceDiskId', None)
+        if 'licenses' in image:
+            extra['licenses'] = image.get('licenses', None)
 
         return GCENodeImage(id=image['id'], name=image['name'], driver=self,
                             extra=extra)

--- a/libcloud/test/compute/fixtures/gce/projects_debian-cloud_global_images.json
+++ b/libcloud/test/compute/fixtures/gce/projects_debian-cloud_global_images.json
@@ -42,7 +42,9 @@
       "archiveSizeBytes": "255972840",
       "creationTimestamp": "2013-05-09T12:56:21.720-07:00",
       "deprecated": {
-        "deprecated": "2013-11-12T21:00:00Z",
+        "deprecated": "2064-03-11T20:18:36.194-07:00",
+        "obsolete": "2074-03-11T20:18:36.194-07:00",
+        "deleted": "2084-03-11T20:18:36.194-07:00",
         "replacement": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20131014",
         "state": "DEPRECATED"
       },
@@ -162,7 +164,9 @@
       "archiveSizeBytes": "300710522",
       "creationTimestamp": "2013-10-11T09:26:47.736-07:00",
       "deprecated": {
-        "deprecated": "2013-11-14T00:00:00Z",
+        "deprecated": "2064-03-11T20:18:36.194-07:00",
+        "obsolete": "2074-03-11T20:18:36.194-07:00",
+        "deleted": "2084-03-11T20:18:36.194-07:00",
         "replacement": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20131014",
         "state": "DEPRECATED"
       },

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -142,8 +142,10 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
     def test_list_images(self):
         local_images = self.driver.list_images()
         debian_images = self.driver.list_images(ex_project='debian-cloud')
+        local_plus_deb = self.driver.list_images(['debian-cloud', 'project_name'])
         self.assertEqual(len(local_images), 3)
         self.assertEqual(len(debian_images), 19)
+        self.assertEqual(len(local_plus_deb), 22)
         self.assertEqual(local_images[0].name, 'debian-7-wheezy-v20130617')
         self.assertEqual(local_images[1].name, 'centos-6-v20131118')
 
@@ -531,9 +533,18 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         self.assertTrue(deleted)
 
     def test_ex_deprecate_image(self):
-        image = self.driver.ex_get_image('debian-6')
-        deprecated = image.deprecate('debian-7', 'DEPRECATED')
+        dep_ts = '2064-03-11T20:18:36.194-07:00'
+        obs_ts = '2074-03-11T20:18:36.194-07:00'
+        del_ts = '2084-03-11T20:18:36.194-07:00'
+        image = self.driver.ex_get_image('debian-6-squeeze-v20130926')
+        deprecated = image.deprecate('debian-7', 'DEPRECATED',
+                                     deprecated=dep_ts,
+                                     obsolete=obs_ts,
+                                     deleted=del_ts)
         self.assertTrue(deprecated)
+        self.assertTrue(image.extra['deprecated']['deprecated'], dep_ts)
+        self.assertTrue(image.extra['deprecated']['obsolete'], obs_ts)
+        self.assertTrue(image.extra['deprecated']['deleted'], del_ts)
 
     def test_ex_destroy_firewall(self):
         firewall = self.driver.ex_get_firewall('lcfirewall')
@@ -626,6 +637,10 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         image = self.driver.ex_get_image(partial_name)
         self.assertEqual(image.name, 'debian-6-squeeze-v20130926')
         self.assertTrue(image.extra['description'].startswith('Debian'))
+
+        partial_name = 'debian-7'
+        image = self.driver.ex_get_image(partial_name, ['debian-cloud'])
+        self.assertEqual(image.name, 'debian-7-wheezy-v20131120')
 
     def test_ex_copy_image(self):
         name = 'coreos'


### PR DESCRIPTION
Updates to improve the `GCENodeImage` coverage of the GCE API.  Specifically, this update has:
- Added object attributes to match the upstream Image resource (e.g. `diskSizeGb`, `sourceType`, etc)
- Moving toward deprecating older attributes such as `preferredKernel`. This has long been removed from the GCE API, but there is a chance very old customer images still retain this value.
- Add support for setting timestamps for deprecating images for when they would will be automatically marked as `DELETED`, `OBSOLETE`, and `DEPRECATED`.
- Also adding a nice-to-have feature for allowing users to specify a search-list of projects versus just the user's project and hard-coded list of supported image projects.

No breaking changes introduced and tests have been enhanced for these changes.
