### PR TITLE
[google compute] improved TargetPool API coverage

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -408,6 +408,39 @@ class GCETargetPool(UuidMixin):
         return self.driver.ex_targetpool_remove_healthcheck(
             targetpool=self, healthcheck=healthcheck)
 
+    def set_backup_targetpool(self, backup_targetpool, failover_ratio=0.1):
+        """
+        Set a backup targetpool.
+
+        :param  backup_targetpool: The existing targetpool to use for
+                                   failover traffic.
+        :type   backup_targetpool: :class:`GCETargetPool`
+
+        :param  failover_ratio: The percentage of healthy VMs must fall at or
+                                below this value before traffic will be sent
+                                to the backup targetpool (default 0.10)
+        :type   failover_ratio: ``float``
+
+        :return:  True if successful
+        :rtype:   ``bool``
+        """
+        return self.driver.ex_targetpool_set_backup_targetpool(
+            targetpool=self, backup_targetpool=backup_targetpool,
+            failover_ratio=failover_ratio)
+
+    def get_health(self, node=None):
+        """
+        Return a hash of target pool instances and their health.
+
+        :param  node: Optional node to specify if only a specific node's
+                      health status should be returned
+        :type   node: ``str``, ``GCENode``, or ``None``
+
+        :return: List of hashes of nodes and their respective health
+        :rtype:  ``list`` of ``dict``
+        """
+        return self.driver.ex_targetpool_get_health(targetpool=self, node=node)
+
     def destroy(self):
         """
         Destroy this Target Pool
@@ -1565,7 +1598,8 @@ class GCENodeDriver(NodeDriver):
         return node_list
 
     def ex_create_targetpool(self, name, region=None, healthchecks=None,
-                             nodes=None, session_affinity=None):
+                             nodes=None, session_affinity=None,
+                             backup_pool=None, failover_ratio=None):
         """
         Create a target pool.
 
@@ -1586,11 +1620,27 @@ class GCENodeDriver(NodeDriver):
                                      affinity.
         :type     session_affinity:  ``str``
 
