### PR TITLE
[google compute] improved API coverage for Projects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,6 +61,10 @@ Compute
   (GITHUB-401)
   [Eric Johnson]
 
+- AWS: Set proper disk size in c3.X instance types
+  (GITHUB-405)
+  [Itxaka Serrano]
+
 Storage
 ~~~~~~~
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -57,6 +57,10 @@ Compute
   (GITHUB-390, GITHUB-394)
   [Eric Johnson]
 
+- GCE: Add missing snapshot attributes.
+  (GITHUB-401)
+  [Eric Johnson]
+
 Changes with Apache Libcloud 0.16.0
 -----------------------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,10 @@ Compute
   (GITHUB-397)
   [Eric Johnson]
 
+- GCE: Improve MachineType (size) coverage of GCE API
+  (GITHUB-396)
+  [Eric Johnson]
+
 Changes with Apache Libcloud 0.16.0
 -----------------------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,10 @@ Compute
   (GITHUB-396)
   [Eric Johnson]
 
+- GCE: Improved Images coverage
+  (GITHUB-395)
+  [Eric Johnson]
+
 Changes with Apache Libcloud 0.16.0
 -----------------------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,10 @@ Compute
   (GITHUB-373)
   [Itxaka Serrano]
 
+- Add description argument to GCE Network
+  (GITHUB-397)
+  [Eric Johnson]
+
 Changes with Apache Libcloud 0.16.0
 -----------------------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -53,6 +53,10 @@ Compute
   (GITHUB-395)
   [Eric Johnson]
 
+- GCE: Support for global IP addresses.
+  (GITHUB-390, GITHUB-394)
+  [Eric Johnson]
+
 Changes with Apache Libcloud 0.16.0
 -----------------------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,6 +61,16 @@ Compute
   (GITHUB-401)
   [Eric Johnson]
 
+Storage
+~~~~~~~
+
+- Allow user to pass ``headers`` argument to the ``upload_object`` and
+  ``upload_object_via_stream`` method.
+
+  This way user can specify CORS headers with the drivers which support that.
+  (GITHUB-403, GITHUB-404)
+  [Peter Schmidt]
+
 Changes with Apache Libcloud 0.16.0
 -----------------------------------
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -36,9 +36,9 @@ Code style guide
 * Use 79 characters in a line
 * Make sure edited file doesn't contain any trailing whitespace
 * You can verify that your modifications don't break any rules by running the
-  ``flake8`` script - e.g. ``flake8 libcloud/edited_file.py.`` or
+  ``flake8`` script - e.g. ``flake8 libcloud/edited_file.py`` or
   ``tox -e lint``.
