### PR TITLE
[google compute] adding Routes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,6 +61,10 @@ Compute
   (GITHUB-401)
   [Eric Johnson]
 
+- AWS: Set proper disk size in c3.X instance types
+  (GITHUB-405)
+  [Itxaka Serrano]
+
 Storage
 ~~~~~~~
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -57,6 +57,10 @@ Compute
   (GITHUB-390, GITHUB-394)
   [Eric Johnson]
 
+- GCE: Add missing snapshot attributes.
+  (GITHUB-401)
+  [Eric Johnson]
+
 Changes with Apache Libcloud 0.16.0
 -----------------------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,6 +61,16 @@ Compute
   (GITHUB-401)
   [Eric Johnson]
 
+Storage
+~~~~~~~
+
+- Allow user to pass ``headers`` argument to the ``upload_object`` and
+  ``upload_object_via_stream`` method.
+
+  This way user can specify CORS headers with the drivers which support that.
+  (GITHUB-403, GITHUB-404)
+  [Peter Schmidt]
+
 Changes with Apache Libcloud 0.16.0
 -----------------------------------
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -36,9 +36,9 @@ Code style guide
 * Use 79 characters in a line
 * Make sure edited file doesn't contain any trailing whitespace
 * You can verify that your modifications don't break any rules by running the
-  ``flake8`` script - e.g. ``flake8 libcloud/edited_file.py.`` or
+  ``flake8`` script - e.g. ``flake8 libcloud/edited_file.py`` or
   ``tox -e lint``.
-  Second command fill run flake8 on all the files in the repository.
+  Second command will run flake8 on all the files in the repository.
 
 And most importantly, follow the existing style in the file you are editing and
 **be consistent**.

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -219,35 +219,35 @@ INSTANCE_TYPES = {
         'id': 'c3.large',
         'name': 'Compute Optimized Large Instance',
         'ram': 3750,
-        'disk': 16,
+        'disk': 32,  # x2
         'bandwidth': None
     },
     'c3.xlarge': {
         'id': 'c3.xlarge',
         'name': 'Compute Optimized Extra Large Instance',
-        'ram': 7000,
-        'disk': 40,
+        'ram': 7500,
+        'disk': 80,  # x2
         'bandwidth': None
     },
     'c3.2xlarge': {
         'id': 'c3.2xlarge',
         'name': 'Compute Optimized Double Extra Large Instance',
         'ram': 15000,
-        'disk': 80,
+        'disk': 160,  # x2
         'bandwidth': None
     },
     'c3.4xlarge': {
         'id': 'c3.4xlarge',
         'name': 'Compute Optimized Quadruple Extra Large Instance',
         'ram': 30000,
-        'disk': 160,
+        'disk': 320,  # x2
         'bandwidth': None
     },
     'c3.8xlarge': {
         'id': 'c3.8xlarge',
         'name': 'Compute Optimized Eight Extra Large Instance',
         'ram': 60000,
-        'disk': 320,
+        'disk': 640,  # x2
         'bandwidth': None
     },
     'cr1.8xlarge': {

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -3837,6 +3837,16 @@ class GCENodeDriver(NodeDriver):
         extra['selfLink'] = snapshot.get('selfLink')
         extra['creationTimestamp'] = snapshot.get('creationTimestamp')
         extra['sourceDisk'] = snapshot.get('sourceDisk')
+        if 'description' in snapshot:
+            extra['description'] = snapshot['description']
+        if 'sourceDiskId' in snapshot:
+            extra['sourceDiskId'] = snapshot['sourceDiskId']
+        if 'storageBytes' in snapshot:
+            extra['storageBytes'] = snapshot['storageBytes']
+        if 'storageBytesStatus' in snapshot:
+            extra['storageBytesStatus'] = snapshot['storageBytesStatus']
+        if 'licenses' in snapshot:
+            extra['licenses'] = snapshot['licenses']
 
         return GCESnapshot(id=snapshot['id'], name=snapshot['name'],
                            size=snapshot['diskSizeGb'],

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -3911,6 +3911,7 @@ class GCENodeDriver(NodeDriver):
         extra['selfLink'] = zone.get('selfLink')
         extra['creationTimestamp'] = zone.get('creationTimestamp')
         extra['description'] = zone.get('description')
+        extra['region'] = zone.get('region')
 
         deprecated = zone.get('deprecated')
 

--- a/libcloud/storage/base.py
+++ b/libcloud/storage/base.py
@@ -361,7 +361,7 @@ class StorageDriver(BaseDriver):
             'download_object_as_stream not implemented for this driver')
 
     def upload_object(self, file_path, container, object_name, extra=None,
-                      verify_hash=True):
+                      verify_hash=True, headers=None):
         """
         Upload an object currently located on a disk.
 
@@ -380,6 +380,11 @@ class StorageDriver(BaseDriver):
         :param extra: Extra attributes (driver specific). (optional)
         :type extra: ``dict``
 
+        :param headers: (optional) Additional request headers,
+            such as CORS headers. For example:
+            headers = {'Access-Control-Allow-Origin': 'http://mozilla.com'}
+        :type headers: ``dict``
+
         :rtype: :class:`Object`
         """
         raise NotImplementedError(
@@ -387,7 +392,8 @@ class StorageDriver(BaseDriver):
 
     def upload_object_via_stream(self, iterator, container,
                                  object_name,
-                                 extra=None):
+                                 extra=None,
+                                 headers=None):
         """
         Upload an object using an iterator.
 
@@ -405,19 +411,24 @@ class StorageDriver(BaseDriver):
         function which uses fs.stat function to determine the file size and it
         doesn't need to buffer whole object in the memory.
 
-        :type iterator: :class:`object`
         :param iterator: An object which implements the iterator interface.
+        :type iterator: :class:`object`
 
-        :type container: :class:`Container`
         :param container: Destination container.
+        :type container: :class:`Container`
 
-        :type object_name: ``str``
         :param object_name: Object name.
+        :type object_name: ``str``
 
-        :type extra: ``dict``
         :param extra: (optional) Extra attributes (driver specific). Note:
             This dictionary must contain a 'content_type' key which represents
             a content type of the stored object.
+        :type extra: ``dict``
+
+        :param headers: (optional) Additional request headers,
+            such as CORS headers. For example:
+            headers = {'Access-Control-Allow-Origin': 'http://mozilla.com'}
+        :type headers: ``dict``
 
         :rtype: ``object``
         """