+        :keyword  backup_pool: Optional backup targetpool to take over traffic
+                               if the failover_ratio is exceeded.
+        :type     backup_pool: ``GCETargetPool`` or ``None``
+
+        :keyword  failover_ratio: The percentage of healthy VMs must fall at
+                                  or below this value before traffic will be
+                                  sent to the backup_pool.
+        :type     failover_ratio: :class:`GCETargetPool` or ``None``
+
         :return:  Target Pool object
         :rtype:   :class:`GCETargetPool`
         """
-        region = region or self.region
         targetpool_data = {}
+        region = region or self.region
+        if backup_pool and not failover_ratio:
+            failover_ratio = 0.1
+            targetpool_data['failoverRatio'] = failover_ratio
+            targetpool_data['backupPool'] = backup_pool.extra['selfLink']
+        if failover_ratio and not backup_pool:
+            e = "Must supply a backup targetPool when setting failover_ratio"
+            raise ValueError(e)
         targetpool_data['name'] = name
         if not hasattr(region, 'name'):
             region = self.ex_get_region(region)
@@ -1773,6 +1823,80 @@ class GCENodeDriver(NodeDriver):
                                       data=firewall_data)
 
         return self.ex_get_firewall(firewall.name)
+
+    def ex_targetpool_get_health(self, targetpool, node=None):
+        """
+        Return a hash of target pool instances and their health.
+
+        :param  targetpool: Targetpool containing healthchecked instances.
+        :type   targetpool: :class:`GCETargetPool`
+
+        :param  node: Optional node to specify if only a specific node's
+                      health status should be returned
+        :type   node: ``str``, ``GCENode``, or ``None``
+
+        :return: List of hashes of instances and their respective health,
+                 e.g. [{'node': ``GCENode``, 'health': 'UNHEALTHY'}, ...]
+        :rtype:  ``list`` of ``dict``
+        """
+        health = []
+        region_name = targetpool.region.name
+        request = '/regions/%s/targetPools/%s/getHealth' % (region_name,
+                                                            targetpool.name)
+
+        if node is not None:
+            if hasattr(node, 'name'):
+                node_name = node.name
+            else:
+                node_name = node
+
+        nodes = targetpool.nodes
+        for node_object in nodes:
+            if node:
+                if node_name == node_object.name:
+                    body = {'instance': node_object.extra['selfLink']}
+                    resp = self.connection.request(request, method='POST',
+                                                   data=body).object
+                    status = resp['healthStatus'][0]['healthState']
+                    health.append({'node': node_object, 'health': status})
+            else:
+                body = {'instance': node_object.extra['selfLink']}
+                resp = self.connection.request(request, method='POST',
+                                               data=body).object
+                status = resp['healthStatus'][0]['healthState']
+                health.append({'node': node_object, 'health': status})
+        return health
+
+    def ex_targetpool_set_backup_targetpool(self, targetpool,
+                                            backup_targetpool,
+                                            failover_ratio=0.1):
+        """
+        Set a backup targetpool.
+
+        :param  targetpool: The existing primary targetpool
+        :type   targetpool: :class:`GCETargetPool`
+
+        :param  backup_targetpool: The existing targetpool to use for
+                                   failover traffic.
+        :type   backup_targetpool: :class:`GCETargetPool`
+
+        :param  failover_ratio: The percentage of healthy VMs must fall at or
+                                below this value before traffic will be sent
+                                to the backup targetpool (default 0.10)
+        :type   failover_ratio: ``float``
+
+        :return:  True if successful
+        :rtype:   ``bool``
+        """
+        region = targetpool.region.name
+        name = targetpool.name
+        req_data = {'target': backup_targetpool.extra['selfLink']}
+        params = {'failoverRatio': failover_ratio}
+
+        request = '/regions/%s/targetPools/%s/setBackup' % (region, name)
+        self.connection.async_request(request, method='POST', data=req_data,
+                                      params=params)
+        return True
 
     def ex_targetpool_add_node(self, targetpool, node):
         """
@@ -3734,6 +3858,13 @@ class GCENodeDriver(NodeDriver):
             except ResourceNotFoundError:
                 node = n
             node_list.append(node)
+
+        if 'failoverRatio' in targetpool:
+            extra['failoverRatio'] = targetpool['failoverRatio']
+        if 'backupPool' in targetpool:
+            tp_split = targetpool['backupPool'].split('/')
+            extra['backupPool'] = self.ex_get_targetpool(tp_split[10],
+                                                         tp_split[8])
 
         return GCETargetPool(id=targetpool['id'], name=targetpool['name'],
                              region=region, healthchecks=healthcheck_list,

--- a/libcloud/test/compute/fixtures/gce/aggregated_targetPools.json
+++ b/libcloud/test/compute/fixtures/gce/aggregated_targetPools.json
@@ -56,6 +56,39 @@
           "region": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1",
           "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1/targetPools/www-pool",
           "sessionAffinity": "NONE"
+        },
+        {
+          "kind": "compute#targetPool",
+          "id": "17914960036329768493",
+          "creationTimestamp": "2014-11-26T08:37:28.831-08:00",
+          "name": "backup-pool",
+          "description": "",
+          "region": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1",
+          "healthChecks": [
+           "https://www.googleapis.com/compute/v1/projects/project_name/global/httpHealthChecks/default-health-check"
+          ],
+          "instances": [
+           "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-b/instances/libcloud-lb-demo-www-002"
+          ],
+          "sessionAffinity": "CLIENT_IP",
+          "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1/targetPools/backup-pool"
+        },
+        {
+          "kind": "compute#targetPool",
+          "id": "11474672125700394323",
+          "creationTimestamp": "2014-11-24T12:52:13.366-08:00",
+          "name": "lb-pool",
+          "region": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1",
+          "healthChecks": [
+           "https://www.googleapis.com/compute/v1/projects/project_name/global/httpHealthChecks/libcloud-lb-demo-healthcheck"
+          ],
+          "instances": [
+           "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-b/instances/libcloud-lb-demo-www-000"
+          ],
+          "sessionAffinity": "NONE",
+          "failoverRatio": 0.1,
+          "backupPool": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1/targetPools/backup-pool",
+          "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1/targetPools/lb-pool"
         }
       ]
     },