-  Second command fill run flake8 on all the files in the repository.
+  Second command will run flake8 on all the files in the repository.
 
 And most importantly, follow the existing style in the file you are editing and
 **be consistent**.

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -219,35 +219,35 @@ INSTANCE_TYPES = {
         'id': 'c3.large',
         'name': 'Compute Optimized Large Instance',
         'ram': 3750,
-        'disk': 16,
+        'disk': 32,  # x2
         'bandwidth': None
     },
     'c3.xlarge': {
         'id': 'c3.xlarge',
         'name': 'Compute Optimized Extra Large Instance',
-        'ram': 7000,
-        'disk': 40,
+        'ram': 7500,
+        'disk': 80,  # x2
         'bandwidth': None
     },
     'c3.2xlarge': {
         'id': 'c3.2xlarge',
         'name': 'Compute Optimized Double Extra Large Instance',
         'ram': 15000,
-        'disk': 80,
+        'disk': 160,  # x2
         'bandwidth': None
     },
     'c3.4xlarge': {
         'id': 'c3.4xlarge',
         'name': 'Compute Optimized Quadruple Extra Large Instance',
         'ram': 30000,
-        'disk': 160,
+        'disk': 320,  # x2
         'bandwidth': None
     },
     'c3.8xlarge': {
         'id': 'c3.8xlarge',
         'name': 'Compute Optimized Eight Extra Large Instance',
         'ram': 60000,
-        'disk': 320,
+        'disk': 640,  # x2
         'bandwidth': None
     },
     'cr1.8xlarge': {

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -3808,6 +3808,16 @@ class GCENodeDriver(NodeDriver):
         extra['selfLink'] = snapshot.get('selfLink')
         extra['creationTimestamp'] = snapshot.get('creationTimestamp')
         extra['sourceDisk'] = snapshot.get('sourceDisk')
+        if 'description' in snapshot:
+            extra['description'] = snapshot['description']
+        if 'sourceDiskId' in snapshot:
+            extra['sourceDiskId'] = snapshot['sourceDiskId']
+        if 'storageBytes' in snapshot:
+            extra['storageBytes'] = snapshot['storageBytes']
+        if 'storageBytesStatus' in snapshot:
+            extra['storageBytesStatus'] = snapshot['storageBytesStatus']
+        if 'licenses' in snapshot:
+            extra['licenses'] = snapshot['licenses']
 
         return GCESnapshot(id=snapshot['id'], name=snapshot['name'],
                            size=snapshot['diskSizeGb'],

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -1361,7 +1361,7 @@ class GCENodeDriver(NodeDriver):
 
         return self.ex_get_image(name)
 
-    def ex_create_network(self, name, cidr):
+    def ex_create_network(self, name, cidr, description=None):
         """
         Create a network.
 
@@ -1369,7 +1369,10 @@ class GCENodeDriver(NodeDriver):
         :type   name: ``str``
 
         :param  cidr: Address range of network in CIDR format.
-        :type  cidr: ``str``
+        :type   cidr: ``str``
+
+        :param  description: Custom description for the network.
+        :type   description: ``str`` or ``None``
 
         :return:  Network object
         :rtype:   :class:`GCENetwork`
@@ -1377,6 +1380,7 @@ class GCENodeDriver(NodeDriver):
         network_data = {}
         network_data['name'] = name
         network_data['IPv4Range'] = cidr
+        network_data['description'] = description
 
         request = '/global/networks'
 

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -3646,11 +3646,27 @@ class GCENodeDriver(NodeDriver):
         :rtype: :class:`GCENodeSize`
         """
         extra = {}
+        disk_size = 10
         extra['selfLink'] = machine_type.get('selfLink')
+        extra['creationTimestamp'] = machine_type.get('creationTimestamp')
         extra['zone'] = self.ex_get_zone(machine_type['zone'])
         extra['description'] = machine_type.get('description')
         extra['guestCpus'] = machine_type.get('guestCpus')
-        extra['creationTimestamp'] = machine_type.get('creationTimestamp')
+        extra['memoryMb'] = machine_type.get('memoryMb')
+        extra['maximumPersistentDisks'] = \
+            machine_type.get('maximumPersistentDisks')
+        if 'imageSpaceGb' in machine_type:
+            extra['imageSpaceGb'] = machine_type.get('imageSpaceGb')
+            disk_size = extra['imageSpaceGb']
+        if 'maximumPersistentDisksSizeGb' in machine_type:
+            extra['maximumPersistentDisksSizeGb'] = \
+                int(machine_type.get('maximumPersistentDisksSizeGb'))
+            disk_size = extra['maximumPersistentDisksSizeGb']
+        if 'deprecated' in machine_type:
+            extra['deprecated'] = machine_type.get('deprecated')
+        if 'scratchDisks' in machine_type:
+            extra['scratchDisks'] = machine_type.get('scratchDisks')
+
         try:
             price = self._get_size_price(size_id=machine_type['name'])
         except KeyError:
@@ -3658,8 +3674,8 @@ class GCENodeDriver(NodeDriver):
 
         return GCENodeSize(id=machine_type['id'], name=machine_type['name'],
                            ram=machine_type.get('memoryMb'),
-                           disk=machine_type.get('imageSpaceGb'),
-                           bandwidth=0, price=price, driver=self, extra=extra)
+                           disk=disk_size, bandwidth=0, price=price,
+                           driver=self, extra=extra)
 
     def _to_project(self, project):
         """

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -3882,6 +3882,7 @@ class GCENodeDriver(NodeDriver):
         extra['selfLink'] = zone.get('selfLink')
         extra['creationTimestamp'] = zone.get('creationTimestamp')
         extra['description'] = zone.get('description')
+        extra['region'] = zone.get('region')
 
         deprecated = zone.get('deprecated')
 

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -304,6 +304,54 @@ class GCEProject(UuidMixin):
         self.extra = extra
         UuidMixin.__init__(self)
 
+    def set_common_instance_metadata(self, metadata=None, force=False):
+        """
+        Set common instance metadata for the project. Common uses
+        are for setting 'sshKeys', or setting a project-wide
+        'startup-script' for all nodes (instances).  Passing in
+        ``None`` for the 'metadata' parameter will clear out all common
+        instance metadata *except* for 'sshKeys'. If you also want to
+        update 'sshKeys', set the 'force' paramater to ``True``.
+
+        :param  metadata: Dictionay of metadata. Can be either a standard
+                          python dictionary, or the format expected by
+                          GCE (e.g. {'items': [{'key': k1, 'value': v1}, ...}]
+        :type   metadata: ``dict`` or ``None``
+
+        :param  force: Force update of 'sshKeys'. If force is ``False`` (the
+                       default), existing sshKeys will be retained. Setting
+                       force to ``True`` will either replace sshKeys if a new
+                       a new value is supplied, or deleted if no new value
+                       is supplied.
+        :type   force: ``bool``
+
+        :return: True if successful
+        :rtype:  ``bool``
+        """
+        return self.driver.ex_set_common_instance_metadata(self, metadata)
+
+    def set_usage_export_bucket(self, bucket, prefix=None):
+        """
+        Used to retain Compute Engine resource usage, storing the CSV data in
+        a Google Cloud Storage bucket. See the
+        `docs <https://cloud.google.com/compute/docs/usage-export>`_ for more
+        information. Please ensure you have followed the necessary setup steps
+        prior to enabling this feature (e.g. bucket exists, ACLs are in place,
+        etc.)
+
+        :param  bucket: Name of the Google Cloud Storage bucket. Specify the
+                        name in either 'gs://<bucket_name>' or the full URL
+                        'https://storage.googleapis.com/<bucket_name>'.
+        :type   bucket: ``str``
+
+        :param  prefix: Optional prefix string for all reports.
+        :type   prefix: ``str`` or ``None``
+
+        :return: True if successful
+        :rtype:  ``bool``
+        """
+        return self.driver.ex_set_usage_export_bucket(self, bucket, prefix)
+
     def __repr__(self):
         return '<GCEProject id="%s" name="%s">' % (self.id, self.name)
 
@@ -620,6 +668,92 @@ class GCENodeDriver(NodeDriver):
             self.region = self._get_region_from_zone(self.zone)
         else:
             self.region = None
+
+    def ex_set_usage_export_bucket(self, bucket, prefix=None):
+        """
+        Used to retain Compute Engine resource usage, storing the CSV data in
+        a Google Cloud Storage bucket. See the
+        `docs <https://cloud.google.com/compute/docs/usage-export>`_ for more
+        information. Please ensure you have followed the necessary setup steps
+        prior to enabling this feature (e.g. bucket exists, ACLs are in place,
+        etc.)
+
+        :param  bucket: Name of the Google Cloud Storage bucket. Specify the
+                        name in either 'gs://<bucket_name>' or the full URL
+                        'https://storage.googleapis.com/<bucket_name>'.
+        :type   bucket: ``str``
+
+        :param  prefix: Optional prefix string for all reports.
+        :type   prefix: ``str`` or ``None``
+
+        :return: True if successful
+        :rtype:  ``bool``
+        """
+        if bucket.startswith('https://www.googleapis.com/') or \
+                bucket.startswith('gs://'):
+            data = {'bucketName': bucket}
+        else:
+            raise ValueError("Invalid bucket name: %s" % bucket)
+        if prefix:
+            data['reportNamePrefix'] = prefix
+
+        request = '/setUsageExportBucket'
+        self.connection.async_request(request, method='POST', data=data)
+        return True
+
+    def ex_set_common_instance_metadata(self, metadata=None, force=False):
+        """
+        Set common instance metadata for the project. Common uses
+        are for setting 'sshKeys', or setting a project-wide
+        'startup-script' for all nodes (instances).  Passing in
+        ``None`` for the 'metadata' parameter will clear out all common
+        instance metadata *except* for 'sshKeys'. If you also want to
+        update 'sshKeys', set the 'force' paramater to ``True``.
+
+        :param  metadata: Dictionay of metadata. Can be either a standard
+                          python dictionary, or the format expected by
+                          GCE (e.g. {'items': [{'key': k1, 'value': v1}, ...}]
+        :type   metadata: ``dict`` or ``None``
+
+        :param  force: Force update of 'sshKeys'. If force is ``False`` (the
+                       default), existing sshKeys will be retained. Setting
+                       force to ``True`` will either replace sshKeys if a new
+                       a new value is supplied, or deleted if no new value
+                       is supplied.
+        :type   force: ``bool``
+
+        :return: True if successful
+        :rtype:  ``bool``
+        """
+        if metadata:
+            if not isinstance(metadata, dict):
+                raise ValueError("Metadata must be a python dictionary.")
+
+            if 'items' not in metadata:
+                items = []
+                for k, v in metadata.items():
+                    items.append({'key': k, 'value': v})
+                metadata = {'items': items}
+            elif not isinstance(metadata['items'], list):
+                raise ValueError("Invalid GCE metadata format.")
+
+        request = '/setCommonInstanceMetadata'
+
+        project = self.ex_get_project()
+        current_metadata = project.extra['commonInstanceMetadata']
+        fingerprint = current_metadata['fingerprint']
+
+        # grab copy of current 'sshKeys' in case we want to retain them
+        current_keys = ""
+        for md in current_metadata['items']:
+            if md['key'] == 'sshKeys':
+                current_keys = md['value']
+
+        new_md = self._set_project_metadata(metadata, force, current_keys)
+
+        md = {'fingerprint': fingerprint, 'items': new_md}
+        self.connection.async_request(request, method='POST', data=md)
+        return True
 
     def ex_list_addresses(self, region=None):
         """
@@ -3538,6 +3672,11 @@ class GCENodeDriver(NodeDriver):
         extra['creationTimestamp'] = project.get('creationTimestamp')
         extra['description'] = project.get('description')
         metadata = project['commonInstanceMetadata'].get('items')
+        if 'commonInstanceMetadata' in project:
+            # add this struct to get 'fingerprint' too
+            extra['commonInstanceMetadata'] = project['commonInstanceMetadata']
+        if 'usageExportLocation' in project:
+            extra['usageExportLocation'] = project['usageExportLocation']
 
         return GCEProject(id=project['id'], name=project['name'],
                           metadata=metadata, quotas=project.get('quotas'),
@@ -3664,3 +3803,48 @@ class GCENodeDriver(NodeDriver):
         return GCEZone(id=zone['id'], name=zone['name'], status=zone['status'],
                        maintenance_windows=zone.get('maintenanceWindows'),
                        deprecated=deprecated, driver=self, extra=extra)
+
+    def _set_project_metadata(self, metadata=None, force=False,
+                              current_keys=""):
+        """
+        Return the GCE-friendly dictionary of metadata with/without an
+        entry for 'sshKeys' based on params for 'force' and 'current_keys'.
+        This method was added to simplify the set_common_instance_metadata
+        method and make it easier to test.
+
+        :param  metadata: The GCE-formatted dict (e.g. 'items' list of dicts)
+        :type   metadata: ``dict`` or ``None``
+
+        :param  force: Flag to specify user preference for keeping current_keys
+        :type   force: ``bool``
+
+        :param  current_keys: The value, if any, of existing 'sshKeys'
+        :type   current_keys: ``str``
+
+        :return: GCE-friendly metadata dict
+        :rtype:  ``dict``
+        """
+        if metadata is None:
+            # User wants to delete metdata, but if 'force' is False
+            # and we already have sshKeys, we should retain them.
+            # Otherwise, delete ALL THE THINGS!
+            if not force and current_keys:
+                new_md = [{'key': 'sshKeys', 'value': current_keys}]
+            else:
+                new_md = []
+        else:
+            # User is providing new metadata. If 'force' is False, they
+            # want to preserve existing sshKeys, otherwise 'force' is True
+            # and the user wants to add/replace sshKeys.
+            new_md = metadata['items']
+            if not force and current_keys:
+                # not sure how duplicate keys would be resolved, so ensure
+                # existing 'sshKeys' entry is removed.
+                updated_md = []
+                for d in new_md:
+                    if d['key'] != 'sshKeys':
+                        updated_md.append({'key': d['key'],
+                                          'value': d['value']})
+                new_md = updated_md
+                new_md.append({'key': 'sshKeys', 'value': current_keys})
+        return new_md

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -243,7 +243,8 @@ class GCENodeImage(NodeImage):
         """
         return self.driver.ex_delete_image(image=self)
 
-    def deprecate(self, replacement, state):
+    def deprecate(self, replacement, state, deprecated=None, obsolete=None,
+                  deleted=None):
         """
         Deprecate this image
 
@@ -254,10 +255,20 @@ class GCENodeImage(NodeImage):
                        \'DELETED\', \'DEPRECATED\' or \'OBSOLETE\'.
         :type   state: ``str``
 
+        :param  deprecated: RFC3339 timestamp to mark DEPRECATED
+        :type   deprecated: ``str`` or ``None``
+
+        :param  obsolete: RFC3339 timestamp to mark OBSOLETE
+        :type   obsolete: ``str`` or ``None``
+
+        :param  deleted: RFC3339 timestamp to mark DELETED
+        :type   deleted: ``str`` or ``None``
+
         :return: True if successful
         :rtype:  ``bool``
         """
-        return self.driver.ex_deprecate_image(self, replacement, state)
+        return self.driver.ex_deprecate_image(self, replacement, state,
+                                              deprecated, obsolete, deleted)
 
 
 class GCENetwork(UuidMixin):
@@ -856,7 +867,7 @@ class GCENodeDriver(NodeDriver):
         Return a list of image objects for a project.
 
         :keyword  ex_project: Optional alternate project name.
-        :type     ex_project: ``str`` or ``None``
+        :type     ex_project: ``str``, ``list`` of ``str``, or ``None``
 
         :return:  List of GCENodeImage objects
         :rtype:   ``list`` of :class:`GCENodeImage`
@@ -864,18 +875,25 @@ class GCENodeDriver(NodeDriver):
         request = '/global/images'
         if ex_project is None:
             response = self.connection.request(request, method='GET').object
+            list_images = [self._to_node_image(i) for i in
+                           response.get('items', [])]
         else:
+            list_images = []
             # Save the connection request_path
             save_request_path = self.connection.request_path
-            # Override the connection request path
-            new_request_path = save_request_path.replace(self.project,
-                                                         ex_project)
-            self.connection.request_path = new_request_path
-            response = self.connection.request(request, method='GET').object
+            if isinstance(ex_project, str):
+                ex_project = [ex_project]
+            for proj in ex_project:
+                # Override the connection request path
+                new_request_path = save_request_path.replace(self.project,
+                                                             proj)
+                self.connection.request_path = new_request_path
+                response = self.connection.request(request,
+                                                   method='GET').object
+                list_images.extend([self._to_node_image(i) for i in
+                                    response.get('items', [])])
             # Restore the connection request_path
             self.connection.request_path = save_request_path
-        list_images = [self._to_node_image(i) for i in
-                       response.get('items', [])]
         return list_images
 
     def list_locations(self):
@@ -2320,7 +2338,8 @@ class GCENodeDriver(NodeDriver):
         self.connection.async_request(request, method='DELETE')
         return True
 
-    def ex_deprecate_image(self, image, replacement, state=None):
+    def ex_deprecate_image(self, image, replacement, state=None,
+                           deprecated=None, obsolete=None, deleted=None):
         """
         Deprecate a specific image resource.
 
@@ -2332,6 +2351,15 @@ class GCENodeDriver(NodeDriver):
 
         :param  state: State of the image
         :type   state: ``str``
+
+        :param  deprecated: RFC3339 timestamp to mark DEPRECATED
+        :type   deprecated: ``str`` or ``None``
+
+        :param  obsolete: RFC3339 timestamp to mark OBSOLETE
+        :type   obsolete: ``str`` or ``None``
+
+        :param  deleted: RFC3339 timestamp to mark DELETED
+        :type   deleted: ``str`` or ``None``
 
         :return: True if successful
         :rtype:  ``bool``
@@ -2355,6 +2383,27 @@ class GCENodeDriver(NodeDriver):
             'state': state,
             'replacement': replacement.extra['selfLink'],
         }
+
+        if deprecated is not None:
+            try:
+                _ = timestamp_to_datetime(deprecated)    # NOQA
+            except:
+                raise ValueError('deprecated must be an RFC3339 timestamp')
+            image_data['deprecated'] = deprecated
+
+        if obsolete is not None:
+            try:
+                _ = timestamp_to_datetime(obsolete)      # NOQA
+            except:
+                raise ValueError('obsolete must be an RFC3339 timestamp')
+            image_data['obsolete'] = obsolete
+
+        if deleted is not None:
+            try:
+                _ = timestamp_to_datetime(deleted)       # NOQA
+            except:
+                raise ValueError('deleted must be an RFC3339 timestamp')
+            image_data['deleted'] = deleted
 
         request = '/global/images/%s/deprecate' % (image.name)
 
@@ -2661,7 +2710,7 @@ class GCENodeDriver(NodeDriver):
         response = self.connection.request(request, method='GET').object
         return self._to_forwarding_rule(response)
 
-    def ex_get_image(self, partial_name):
+    def ex_get_image(self, partial_name, ex_project_list=None):
         """
         Return an GCENodeImage object based on the name or link provided.
 
@@ -2676,10 +2725,11 @@ class GCENodeDriver(NodeDriver):
         if partial_name.startswith('https://'):
             response = self.connection.request(partial_name, method='GET')
             return self._to_node_image(response.object)
-        image = self._match_images(None, partial_name)
+        image = self._match_images(ex_project_list, partial_name)
         if not image:
             if (partial_name.startswith('debian') or
-                    partial_name.startswith('backports')):
+                    partial_name.startswith('backports') or
+                    partial_name.startswith('nvme-backports')):
                 image = self._match_images('debian-cloud', partial_name)
             elif partial_name.startswith('centos'):
                 image = self._match_images('centos-cloud', partial_name)
@@ -3554,11 +3604,24 @@ class GCENodeDriver(NodeDriver):
         :rtype: :class:`GCENodeImage`
         """
         extra = {}
-        extra['preferredKernel'] = image.get('preferredKernel', None)
+        if 'preferredKernel' in image:
+            extra['preferredKernel'] = image.get('preferredKernel', None)
         extra['description'] = image.get('description', None)
         extra['creationTimestamp'] = image.get('creationTimestamp')
         extra['selfLink'] = image.get('selfLink')
-        extra['deprecated'] = image.get('deprecated', None)
+        if 'deprecated' in image:
+            extra['deprecated'] = image.get('deprecated', None)
+        extra['sourceType'] = image.get('sourceType', None)
+        extra['rawDisk'] = image.get('rawDisk', None)
+        extra['status'] = image.get('status', None)
+        extra['archiveSizeBytes'] = image.get('archiveSizeBytes', None)
+        extra['diskSizeGb'] = image.get('diskSizeGb', None)
+        if 'sourceDisk' in image:
+            extra['sourceDisk'] = image.get('sourceDisk', None)
+        if 'sourceDiskId' in image:
+            extra['sourceDiskId'] = image.get('sourceDiskId', None)
+        if 'licenses' in image:
+            extra['licenses'] = image.get('licenses', None)
 
         return GCENodeImage(id=image['id'], name=image['name'], driver=self,
                             extra=extra)
@@ -3646,27 +3709,11 @@ class GCENodeDriver(NodeDriver):
         :rtype: :class:`GCENodeSize`
         """
         extra = {}
-        disk_size = 10
         extra['selfLink'] = machine_type.get('selfLink')
-        extra['creationTimestamp'] = machine_type.get('creationTimestamp')
         extra['zone'] = self.ex_get_zone(machine_type['zone'])
         extra['description'] = machine_type.get('description')
         extra['guestCpus'] = machine_type.get('guestCpus')
-        extra['memoryMb'] = machine_type.get('memoryMb')
-        extra['maximumPersistentDisks'] = \
-            machine_type.get('maximumPersistentDisks')
-        if 'imageSpaceGb' in machine_type:
-            extra['imageSpaceGb'] = machine_type.get('imageSpaceGb')
-            disk_size = extra['imageSpaceGb']
-        if 'maximumPersistentDisksSizeGb' in machine_type:
-            extra['maximumPersistentDisksSizeGb'] = \
-                int(machine_type.get('maximumPersistentDisksSizeGb'))
-            disk_size = extra['maximumPersistentDisksSizeGb']
-        if 'deprecated' in machine_type:
-            extra['deprecated'] = machine_type.get('deprecated')
-        if 'scratchDisks' in machine_type:
-            extra['scratchDisks'] = machine_type.get('scratchDisks')
-
+        extra['creationTimestamp'] = machine_type.get('creationTimestamp')
         try:
             price = self._get_size_price(size_id=machine_type['name'])
         except KeyError:
@@ -3674,8 +3721,8 @@ class GCENodeDriver(NodeDriver):
 
         return GCENodeSize(id=machine_type['id'], name=machine_type['name'],
                            ram=machine_type.get('memoryMb'),
-                           disk=disk_size, bandwidth=0, price=price,
-                           driver=self, extra=extra)
+                           disk=machine_type.get('imageSpaceGb'),
+                           bandwidth=0, price=price, driver=self, extra=extra)
 
     def _to_project(self, project):
         """

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -97,8 +97,9 @@ class GCEAddress(UuidMixin):
         return self.driver.ex_destroy_address(address=self)
 
     def __repr__(self):
-        return '<GCEAddress id="%s" name="%s" address="%s">' % (
-            self.id, self.name, self.address)
+        return '<GCEAddress id="%s" name="%s" address="%s" region="%s">' % (
+            self.id, self.name, self.address,
+            (hasattr(self.region, "name") and self.region.name or self.region))
 
 
 class GCEFailedDisk(object):
@@ -768,21 +769,25 @@ class GCENodeDriver(NodeDriver):
 
     def ex_list_addresses(self, region=None):
         """
-        Return a list of static addresses for a region or all.
+        Return a list of static addresses for a region, 'global', or all.
 
         :keyword  region: The region to return addresses from. For example:
                           'us-central1'.  If None, will return addresses from
                           region of self.zone.  If 'all', will return all
-                          addresses.
+                          addresses. If 'global', it will return addresses in
+                          the global namespace.
         :type     region: ``str`` or ``None``
 
         :return: A list of static address objects.
         :rtype: ``list`` of :class:`GCEAddress`
         """
         list_addresses = []
-        region = self._set_region(region)
+        if region != 'global':
+            region = self._set_region(region)
         if region is None:
             request = '/aggregated/addresses'
+        elif region == 'global':
+            request = '/global/addresses'
         else:
             request = '/regions/%s/addresses' % (region.name)
         response = self.connection.request(request, method='GET').object
@@ -1092,12 +1097,13 @@ class GCENodeDriver(NodeDriver):
     def ex_create_address(self, name, region=None, address=None,
                           description=None):
         """
-        Create a static address in a region.
+        Create a static address in a region, or a global address.
 
         :param  name: Name of static address
         :type   name: ``str``
 
         :keyword  region: Name of region for the address (e.g. 'us-central1')
+                          Use 'global' to create a global address.
         :type     region: ``str`` or :class:`GCERegion`
 
         :keyword  address: Ephemeral IP address to promote to a static one
@@ -1111,7 +1117,7 @@ class GCENodeDriver(NodeDriver):
         :rtype:   :class:`GCEAddress`
         """
         region = region or self.region
-        if not hasattr(region, 'name'):
+        if region != 'global' and not hasattr(region, 'name'):
             region = self.ex_get_region(region)
         elif region is None:
             raise ValueError('REGION_NOT_SPECIFIED',
@@ -1121,7 +1127,10 @@ class GCENodeDriver(NodeDriver):
             address_data['address'] = address
         if description:
             address_data['description'] = description
-        request = '/regions/%s/addresses' % (region.name)
+        if region == 'global':
+            request = '/global/addresses'
+        else:
+            request = '/regions/%s/addresses' % (region.name)
         self.connection.async_request(request, method='POST',
                                       data=address_data)
         return self.ex_get_address(name, region=region)
@@ -2315,8 +2324,11 @@ class GCENodeDriver(NodeDriver):
         if not hasattr(address, 'name'):
             address = self.ex_get_address(address)
 
-        request = '/regions/%s/addresses/%s' % (address.region.name,
-                                                address.name)
+        if hasattr(address.region, 'name'):
+            request = '/regions/%s/addresses/%s' % (address.region.name,
+                                                    address.name)
+        else:
+            request = '/global/addresses/%s' % (address.name)
 
         self.connection.async_request(request, method='DELETE')
         return True
@@ -2656,9 +2668,12 @@ class GCENodeDriver(NodeDriver):
         :return:  An Address object for the address
         :rtype:   :class:`GCEAddress`
         """
-        region = self._set_region(region) or self._find_zone_or_region(
-            name, 'addresses', region=True, res_name='Address')
-        request = '/regions/%s/addresses/%s' % (region.name, name)
+        if region == 'global':
+            request = '/global/addresses/%s' % (name)
+        else:
+            region = self._set_region(region) or self._find_zone_or_region(
+                name, 'addresses', region=True, res_name='Address')
+            request = '/regions/%s/addresses/%s' % (region.name, name)
         response = self.connection.request(request, method='GET').object
         return self._to_address(response)
 
@@ -3478,7 +3493,10 @@ class GCENodeDriver(NodeDriver):
         """
         extra = {}
 
-        region = self.ex_get_region(address['region'])
+        if 'region' in address:
+            region = self.ex_get_region(address['region'])
+        else:
+            region = 'global'
 
         extra['selfLink'] = address.get('selfLink')
         extra['status'] = address.get('status')

--- a/libcloud/httplib_ssl.py
+++ b/libcloud/httplib_ssl.py
@@ -277,7 +277,7 @@ class LibcloudHTTPSConnection(httplib.HTTPSConnection, LibcloudBaseConnection):
                                     self.cert_file,
                                     cert_reqs=ssl.CERT_REQUIRED,
                                     ca_certs=self.ca_cert,
-                                    ssl_version=ssl.PROTOCOL_TLSv1)
+                                    ssl_version=libcloud.security.SSL_VERSION)
         cert = self.sock.getpeercert()
         try:
             match_hostname(cert, self.host)

--- a/libcloud/security.py
+++ b/libcloud/security.py
@@ -24,8 +24,17 @@ Usage:
 """
 
 import os
+import ssl
+
+__all__ = [
+    'VERIFY_SSL_CERT',
+    'SSL_VERSION',
+    'CA_CERTS_PATH'
+]
 
 VERIFY_SSL_CERT = True
+
+SSL_VERSION = ssl.PROTOCOL_TLSv1
 
 # File containing one or more PEM-encoded CA certificates
 # concatenated together.

--- a/libcloud/storage/base.py
+++ b/libcloud/storage/base.py
@@ -361,7 +361,7 @@ class StorageDriver(BaseDriver):
             'download_object_as_stream not implemented for this driver')
 
     def upload_object(self, file_path, container, object_name, extra=None,
-                      verify_hash=True):
+                      verify_hash=True, headers=None):
         """
         Upload an object currently located on a disk.
 
@@ -380,6 +380,11 @@ class StorageDriver(BaseDriver):
         :param extra: Extra attributes (driver specific). (optional)
         :type extra: ``dict``
 
+        :param headers: (optional) Additional request headers,
+            such as CORS headers. For example:
+            headers = {'Access-Control-Allow-Origin': 'http://mozilla.com'}
+        :type headers: ``dict``
+
         :rtype: :class:`Object`
         """
         raise NotImplementedError(
@@ -387,7 +392,8 @@ class StorageDriver(BaseDriver):
 
     def upload_object_via_stream(self, iterator, container,
                                  object_name,
-                                 extra=None):
+                                 extra=None,
+                                 headers=None):
         """
         Upload an object using an iterator.
 
@@ -405,19 +411,24 @@ class StorageDriver(BaseDriver):
         function which uses fs.stat function to determine the file size and it
         doesn't need to buffer whole object in the memory.
 
-        :type iterator: :class:`object`
         :param iterator: An object which implements the iterator interface.
+        :type iterator: :class:`object`
 
-        :type container: :class:`Container`
         :param container: Destination container.
+        :type container: :class:`Container`
 
-        :type object_name: ``str``
         :param object_name: Object name.
+        :type object_name: ``str``
 
-        :type extra: ``dict``
         :param extra: (optional) Extra attributes (driver specific). Note:
             This dictionary must contain a 'content_type' key which represents
             a content type of the stored object.
+        :type extra: ``dict``
+
+        :param headers: (optional) Additional request headers,
+            such as CORS headers. For example:
+            headers = {'Access-Control-Allow-Origin': 'http://mozilla.com'}
+        :type headers: ``dict``
 
         :rtype: ``object``
         """
@@ -428,8 +439,8 @@ class StorageDriver(BaseDriver):
         """
         Delete an object.
 
-        :type obj: :class:`Object`
         :param obj: Object instance.
+        :type obj: :class:`Object`
 
         :return: ``bool`` True on success.
         :rtype: ``bool``
@@ -441,8 +452,8 @@ class StorageDriver(BaseDriver):
         """
         Create a new container.
 
-        :type container_name: ``str``
         :param container_name: Container name.
+        :type container_name: ``str``
 
         :return: Container instance on success.
         :rtype: :class:`Container`
@@ -454,8 +465,8 @@ class StorageDriver(BaseDriver):
         """
         Delete a container.
 
-        :type container: :class:`Container`
         :param container: Container instance
+        :type container: :class:`Container`
 
         :return: ``True`` on success, ``False`` otherwise.
         :rtype: ``bool``
@@ -468,23 +479,23 @@ class StorageDriver(BaseDriver):
         """
         Call passed callback and start transfer of the object'
 
-        :type obj: :class:`Object`
         :param obj: Object instance.
+        :type obj: :class:`Object`
 
-        :type callback: :class:`function`
         :param callback: Function which is called with the passed
             callback_kwargs
+        :type callback: :class:`function`
 
-        :type callback_kwargs: ``dict``
         :param callback_kwargs: Keyword arguments which are passed to the
              callback.
+        :type callback_kwargs: ``dict``
 
-        :typed response: :class:`Response`
         :param response: Response instance.
+        :type response: :class:`Response`
 
-        :type success_status_code: ``int``
         :param success_status_code: Status code which represents a successful
                                     transfer (defaults to httplib.OK)
+        :type success_status_code: ``int``
 
         :return: ``True`` on success, ``False`` otherwise.
         :rtype: ``bool``
@@ -507,26 +518,26 @@ class StorageDriver(BaseDriver):
         """
         Save object to the provided path.
 
-        :type response: :class:`RawResponse`
         :param response: RawResponse instance.
+        :type response: :class:`RawResponse`
 
-        :type obj: :class:`Object`
         :param obj: Object instance.
+        :type obj: :class:`Object`
 
-        :type destination_path: ``str``
         :param destination_path: Destination directory.
+        :type destination_path: ``str``
 
-        :type delete_on_failure: ``bool``
         :param delete_on_failure: True to delete partially downloaded object if
                                   the download fails.
+        :type delete_on_failure: ``bool``
 
-        :type overwrite_existing: ``bool``
         :param overwrite_existing: True to overwrite a local path if it already
                                    exists.
+        :type overwrite_existing: ``bool``
 
-        :type chunk_size: ``int``
         :param chunk_size: Optional chunk size
             (defaults to ``libcloud.storage.base.CHUNK_SIZE``, 8kb)
+        :type chunk_size: ``int``
 
         :return: ``True`` on success, ``False`` otherwise.
         :rtype: ``bool``
@@ -660,20 +671,20 @@ class StorageDriver(BaseDriver):
         """
         Upload data stored in a string.
 
-        :type response: :class:`RawResponse`
         :param response: RawResponse object.
+        :type response: :class:`RawResponse`
 
-        :type data: ``str``
         :param data: Data to upload.
+        :type data: ``str``
 
-        :type calculate_hash: ``bool``
         :param calculate_hash: True to calculate hash of the transferred data.
-                               (defauls to True).
+                               (defaults to True).
+        :type calculate_hash: ``bool``
 
-        :rtype: ``tuple``
         :return: First item is a boolean indicator of success, second
                  one is the uploaded data MD5 hash and the third one
                  is the number of transferred bytes.
+        :rtype: ``tuple``
         """
         bytes_transferred = 0
         data_hash = None
@@ -701,23 +712,23 @@ class StorageDriver(BaseDriver):
         """
         Stream a data over an http connection.
 
-        :type response: :class:`RawResponse`
         :param response: RawResponse object.
+        :type response: :class:`RawResponse`
 
-        :type iterator: :class:`object`
         :param response: An object which implements an iterator interface
                          or a File like object with read method.
+        :type iterator: :class:`object`
 
-        :type chunked: ``bool``
         :param chunked: True if the chunked transfer encoding should be used
                         (defauls to False).
+        :type chunked: ``bool``
 
-        :type calculate_hash: ``bool``
         :param calculate_hash: True to calculate hash of the transferred data.
                                (defauls to True).
+        :type calculate_hash: ``bool``
 
-        :type chunk_size: ``int``
         :param chunk_size: Optional chunk size (defaults to ``CHUNK_SIZE``)
+        :type chunk_size: ``int``
 
         :rtype: ``tuple``
         :return: First item is a boolean indicator of success, second

--- a/libcloud/storage/drivers/cloudfiles.py
+++ b/libcloud/storage/drivers/cloudfiles.py
@@ -414,7 +414,7 @@ class CloudFilesStorageDriver(StorageDriver, OpenStackDriverMixin):
                                 success_status_code=httplib.OK)
 
     def upload_object(self, file_path, container, object_name, extra=None,
-                      verify_hash=True):
+                      verify_hash=True, headers=None):
         """
         Upload an object.
 
@@ -427,10 +427,11 @@ class CloudFilesStorageDriver(StorageDriver, OpenStackDriverMixin):
                                 upload_func=upload_func,
                                 upload_func_kwargs=upload_func_kwargs,
                                 extra=extra, file_path=file_path,
-                                verify_hash=verify_hash)
+                                verify_hash=verify_hash, headers=headers)
 
     def upload_object_via_stream(self, iterator,
-                                 container, object_name, extra=None):
+                                 container, object_name, extra=None,
+                                 headers=None):
         if isinstance(iterator, file):
             iterator = iter(iterator)
 
