### PR TITLE
[LIBCLOUD-639] Python 3 Error: "Invalid argument %r for b()" when using upload_object_via_stream

### DIFF
--- a/libcloud/storage/base.py
+++ b/libcloud/storage/base.py
@@ -742,7 +742,8 @@ class StorageDriver(BaseDriver):
         if calculate_hash:
             data_hash = self._get_hash_function()
 
-        generator = libcloud.utils.files.read_in_chunks(iterator, chunk_size)
+        generator = libcloud.utils.files.read_in_chunks(iterator, chunk_size,
+                                                        fill_size=True)
 
         bytes_transferred = 0
         try:

--- a/libcloud/utils/files.py
+++ b/libcloud/utils/files.py
@@ -38,7 +38,7 @@ def read_in_chunks(iterator, chunk_size=None, fill_size=False,
     """
     Return a generator which yields data in chunks.
 
-    :param terator: An object which implements an iterator interface
+    :param iterator: An object which implements an iterator interface
                      or a File like object with read method.
     :type iterator: :class:`object` which implements iterator interface.
 

--- a/libcloud/utils/py3.py
+++ b/libcloud/utils/py3.py
@@ -85,6 +85,8 @@ if PY3:
             return s.encode('utf-8')
         elif isinstance(s, bytes):
             return s
+        elif isinstance(s, int):
+            return bytes([s])
         else:
             raise TypeError("Invalid argument %r for b()" % (s,))
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/LIBCLOUD-639