--- a/libcloud/test/compute/fixtures/gce/operations_operation_regions_us-central1_targetPools_lb_pool_setBackup_post.json
+++ b/libcloud/test/compute/fixtures/gce/operations_operation_regions_us-central1_targetPools_lb_pool_setBackup_post.json
@@ -1,0 +1,16 @@
+{
+  "endTime": "2013-09-03T01:29:07.021-07:00",
+  "id": "04072826501537092633",
+  "insertTime": "2013-09-03T01:29:03.082-07:00",
+  "kind": "compute#operation",
+  "name": "operation-regions_us-central1_targetPools_lb_pool_setBackup_post",
+  "operationType": "setBackup",
+  "progress": 100,
+  "region": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1/operations/operation-regions_us-central1_targetPools_lb_pool_setBackup_post",
+  "startTime": "2013-09-03T01:29:03.145-07:00",
+  "status": "DONE",
+  "targetId": "16862638289615591831",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1/targetPools/lb-pool",
+  "user": "user@gserviceaccount.com"
+}

--- a/libcloud/test/compute/fixtures/gce/regions_us-central1_targetPools.json
+++ b/libcloud/test/compute/fixtures/gce/regions_us-central1_targetPools.json
@@ -31,6 +31,39 @@
       "name": "libcloud-lb-demo-lb-tp",
       "region": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1",
       "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1/targetPools/libcloud-lb-demo-lb-tp"
+    },
+    {
+      "kind": "compute#targetPool",
+      "id": "17914960036329768493",
+      "creationTimestamp": "2014-11-26T08:37:28.831-08:00",
+      "name": "backup-pool",
+      "description": "",
+      "region": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1",
+      "healthChecks": [
+       "https://www.googleapis.com/compute/v1/projects/project_name/global/httpHealthChecks/default-health-check"
+      ],
+      "instances": [
+       "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-b/instances/libcloud-lb-demo-www-002"
+      ],
+      "sessionAffinity": "CLIENT_IP",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1/targetPools/backup-pool"
+    },
+    {
+      "kind": "compute#targetPool",
+      "id": "11474672125700394323",
+      "creationTimestamp": "2014-11-24T12:52:13.366-08:00",
+      "name": "lb-pool",
+      "region": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1",
+      "healthChecks": [
+       "https://www.googleapis.com/compute/v1/projects/project_name/global/httpHealthChecks/libcloud-lb-demo-healthcheck"
+      ],
+      "instances": [
+       "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-b/instances/libcloud-lb-demo-www-000"
+      ],
+      "sessionAffinity": "NONE",
+      "failoverRatio": 0.1,
+      "backupPool": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1/targetPools/backup-pool",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1/targetPools/lb-pool"
     }
   ],
   "kind": "compute#targetPoolList",

--- a/libcloud/test/compute/fixtures/gce/regions_us-central1_targetPools_backup_pool.json
+++ b/libcloud/test/compute/fixtures/gce/regions_us-central1_targetPools_backup_pool.json
@@ -1,0 +1,15 @@
+{
+  "creationTimestamp": "2013-09-03T00:51:05.300-07:00",
+  "healthChecks": [
+    "https://www.googleapis.com/compute/v1/projects/project_name/global/httpHealthChecks/libcloud-lb-demo-healthcheck"
+  ],
+  "id": "13598380121688918358",
+  "instances": [
+    "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-b/instances/libcloud-lb-demo-www-000",
+    "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-b/instances/libcloud-lb-demo-www-001"
+  ],
+  "kind": "compute#targetPool",
+  "name": "backup-pool",
+  "region": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1/targetPools/backup-pool"
+}