@@ -440,7 +441,8 @@ class CloudFilesStorageDriver(StorageDriver, OpenStackDriverMixin):
         return self._put_object(container=container, object_name=object_name,
                                 upload_func=upload_func,
                                 upload_func_kwargs=upload_func_kwargs,
-                                extra=extra, iterator=iterator)
+                                extra=extra, iterator=iterator,
+                                headers=headers)
 
     def delete_object(self, obj):
         container_name = self._encode_container_name(obj.container.name)
@@ -752,7 +754,7 @@ class CloudFilesStorageDriver(StorageDriver, OpenStackDriverMixin):
 
     def _put_object(self, container, object_name, upload_func,
                     upload_func_kwargs, extra=None, file_path=None,
-                    iterator=None, verify_hash=True):
+                    iterator=None, verify_hash=True, headers=None):
         extra = extra or {}
         container_name_encoded = self._encode_container_name(container.name)
         object_name_encoded = self._encode_object_name(object_name)
@@ -760,7 +762,7 @@ class CloudFilesStorageDriver(StorageDriver, OpenStackDriverMixin):
         meta_data = extra.get('meta_data', None)
         content_disposition = extra.get('content_disposition', None)
 
-        headers = {}
+        headers = headers or {}
         if meta_data:
             for key, value in list(meta_data.items()):
                 key = 'X-Object-Meta-%s' % (key)

