### PR TITLE
[LIBCLOUD-610] gce: better error message for missing key file

### DIFF
--- a/libcloud/common/google.py
+++ b/libcloud/common/google.py
@@ -488,6 +488,9 @@ class GoogleServiceAcctAuthConnection(GoogleBaseAuthConnection):
         # The message contains both the header and claim set
         message = '%s.%s' % (header_enc, claim_set_enc)
         # Then the message is signed using the key supplied
+        if not os.access(self.key, os.F_OK | os.R_OK):
+            raise ValueError("Missing (or not readable) key "
+                             "file: '%s'" % (self.key))
         key = RSA.importKey(self.key)
         hash_func = SHA256.new(message)
         signer = PKCS1_v1_5.new(key)


### PR DESCRIPTION
This small fix addresses feedback in https://issues.apache.org/jira/browse/LIBCLOUD-610. A check is introduced for the existence and readability of the private key file before passing it on to pycrypto.  If the check fails, the user is notified that the private key file is not present or readable.