@@ -428,8 +439,8 @@ class StorageDriver(BaseDriver):
         """
         Delete an object.
 
-        :type obj: :class:`Object`
         :param obj: Object instance.
+        :type obj: :class:`Object`
 
         :return: ``bool`` True on success.
         :rtype: ``bool``
@@ -441,8 +452,8 @@ class StorageDriver(BaseDriver):
         """
         Create a new container.
 
-        :type container_name: ``str``
         :param container_name: Container name.
+        :type container_name: ``str``
 
         :return: Container instance on success.
         :rtype: :class:`Container`
@@ -454,8 +465,8 @@ class StorageDriver(BaseDriver):
         """
         Delete a container.
 
-        :type container: :class:`Container`
         :param container: Container instance
+        :type container: :class:`Container`
 
         :return: ``True`` on success, ``False`` otherwise.
         :rtype: ``bool``
@@ -468,23 +479,23 @@ class StorageDriver(BaseDriver):
         """
         Call passed callback and start transfer of the object'
 
-        :type obj: :class:`Object`
         :param obj: Object instance.
+        :type obj: :class:`Object`
 
-        :type callback: :class:`function`
         :param callback: Function which is called with the passed
             callback_kwargs
+        :type callback: :class:`function`
 
-        :type callback_kwargs: ``dict``
         :param callback_kwargs: Keyword arguments which are passed to the
              callback.
+        :type callback_kwargs: ``dict``
 
-        :typed response: :class:`Response`
         :param response: Response instance.
+        :type response: :class:`Response`
 
-        :type success_status_code: ``int``
         :param success_status_code: Status code which represents a successful
                                     transfer (defaults to httplib.OK)
+        :type success_status_code: ``int``
 
         :return: ``True`` on success, ``False`` otherwise.
         :rtype: ``bool``