--- a/libcloud/test/compute/fixtures/gce/aggregated_addresses.json
+++ b/libcloud/test/compute/fixtures/gce/aggregated_addresses.json
@@ -64,6 +64,20 @@
         ],
         "message": "There are no results for scope 'regions/us-central2' on this page."
       }
+    },
+    "global": {
+      "addresses": [
+        {
+          "address": "173.99.99.99",
+          "creationTimestamp": "2013-06-26T12:21:40.625-07:00",
+          "description": "",
+          "id": "01531551729918243104",
+          "kind": "compute#address",
+          "name": "lcaddressglobal",
+          "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/addresses/lcaddressglobal",
+          "status": "RESERVED"
+        }
+      ]
     }
   },
   "kind": "compute#addressAggregatedList",

--- a/libcloud/test/compute/fixtures/gce/global_addresses.json
+++ b/libcloud/test/compute/fixtures/gce/global_addresses.json
@@ -1,0 +1,17 @@
+{
+  "id": "projects/project_name/global/addresses",
+  "items": [
+    {
+      "address": "173.99.99.99",
+      "creationTimestamp": "2013-06-26T09:48:31.184-07:00",
+      "description": "",
+      "id": "17634862894218443422",
+      "kind": "compute#address",
+      "name": "lcaddressglobal",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/addresses/lcaddressglobal",
+      "status": "RESERVED"
+    }
+  ],
+  "kind": "compute#addressList",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/addresses"
+}

