### PR TITLE
[LIBCLOUD-602] improve gce.image_list()

### DIFF
--- a/libcloud/test/compute/fixtures/gce/global_images.json
+++ b/libcloud/test/compute/fixtures/gce/global_images.json
@@ -1,51 +1,23 @@
 {
-  "id": "projects/project_name/global/images",
-  "items": [
-    {
-      "creationTimestamp": "2013-06-19T13:47:20.563-07:00",
-      "description": "Local Debian GNU/Linux 7.1 (wheezy) built on 2013-06-17",
-      "id": "1549141992333368759",
-      "kind": "compute#image",
-      "name": "debian-7-wheezy-v20130617",
-      "preferredKernel": "https://www.googleapis.com/compute/v1/projects/google/global/kernels/gce-v20130603",
-      "rawDisk": {
-        "containerType": "TAR",
-        "source": ""
-      },
-      "selfLink": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20130617",
-      "sourceType": "RAW",
-      "status": "READY"
-    },
-    {
-      "creationTimestamp": "2013-11-18T12:24:21.560-07:00",
-      "id": "1539141992335368259",
-      "kind": "compute#image",
-      "name": "centos-6-v20131118",
-      "preferredKernel": "https://www.googleapis.com/compute/v1/projects/google/global/kernels/gce-v20130603",
-      "rawDisk": {
-        "containerType": "TAR",
-        "source": ""
-      },
-      "selfLink": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/centos-6-v20131118",
-      "sourceType": "RAW",
-      "status": "READY"
-    },
-    {
-      "creationTimestamp": "2014-03-09T21:04:31.291-07:00",
-      "description": "CoreOS test image",
-      "id": "15196339658718959621",
-      "kind": "compute#image",
-      "name": "coreos",
-      "preferredKernel": "https://www.googleapis.com/compute/v1/projects/google/global/kernels/gce-v20130603",
-      "rawDisk": {
-        "containerType": "TAR",
-        "source": ""
-      },
-      "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/images/coreos",
-      "sourceType": "RAW",
-      "status": "READY"
-    }
-  ],
-  "kind": "compute#imageList",
-  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/images"
+ "kind": "compute#imageList",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/images",
+ "id": "projects/project_name/global/images",
+ "items": [
+  {
+
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/images/aws-ubuntu",
+   "id": "15632509721401584263",
+   "creationTimestamp": "2014-12-09T09:26:27.234-08:00",
+   "name": "aws-ubuntu",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "243720274",
+   "diskSizeGb": "10"
+  }
+ ]
 }

--- a/libcloud/test/compute/fixtures/gce/global_images_debian_7_wheezy_v20131014_deprecate.json
+++ b/libcloud/test/compute/fixtures/gce/global_images_debian_7_wheezy_v20131014_deprecate.json
@@ -5,7 +5,7 @@
     "startTime": "2014-03-11T20:18:36.194-07:00",
     "insertTime": "2014-03-11T20:18:36.110-07:00",
     "targetId": "10034929421075729520",
-    "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/images/debian_6_squeeze_v20130926",
+    "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/images/debian_7_wheezy_v20131014",
     "operationType": "setDeprecation",
     "progress": 0,
     "id": "11223768474922166090",

--- a/libcloud/test/compute/fixtures/gce/global_images_debian_7_wheezy_v20131120_delete.json
+++ b/libcloud/test/compute/fixtures/gce/global_images_debian_7_wheezy_v20131120_delete.json
@@ -3,7 +3,7 @@
  "id": "10762099380229198553",
  "name": "operation-global_images_debian7_delete",
  "operationType": "delete",
- "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/images/debian-7-wheezy-v20130617",
+ "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/images/debian-7-wheezy-v20131120",
  "targetId": "14881612020726561163",
  "status": "PENDING",
  "user": "user@developer.gserviceaccount.com",

--- a/libcloud/test/compute/fixtures/gce/operations_operation_global_images_debian7_delete.json
+++ b/libcloud/test/compute/fixtures/gce/operations_operation_global_images_debian7_delete.json
@@ -3,7 +3,7 @@
  "id": "10762099380229198553",
  "name": "operation-global_images_debian7_delete",
  "operationType": "delete",
- "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/images/debian-7-wheezy-v20130617",
+ "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/images/debian-7-wheezy-v20131120",
  "targetId": "14881612020726561163",
  "status": "DONE",
  "user": "user@developer.gserviceaccount.com",

