### PR TITLE
@Added JoyentNodeDriver.ex_get_node()

### DIFF
--- a/libcloud/compute/drivers/joyent.py
+++ b/libcloud/compute/drivers/joyent.py
@@ -205,7 +205,6 @@ class JoyentNodeDriver(NodeDriver):
         result = self.connection.request('/my/machines/%s' % (node.id),
                                          data=data, method='POST')
         return result.status == httplib.ACCEPTED
-        
 
     def ex_get_node(self, node_id):
         """
@@ -217,7 +216,7 @@ class JoyentNodeDriver(NodeDriver):
         :return:  A Node object for the node
         :rtype:   :class:`Node`
         """
-        result = self.connection.request('/my/machines/%s' % node.id)
+        result = self.connection.request('/my/machines/%s' % node_id)
         return self._to_node(result.object)
 
     def _to_node(self, data):

--- a/libcloud/compute/drivers/joyent.py
+++ b/libcloud/compute/drivers/joyent.py
@@ -205,6 +205,20 @@ class JoyentNodeDriver(NodeDriver):
         result = self.connection.request('/my/machines/%s' % (node.id),
                                          data=data, method='POST')
         return result.status == httplib.ACCEPTED
+        
+
+    def ex_get_node(self, node_id):
+        """
+        Return a Node object based on a node ID.
+
+        :param  node_id: ID of the node
+        :type   node_id: ``str``
+
+        :return:  A Node object for the node
+        :rtype:   :class:`Node`
+        """
+        result = self.connection.request('/my/machines/%s' % node.id)
+        return self._to_node(result.object)
 
     def _to_node(self, data):
         state = NODE_STATE_MAP[data['state']]

--- a/libcloud/test/compute/test_joyent.py
+++ b/libcloud/test/compute/test_joyent.py
@@ -100,6 +100,15 @@ class JoyentTestCase(unittest.TestCase):
         node = self.driver.list_nodes()[0]
         self.assertTrue(self.driver.ex_start_node(node))
 
+    def test_ex_get_node(self):
+        node_id = '2fb67f5f-53f2-40ab-9d99-b9ff68cfb2ab'
+        node = self.driver.ex_get_node(node_id)
+        self.assertEqual(node.name, 'testlc')
+
+        missing_node = 'dummy-node'
+        self.assertRaises(Exception, self.driver.ex_get_node,
+                          missing_node, 'all')
+
 
 class JoyentHttp(MockHttp):
     fixtures = ComputeFileFixtures('joyent')
@@ -121,7 +130,8 @@ class JoyentHttp(MockHttp):
 
     def _my_machines_2fb67f5f_53f2_40ab_9d99_b9ff68cfb2ab(self, method, url,
                                                           body, headers):
-        return (httplib.ACCEPTED, '', {}, httplib.responses[httplib.ACCEPTED])
+        body = self.fixtures.load('my_machines_create.json')
+        return (httplib.ACCEPTED, body, {}, httplib.responses[httplib.ACCEPTED])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Joyent didn't have a method for get only one Node.

Because I doesn't want to make a for loop for find a node, I added this method.
Error raising is better too with that, a real Joyent's error message is now raised.