--- a/libcloud/test/compute/fixtures/gce/global_addresses_lcaddressglobal.json
+++ b/libcloud/test/compute/fixtures/gce/global_addresses_lcaddressglobal.json
@@ -1,0 +1,10 @@
+{
+  "address": "173.99.99.99",
+  "creationTimestamp": "2013-06-26T12:21:40.625-07:00",
+  "description": "",
+  "id": "01531551729918243104",
+  "kind": "compute#address",
+  "name": "lcaddressglobal",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/addresses/lcaddressglobal",
+  "status": "RESERVED"
+}

--- a/libcloud/test/compute/fixtures/gce/global_addresses_lcaddressglobal_delete.json
+++ b/libcloud/test/compute/fixtures/gce/global_addresses_lcaddressglobal_delete.json
@@ -1,0 +1,14 @@
+{
+  "id": "7128783508312083402",
+  "insertTime": "2013-06-26T12:21:44.075-07:00",
+  "kind": "compute#operation",
+  "name": "operation-global_addresses_lcaddressglobal_delete",
+  "operationType": "delete",
+  "progress": 0,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/operations/operation-global_addresses_lcaddressglobal_delete",
+  "startTime": "2013-06-26T12:21:44.110-07:00",
+  "status": "PENDING",
+  "targetId": "01531551729918243104",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/addresses/lcaddressglobal",
+  "user": "foo@developer.gserviceaccount.com"
+}