--- a/libcloud/test/compute/fixtures/gce/projects_centos-cloud_global_images.json
+++ b/libcloud/test/compute/fixtures/gce/projects_centos-cloud_global_images.json
@@ -1,0 +1,479 @@
+{
+ "kind": "compute#imageList",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images",
+ "id": "projects/centos-cloud/global/images",
+ "items": [
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20131120",
+   "id": "11748647391859510935",
+   "creationTimestamp": "2013-11-25T15:13:50.611-08:00",
+   "name": "centos-6-v20131120",
+   "description": "SCSI-enabled CentOS 6 built on 2013-11-20",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20140318"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "269993565",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20140318",
+   "id": "11743140967858608122",
+   "creationTimestamp": "2014-03-19T15:01:13.388-07:00",
+   "name": "centos-6-v20140318",
+   "description": "CentOS 6.5 x86_64 built on 2014-03-18",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20140408"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "341230444",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20140408",
+   "id": "18033188469723077298",
+   "creationTimestamp": "2014-04-09T10:31:57.518-07:00",
+   "name": "centos-6-v20140408",
+   "description": "CentOS 6.5 x86_64 built on 2014-04-08",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20140415"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "342252847",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20140415",
+   "id": "10463166969914166288",
+   "creationTimestamp": "2014-04-22T12:05:16.927-07:00",
+   "name": "centos-6-v20140415",
+   "description": "CentOS 6.5 x86_64 built on 2014-04-15",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20140522"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "1026663807",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20140522",
+   "id": "14390164727436022001",
+   "creationTimestamp": "2014-06-03T10:21:42.109-07:00",
+   "name": "centos-6-v20140522",
+   "description": "CentOS 6.5 x86_64 built on 2014-05-22",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20140606"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "1028292810",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20140605",
+   "id": "16310166269920012092",
+   "creationTimestamp": "2014-06-05T11:04:45.767-07:00",
+   "name": "centos-6-v20140605",
+   "description": "CentOS 6.5 x86_64 built on 2014-06-05",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20140606"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "1028745777",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20140606",
+   "id": "6290630306542078308",
+   "creationTimestamp": "2014-06-06T13:16:42.265-07:00",
+   "name": "centos-6-v20140606",
+   "description": "CentOS 6.5 x86_64 built on 2014-06-06",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20140619"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "1028757792",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20140619",
+   "id": "3614861379648377676",
+   "creationTimestamp": "2014-06-24T13:28:11.552-07:00",
+   "name": "centos-6-v20140619",
+   "description": "CentOS 6.5 x86_64 built on 2014-06-19",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20140718"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "1029860991",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20140718",
+   "id": "16259951858818091437",
+   "creationTimestamp": "2014-07-24T09:02:18.298-07:00",
+   "name": "centos-6-v20140718",
+   "description": "CentOS 6.5 x86_64 built on 2014-07-18",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20140924"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "1031630715",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20140924",
+   "id": "13087714199807465700",
+   "creationTimestamp": "2014-09-24T19:21:53.421-07:00",
+   "name": "centos-6-v20140924",
+   "description": "CentOS 6.5 x86_64 built on 2014-09-24",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20140926"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "1040237724",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20140926",
+   "id": "2580521871229876339",
+   "creationTimestamp": "2014-09-29T09:26:44.364-07:00",
+   "name": "centos-6-v20140926",
+   "description": "CentOS 6.5 x86_64 built on 2014-09-26",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20141007"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "1040082792",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20141007",
+   "id": "3381938258505751441",
+   "creationTimestamp": "2014-10-16T14:52:10.720-07:00",
+   "name": "centos-6-v20141007",
+   "description": "CentOS 6.5 x86_64 built on 2014-10-07",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20141016"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "1040311077",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20141016",
+   "id": "2365868823508405185",
+   "creationTimestamp": "2014-10-17T16:46:57.144-07:00",
+   "name": "centos-6-v20141016",
+   "description": "CentOS 6.5 x86_64 built on 2014-10-16",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20141021"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "1040361036",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20141021",
+   "id": "10836725743769588052",
+   "creationTimestamp": "2014-10-22T18:24:03.632-07:00",
+   "name": "centos-6-v20141021",
+   "description": "CentOS 6.5 x86_64 built on 2014-10-21",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20141108"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "1040416587",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20141108",
+   "id": "4053040619898291132",
+   "creationTimestamp": "2014-11-10T14:25:17.670-08:00",
+   "name": "centos-6-v20141108",
+   "description": "CentOS 6.6 x86_64 built on 2014-11-08",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20141205"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "1049466963",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20141205",
+   "id": "17207937043950962086",
+   "creationTimestamp": "2014-12-08T16:14:54.943-08:00",
+   "name": "centos-6-v20141205",
+   "description": "CentOS 6.6 x86_64 built on 2014-12-05",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "1056393081",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20140903",
+   "id": "4568702763004249623",
+   "creationTimestamp": "2014-09-04T09:50:19.966-07:00",
+   "name": "centos-7-v20140903",
+   "description": "CentOS 7.0 x86_64 built on 2014-09-03",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20140924"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "1168167201",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20140924",
+   "id": "4822681162745636585",
+   "creationTimestamp": "2014-09-24T19:57:13.650-07:00",
+   "name": "centos-7-v20140924",
+   "description": "CentOS 7 x86_64 built on 2014-09-24",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20140926"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "1181699781",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20140926",
+   "id": "11630347837395986864",
+   "creationTimestamp": "2014-09-29T09:29:54.626-07:00",
+   "name": "centos-7-v20140926",
+   "description": "CentOS 7 x86_64 built on 2014-09-26",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20141007"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "1182441174",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20141007",
+   "id": "13420104487111729570",
+   "creationTimestamp": "2014-10-16T14:18:33.905-07:00",
+   "name": "centos-7-v20141007",
+   "description": "CentOS 7.0 x86_64 built on 2014-10-07",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20141016"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "1182982164",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20141016",
+   "id": "4506010319257803087",
+   "creationTimestamp": "2014-10-17T16:43:06.539-07:00",
+   "name": "centos-7-v20141016",
+   "description": "CentOS 7.0 x86_64 built on 2014-10-16",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20141021"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "1184558412",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20141021",
+   "id": "4536638025069785573",
+   "creationTimestamp": "2014-10-22T18:27:40.851-07:00",
+   "name": "centos-7-v20141021",
+   "description": "CentOS 7 x86_64 built on 2014-10-21",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20141108"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "1183591245",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20141108",
+   "id": "853041310537923411",
+   "creationTimestamp": "2014-11-10T14:22:16.416-08:00",
+   "name": "centos-7-v20141108",
+   "description": "CentOS 7 x86_64 built on 2014-11-08",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20141205"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "1192600188",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20141205",
+   "id": "9955643093605856709",
+   "creationTimestamp": "2014-12-08T16:35:02.271-08:00",
+   "name": "centos-7-v20141205",
+   "description": "CentOS 7 x86_64 built on 2014-12-05",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "1196735889",
+   "diskSizeGb": "10"
+  }
+ ]
+}