@@ -507,26 +518,26 @@ class StorageDriver(BaseDriver):
         """
         Save object to the provided path.
 
-        :type response: :class:`RawResponse`
         :param response: RawResponse instance.
+        :type response: :class:`RawResponse`
 
-        :type obj: :class:`Object`
         :param obj: Object instance.
+        :type obj: :class:`Object`
 
-        :type destination_path: ``str``
         :param destination_path: Destination directory.
+        :type destination_path: ``str``
 
-        :type delete_on_failure: ``bool``
         :param delete_on_failure: True to delete partially downloaded object if
                                   the download fails.
+        :type delete_on_failure: ``bool``
 
-        :type overwrite_existing: ``bool``
         :param overwrite_existing: True to overwrite a local path if it already
                                    exists.
+        :type overwrite_existing: ``bool``
 
-        :type chunk_size: ``int``
         :param chunk_size: Optional chunk size
             (defaults to ``libcloud.storage.base.CHUNK_SIZE``, 8kb)
+        :type chunk_size: ``int``
 
         :return: ``True`` on success, ``False`` otherwise.
         :rtype: ``bool``
@@ -660,20 +671,20 @@ class StorageDriver(BaseDriver):
         """
         Upload data stored in a string.
 
-        :type response: :class:`RawResponse`
         :param response: RawResponse object.
+        :type response: :class:`RawResponse`
 
-        :type data: ``str``
         :param data: Data to upload.
+        :type data: ``str``
 
-        :type calculate_hash: ``bool``
         :param calculate_hash: True to calculate hash of the transferred data.
-                               (defauls to True).
+                               (defaults to True).
+        :type calculate_hash: ``bool``
 
-        :rtype: ``tuple``
         :return: First item is a boolean indicator of success, second
                  one is the uploaded data MD5 hash and the third one
                  is the number of transferred bytes.
+        :rtype: ``tuple``
         """
         bytes_transferred = 0
         data_hash = None
@@ -701,23 +712,23 @@ class StorageDriver(BaseDriver):
         """
         Stream a data over an http connection.
 
-        :type response: :class:`RawResponse`
         :param response: RawResponse object.
+        :type response: :class:`RawResponse`
 
-        :type iterator: :class:`object`
         :param response: An object which implements an iterator interface
                          or a File like object with read method.
+        :type iterator: :class:`object`
 
-        :type chunked: ``bool``
         :param chunked: True if the chunked transfer encoding should be used
                         (defauls to False).
+        :type chunked: ``bool``
 
-        :type calculate_hash: ``bool``
         :param calculate_hash: True to calculate hash of the transferred data.
                                (defauls to True).
+        :type calculate_hash: ``bool``
 
-        :type chunk_size: ``int``
         :param chunk_size: Optional chunk size (defaults to ``CHUNK_SIZE``)
+        :type chunk_size: ``int``
 
         :rtype: ``tuple``
         :return: First item is a boolean indicator of success, second