--- a/libcloud/test/compute/fixtures/gce/global_addresses_post.json
+++ b/libcloud/test/compute/fixtures/gce/global_addresses_post.json
@@ -1,0 +1,13 @@
+{
+  "id": "16064059851942653139",
+  "insertTime": "2013-06-26T12:21:40.299-07:00",
+  "kind": "compute#operation",
+  "name": "operation-global_addresses_post",
+  "operationType": "insert",
+  "progress": 0,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/operations/operation-global_addresses_post",
+  "startTime": "2013-06-26T12:21:40.358-07:00",
+  "status": "PENDING",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/addresses/lcaddressglobal",
+  "user": "foo@developer.gserviceaccount.com"
+}

--- a/libcloud/test/compute/fixtures/gce/global_networks_lcnetwork.json
+++ b/libcloud/test/compute/fixtures/gce/global_networks_lcnetwork.json
@@ -2,6 +2,7 @@
   "IPv4Range": "10.11.0.0/16",
   "creationTimestamp": "2013-06-26T10:05:03.500-07:00",
   "gatewayIPv4": "10.11.0.1",
+  "description": "A custom network",
   "id": "16211908079305042870",
   "kind": "compute#network",
   "name": "lcnetwork",

--- a/libcloud/test/compute/fixtures/gce/operations_operation_global_addresses_lcaddressglobal_delete.json
+++ b/libcloud/test/compute/fixtures/gce/operations_operation_global_addresses_lcaddressglobal_delete.json
@@ -1,0 +1,14 @@
+{
+  "id": "7128783508312083402",
+  "insertTime": "2013-06-26T12:21:44.075-07:00",
+  "kind": "compute#operation",
+  "name": "operation-global_addresses_lcaddressglobal_delete",
+  "operationType": "delete",
+  "progress": 100,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/operations/operation-global_addresses_lcaddressglobal_delete",
+  "startTime": "2013-06-26T12:21:44.110-07:00",
+  "status": "DONE",
+  "targetId": "01531551729918243104",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/addresses/lcaddressglobal",
+  "user": "foo@developer.gserviceaccount.com"
+}

--- a/libcloud/test/compute/fixtures/gce/operations_operation_global_addresses_post.json
+++ b/libcloud/test/compute/fixtures/gce/operations_operation_global_addresses_post.json
@@ -1,0 +1,14 @@
+{
+  "id": "16064059851942653139",
+  "insertTime": "2013-06-26T12:21:40.299-07:00",
+  "kind": "compute#operation",
+  "name": "operation-global_addresses_post",
+  "operationType": "insert",
+  "progress": 100,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/operations/operation-global_addresses_post",
+  "startTime": "2013-06-26T12:21:40.358-07:00",
+  "status": "DONE",
+  "targetId": "01531551729918243104",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/addresses/lcaddressglobal",
+  "user": "foo@developer.gserviceaccount.com"
+}

--- a/libcloud/test/compute/fixtures/gce/operations_operation_setCommonInstanceMetadata.json
+++ b/libcloud/test/compute/fixtures/gce/operations_operation_setCommonInstanceMetadata.json
@@ -1,0 +1,15 @@
+{
+  "endTime": "2013-06-26T10:05:07.630-07:00",
+  "id": "3681664092089171723",
+  "insertTime": "2013-06-26T10:05:03.271-07:00",
+  "kind": "compute#operation",
+  "name": "operation-setCommonInstanceMetadat",
+  "operationType": "insert",
+  "progress": 100,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/operations/operation-setCommonInstanceMetadata",
+  "startTime": "2013-06-26T10:05:03.315-07:00",
+  "status": "DONE",
+  "targetId": "16211908079305042870",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/setCommonInstanceMetadata",
+  "user": "foo@developer.gserviceaccount.com"
+}

--- a/libcloud/test/compute/fixtures/gce/operations_operation_setUsageExportBucket.json
+++ b/libcloud/test/compute/fixtures/gce/operations_operation_setUsageExportBucket.json
@@ -1,0 +1,14 @@
+{
+ "kind": "compute#operation",
+ "id": "17203609782824174066",
+ "name": "operation-setUsageExportBucket",
+ "operationType": "setUsageExportBucket",
+ "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name",
+ "targetId": "8116069320260064853",
+ "status": "DONE",
+ "user": "erjohnso@google.com",
+ "progress": 100,
+ "insertTime": "2014-11-21T06:58:03.602-08:00",
+ "startTime": "2014-11-21T06:58:04.018-08:00",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/operations/operation-setUsageExportBucket"
+}

