### PR TITLE
[google compute] adding all list params to all list functions

### DIFF
--- a/libcloud/test/compute/fixtures/gce/list-dt-1.json
+++ b/libcloud/test/compute/fixtures/gce/list-dt-1.json
@@ -1,0 +1,18 @@
+{
+ "kind": "compute#diskTypeList",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/graphite-demos/zones/us-central1-a/diskTypes",
+ "id": "projects/graphite-demos/zones/us-central1-a/diskTypes",
+ "items": [
+  {
+   "kind": "compute#diskType",
+   "creationTimestamp": "2014-10-17T16:09:45.266-07:00",
+   "name": "local-ssd",
+   "description": "Local SSD",
+   "validDiskSize": "375GB-375GB",
+   "zone": "https://content.googleapis.com/compute/v1/projects/graphite-demos/zones/us-central1-a",
+   "selfLink": "https://content.googleapis.com/compute/v1/projects/graphite-demos/zones/us-central1-a/diskTypes/local-ssd",
+   "defaultDiskSizeGb": "375"
+  }
+ ],
+ "nextPageToken": "CjII2Mu46ZLswgI6JwoCGAEKAiAACgIYAQoCIAAKAhgbCgsqCWxvY2FsLXNzZAoEILPqAQ=="
+}

--- a/libcloud/test/compute/fixtures/gce/list-dt-2.json
+++ b/libcloud/test/compute/fixtures/gce/list-dt-2.json
@@ -1,0 +1,18 @@
+{
+ "kind": "compute#diskTypeList",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/graphite-demos/zones/us-central1-a/diskTypes",
+ "id": "projects/graphite-demos/zones/us-central1-a/diskTypes",
+ "items": [
+  {
+   "kind": "compute#diskType",
+   "creationTimestamp": "2014-06-02T11:07:28.529-07:00",
+   "name": "pd-ssd",
+   "description": "SSD Persistent Disk",
+   "validDiskSize": "10GB-10240GB",
+   "zone": "https://content.googleapis.com/compute/v1/projects/graphite-demos/zones/us-central1-a",
+   "selfLink": "https://content.googleapis.com/compute/v1/projects/graphite-demos/zones/us-central1-a/diskTypes/pd-ssd",
+   "defaultDiskSizeGb": "100"
+  }
+ ],
+ "nextPageToken": "Ci8I6LnVipPswgI6JAoCGAEKAiAACgIYAQoCIAAKAhgbCggqBnBkLXNzZAoEILLqAQ=="
+}

--- a/libcloud/test/compute/fixtures/gce/list-dt-3.json
+++ b/libcloud/test/compute/fixtures/gce/list-dt-3.json
@@ -1,0 +1,17 @@
+{
+ "kind": "compute#diskTypeList",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/graphite-demos/zones/us-central1-a/diskTypes",
+ "id": "projects/graphite-demos/zones/us-central1-a/diskTypes",
+ "items": [
+  {
+   "kind": "compute#diskType",
+   "creationTimestamp": "2014-06-02T11:07:28.530-07:00",
+   "name": "pd-standard",
+   "description": "Standard Persistent Disk",
+   "validDiskSize": "10GB-10240GB",
+   "zone": "https://content.googleapis.com/compute/v1/projects/graphite-demos/zones/us-central1-a",
+   "selfLink": "https://content.googleapis.com/compute/v1/projects/graphite-demos/zones/us-central1-a/diskTypes/pd-standard",
+   "defaultDiskSizeGb": "500"
+  }
+ ]
+}

--- a/libcloud/test/compute/fixtures/gce/list-dt-filter.json
+++ b/libcloud/test/compute/fixtures/gce/list-dt-filter.json
@@ -1,0 +1,27 @@
+{
+ "kind": "compute#diskTypeList",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/graphite-demos/zones/us-central1-a/diskTypes",
+ "id": "projects/graphite-demos/zones/us-central1-a/diskTypes",
+ "items": [
+  {
+   "kind": "compute#diskType",
+   "creationTimestamp": "2014-06-02T11:07:28.529-07:00",
+   "name": "pd-ssd",
+   "description": "SSD Persistent Disk",
+   "validDiskSize": "10GB-10240GB",
+   "zone": "https://content.googleapis.com/compute/v1/projects/graphite-demos/zones/us-central1-a",
+   "selfLink": "https://content.googleapis.com/compute/v1/projects/graphite-demos/zones/us-central1-a/diskTypes/pd-ssd",
+   "defaultDiskSizeGb": "100"
+  },
+  {
+   "kind": "compute#diskType",
+   "creationTimestamp": "2014-06-02T11:07:28.530-07:00",
+   "name": "pd-standard",
+   "description": "Standard Persistent Disk",
+   "validDiskSize": "10GB-10240GB",
+   "zone": "https://content.googleapis.com/compute/v1/projects/graphite-demos/zones/us-central1-a",
+   "selfLink": "https://content.googleapis.com/compute/v1/projects/graphite-demos/zones/us-central1-a/diskTypes/pd-standard",
+   "defaultDiskSizeGb": "500"
+  }
+ ]
+}

