### PR TITLE
[google compute] add missing description to GCENetwork

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -1227,7 +1227,7 @@ class GCENodeDriver(NodeDriver):
 
         return self.ex_get_image(name)
 
-    def ex_create_network(self, name, cidr):
+    def ex_create_network(self, name, cidr, description=None):
         """
         Create a network.
 
@@ -1235,7 +1235,10 @@ class GCENodeDriver(NodeDriver):
         :type   name: ``str``
 
         :param  cidr: Address range of network in CIDR format.
-        :type  cidr: ``str``
+        :type   cidr: ``str``
+
+        :param  description: Custom description for the network.
+        :type   description: ``str`` or ``None``
 
         :return:  Network object
         :rtype:   :class:`GCENetwork`
@@ -1243,6 +1246,7 @@ class GCENodeDriver(NodeDriver):
         network_data = {}
         network_data['name'] = name
         network_data['IPv4Range'] = cidr
+        network_data['description'] = description
 
         request = '/global/networks'
 

--- a/libcloud/test/compute/fixtures/gce/global_networks_lcnetwork.json
+++ b/libcloud/test/compute/fixtures/gce/global_networks_lcnetwork.json
@@ -2,6 +2,7 @@
   "IPv4Range": "10.11.0.0/16",
   "creationTimestamp": "2013-06-26T10:05:03.500-07:00",
   "gatewayIPv4": "10.11.0.1",
+  "description": "A custom network",
   "id": "16211908079305042870",
   "kind": "compute#network",
   "name": "lcnetwork",

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -641,6 +641,7 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         self.assertEqual(network.name, network_name)
         self.assertEqual(network.cidr, '10.11.0.0/16')
         self.assertEqual(network.extra['gatewayIPv4'], '10.11.0.1')
+        self.assertEqual(network.extra['description'], 'A custom network')
 
     def test_ex_get_node(self):
         node_name = 'node-name'


### PR DESCRIPTION
Minor fix to add missing `description` attribute to `GCENetwork`.