--- a/libcloud/test/compute/fixtures/gce/project.json
+++ b/libcloud/test/compute/fixtures/gce/project.json
@@ -1,59 +1,98 @@
 {
-  "commonInstanceMetadata": {
-    "items": [
-      {
-        "key": "sshKeys",
-        "value": "ASDFASDF"
-      }
-    ],
-    "kind": "compute#metadata"
+ "kind": "compute#project",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name",
+ "id": "8116069320260064853",
+ "creationTimestamp": "2014-01-21T10:30:53.390-08:00",
+ "name": "project_name",
+ "description": "",
+ "commonInstanceMetadata": {
+  "kind": "compute#metadata",
+  "fingerprint": "3zEcGBxH6Vs=",
+  "items": [
+   {
+    "key": "sshKeys",
+    "value": "ABCDEF"
+   },
+   {
+    "key": "startup-script",
+    "value": "#!/bin/bash\n\nAUTO_SCRIPT=$(curl -s http://metadata/computeMetadata/v1/instance/attributes/my-auto-script -H \"Metadata-Flavor: Google\")\nCHECK=${AUTO_SCRIPT:-disabled}\n\nif [ \"${CHECK}\" = \"enabled\" -a -f /etc/debian_version ]; then\n    export DEBIAN_FRONTEND=noninteractive\n    apt-get -q -y update\n    apt-get -q -y install git vim tmux\n    fi\nexit 0\n"
+   }
+  ]
+ },
+ "quotas": [
+  {
+   "metric": "SNAPSHOTS",
+   "limit": 1000,
+   "usage": 1
   },
-  "creationTimestamp": "2013-02-05T16:19:20.516-08:00",
-  "description": "",
-  "id": "2193465259114366848",
-  "kind": "compute#project",
-  "name": "project_name",
-  "quotas": [
-    {
-      "limit": 1000.0,
-      "metric": "SNAPSHOTS",
-      "usage": 0.0
-    },
-    {
-      "limit": 5.0,
-      "metric": "NETWORKS",
-      "usage": 3.0
-    },
-    {
-      "limit": 100.0,
-      "metric": "FIREWALLS",
-      "usage": 5.0
-    },
-    {
-      "limit": 100.0,
-      "metric": "IMAGES",
-      "usage": 0.0
-    },
-    {
-      "limit": 100.0,
-      "metric": "ROUTES",
-      "usage": 6.0
-    },
-    {
-      "limit": 50.0,
-      "metric": "FORWARDING_RULES",
-      "usage": 0.0
-    },
-    {
-      "limit": 50.0,
-      "metric": "TARGET_POOLS",
-      "usage": 1.0
-    },
-    {
-      "limit": 50.0,
-      "metric": "HEALTH_CHECKS",
-      "usage": 1.0
-    }
-  ],
-  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name"
+  {
+   "metric": "NETWORKS",
+   "limit": 5,
+   "usage": 3
+  },
+  {
+   "metric": "FIREWALLS",
+   "limit": 100,
+   "usage": 6
+  },
+  {
+   "metric": "IMAGES",
+   "limit": 100,
+   "usage": 1
+  },
+  {
+   "metric": "STATIC_ADDRESSES",
+   "limit": 7,
+   "usage": 1
+  },
+  {
+   "metric": "ROUTES",
+   "limit": 100,
+   "usage": 2
+  },
+  {
+   "metric": "FORWARDING_RULES",
+   "limit": 50,
+   "usage": 0
+  },
+  {
+   "metric": "TARGET_POOLS",
+   "limit": 50,
+   "usage": 0
+  },
+  {
+   "metric": "HEALTH_CHECKS",
+   "limit": 50,
+   "usage": 1
+  },
+  {
+   "metric": "IN_USE_ADDRESSES",
+   "limit": 23,
+   "usage": 0
+  },
+  {
+   "metric": "TARGET_INSTANCES",
+   "limit": 50,
+   "usage": 3
+  },
+  {
+   "metric": "TARGET_HTTP_PROXIES",
+   "limit": 50,
+   "usage": 0
+  },
+  {
+   "metric": "URL_MAPS",
+   "limit": 50,
+   "usage": 1
+  },
+  {
+   "metric": "BACKEND_SERVICES",
+   "limit": 50,
+   "usage": 1
+  }
+ ],
+ "usageExportLocation": {
+  "bucketName": "gs://graphite-usage-reports",
+  "reportNamePrefix": "graphite-report"
+ }
 }

--- a/libcloud/test/compute/fixtures/gce/projects_debian-cloud_global_images.json
+++ b/libcloud/test/compute/fixtures/gce/projects_debian-cloud_global_images.json
@@ -42,7 +42,9 @@
       "archiveSizeBytes": "255972840",
       "creationTimestamp": "2013-05-09T12:56:21.720-07:00",
       "deprecated": {
-        "deprecated": "2013-11-12T21:00:00Z",
+        "deprecated": "2064-03-11T20:18:36.194-07:00",
+        "obsolete": "2074-03-11T20:18:36.194-07:00",
+        "deleted": "2084-03-11T20:18:36.194-07:00",
         "replacement": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20131014",
         "state": "DEPRECATED"
       },
@@ -162,7 +164,9 @@
       "archiveSizeBytes": "300710522",
       "creationTimestamp": "2013-10-11T09:26:47.736-07:00",
       "deprecated": {
-        "deprecated": "2013-11-14T00:00:00Z",
+        "deprecated": "2064-03-11T20:18:36.194-07:00",
+        "obsolete": "2074-03-11T20:18:36.194-07:00",
+        "deleted": "2084-03-11T20:18:36.194-07:00",
         "replacement": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20131014",
         "state": "DEPRECATED"
       },

--- a/libcloud/test/compute/fixtures/gce/setCommonInstanceMetadata_post.json
+++ b/libcloud/test/compute/fixtures/gce/setCommonInstanceMetadata_post.json
@@ -1,0 +1,15 @@
+{
+  "endTime": "2013-06-26T10:05:07.630-07:00",
+  "id": "3681664092089171723",
+  "insertTime": "2013-06-26T10:05:03.271-07:00",
+  "kind": "compute#operation",
+  "name": "operation-setCommonInstanceMetadata",
+  "operationType": "insert",
+  "progress": 0,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/operations/operation-setCommonInstanceMetadata",
+  "startTime": "2013-06-26T10:05:03.315-07:00",
+  "status": "PENDING",
+  "targetId": "16211908079305042870",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/setCommonInstanceMetadata",
+  "user": "foo@developer.gserviceaccount.com"
+}

--- a/libcloud/test/compute/fixtures/gce/setUsageExportBucket_post.json
+++ b/libcloud/test/compute/fixtures/gce/setUsageExportBucket_post.json
@@ -1,0 +1,14 @@
+{
+ "kind": "compute#operation",
+ "id": "17203609782824174066",
+ "name": "operation-setUsageExportBucket",
+ "operationType": "setUsageExportBucket",
+ "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name",
+ "targetId": "8116069320260064853",
+ "status": "PENDING",
+ "user": "erjohnso@google.com",
+ "progress": 0,
+ "insertTime": "2014-11-21T06:58:03.602-08:00",
+ "startTime": "2014-11-21T06:58:04.018-08:00",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/operations/operation-setUsageExportBucket"
+}

--- a/libcloud/test/compute/fixtures/gce/zones_us-central1-a_machineTypes_n1-standard-1.json
+++ b/libcloud/test/compute/fixtures/gce/zones_us-central1-a_machineTypes_n1-standard-1.json
@@ -1,13 +1,14 @@
 {
- "kind": "compute#machineType",
- "id": "12907738072351752276",
- "creationTimestamp": "2012-06-07T13:48:14.670-07:00",
- "name": "n1-standard-1",
- "description": "1 vCPU, 3.75 GB RAM",
- "guestCpus": 1,
- "memoryMb": 3840,
- "maximumPersistentDisks": 16,
- "maximumPersistentDisksSizeGb": "10240",
- "zone": "us-central1-a",
- "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/machineTypes/n1-standard-1"
+  "creationTimestamp": "2012-06-07T13:48:14.670-07:00",
+  "description": "1 vCPU, 3.75 GB RAM",
+  "guestCpus": 1,
+  "id": "11077240422128681563",
+  "imageSpaceGb": 10,
+  "kind": "compute#machineType",
+  "maximumPersistentDisks": 16,
+  "maximumPersistentDisksSizeGb": "10240",
+  "memoryMb": 3840,
+  "name": "n1-standard-1",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/machineTypes/n1-standard-1",
+  "zone": "us-central1-a"
 }

--- a/libcloud/test/compute/fixtures/gce/zones_us-central1-a_machineTypes_n1-standard-1.json
+++ b/libcloud/test/compute/fixtures/gce/zones_us-central1-a_machineTypes_n1-standard-1.json
@@ -1,14 +1,13 @@
 {
-  "creationTimestamp": "2012-06-07T13:48:14.670-07:00",
-  "description": "1 vCPU, 3.75 GB RAM",
-  "guestCpus": 1,
-  "id": "11077240422128681563",
-  "imageSpaceGb": 10,
-  "kind": "compute#machineType",
-  "maximumPersistentDisks": 16,
-  "maximumPersistentDisksSizeGb": "10240",
-  "memoryMb": 3840,
-  "name": "n1-standard-1",
-  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/machineTypes/n1-standard-1",
-  "zone": "us-central1-a"
+ "kind": "compute#machineType",
+ "id": "12907738072351752276",
+ "creationTimestamp": "2012-06-07T13:48:14.670-07:00",
+ "name": "n1-standard-1",
+ "description": "1 vCPU, 3.75 GB RAM",
+ "guestCpus": 1,
+ "memoryMb": 3840,
+ "maximumPersistentDisks": 16,
+ "maximumPersistentDisksSizeGb": "10240",
+ "zone": "us-central1-a",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/machineTypes/n1-standard-1"
 }

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -641,6 +641,7 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         self.assertEqual(network.name, network_name)
         self.assertEqual(network.cidr, '10.11.0.0/16')
         self.assertEqual(network.extra['gatewayIPv4'], '10.11.0.1')
+        self.assertEqual(network.extra['description'], 'A custom network')
 
     def test_ex_get_node(self):
         node_name = 'node-name'

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -659,9 +659,100 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         project = self.driver.ex_get_project()
         self.assertEqual(project.name, 'project_name')
         networks_quota = project.quotas[1]
-        self.assertEqual(networks_quota['usage'], 3.0)
-        self.assertEqual(networks_quota['limit'], 5.0)
+        self.assertEqual(networks_quota['usage'], 3)
+        self.assertEqual(networks_quota['limit'], 5)
         self.assertEqual(networks_quota['metric'], 'NETWORKS')
+        self.assertTrue('fingerprint' in project.extra['commonInstanceMetadata'])
+        self.assertTrue('items' in project.extra['commonInstanceMetadata'])
+        self.assertTrue('usageExportLocation' in project.extra)
+        self.assertTrue('bucketName' in project.extra['usageExportLocation'])
+        self.assertTrue(project.extra['usageExportLocation']['bucketName'], 'gs://graphite-usage-reports')
+
+    def test_ex_set_usage_export_bucket(self):
+        self.assertRaises(ValueError,
+                          self.driver.ex_set_usage_export_bucket, 'foo')
+        bucket_name = 'gs://foo'
+        self.driver.ex_set_usage_export_bucket(bucket_name)
+
+        bucket_name = 'https://www.googleapis.com/foo'
+        self.driver.ex_set_usage_export_bucket(bucket_name)
+
+    def test__set_project_metadata(self):
+        self.assertEqual(len(self.driver._set_project_metadata(None, False, "")), 0)
+
+        # 'delete' metadata, but retain current sshKeys
+        md = self.driver._set_project_metadata(None, False, "this is a test")
+        self.assertEqual(len(md), 1)
+        self.assertEqual(md[0]['key'], 'sshKeys')
+        self.assertEqual(md[0]['value'], 'this is a test')
+
+        # 'delete' metadata *and* any existing sshKeys
+        md = self.driver._set_project_metadata(None, True, "this is a test")
+        self.assertEqual(len(md), 0)
+
+        # add new metadata, keep existing sshKeys, since the new value also
+        # has 'sshKeys', we want the final struct to only have one ke/value
+        # of sshKeys and it should be the "current_keys"
+        gce_md = {'items': [{'key': 'foo', 'value': 'one'},
+                            {'key': 'sshKeys', 'value': 'another test'}]}
+        md = self.driver._set_project_metadata(gce_md, False, "this is a test")
+        self.assertEqual(len(md), 2, str(md))
+        sshKeys = ""
+        count = 0
+        for d in md:
+            if d['key'] == 'sshKeys':
+                count += 1
+                sshKeys = d['value']
+        self.assertEqual(sshKeys, 'this is a test')
+        self.assertEqual(count, 1)
+
+        # add new metadata, overwrite existing sshKeys, in this case, the
+        # existing 'sshKeys' value should be replaced
+        gce_md = {'items': [{'key': 'foo', 'value': 'one'},
+                            {'key': 'sshKeys', 'value': 'another test'}]}
+        md = self.driver._set_project_metadata(gce_md, True, "this is a test")
+        self.assertEqual(len(md), 2, str(md))
+        sshKeys = ""
+        count = 0
+        for d in md:
+            if d['key'] == 'sshKeys':
+                count += 1
+                sshKeys = d['value']
+        self.assertEqual(sshKeys, 'another test')
+        self.assertEqual(count, 1)
+
+        # add new metadata, remove existing sshKeys. in this case, we had an
+        # 'sshKeys' entry, but it will be removed entirely
+        gce_md = {'items': [{'key': 'foo', 'value': 'one'},
+                            {'key': 'nokeys', 'value': 'two'}]}
+        md = self.driver._set_project_metadata(gce_md, True, "this is a test")
+        self.assertEqual(len(md), 2, str(md))
+        sshKeys = ""
+        count = 0
+        for d in md:
+            if d['key'] == 'sshKeys':
+                count += 1
+                sshKeys = d['value']
+        self.assertEqual(sshKeys, '')
+        self.assertEqual(count, 0)
+
+    def test_ex_set_common_instance_metadata(self):
+        # test non-dict
+        self.assertRaises(ValueError,
+                          self.driver.ex_set_common_instance_metadata,
+                          ['bad', 'type'])
+        # test standard python dict
+        pydict = {'foo': 'pydict', 'one': 1}
+        self.driver.ex_set_common_instance_metadata(pydict)
+        # test GCE badly formatted dict
+        bad_gcedict = {'items': 'foo'}
+        self.assertRaises(ValueError,
+                          self.driver.ex_set_common_instance_metadata,
+                          bad_gcedict)
+        # test gce formatted dict
+        gcedict = {'items': [{'key': 'gcedict', 'value': 'v1'},
+                             {'key': 'gcedict', 'value': 'v2'}]}
+        self.driver.ex_set_common_instance_metadata(gcedict)
 
     def test_ex_get_region(self):
         region_name = 'us-central1'
@@ -731,6 +822,16 @@ class GCEMockHttp(MockHttpTestCase):
                                                                 use_param,
                                                                 qs, path)
         return method_name