--- a/libcloud/test/compute/fixtures/gce/projects_coreos-cloud_global_images.json
+++ b/libcloud/test/compute/fixtures/gce/projects_coreos-cloud_global_images.json
@@ -1,0 +1,1515 @@
+{
+ "kind": "compute#imageList",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images",
+ "id": "projects/coreos-cloud/global/images",
+ "items": [
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-282-0-0-v20140410",
+   "id": "4545075671331449642",
+   "creationTimestamp": "2014-04-10T13:37:09.105-07:00",
+   "name": "coreos-alpha-282-0-0-v20140410",
+   "description": "CoreOS (alpha)",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "191704931",
+   "diskSizeGb": "6"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-298-0-0-v20140425",
+   "id": "13394839002167516366",
+   "creationTimestamp": "2014-04-25T16:05:41.718-07:00",
+   "name": "coreos-alpha-298-0-0-v20140425",
+   "description": "CoreOS alpha 298.0.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "194267903",
+   "diskSizeGb": "6"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-310-1-0-v20140508",
+   "id": "11111206691445863910",
+   "creationTimestamp": "2014-05-07T17:20:35.575-07:00",
+   "name": "coreos-alpha-310-1-0-v20140508",
+   "description": "CoreOS alpha 310.1.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "196010234",
+   "diskSizeGb": "6"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-315-0-0-v20140512",
+   "id": "16022942869504160",
+   "creationTimestamp": "2014-05-12T16:24:23.130-07:00",
+   "name": "coreos-alpha-315-0-0-v20140512",
+   "description": "CoreOS alpha 315.0.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "195832144",
+   "diskSizeGb": "6"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-317-0-0-v20140515",
+   "id": "11739259381666430485",
+   "creationTimestamp": "2014-05-15T10:42:51.748-07:00",
+   "name": "coreos-alpha-317-0-0-v20140515",
+   "description": "CoreOS alpha 317.0.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "195591890",
+   "diskSizeGb": "6"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-324-1-0-v20140522",
+   "id": "3998011925663216170",
+   "creationTimestamp": "2014-05-22T11:10:59.683-07:00",
+   "name": "coreos-alpha-324-1-0-v20140522",
+   "description": "CoreOS alpha 324.1.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "198854961",
+   "diskSizeGb": "6"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-324-2-0-v20140528",
+   "id": "6833110226481787934",
+   "creationTimestamp": "2014-05-28T12:04:45.280-07:00",
+   "name": "coreos-alpha-324-2-0-v20140528",
+   "description": "CoreOS alpha 324.2.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "198872299",
+   "diskSizeGb": "6"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-324-3-0-v20140530",
+   "id": "2096033640183904088",
+   "creationTimestamp": "2014-05-30T10:10:54.644-07:00",
+   "name": "coreos-alpha-324-3-0-v20140530",
+   "description": "CoreOS alpha 324.3.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "198897147",
+   "diskSizeGb": "6"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-324-4-0-v20140607",
+   "id": "13657407932096700402",
+   "creationTimestamp": "2014-06-06T17:48:24.952-07:00",
+   "name": "coreos-alpha-324-4-0-v20140607",
+   "description": "CoreOS alpha 324.4.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "198687188",
+   "diskSizeGb": "6"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-324-5-0-v20140607",
+   "id": "2289397358548509631",
+   "creationTimestamp": "2014-06-07T15:11:14.415-07:00",
+   "name": "coreos-alpha-324-5-0-v20140607",
+   "description": "CoreOS alpha 324.5.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "198701072",
+   "diskSizeGb": "6"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-338-0-0-v20140604",
+   "id": "6110535785379416957",
+   "creationTimestamp": "2014-06-04T15:57:45.096-07:00",
+   "name": "coreos-alpha-338-0-0-v20140604",
+   "description": "CoreOS alpha 338.0.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "204832142",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-342-0-0-v20140608",
+   "id": "14338602172513809268",
+   "creationTimestamp": "2014-06-08T10:50:15.283-07:00",
+   "name": "coreos-alpha-342-0-0-v20140608",
+   "description": "CoreOS alpha 342.0.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "204558347",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-342-1-0-v20140608",
+   "id": "13330227154553534732",
+   "creationTimestamp": "2014-06-08T14:57:01.770-07:00",
+   "name": "coreos-alpha-342-1-0-v20140608",
+   "description": "CoreOS alpha 342.1.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "204688415",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-343-0-0-v20140609",
+   "id": "1988715371441632844",
+   "creationTimestamp": "2014-06-09T14:29:28.178-07:00",
+   "name": "coreos-alpha-343-0-0-v20140609",
+   "description": "CoreOS alpha 343.0.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "204553796",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-349-0-0-v20140616",
+   "id": "16583233600096079991",
+   "creationTimestamp": "2014-06-16T15:42:37.127-07:00",
+   "name": "coreos-alpha-349-0-0-v20140616",
+   "description": "CoreOS alpha 349.0.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "204556764",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-353-0-0-v20140621",
+   "id": "6651180993237136697",
+   "creationTimestamp": "2014-06-20T17:12:53.636-07:00",
+   "name": "coreos-alpha-353-0-0-v20140621",
+   "description": "CoreOS alpha 353.0.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "204893692",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-361-0-0-v20140627",
+   "id": "16595596722360750984",
+   "creationTimestamp": "2014-06-27T11:18:42.680-07:00",
+   "name": "coreos-alpha-361-0-0-v20140627",
+   "description": "CoreOS alpha 361.0.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "204875098",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-367-0-0-v20140703",
+   "id": "14830409198434884170",
+   "creationTimestamp": "2014-07-03T15:13:10.342-07:00",
+   "name": "coreos-alpha-367-0-0-v20140703",
+   "description": "CoreOS alpha 367.0.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "202900963",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-367-1-0-v20140713",
+   "id": "4506608247976466482",
+   "creationTimestamp": "2014-07-12T19:19:03.327-07:00",
+   "name": "coreos-alpha-367-1-0-v20140713",
+   "description": "CoreOS alpha 367.1.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "202819993",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-379-2-0-v20140715",
+   "id": "10214880843477717813",
+   "creationTimestamp": "2014-07-15T16:26:03.323-07:00",
+   "name": "coreos-alpha-379-2-0-v20140715",
+   "description": "CoreOS alpha 379.2.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "204225959",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-379-3-0-v20140716",
+   "id": "9717320542649493270",
+   "creationTimestamp": "2014-07-16T10:06:14.830-07:00",
+   "name": "coreos-alpha-379-3-0-v20140716",
+   "description": "CoreOS alpha 379.3.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "204475873",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-386-1-0-v20140723",
+   "id": "8762908517570017855",
+   "creationTimestamp": "2014-07-23T13:21:42.787-07:00",
+   "name": "coreos-alpha-386-1-0-v20140723",
+   "description": "CoreOS alpha 386.1.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "214809962",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-394-0-0-v20140801",
+   "id": "13449834147524152564",
+   "creationTimestamp": "2014-08-01T11:20:09.394-07:00",
+   "name": "coreos-alpha-394-0-0-v20140801",
+   "description": "CoreOS alpha 394.0.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "215030100",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-399-0-0-v20140806",
+   "id": "9424565426493971034",
+   "creationTimestamp": "2014-08-05T17:45:57.966-07:00",
+   "name": "coreos-alpha-399-0-0-v20140806",
+   "description": "CoreOS alpha 399.0.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "218427609",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-402-2-0-v20140807",
+   "id": "17172174175513198150",
+   "creationTimestamp": "2014-08-07T16:54:36.859-07:00",
+   "name": "coreos-alpha-402-2-0-v20140807",
+   "description": "CoreOS alpha 402.2.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "218464656",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-410-0-0-v20140818",
+   "id": "5447152525517666471",
+   "creationTimestamp": "2014-08-18T11:28:12.278-07:00",
+   "name": "coreos-alpha-410-0-0-v20140818",
+   "description": "CoreOS alpha 410.0.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "218443034",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-423-0-0-v20140828",
+   "id": "3564803995591182122",
+   "creationTimestamp": "2014-08-28T15:39:30.525-07:00",
+   "name": "coreos-alpha-423-0-0-v20140828",
+   "description": "CoreOS alpha 423.0.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "210763062",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-431-0-0-v20140905",
+   "id": "2005848009016889709",
+   "creationTimestamp": "2014-09-05T13:53:53.863-07:00",
+   "name": "coreos-alpha-431-0-0-v20140905",
+   "description": "CoreOS alpha 431.0.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "208605209",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-435-0-0-v20140910",
+   "id": "13332314615344703276",
+   "creationTimestamp": "2014-09-10T11:54:21.707-07:00",
+   "name": "coreos-alpha-435-0-0-v20140910",
+   "description": "CoreOS alpha 435.0.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "210142911",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-438-0-0-v20140913",
+   "id": "5230953556156640067",
+   "creationTimestamp": "2014-09-13T12:12:44.675-07:00",
+   "name": "coreos-alpha-438-0-0-v20140913",
+   "description": "CoreOS alpha 438.0.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "210475454",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-440-0-0-v20140915",
+   "id": "5334314307925303424",
+   "creationTimestamp": "2014-09-15T15:21:20.116-07:00",
+   "name": "coreos-alpha-440-0-0-v20140915",
+   "description": "CoreOS alpha 440.0.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "210345834",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-444-0-0-v20140919",
+   "id": "13961453531244096097",
+   "creationTimestamp": "2014-09-19T13:43:08.003-07:00",
+   "name": "coreos-alpha-444-0-0-v20140919",
+   "description": "CoreOS alpha 444.0.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "210601371",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-452-0-0-v20140926",
+   "id": "15205532858154654172",
+   "creationTimestamp": "2014-09-26T13:13:30.539-07:00",
+   "name": "coreos-alpha-452-0-0-v20140926",
+   "description": "CoreOS alpha 452.0.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "211112758",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-457-0-0-v20141002",
+   "id": "9789565658376148526",
+   "creationTimestamp": "2014-10-01T18:49:01.683-07:00",
+   "name": "coreos-alpha-457-0-0-v20141002",
+   "description": "CoreOS alpha 457.0.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "211116656",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-459-0-0-v20141003",
+   "id": "12778368443622282257",
+   "creationTimestamp": "2014-10-03T15:37:32.621-07:00",
+   "name": "coreos-alpha-459-0-0-v20141003",
+   "description": "CoreOS alpha 459.0.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "211079895",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-471-1-0-v20141016",
+   "id": "5868321226342539344",
+   "creationTimestamp": "2014-10-15T17:58:49.120-07:00",
+   "name": "coreos-alpha-471-1-0-v20141016",
+   "description": "CoreOS alpha 471.1.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "212426664",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-472-0-0-v20141017",
+   "id": "4576009004678324232",
+   "creationTimestamp": "2014-10-17T13:25:52.653-07:00",
+   "name": "coreos-alpha-472-0-0-v20141017",
+   "description": "CoreOS alpha 472.0.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "209948512",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-490-0-0-v20141104",
+   "id": "13920393620518010014",
+   "creationTimestamp": "2014-11-04T14:22:35.647-08:00",
+   "name": "coreos-alpha-490-0-0-v20141104",
+   "description": "CoreOS alpha 490.0.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "214899846",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-493-0-0-v20141107",
+   "id": "6901289773390612149",
+   "creationTimestamp": "2014-11-06T17:07:25.804-08:00",
+   "name": "coreos-alpha-493-0-0-v20141107",
+   "description": "CoreOS alpha 493.0.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "214900059",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-494-0-0-v20141108",
+   "id": "16984733952836989634",
+   "creationTimestamp": "2014-11-08T08:14:39.763-08:00",
+   "name": "coreos-alpha-494-0-0-v20141108",
+   "description": "CoreOS alpha 494.0.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "217341810",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-505-1-0-v20141119",
+   "id": "6377208203517836508",
+   "creationTimestamp": "2014-11-19T11:58:34.839-08:00",
+   "name": "coreos-alpha-505-1-0-v20141119",
+   "description": "CoreOS alpha 505.1.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "220202141",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-507-0-0-v20141121",
+   "id": "2812520923267400303",
+   "creationTimestamp": "2014-11-20T16:53:33.724-08:00",
+   "name": "coreos-alpha-507-0-0-v20141121",
+   "description": "CoreOS alpha 507.0.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "220243128",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-509-0-0-v20141122",
+   "id": "17634437931750438301",
+   "creationTimestamp": "2014-11-22T12:07:41.631-08:00",
+   "name": "coreos-alpha-509-0-0-v20141122",
+   "description": "CoreOS alpha 509.0.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "215896616",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-509-1-0-v20141124",
+   "id": "15997978649119901106",
+   "creationTimestamp": "2014-11-24T13:54:40.347-08:00",
+   "name": "coreos-alpha-509-1-0-v20141124",
+   "description": "CoreOS alpha 509.1.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "220158301",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-522-0-0-v20141205",
+   "id": "3688346254254255171",
+   "creationTimestamp": "2014-12-05T11:12:11.016-08:00",
+   "name": "coreos-alpha-522-0-0-v20141205",
+   "description": "CoreOS alpha 522.0.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "220671632",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-522-1-0-v20141211",
+   "id": "17994276440547647719",
+   "creationTimestamp": "2014-12-11T12:59:25.259-08:00",
+   "name": "coreos-alpha-522-1-0-v20141211",
+   "description": "CoreOS alpha 522.1.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "220746106",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-522-2-0-v20141217",
+   "id": "14750233033823203541",
+   "creationTimestamp": "2014-12-17T11:07:40.413-08:00",
+   "name": "coreos-alpha-522-2-0-v20141217",
+   "description": "CoreOS alpha 522.2.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "220706464",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-534-1-0-v20141219",
+   "id": "9382201742109997553",
+   "creationTimestamp": "2014-12-18T16:02:57.257-08:00",
+   "name": "coreos-alpha-534-1-0-v20141219",
+   "description": "CoreOS alpha 534.1.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-536-0-0-v20141220"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "150760714",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-536-0-0-v20141220",
+   "id": "17499586025310826725",
+   "creationTimestamp": "2014-12-20T13:19:46.596-08:00",
+   "name": "coreos-alpha-536-0-0-v20141220",
+   "description": "CoreOS alpha 536.0.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-540-0-0-v20141223"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "150727446",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-540-0-0-v20141223",
+   "id": "2686834707529846588",
+   "creationTimestamp": "2014-12-23T13:10:58.507-08:00",
+   "name": "coreos-alpha-540-0-0-v20141223",
+   "description": "CoreOS alpha 540.0.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "147379024",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-beta-310-1-0-v20140508",
+   "id": "2504761896178375059",
+   "creationTimestamp": "2014-05-08T16:21:25.030-07:00",
+   "name": "coreos-beta-310-1-0-v20140508",
+   "description": "CoreOS beta 310.1.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-beta-494-5-0-v20141211"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "196007489",
+   "diskSizeGb": "6"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-beta-324-3-0-v20140602",
+   "id": "5956689618368737465",
+   "creationTimestamp": "2014-06-02T13:23:43.465-07:00",
+   "name": "coreos-beta-324-3-0-v20140602",
+   "description": "CoreOS beta 324.3.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-beta-494-5-0-v20141211"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "198895988",
+   "diskSizeGb": "6"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-beta-324-5-0-v20140609",
+   "id": "11953277661482892448",
+   "creationTimestamp": "2014-06-09T09:49:34.235-07:00",
+   "name": "coreos-beta-324-5-0-v20140609",
+   "description": "CoreOS beta 324.5.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-beta-494-5-0-v20141211"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "198718133",
+   "diskSizeGb": "6"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-beta-353-0-0-v20140625",
+   "id": "11516237452648076812",
+   "creationTimestamp": "2014-06-25T13:29:04.367-07:00",
+   "name": "coreos-beta-353-0-0-v20140625",
+   "description": "CoreOS beta 353.0.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-beta-494-5-0-v20141211"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "204844190",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-beta-367-1-0-v20140715",
+   "id": "12967199568595368851",
+   "creationTimestamp": "2014-07-15T16:24:00.178-07:00",
+   "name": "coreos-beta-367-1-0-v20140715",
+   "description": "CoreOS beta 367.1.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-beta-494-5-0-v20141211"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "202795742",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-beta-410-0-0-v20140825",
+   "id": "5879404002456449175",
+   "creationTimestamp": "2014-08-25T12:43:37.337-07:00",
+   "name": "coreos-beta-410-0-0-v20140825",
+   "description": "CoreOS beta 410.0.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-beta-494-5-0-v20141211"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "218397098",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-beta-440-0-0-v20140918",
+   "id": "16470992918251712233",
+   "creationTimestamp": "2014-09-18T15:25:30.677-07:00",
+   "name": "coreos-beta-440-0-0-v20140918",
+   "description": "CoreOS beta 440.0.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-beta-494-5-0-v20141211"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "210355603",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-beta-444-2-0-v20140926",
+   "id": "12871847181887001345",
+   "creationTimestamp": "2014-09-26T08:59:23.897-07:00",
+   "name": "coreos-beta-444-2-0-v20140926",
+   "description": "CoreOS beta 444.2.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-beta-494-5-0-v20141211"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "210521891",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-beta-444-3-0-v20141002",
+   "id": "7978986993043599036",
+   "creationTimestamp": "2014-10-01T18:58:31.452-07:00",
+   "name": "coreos-beta-444-3-0-v20141002",
+   "description": "CoreOS beta 444.3.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-beta-494-5-0-v20141211"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "210748822",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-beta-444-4-0-v20141007",
+   "id": "3564014796395385926",
+   "creationTimestamp": "2014-10-07T15:07:46.523-07:00",
+   "name": "coreos-beta-444-4-0-v20141007",
+   "description": "CoreOS beta 444.4.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-beta-494-5-0-v20141211"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "210707776",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-beta-444-5-0-v20141016",
+   "id": "13297038239143916423",
+   "creationTimestamp": "2014-10-15T19:47:19.726-07:00",
+   "name": "coreos-beta-444-5-0-v20141016",
+   "description": "CoreOS beta 444.5.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-beta-494-5-0-v20141211"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "210865263",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-beta-494-0-0-v20141117",
+   "id": "8506154037185657987",
+   "creationTimestamp": "2014-11-17T10:16:15.255-08:00",
+   "name": "coreos-beta-494-0-0-v20141117",
+   "description": "CoreOS beta 494.0.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-beta-494-5-0-v20141211"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "217341172",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-beta-494-1-0-v20141124",
+   "id": "2468958217438571789",
+   "creationTimestamp": "2014-11-24T14:02:13.599-08:00",
+   "name": "coreos-beta-494-1-0-v20141124",
+   "description": "CoreOS beta 494.1.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-beta-494-5-0-v20141211"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "217657127",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-beta-494-4-0-v20141204",
+   "id": "3901953085416533827",
+   "creationTimestamp": "2014-12-04T15:52:43.520-08:00",
+   "name": "coreos-beta-494-4-0-v20141204",
+   "description": "CoreOS beta 494.4.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-beta-494-5-0-v20141211"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "217129760",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-beta-494-5-0-v20141211",
+   "id": "11721688361939601432",
+   "creationTimestamp": "2014-12-11T13:07:37.057-08:00",
+   "name": "coreos-beta-494-5-0-v20141211",
+   "description": "CoreOS beta 494.5.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-beta-522-2-0-v20141218"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "217091382",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-beta-522-2-0-v20141218",
+   "id": "18164147672853893958",
+   "creationTimestamp": "2014-12-18T13:29:11.177-08:00",
+   "name": "coreos-beta-522-2-0-v20141218",
+   "description": "CoreOS beta 522.2.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-beta-522-3-0-v20141226"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "220704959",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-beta-522-3-0-v20141226",
+   "id": "14171939663085407486",
+   "creationTimestamp": "2014-12-26T15:04:01.237-08:00",
+   "name": "coreos-beta-522-3-0-v20141226",
+   "description": "CoreOS beta 522.3.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "220932284",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-stable-367-1-0-v20140724",
+   "id": "2599882482782401961",
+   "creationTimestamp": "2014-07-24T09:50:20.940-07:00",
+   "name": "coreos-stable-367-1-0-v20140724",
+   "description": "CoreOS stable 367.1.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-stable-444-5-0-v20141016"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "202820713",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-stable-410-0-0-v20140902",
+   "id": "5505931863348151915",
+   "creationTimestamp": "2014-09-02T09:51:46.932-07:00",
+   "name": "coreos-stable-410-0-0-v20140902",
+   "description": "CoreOS stable 410.0.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-stable-444-5-0-v20141016"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "218443267",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-stable-410-1-0-v20140926",
+   "id": "8454778862121230636",
+   "creationTimestamp": "2014-09-26T09:02:19.616-07:00",
+   "name": "coreos-stable-410-1-0-v20140926",
+   "description": "CoreOS stable 410.1.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-stable-444-5-0-v20141016"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "218502022",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-stable-410-2-0-v20141002",
+   "id": "1371462217027433294",
+   "creationTimestamp": "2014-10-01T21:02:17.237-07:00",
+   "name": "coreos-stable-410-2-0-v20141002",
+   "description": "CoreOS stable 410.2.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-stable-444-5-0-v20141016"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "218492705",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-stable-444-4-0-v20141010",
+   "id": "12833596236536500344",
+   "creationTimestamp": "2014-10-10T12:03:27.815-07:00",
+   "name": "coreos-stable-444-4-0-v20141010",
+   "description": "CoreOS stable 444.4.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-stable-444-5-0-v20141016"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "210658089",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-stable-444-5-0-v20141016",
+   "id": "10607414105577455345",
+   "creationTimestamp": "2014-10-16T13:19:45.855-07:00",
+   "name": "coreos-stable-444-5-0-v20141016",
+   "description": "CoreOS stable 444.5.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-stable-494-3-0-v20141203"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "210821109",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-stable-494-3-0-v20141203",
+   "id": "15950760641457393522",
+   "creationTimestamp": "2014-12-03T10:58:23.402-08:00",
+   "name": "coreos-stable-494-3-0-v20141203",
+   "description": "CoreOS stable 494.3.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-stable-494-4-0-v20141204"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "216979469",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-stable-494-4-0-v20141204",
+   "id": "15925813888167964156",
+   "creationTimestamp": "2014-12-04T12:34:55.496-08:00",
+   "name": "coreos-stable-494-4-0-v20141204",
+   "description": "CoreOS stable 494.4.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-stable-494-5-0-v20141215"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "217085384",
+   "diskSizeGb": "9"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-stable-494-5-0-v20141215",
+   "id": "8254035885037496682",
+   "creationTimestamp": "2014-12-15T11:57:55.509-08:00",
+   "name": "coreos-stable-494-5-0-v20141215",
+   "description": "CoreOS stable 494.5.0",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "217069504",
+   "diskSizeGb": "9"
+  }
+ ]
+}