--- a/libcloud/storage/drivers/cloudfiles.py
+++ b/libcloud/storage/drivers/cloudfiles.py
@@ -414,7 +414,7 @@ class CloudFilesStorageDriver(StorageDriver, OpenStackDriverMixin):
                                 success_status_code=httplib.OK)
 
     def upload_object(self, file_path, container, object_name, extra=None,
-                      verify_hash=True):
+                      verify_hash=True, headers=None):
         """
         Upload an object.
 
@@ -427,10 +427,11 @@ class CloudFilesStorageDriver(StorageDriver, OpenStackDriverMixin):
                                 upload_func=upload_func,
                                 upload_func_kwargs=upload_func_kwargs,
                                 extra=extra, file_path=file_path,
-                                verify_hash=verify_hash)
+                                verify_hash=verify_hash, headers=headers)
 
     def upload_object_via_stream(self, iterator,
-                                 container, object_name, extra=None):
+                                 container, object_name, extra=None,
+                                 headers=None):
         if isinstance(iterator, file):
             iterator = iter(iterator)
 
@@ -440,7 +441,8 @@ class CloudFilesStorageDriver(StorageDriver, OpenStackDriverMixin):
         return self._put_object(container=container, object_name=object_name,
                                 upload_func=upload_func,
                                 upload_func_kwargs=upload_func_kwargs,
-                                extra=extra, iterator=iterator)
+                                extra=extra, iterator=iterator,
+                                headers=headers)
 
     def delete_object(self, obj):
         container_name = self._encode_container_name(obj.container.name)
@@ -752,7 +754,7 @@ class CloudFilesStorageDriver(StorageDriver, OpenStackDriverMixin):
 
     def _put_object(self, container, object_name, upload_func,
                     upload_func_kwargs, extra=None, file_path=None,
-                    iterator=None, verify_hash=True):
+                    iterator=None, verify_hash=True, headers=None):
         extra = extra or {}
         container_name_encoded = self._encode_container_name(container.name)
         object_name_encoded = self._encode_object_name(object_name)
@@ -760,7 +762,7 @@ class CloudFilesStorageDriver(StorageDriver, OpenStackDriverMixin):
         meta_data = extra.get('meta_data', None)
         content_disposition = extra.get('content_disposition', None)
 
-        headers = {}
+        headers = headers or {}
         if meta_data:
             for key, value in list(meta_data.items()):
                 key = 'X-Object-Meta-%s' % (key)

--- a/libcloud/test/compute/fixtures/gce/global_routes.json
+++ b/libcloud/test/compute/fixtures/gce/global_routes.json
@@ -1,0 +1,58 @@
+{
+ "kind": "compute#routeList",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/routes",
+ "id": "projects/project_name/global/routes",
+ "items": [
+  {
+   "kind": "compute#route",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/routes/default-route-17d11bbbba01ce80",
+   "id": "15220239546867835355",
+   "creationTimestamp": "2014-01-21T10:30:55.592-08:00",
+   "name": "default-route-17d11bbbba01ce80",
+   "description": "Default route to the virtual network.",
+   "network": "https://www.googleapis.com/compute/v1/projects/project_name/global/networks/default",
+   "destRange": "10.240.0.0/16",
+   "priority": 1000,
+   "nextHopNetwork": "https://www.googleapis.com/compute/v1/projects/project_name/global/networks/default"
+  },
+  {
+   "kind": "compute#route",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/routes/default-route-e1808a2caeaf17fb",
+   "id": "4898173129042082424",
+   "creationTimestamp": "2014-01-21T10:30:55.584-08:00",
+   "name": "default-route-e1808a2caeaf17fb",
+   "description": "Default route to the Internet.",
+   "network": "https://www.googleapis.com/compute/v1/projects/project_name/global/networks/default",
+   "destRange": "0.0.0.0/0",
+   "priority": 1000,
+   "nextHopGateway": "https://www.googleapis.com/compute/v1/projects/project_name/global/gateways/default-internet-gateway"
+  },
+  {
+   "kind": "compute#route",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/routes/lcdemoroute",
+   "id": "14575183394193523469",
+   "creationTimestamp": "2014-11-25T11:00:45.062-08:00",
+   "name": "lcdemoroute",
+   "network": "https://www.googleapis.com/compute/v1/projects/project_name/global/networks/default",
+   "tags": [
+    "tag1",
+    "tag2"
+   ],
+   "destRange": "192.168.25.0/24",
+   "priority": 1000,
+   "nextHopInstance": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-f/instances/libcloud-100",
+   "warnings": [
+    {
+     "code": "NEXT_HOP_CANNOT_IP_FORWARD",
+     "message": "Next hop instance 'https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-f/instances/libcloud-100' cannot forward ip traffic. The next hop instance must have canIpForward set.",
+     "data": [
+      {
+       "key": "instance",
+       "value": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-f/instances/libcloud-100"
+      }
+     ]
+    }
+   ]
+  }
+ ]
+}

--- a/libcloud/test/compute/fixtures/gce/global_routes_lcdemoroute.json
+++ b/libcloud/test/compute/fixtures/gce/global_routes_lcdemoroute.json
@@ -1,0 +1,27 @@
+{
+ "kind": "compute#route",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/routes/lcdemoroute",
+ "id": "14575183394193523469",
+ "creationTimestamp": "2014-11-25T11:00:45.062-08:00",
+ "name": "lcdemoroute",
+ "network": "https://www.googleapis.com/compute/v1/projects/project_name/global/networks/default",
+ "tags": [
+  "tag1",
+  "tag2"
+ ],
+ "destRange": "192.168.25.0/24",
+ "priority": 1000,
+ "nextHopInstance": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-f/instances/libcloud-100",
+ "warnings": [
+  {
+   "code": "NEXT_HOP_CANNOT_IP_FORWARD",
+   "message": "Next hop instance 'https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-f/instances/libcloud-100' cannot forward ip traffic. The next hop instance must have canIpForward set.",
+   "data": [
+    {
+     "key": "instance",
+     "value": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-f/instances/libcloud-100"
+    }
+   ]
+  }
+ ]
+}

--- a/libcloud/test/compute/fixtures/gce/global_routes_lcdemoroute_delete.json
+++ b/libcloud/test/compute/fixtures/gce/global_routes_lcdemoroute_delete.json
@@ -1,0 +1,13 @@
+{
+ "kind": "compute#operation",
+ "id": "17322940416642455149",
+ "name": "operation-global_routes_lcdemoroute_delete",
+ "operationType": "destroy",
+ "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/routes/lcdemoroute",
+ "status": "PENDING",
+ "user": "erjohnso@google.com",
+ "progress": 0,
+ "insertTime": "2014-11-25T11:00:44.049-08:00",
+ "startTime": "2014-11-25T11:00:44.385-08:00",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/operations/operation-global_routes_lcdemoroute_delete"
+}

--- a/libcloud/test/compute/fixtures/gce/global_routes_post.json
+++ b/libcloud/test/compute/fixtures/gce/global_routes_post.json
@@ -1,0 +1,13 @@
+{
+ "kind": "compute#operation",
+ "id": "17322940416642455149",
+ "name": "operation-global_routes_post",
+ "operationType": "insert",
+ "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/routes/lcdemoroute",
+ "status": "PENDING",
+ "user": "erjohnso@google.com",
+ "progress": 0,
+ "insertTime": "2014-11-25T11:00:44.049-08:00",
+ "startTime": "2014-11-25T11:00:44.385-08:00",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/operations/operation-global_routes_post"
+}

--- a/libcloud/test/compute/fixtures/gce/operations_operation_global_routes_lcdemoroute_delete.json
+++ b/libcloud/test/compute/fixtures/gce/operations_operation_global_routes_lcdemoroute_delete.json
@@ -1,0 +1,13 @@
+{
+ "kind": "compute#operation",
+ "id": "17322940416642455149",
+ "name": "operation-global_route_lcdemoroute",
+ "operationType": "destroy",
+ "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/routes/lcdemoroute",
+ "status": "DONE",
+ "user": "erjohnso@google.com",
+ "progress": 100,
+ "insertTime": "2014-11-25T11:00:44.049-08:00",
+ "startTime": "2014-11-25T11:00:44.385-08:00",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/operations/operation-global_route_lcdemoroute"
+}

--- a/libcloud/test/compute/fixtures/gce/operations_operation_global_routes_post.json
+++ b/libcloud/test/compute/fixtures/gce/operations_operation_global_routes_post.json
@@ -1,0 +1,13 @@
+{
+ "kind": "compute#operation",
+ "id": "17322940416642455149",
+ "name": "operation-global_routes_lcdemoroute_post",
+ "operationType": "insert",
+ "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/routes/lcdemoroute",
+ "status": "DONE",
+ "user": "erjohnso@google.com",
+ "progress": 100,
+ "insertTime": "2014-11-25T11:00:44.049-08:00",
+ "startTime": "2014-11-25T11:00:44.385-08:00",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/operations/operation-global_routes_lcdemoroute_post"
+}

--- a/tox.ini
+++ b/tox.ini
@@ -12,17 +12,6 @@ deps = backports.ssl_match_hostname
 commands = cp libcloud/test/secrets.py-dist libcloud/test/secrets.py
            python setup.py test
 
-[testenv:py26]
-deps = backports.ssl_match_hostname
-       mock
-       unittest2
-       lockfile
-       paramiko
-       coverage
-commands = cp libcloud/test/secrets.py-dist libcloud/test/secrets.py
-           python setup.py test
-           python setup.py coverage
-
 [testenv:py25]
 setenv = PIP_INSECURE=1
 deps = backports.ssl_match_hostname
@@ -32,6 +21,12 @@ deps = backports.ssl_match_hostname
        ssl
        simplejson
        paramiko
+
+[testenv:pypy]
+deps = backports.ssl_match_hostname
+       mock
+       unittest2
+       lockfile
 
 [testenv:py32]
 deps = backports.ssl_match_hostname


### PR DESCRIPTION
This PR adds support for Google Compute Engine's Routes.  This covers adding, listing, deleting, and fetching routes (all standard operations).  The Routes API is here[1] and the GCE docs for routes are here[2]

Includes tests and new fixtures.

[1] https://cloud.google.com/compute/docs/reference/latest/routes
[2] https://cloud.google.com/compute/docs/networking#routing
