### PR TITLE
[google compute] add region attr to zone

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -3743,6 +3743,7 @@ class GCENodeDriver(NodeDriver):
         extra['selfLink'] = zone.get('selfLink')
         extra['creationTimestamp'] = zone.get('creationTimestamp')
         extra['description'] = zone.get('description')
+        extra['region'] = zone.get('region')
 
         deprecated = zone.get('deprecated')
 


### PR DESCRIPTION
One-liner fix to add missing `region` to the `GCEZone` object.