--- a/libcloud/test/compute/fixtures/gce/projects_debian-cloud_global_images.json
+++ b/libcloud/test/compute/fixtures/gce/projects_debian-cloud_global_images.json
@@ -346,7 +346,9 @@
       "archiveSizeBytes": "405683884",
       "creationTimestamp": "2013-10-28T13:52:08.233-07:00",
       "deprecated": {
-        "deprecated": "2013-12-02T12:00:00Z",
+        "deprecated": "2064-03-11T20:18:36.194-07:00",
+        "obsolete":  "2074-03-11T20:18:36.194-07:00",
+        "deleted": "2084-03-11T20:18:36.194-07:00",
         "replacement": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20131120",
         "state": "DEPRECATED"
       },

--- a/libcloud/test/compute/fixtures/gce/projects_gce-nvme_global_images.json
+++ b/libcloud/test/compute/fixtures/gce/projects_gce-nvme_global_images.json
@@ -1,0 +1,55 @@
+{
+ "kind": "compute#imageList",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/gce-nvme/global/images",
+ "id": "projects/gce-nvme/global/images",
+ "items": [
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/gce-nvme/global/images/nvme-backports-debian-7-wheezy-v20140904",
+   "id": "11933993573261788709",
+   "creationTimestamp": "2014-11-05T20:09:29.302-08:00",
+   "name": "nvme-backports-debian-7-wheezy-v20140904",
+   "description": "NVMe optimized Debian GNU/Linux 7.6 (wheezy) amd64 with backports kernel and SSH packages built on 2014-09-04",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "158683343",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/gce-nvme/global/images/nvme-backports-debian-7-wheezy-v20140926",
+   "id": "16689990597272015714",
+   "creationTimestamp": "2014-10-20T22:01:24.039-07:00",
+   "name": "nvme-backports-debian-7-wheezy-v20140926",
+   "description": "NVMe optimized Debian GNU/Linux 7.6 (wheezy) amd64 with backports kernel and SSH packages built on 2014-09-26",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "221456136",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/gce-nvme/global/images/nvme-backports-debian-7-wheezy-v20141108",
+   "id": "9219956677399420856",
+   "creationTimestamp": "2014-11-14T10:55:03.809-08:00",
+   "name": "nvme-backports-debian-7-wheezy-v20141108",
+   "description": "NVMe optimized Debian GNU/Linux 7.6 (wheezy) amd64 with backports kernel and SSH packages built on 2014-11-08",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "162245079",
+   "diskSizeGb": "10"
+  }
+ ]
+}

