### PR TITLE
fix ex_disk_auto_delete for create_node()

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -3122,11 +3122,14 @@ class GCENodeDriver(NodeDriver):
         node_data['serviceAccounts'] = set_scopes
 
         if boot_disk:
+            if not isinstance(ex_disk_auto_delete, bool):
+                raise ValueError("ex_disk_auto_delete field is not a bool.")
             disks = [{'kind': 'compute#attachedDisk',
                       'boot': True,
                       'type': 'PERSISTENT',
                       'mode': 'READ_WRITE',
                       'deviceName': boot_disk.name,
+                      'autoDelete': ex_disk_auto_delete,
                       'zone': boot_disk.extra['zone'].extra['selfLink'],
                       'source': boot_disk.extra['selfLink']}]
             node_data['disks'] = disks


### PR DESCRIPTION
create_node() has a parameter ex_disk_auto_delete that is True by default, but autoDelete attribute is never set for boot disks
