### PR TITLE
[google compute] improve MachineType (size) coverage of GCE API

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -3508,11 +3508,27 @@ class GCENodeDriver(NodeDriver):
         :rtype: :class:`GCENodeSize`
         """
         extra = {}
+        disk_size = 10
         extra['selfLink'] = machine_type.get('selfLink')
+        extra['creationTimestamp'] = machine_type.get('creationTimestamp')
         extra['zone'] = self.ex_get_zone(machine_type['zone'])
         extra['description'] = machine_type.get('description')
         extra['guestCpus'] = machine_type.get('guestCpus')
-        extra['creationTimestamp'] = machine_type.get('creationTimestamp')
+        extra['memoryMb'] = machine_type.get('memoryMb')
+        extra['maximumPersistentDisks'] = \
+            machine_type.get('maximumPersistentDisks')
+        if 'imageSpaceGb' in machine_type:
+            extra['imageSpaceGb'] = machine_type.get('imageSpaceGb')
+            disk_size = extra['imageSpaceGb']
+        if 'maximumPersistentDisksSizeGb' in machine_type:
+            extra['maximumPersistentDisksSizeGb'] = \
+                int(machine_type.get('maximumPersistentDisksSizeGb'))
+            disk_size = extra['maximumPersistentDisksSizeGb']
+        if 'deprecated' in machine_type:
+            extra['deprecated'] = machine_type.get('deprecated')
+        if 'scratchDisks' in machine_type:
+            extra['scratchDisks'] = machine_type.get('scratchDisks')
+
         try:
             price = self._get_size_price(size_id=machine_type['name'])
         except KeyError:
@@ -3520,8 +3536,8 @@ class GCENodeDriver(NodeDriver):
 
         return GCENodeSize(id=machine_type['id'], name=machine_type['name'],
                            ram=machine_type.get('memoryMb'),
-                           disk=machine_type.get('imageSpaceGb'),
-                           bandwidth=0, price=price, driver=self, extra=extra)
+                           disk=disk_size, bandwidth=0, price=price,
+                           driver=self, extra=extra)
 
     def _to_project(self, project):
         """

--- a/libcloud/test/compute/fixtures/gce/zones_us-central1-a_machineTypes_n1-standard-1.json
+++ b/libcloud/test/compute/fixtures/gce/zones_us-central1-a_machineTypes_n1-standard-1.json
@@ -1,14 +1,13 @@
 {
-  "creationTimestamp": "2012-06-07T13:48:14.670-07:00",
-  "description": "1 vCPU, 3.75 GB RAM",
-  "guestCpus": 1,
-  "id": "11077240422128681563",
-  "imageSpaceGb": 10,
-  "kind": "compute#machineType",
-  "maximumPersistentDisks": 16,
-  "maximumPersistentDisksSizeGb": "10240",
-  "memoryMb": 3840,
-  "name": "n1-standard-1",
-  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/machineTypes/n1-standard-1",
-  "zone": "us-central1-a"
+ "kind": "compute#machineType",
+ "id": "12907738072351752276",
+ "creationTimestamp": "2012-06-07T13:48:14.670-07:00",
+ "name": "n1-standard-1",
+ "description": "1 vCPU, 3.75 GB RAM",
+ "guestCpus": 1,
+ "memoryMb": 3840,
+ "maximumPersistentDisks": 16,
+ "maximumPersistentDisksSizeGb": "10240",
+ "zone": "us-central1-a",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/machineTypes/n1-standard-1"
 }

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -675,9 +675,12 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         size = self.driver.ex_get_size(size_name)
         self.assertEqual(size.name, size_name)
         self.assertEqual(size.extra['zone'].name, 'us-central1-a')
-        self.assertEqual(size.disk, 10)
+        self.assertEqual(size.disk, 10240)
         self.assertEqual(size.ram, 3840)
         self.assertEqual(size.extra['guestCpus'], 1)
+        self.assertEqual(size.extra['memoryMb'], 3840)
+        self.assertEqual(size.extra['maximumPersistentDisks'], 16)
+        self.assertEqual(size.extra['maximumPersistentDisksSizeGb'], 10240)
 
     def test_ex_get_targetpool(self):
         targetpool_name = 'lctargetpool'


### PR DESCRIPTION
Minor improvements to GCE Machine Types (sizes in libcloud parlance) to match GCE API.
- added missing resource attributes to `GCENodeSize`
- hiding some parameters from `extra` since they've been removed (namely `imageSpaceGb`)
- minor change to the disk.size value based on presence/absence of attributes

Updated test fixture and test.