--- a/libcloud/test/compute/fixtures/gce/projects_google-containers_global_images.json
+++ b/libcloud/test/compute/fixtures/gce/projects_google-containers_global_images.json
@@ -1,0 +1,179 @@
+{
+ "kind": "compute#imageList",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/google-containers/global/images",
+ "id": "projects/google-containers/global/images",
+ "items": [
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/google-containers/global/images/container-vm-v20140522",
+   "id": "12928746743513706688",
+   "creationTimestamp": "2014-05-21T15:30:01.045-07:00",
+   "name": "container-vm-v20140522",
+   "description": "Google container VM image, GlueCon 2014 release",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/google-containers/global/images/container-vm-v20140522"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "396961200",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/google-containers/global/images/container-vm-v20140624",
+   "id": "17637324906060386740",
+   "creationTimestamp": "2014-06-24T17:59:38.240-07:00",
+   "name": "container-vm-v20140624",
+   "description": "Google container VM image, Google I/O 2014 release",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/google-containers/global/images/container-vm-v20140624"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "391233093",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/google-containers/global/images/container-vm-v20140710",
+   "id": "17658123443453052547",
+   "creationTimestamp": "2014-07-15T17:29:02.737-07:00",
+   "name": "container-vm-v20140710",
+   "description": "Google container VM image",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/google-containers/global/images/container-vm-v20140710"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "428253862",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/google-containers/global/images/container-vm-v20140731",
+   "id": "7675862044791361451",
+   "creationTimestamp": "2014-08-01T09:41:06.107-07:00",
+   "name": "container-vm-v20140731",
+   "description": "Google container VM image",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/google-containers/global/images/container-vm-v20140731"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "403951165",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/google-containers/global/images/container-vm-v20140826",
+   "id": "5337588031210316441",
+   "creationTimestamp": "2014-08-26T16:19:17.533-07:00",
+   "name": "container-vm-v20140826",
+   "description": "Google container VM image",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/google-containers/global/images/container-vm-v20140826"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "420545090",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/google-containers/global/images/container-vm-v20140925",
+   "id": "7326458020538492469",
+   "creationTimestamp": "2014-09-25T14:23:38.865-07:00",
+   "name": "container-vm-v20140925",
+   "description": "Google container VM image",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/google-containers/global/images/container-vm-v20140925"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "432272421",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/google-containers/global/images/container-vm-v20140929",
+   "id": "17245742661521590081",
+   "creationTimestamp": "2014-09-29T13:49:23.330-07:00",
+   "name": "container-vm-v20140929",
+   "description": "Google container VM image",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/google-containers/global/images/container-vm-v20140929"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "422162733",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/google-containers/global/images/container-vm-v20141016",
+   "id": "857872787891330870",
+   "creationTimestamp": "2014-10-22T13:40:01.068-07:00",
+   "name": "container-vm-v20141016",
+   "description": "Google container VM image",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "432768815",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/google-containers/global/images/container-vm-v20141208",
+   "id": "8037634834499556312",
+   "creationTimestamp": "2014-12-09T15:57:34.413-08:00",
+   "name": "container-vm-v20141208",
+   "description": "Google container VM image",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "413371239",
+   "diskSizeGb": "10"
+  }
+ ]
+}