--- a/libcloud/test/compute/fixtures/gce/regions_us-central1_targetPools_lb_pool.json
+++ b/libcloud/test/compute/fixtures/gce/regions_us-central1_targetPools_lb_pool.json
@@ -1,0 +1,17 @@
+{
+  "kind": "compute#targetPool",
+  "id": "11474672125700394323",
+  "creationTimestamp": "2014-11-24T12:52:13.366-08:00",
+  "name": "lb-pool",
+  "region": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1",
+  "healthChecks": [
+    "https://www.googleapis.com/compute/v1/projects/project_name/global/httpHealthChecks/libcloud-lb-demo-healthcheck"
+  ],
+  "instances": [
+    "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-b/instances/libcloud-lb-demo-www-000"
+  ],
+  "sessionAffinity": "NONE",
+  "failoverRatio": 0.1,
+  "backupPool": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1/targetPools/backup-pool",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1/targetPools/lb-pool"
+}

--- a/libcloud/test/compute/fixtures/gce/regions_us-central1_targetPools_lb_pool_getHealth.json
+++ b/libcloud/test/compute/fixtures/gce/regions_us-central1_targetPools_lb_pool_getHealth.json
@@ -1,0 +1,10 @@
+{
+ "kind": "compute#targetPoolInstanceHealth",
+ "healthStatus": [
+  {
+   "ipAddress": "130.99.99.99",
+   "instance": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/instances/libcloud-lb-demo-www-000",
+   "healthState": "UNHEALTHY"
+  }
+ ]
+}

--- a/libcloud/test/compute/fixtures/gce/regions_us-central1_targetPools_lb_pool_setBackup_post.json
+++ b/libcloud/test/compute/fixtures/gce/regions_us-central1_targetPools_lb_pool_setBackup_post.json
@@ -1,0 +1,16 @@
+{
+  "endTime": "2013-09-03T01:29:07.021-07:00",
+  "id": "04072826501537092633",
+  "insertTime": "2013-09-03T01:29:03.082-07:00",
+  "kind": "compute#operation",
+  "name": "operation-regions_us-central1_targetPools_lb_pool_setBackup_post",
+  "operationType": "setBackup",
+  "progress": 0,
+  "region": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1/operations/operation-regions_us-central1_targetPools_lb_pool_setBackup_post",
+  "startTime": "2013-09-03T01:29:03.145-07:00",
+  "status": "PENDING",
+  "targetId": "16862638289615591831",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1/targetPools/lb-pool",
+  "user": "user@gserviceaccount.com"
+}

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -188,9 +188,9 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         target_pools = self.driver.ex_list_targetpools()
         target_pools_all = self.driver.ex_list_targetpools('all')
         target_pools_uc1 = self.driver.ex_list_targetpools('us-central1')
-        self.assertEqual(len(target_pools), 2)
-        self.assertEqual(len(target_pools_all), 3)
-        self.assertEqual(len(target_pools_uc1), 2)
+        self.assertEqual(len(target_pools), 4)
+        self.assertEqual(len(target_pools_all), 5)
+        self.assertEqual(len(target_pools_uc1), 4)
         self.assertEqual(target_pools[0].name, 'lctargetpool')
         self.assertEqual(target_pools_uc1[0].name, 'lctargetpool')
         names = [t.name for t in target_pools_all]
@@ -460,6 +460,25 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         firewall.source_tags = ['libcloud', 'test']
         firewall2 = self.driver.ex_update_firewall(firewall)
         self.assertTrue(isinstance(firewall2, GCEFirewall))