+
+    def _setUsageExportBucket(self, method, url, body, headers):
+        if method == 'POST':
+            body = self.fixtures.load('setUsageExportBucket_post.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _setCommonInstanceMetadata(self, method, url, body, headers):
+        if method == 'POST':
+            body = self.fixtures.load('setCommonInstanceMetadata_post.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
     def _aggregated_addresses(self, method, url, body, headers):
         body = self.fixtures.load('aggregated_addresses.json')
@@ -859,6 +960,18 @@ class GCEMockHttp(MockHttpTestCase):
                 'global_snapshots_lcsnapshot_delete.json')
         else:
             body = self.fixtures.load('global_snapshots_lcsnapshot.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _global_operations_operation_setUsageExportBucket(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'operations_operation_setUsageExportBucket.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _global_operations_operation_setCommonInstanceMetadata(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'operations_operation_setCommonInstanceMetadata.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
     def _global_operations_operation_global_httpHealthChecks_lchealthcheck_delete(

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -142,8 +142,10 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
     def test_list_images(self):
         local_images = self.driver.list_images()
         debian_images = self.driver.list_images(ex_project='debian-cloud')
+        local_plus_deb = self.driver.list_images(['debian-cloud', 'project_name'])
         self.assertEqual(len(local_images), 3)
         self.assertEqual(len(debian_images), 19)
+        self.assertEqual(len(local_plus_deb), 22)
         self.assertEqual(local_images[0].name, 'debian-7-wheezy-v20130617')
         self.assertEqual(local_images[1].name, 'centos-6-v20131118')
 
@@ -531,9 +533,18 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         self.assertTrue(deleted)
 
     def test_ex_deprecate_image(self):
-        image = self.driver.ex_get_image('debian-6')
-        deprecated = image.deprecate('debian-7', 'DEPRECATED')
+        dep_ts = '2064-03-11T20:18:36.194-07:00'
+        obs_ts = '2074-03-11T20:18:36.194-07:00'
+        del_ts = '2084-03-11T20:18:36.194-07:00'
+        image = self.driver.ex_get_image('debian-6-squeeze-v20130926')
+        deprecated = image.deprecate('debian-7', 'DEPRECATED',
+                                     deprecated=dep_ts,
+                                     obsolete=obs_ts,
+                                     deleted=del_ts)
         self.assertTrue(deprecated)
+        self.assertTrue(image.extra['deprecated']['deprecated'], dep_ts)
+        self.assertTrue(image.extra['deprecated']['obsolete'], obs_ts)
+        self.assertTrue(image.extra['deprecated']['deleted'], del_ts)
 
     def test_ex_destroy_firewall(self):
         firewall = self.driver.ex_get_firewall('lcfirewall')
@@ -626,6 +637,10 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         image = self.driver.ex_get_image(partial_name)
         self.assertEqual(image.name, 'debian-6-squeeze-v20130926')
         self.assertTrue(image.extra['description'].startswith('Debian'))
+
+        partial_name = 'debian-7'
+        image = self.driver.ex_get_image(partial_name, ['debian-cloud'])
+        self.assertEqual(image.name, 'debian-7-wheezy-v20131120')
 
     def test_ex_copy_image(self):
         name = 'coreos'
@@ -767,12 +782,9 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         size = self.driver.ex_get_size(size_name)
         self.assertEqual(size.name, size_name)
         self.assertEqual(size.extra['zone'].name, 'us-central1-a')
-        self.assertEqual(size.disk, 10240)
+        self.assertEqual(size.disk, 10)
         self.assertEqual(size.ram, 3840)
         self.assertEqual(size.extra['guestCpus'], 1)
-        self.assertEqual(size.extra['memoryMb'], 3840)
-        self.assertEqual(size.extra['maximumPersistentDisks'], 16)
-        self.assertEqual(size.extra['maximumPersistentDisksSizeGb'], 10240)
 
     def test_ex_get_targetpool(self):
         targetpool_name = 'lctargetpool'

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -767,9 +767,12 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         size = self.driver.ex_get_size(size_name)
         self.assertEqual(size.name, size_name)
         self.assertEqual(size.extra['zone'].name, 'us-central1-a')
-        self.assertEqual(size.disk, 10)
+        self.assertEqual(size.disk, 10240)
         self.assertEqual(size.ram, 3840)
         self.assertEqual(size.extra['guestCpus'], 1)
+        self.assertEqual(size.extra['memoryMb'], 3840)
+        self.assertEqual(size.extra['maximumPersistentDisks'], 16)
+        self.assertEqual(size.extra['maximumPersistentDisksSizeGb'], 10240)
 
     def test_ex_get_targetpool(self):
         targetpool_name = 'lctargetpool'

--- a/tox.ini
+++ b/tox.ini
@@ -12,17 +12,6 @@ deps = backports.ssl_match_hostname
 commands = cp libcloud/test/secrets.py-dist libcloud/test/secrets.py
            python setup.py test
 
-[testenv:py26]
-deps = backports.ssl_match_hostname
-       mock
-       unittest2
-       lockfile
-       paramiko
-       coverage
-commands = cp libcloud/test/secrets.py-dist libcloud/test/secrets.py
-           python setup.py test
-           python setup.py coverage
-
 [testenv:py25]
 setenv = PIP_INSECURE=1
 deps = backports.ssl_match_hostname
@@ -32,6 +21,12 @@ deps = backports.ssl_match_hostname
        ssl
        simplejson
        paramiko
+
+[testenv:pypy]
+deps = backports.ssl_match_hostname
+       mock
+       unittest2
+       lockfile
 
 [testenv:py32]
 deps = backports.ssl_match_hostname


### PR DESCRIPTION
This PR adds support for:
- Setting common instance metadata. Common instance (or project-wide) metadata is typically used for defining a `startup-script` and setting `sshKeys`.
- Setting a usage export bucket. The usage export feature allows storing compute engine resource usage to Google Cloud Storage.

For setting common instance metadata, there is a safety check (boolean flag) to that must be set to forcefully overwrite or remove `sshKeys`.