--- a/libcloud/test/compute/fixtures/gce/projects_opensuse-cloud_global_images.json
+++ b/libcloud/test/compute/fixtures/gce/projects_opensuse-cloud_global_images.json
@@ -1,0 +1,102 @@
+{
+ "kind": "compute#imageList",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/opensuse-cloud/global/images",
+ "id": "projects/opensuse-cloud/global/images",
+ "items": [
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/opensuse-cloud/global/images/opensuse-13-1-v20140609",
+   "id": "5330388859130445578",
+   "creationTimestamp": "2014-06-09T11:45:56.997-07:00",
+   "name": "opensuse-13-1-v20140609",
+   "description": "",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/opensuse-cloud/global/images/opensuse-13-1-v20140627",
+    "deprecated": "2014-06-27T00:00:00Z"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "872777232",
+   "diskSizeGb": "8"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/opensuse-cloud/global/images/opensuse-13-1-v20140627",
+   "id": "635369188275126205",
+   "creationTimestamp": "2014-06-27T08:44:37.896-07:00",
+   "name": "opensuse-13-1-v20140627",
+   "description": "",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/opensuse-cloud/global/images/opensuse-13-1-v20140711",
+    "deprecated": "2014-07-11T00:00:00Z"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "878545758",
+   "diskSizeGb": "8"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/opensuse-cloud/global/images/opensuse-13-1-v20140711",
+   "id": "414150705420767734",
+   "creationTimestamp": "2014-07-11T14:04:35.210-07:00",
+   "name": "opensuse-13-1-v20140711",
+   "description": "",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/opensuse-cloud/global/images/opensuse-13-1-v20141102",
+    "deprecated": "2014-11-02T00:00:00Z"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "878437869",
+   "diskSizeGb": "8"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/opensuse-cloud/global/images/opensuse-13-1-v20141102",
+   "id": "4629398803823711760",
+   "creationTimestamp": "2014-11-02T04:34:26.263-08:00",
+   "name": "opensuse-13-1-v20141102",
+   "description": "openSUSE 13.1 (built on 2014-11-02)",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "881210631",
+   "diskSizeGb": "8"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/opensuse-cloud/global/images/opensuse-13-2-v20141205",
+   "id": "7015477126275748573",
+   "creationTimestamp": "2014-12-09T05:36:16.085-08:00",
+   "name": "opensuse-13-2-v20141205",
+   "description": "openSUSE 13.2 (built on 2014-12-05)",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "1091494581",
+   "diskSizeGb": "8"
+  }
+ ]
+}

