### PR TITLE
[google compute] Add License resource

### DIFF
--- a/libcloud/test/compute/fixtures/gce/projects_suse-cloud_global_images.json
+++ b/libcloud/test/compute/fixtures/gce/projects_suse-cloud_global_images.json
@@ -1,0 +1,160 @@
+{
+ "kind": "compute#imageList",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/suse-cloud/global/images",
+ "id": "projects/suse-cloud/global/images",
+ "items": [
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/suse-cloud/global/images/sles-11-sp3-v20140306",
+   "id": "3727805086509383287",
+   "creationTimestamp": "2014-03-06T13:13:29.791-08:00",
+   "name": "sles-11-sp3-v20140306",
+   "description": "",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/suse-cloud/global/images/sles-11-sp3-v20140609",
+    "deprecated": "2014-06-09T00:00:00Z"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "354497936",
+   "diskSizeGb": "8",
+   "licenses": [
+    "https://content.googleapis.com/compute/v1/projects/suse-cloud/global/licenses/sles-11"
+   ]
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/suse-cloud/global/images/sles-11-sp3-v20140609",
+   "id": "10656986931280984622",
+   "creationTimestamp": "2014-06-09T10:29:06.385-07:00",
+   "name": "sles-11-sp3-v20140609",
+   "description": "",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/suse-cloud/global/images/sles-11-sp3-v20140712",
+    "deprecated": "2014-07-12T00:00:00Z"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "1191603546",
+   "diskSizeGb": "8",
+   "licenses": [
+    "https://content.googleapis.com/compute/v1/projects/suse-cloud/global/licenses/sles-11"
+   ]
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/suse-cloud/global/images/sles-11-sp3-v20140712",
+   "id": "3415847542100990147",
+   "creationTimestamp": "2014-07-12T03:39:17.695-07:00",
+   "name": "sles-11-sp3-v20140712",
+   "description": "SUSE Linux Enterprise 11 SP3 built on 2014-07-12",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/suse-cloud/global/images/sles-11-sp3-v20140826",
+    "deprecated": "2014-06-26T00:00:00Z"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "1071997074",
+   "diskSizeGb": "8",
+   "licenses": [
+    "https://content.googleapis.com/compute/v1/projects/suse-cloud/global/licenses/sles-11"
+   ]
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/suse-cloud/global/images/sles-11-sp3-v20140826",
+   "id": "588070221570840387",
+   "creationTimestamp": "2014-08-26T14:46:38.449-07:00",
+   "name": "sles-11-sp3-v20140826",
+   "description": "SUSE Linux Enterprise 11 SP3 released on 2014-06-26, built on 2014-08-20",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/suse-cloud/global/images/sles-11-sp3-v20140930",
+    "deprecated": "2014-10-30T00:00:00Z"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "1072617138",
+   "diskSizeGb": "8",
+   "licenses": [
+    "https://content.googleapis.com/compute/v1/projects/suse-cloud/global/licenses/sles-11"
+   ]
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/suse-cloud/global/images/sles-11-sp3-v20140930",
+   "id": "3132872945991231828",
+   "creationTimestamp": "2014-09-30T08:27:46.201-07:00",
+   "name": "sles-11-sp3-v20140930",
+   "description": "SUSE Linux Enterprise Server 11 SP3",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "1102825953",
+   "diskSizeGb": "8",
+   "licenses": [
+    "https://content.googleapis.com/compute/v1/projects/suse-cloud/global/licenses/sles-11"
+   ]
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/suse-cloud/global/images/sles-11-sp3-v20141105",
+   "id": "14793554030256860036",
+   "creationTimestamp": "2014-11-05T16:11:49.996-08:00",
+   "name": "sles-11-sp3-v20141105",
+   "description": "SUSE Linux Enterprise Server 11 SP3 built on 2014-11-05",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "1075782309",
+   "diskSizeGb": "8",
+   "licenses": [
+    "https://content.googleapis.com/compute/v1/projects/suse-cloud/global/licenses/sles-11"
+   ]
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/suse-cloud/global/images/sles-12-v20141023",
+   "id": "15301906009182317384",
+   "creationTimestamp": "2014-10-26T08:14:59.932-07:00",
+   "name": "sles-12-v20141023",
+   "description": "SUSE Linux Enterprise Server 12 built on 2014-10-23",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "1525260684",
+   "diskSizeGb": "8",
+   "licenses": [
+    "https://content.googleapis.com/compute/v1/projects/suse-cloud/global/licenses/sles-12"
+   ]
+  }
+ ]
+}

--- a/libcloud/test/compute/fixtures/gce/projects_suse-cloud_global_licenses_sles_11.json
+++ b/libcloud/test/compute/fixtures/gce/projects_suse-cloud_global_licenses_sles_11.json
@@ -1,0 +1,6 @@
+{
+ "kind": "compute#license",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/suse-cloud/global/licenses/sles-11",
+ "name": "sles-11",
+ "chargesUseFee": true
+}

--- a/libcloud/test/compute/fixtures/gce/projects_suse-cloud_global_licenses_sles_12.json
+++ b/libcloud/test/compute/fixtures/gce/projects_suse-cloud_global_licenses_sles_12.json
@@ -1,0 +1,6 @@
+{
+ "kind": "compute#license",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/suse-cloud/global/licenses/sles-12",
+ "name": "sles-12",
+ "chargesUseFee": true
+}

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -224,6 +224,11 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         names = [s.name for s in sizes_all]
         self.assertEqual(names.count('n1-standard-1'), 5)
 
+    def test_ex_get_license(self):
+        license = self.driver.ex_get_license('suse-cloud', 'sles-12')
+        self.assertTrue(license.name, 'sles-12')
+        self.assertTrue(license.charges_use_fee)
+
     def test_list_disktypes(self):
         disktypes = self.driver.ex_list_disktypes()
         disktypes_all = self.driver.ex_list_disktypes('all')
@@ -732,6 +737,12 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         self.assertEqual(fwr.extra['portRange'], '8000-8500')
         self.assertEqual(fwr.targetpool.name, 'lctargetpool')
         self.assertEqual(fwr.protocol, 'TCP')
+
+    def test_ex_get_image_license(self):
+        image = self.driver.ex_get_image('sles-12-v20141023')
+        self.assertTrue('licenses' in image.extra)
+        self.assertTrue(image.extra['licenses'][0].name, 'sles-12')
+        self.assertTrue(image.extra['licenses'][0].charges_use_fee)
 
     def test_ex_get_image(self):
         partial_name = 'debian-7'
@@ -1400,6 +1411,18 @@ class GCEMockHttp(MockHttpTestCase):
 
     def _project(self, method, url, body, headers):
         body = self.fixtures.load('project.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _projects_suse_cloud_global_licenses_sles_11(self, method, url, body, headers):
+        body = self.fixtures.load('projects_suse-cloud_global_licenses_sles_11.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _projects_suse_cloud_global_licenses_sles_12(self, method, url, body, headers):
+        body = self.fixtures.load('projects_suse-cloud_global_licenses_sles_12.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _projects_suse_cloud_global_images(self, method, url, body, headers):
+        body = self.fixtures.load('projects_suse-cloud_global_images.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
     def _projects_debian_cloud_global_images(self, method, url, body, headers):


### PR DESCRIPTION
Adds Licenses[1] support to the GCE driver to further improve full API coverage.

[1] https://cloud.google.com/compute/docs/reference/latest/licenses