+
+    def test_ex_targetpool_gethealth(self):
+        targetpool = self.driver.ex_get_targetpool('lb-pool')
+        health = targetpool.get_health('libcloud-lb-demo-www-000')
+        self.assertEqual(len(health), 1)
+        self.assertTrue('node' in health[0])
+        self.assertTrue('health' in health[0])
+        self.assertEqual(health[0]['health'], 'UNHEALTHY')
+
+    def test_ex_targetpool_with_backup_pool(self):
+        targetpool = self.driver.ex_get_targetpool('lb-pool')
+        self.assertTrue('backupPool' in targetpool.extra)
+        self.assertTrue('failoverRatio' in targetpool.extra)
+
+    def test_ex_targetpool_setbackup(self):
+        targetpool = self.driver.ex_get_targetpool('lb-pool')
+        backup_targetpool = self.driver.ex_get_targetpool('backup-pool')
+        self.assertTrue(targetpool.set_backup_targetpool(backup_targetpool,
+                                                         0.1))
 
     def test_ex_targetpool_remove_add_node(self):
         targetpool = self.driver.ex_get_targetpool('lctargetpool')
@@ -804,6 +823,10 @@ class GCEMockHttp(MockHttpTestCase):
             body = self.fixtures.load('global_httpHealthChecks.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
+    def _global_httpHealthChecks_default_health_check(self, method, url, body, headers):
+        body = self.fixtures.load('global_httpHealthChecks_basic-check.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
     def _global_httpHealthChecks_basic_check(self, method, url, body, headers):
         body = self.fixtures.load('global_httpHealthChecks_basic-check.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
@@ -1034,6 +1057,12 @@ class GCEMockHttp(MockHttpTestCase):
             'operations_operation_regions_us-central1_targetPools_lctargetpool_removeInstance_post.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
+    def _regions_us_central1_operations_operation_regions_us_central1_targetPools_lb_pool_setBackup_post(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'operations_operation_regions_us-central1_targetPools_lb_pool_setBackup_post.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
     def _regions_us_central1_operations_operation_regions_us_central1_targetPools_lctargetpool_addInstance_post(
             self, method, url, body, headers):
         body = self.fixtures.load(
@@ -1204,6 +1233,16 @@ class GCEMockHttp(MockHttpTestCase):
             body = self.fixtures.load('regions_us-central1_targetPools.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
+    def _regions_us_central1_targetPools_lb_pool_getHealth(self, method, url, body, headers):
+        body = self.fixtures.load(
+            'regions_us-central1_targetPools_lb_pool_getHealth.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _regions_us_central1_targetPools_lb_pool(self, method, url, body, headers):
+        body = self.fixtures.load(
+            'regions_us-central1_targetPools_lb_pool.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
     def _regions_us_central1_targetPools_lctargetpool(self, method, url,
                                                       body, headers):
         if method == 'DELETE':
@@ -1218,6 +1257,12 @@ class GCEMockHttp(MockHttpTestCase):
                                                              body, headers):
         body = self.fixtures.load(
             'regions_us-central1_targetPools_lctargetpool_sticky.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _regions_us_central1_targetPools_backup_pool(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'regions_us-central1_targetPools_backup_pool.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
     def _regions_us_central1_targetPools_libcloud_lb_demo_lb_tp(
@@ -1242,6 +1287,12 @@ class GCEMockHttp(MockHttpTestCase):
             self, method, url, body, headers):
         body = self.fixtures.load(
             'regions_us-central1_targetPools_lctargetpool_removeInstance_post.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _regions_us_central1_targetPools_lb_pool_setBackup(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'regions_us-central1_targetPools_lb_pool_setBackup_post.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
     def _regions_us_central1_targetPools_lctargetpool_addInstance(


### PR DESCRIPTION
This PR improves GCE API coverage for GCE's TargetPool resource. It adds missing attributes along with new methods for calling `getHealth` (determine node health of the targetpool) and `setBackup` (set a failover targetpool).

Tests have been added / enhanced to cover these new methods.