--- a/libcloud/test/compute/fixtures/gce/projects_rhel-cloud_global_images.json
+++ b/libcloud/test/compute/fixtures/gce/projects_rhel-cloud_global_images.json
@@ -1,0 +1,49 @@
+{
+ "kind": "compute#imageList",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images",
+ "id": "projects/rhel-cloud/global/images",
+ "items": [
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/rhel-7-v20141108",
+   "id": "9656001643961289198",
+   "creationTimestamp": "2014-11-10T14:15:28.054-08:00",
+   "name": "rhel-7-v20141108",
+   "description": "Red Hat Enterprise Linux 7.0 x86_64 built on 2014-11-08",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/rhel-cloud/global/images/rhel-7-v20141205"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "1201321944",
+   "diskSizeGb": "10",
+   "licenses": [
+    "https://content.googleapis.com/compute/v1/projects/rhel-cloud/global/licenses/rhel-7-server"
+   ]
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/rhel-7-v20141205",
+   "id": "9718957591079040023",
+   "creationTimestamp": "2014-12-08T17:07:02.804-08:00",
+   "name": "rhel-7-v20141205",
+   "description": "Red Hat Enterprise Linux 7.0 x86_64 built on 2014-12-05",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "1204146084",
+   "diskSizeGb": "10",
+   "licenses": [
+    "https://content.googleapis.com/compute/v1/projects/rhel-cloud/global/licenses/rhel-7-server"
+   ]
+  }
+ ]
+}