--- a/libcloud/test/compute/fixtures/gce/zones_us-central1-a_diskTypes-filter.json
+++ b/libcloud/test/compute/fixtures/gce/zones_us-central1-a_diskTypes-filter.json
@@ -1,0 +1,17 @@
+{
+ "kind": "compute#diskTypeList",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/diskTypes",
+ "id": "projects/project_name/zones/us-central1-a/diskTypes",
+ "items": [
+  {
+   "kind": "compute#diskType",
+   "creationTimestamp": "2014-06-02T11:07:28.529-07:00",
+   "name": "pd-ssd",
+   "description": "SSD Persistent Disk",
+   "validDiskSize": "10GB-10240GB",
+   "zone": "https://content.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a",
+   "selfLink": "https://content.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/diskTypes/pd-ssd",
+   "defaultDiskSizeGb": "100"
+  }
+ ]
+}

--- a/libcloud/test/compute/fixtures/gce/zones_us-central1-a_diskTypes-maxResults-cont.json
+++ b/libcloud/test/compute/fixtures/gce/zones_us-central1-a_diskTypes-maxResults-cont.json
@@ -1,0 +1,17 @@
+{
+ "kind": "compute#diskTypeList",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/diskTypes",
+ "id": "projects/project_name/zones/us-central1-a/diskTypes",
+ "items": [
+  {
+   "kind": "compute#diskType",
+   "creationTimestamp": "2014-06-02T11:07:28.530-07:00",
+   "name": "pd-standard",
+   "description": "Standard Persistent Disk",
+   "validDiskSize": "10GB-10240GB",
+   "zone": "https://content.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a",
+   "selfLink": "https://content.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/diskTypes/pd-standard",
+   "defaultDiskSizeGb": "500"
+  }
+ ]
+}

--- a/libcloud/test/compute/fixtures/gce/zones_us-central1-a_diskTypes-maxResults.json
+++ b/libcloud/test/compute/fixtures/gce/zones_us-central1-a_diskTypes-maxResults.json
@@ -1,0 +1,18 @@
+{
+ "kind": "compute#diskTypeList",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/diskTypes",
+ "id": "projects/project_name/zones/us-central1-a/diskTypes",
+ "items": [
+  {
+   "kind": "compute#diskType",
+   "creationTimestamp": "2014-06-02T11:07:28.529-07:00",
+   "name": "pd-ssd",
+   "description": "SSD Persistent Disk",
+   "validDiskSize": "10GB-10240GB",
+   "zone": "https://content.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a",
+   "selfLink": "https://content.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/diskTypes/pd-ssd",
+   "defaultDiskSizeGb": "100"
+  }
+ ],
+ "nextPageToken": "this_is_my_page_token"
+}

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -229,6 +229,19 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         self.assertTrue(license.name, 'sles-12')
         self.assertTrue(license.charges_use_fee)
 
+    def test_list_disktypes_ex_max_results(self):
+        disktypes = self.driver.ex_list_disktypes(ex_max_results=1)
+        self.assertEqual(len(disktypes), 1)
+        self.assertTrue(disktypes[0].name, 'pd-ssd')
+        disktypes = self.driver.ex_list_disktypes(ex_max_results=1)
+        self.assertEqual(len(disktypes), 1)
+        self.assertTrue(disktypes[0].name, 'pd-standard')
+
+    def test_list_disktypes_ex_filter(self):
+        disktypes = self.driver.ex_list_disktypes(ex_filter='name eq "pd-ss.*"')
+        self.assertEqual(len(disktypes), 1)
+        self.assertTrue(disktypes[0].name, 'pd-ssd')
+
     def test_list_disktypes(self):
         disktypes = self.driver.ex_list_disktypes()
         disktypes_all = self.driver.ex_list_disktypes('all')
@@ -1591,13 +1604,19 @@ class GCEMockHttp(MockHttpTestCase):
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
     def _zones_us_central1_a_diskTypes(self, method, url, body, headers):
-        if method == 'GET':
+        if url.find("filter") != -1:
+            body = self.fixtures.load('zones_us-central1-a_diskTypes-filter.json')
+        elif url.find("maxResults") != -1:
+            if url.find("pageToken") != -1:
+                body = self.fixtures.load('zones_us-central1-a_diskTypes-maxResults-cont.json')
+            else:
+                body = self.fixtures.load('zones_us-central1-a_diskTypes-maxResults.json')
+        else:
             body = self.fixtures.load('zones_us-central1-a_diskTypes.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
     def _zones_us_central1_a_diskTypes_pd_ssd(self, method, url, body, headers):
-        if method == 'GET':
-            body = self.fixtures.load('zones_us-central1-a_diskTypes_pd_ssd.json')
+        body = self.fixtures.load('zones_us-central1-a_diskTypes_pd_ssd.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
     def _zones_us_central1_a_disks(self, method, url, body, headers):


### PR DESCRIPTION
This PR adds support to all `list_XXX()` and `ex_list_XXX()` driver methods using the parameters provided by GCE API as described in this example, https://cloud.google.com/compute/docs/reference/latest/diskTypes/list.
- Users can now provide an `ex_filter` to restrict search results to filter matches such as nodes that match `name eq "test.*"`.
- Users can now step through large resource sets `ex_max_results` for each method call until no more results are returned. In GCE terms, this allows for "pagination" and uses a `pageToken` query parameter to step through the resource set. Users can 'reset' the step pointer by specifying `ex_reset_page_token`, e.g.
  
  ``` python
  subset = gce_driver.ex_list_snapshots(ex_max_results=2):
  while subset:
      # do something with this subset of snapshots...
      subset = gce_driver.ex_list_snapshots(ex_max_results=2)
  gce_driver.ex_list_snapshots(ex_reset_page_token=True)
  ```