--- a/libcloud/test/compute/fixtures/gce/projects_rhel-cloud_global_licenses_rhel_server.json
+++ b/libcloud/test/compute/fixtures/gce/projects_rhel-cloud_global_licenses_rhel_server.json
@@ -1,0 +1,6 @@
+{
+ "kind": "compute#license",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/windows-cloud/global/licenses/rhel-7-server",
+ "name": "rhel-7-server",
+ "chargesUseFee": true
+}

--- a/libcloud/test/compute/fixtures/gce/projects_ubuntu-os-cloud_global_images.json
+++ b/libcloud/test/compute/fixtures/gce/projects_ubuntu-os-cloud_global_images.json
@@ -1,0 +1,169 @@
+{
+ "kind": "compute#imageList",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images",
+ "id": "projects/ubuntu-os-cloud/global/images",
+ "items": [
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-1204-precise-v20141028",
+   "id": "15508054221909398824",
+   "creationTimestamp": "2014-10-29T09:51:42.018-07:00",
+   "name": "ubuntu-1204-precise-v20141028",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-1204-precise-v20141212"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "378614228",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-1204-precise-v20141031",
+   "id": "3216640293232429175",
+   "creationTimestamp": "2014-11-07T00:48:18.673-08:00",
+   "name": "ubuntu-1204-precise-v20141031",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-1204-precise-v20141212"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "1137275331",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-1204-precise-v20141212",
+   "id": "12756823774499736482",
+   "creationTimestamp": "2014-12-17T11:31:59.126-08:00",
+   "name": "ubuntu-1204-precise-v20141212",
+   "description": "Canonical, Ubuntu, 12.04 LTS, amd64 precise image built on 2014-12-12",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "1140352383",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-1404-trusty-v20141028",
+   "id": "17781692821175088041",
+   "creationTimestamp": "2014-10-29T09:51:42.072-07:00",
+   "name": "ubuntu-1404-trusty-v20141028",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-1404-trusty-v20141212"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "375105326",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-1404-trusty-v20141031a",
+   "id": "6500942514398264968",
+   "creationTimestamp": "2014-11-07T00:48:04.471-08:00",
+   "name": "ubuntu-1404-trusty-v20141031a",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-1404-trusty-v20141212"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "1015791618",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-1404-trusty-v20141212",
+   "id": "14921913565797044708",
+   "creationTimestamp": "2014-12-17T11:31:37.868-08:00",
+   "name": "ubuntu-1404-trusty-v20141212",
+   "description": "Canonical, Ubuntu, 14.04 LTS, amd64 trusty image built on 2014-12-12",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "981936603",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-1410-utopic-v20141029",
+   "id": "13898107879086076373",
+   "creationTimestamp": "2014-10-29T09:51:39.609-07:00",
+   "name": "ubuntu-1410-utopic-v20141029",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-1410-utopic-v20141217"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "348037877",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-1410-utopic-v20141030a",
+   "id": "2412636152371793564",
+   "creationTimestamp": "2014-11-07T00:47:53.082-08:00",
+   "name": "ubuntu-1410-utopic-v20141030a",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "deprecated": {
+    "state": "DEPRECATED",
+    "replacement": "https://content.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-1410-utopic-v20141217"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "1044175299",
+   "diskSizeGb": "10"
+  },
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-1410-utopic-v20141217",
+   "id": "6363233028234584116",
+   "creationTimestamp": "2014-12-17T11:31:26.695-08:00",
+   "name": "ubuntu-1410-utopic-v20141217",
+   "description": "Canonical, Ubuntu, 14.10, amd64 utopic image built on 2014-12-17",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "1048366941",
+   "diskSizeGb": "10"
+  }
+ ]
+}

--- a/libcloud/test/compute/fixtures/gce/projects_windows-cloud_global_images.json
+++ b/libcloud/test/compute/fixtures/gce/projects_windows-cloud_global_images.json
@@ -1,0 +1,26 @@
+{
+ "kind": "compute#imageList",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/windows-cloud/global/images",
+ "id": "projects/windows-cloud/global/images",
+ "items": [
+  {
+   "kind": "compute#image",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/windows-cloud/global/images/windows-server-2008-r2-dc-v20141120",
+   "id": "10752443450426453317",
+   "creationTimestamp": "2014-12-02T10:31:56.162-08:00",
+   "name": "windows-server-2008-r2-dc-v20141120",
+   "description": "Microsoft Windows Server 2008 R2 Datacenter Edition built on 2014-11-20",
+   "sourceType": "RAW",
+   "rawDisk": {
+    "source": "",
+    "containerType": "TAR"
+   },
+   "status": "READY",
+   "archiveSizeBytes": "6974709077",
+   "diskSizeGb": "100",
+   "licenses": [
+    "https://content.googleapis.com/compute/v1/projects/windows-cloud/global/licenses/windows-server-2008-r2-dc"
+   ]
+  }
+ ]
+}

--- a/libcloud/test/compute/fixtures/gce/projects_windows-cloud_global_licenses_windows_server_2008_r2_dc.json
+++ b/libcloud/test/compute/fixtures/gce/projects_windows-cloud_global_licenses_windows_server_2008_r2_dc.json
@@ -1,0 +1,6 @@
+{
+ "kind": "compute#license",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/windows-cloud/global/licenses/windows-2008-r2-dc",
+ "name": "windows-2008-r2-dc",
+ "chargesUseFee": true
+}


### PR DESCRIPTION
Improves the GCE driver's `list_images()` method to actually return what the user would expect; a list of vendor supported operating system images including what they have on their own project.  The default behavior now returns on non-deprectated images, but a full list can be returned using the `ex_include_deprecated` param.

Although this changes the behavior of `list_images()`, it more closely matches the behavior of GCE's command-line utility `gcloud compute` that is part of the Cloud SDK package[1]. It is also more likely what the user wants to see anyway.

[1] https://cloud.google.com/sdk/
