### PR TITLE
[google compute] allow use of GCEDiskType in existing methods

### DIFF
--- a/demos/gce_demo.py
+++ b/demos/gce_demo.py
@@ -293,7 +293,7 @@ def main():
 
     # == Setting Metadata for Node ==
     print('Setting Metadata for %s' % node_2.name)
-    if gce.ex_set_node_metadata(node_2, {'foo': 'bar'}):
+    if gce.ex_set_node_metadata(node_2, {'foo': 'bar', 'baz': 'foobarbaz'}):
         print('   Metadata updated for %s' % node_2.name)
     check_node = gce.ex_get_node(node_2.name)
     print('   New Metadata: %s' % check_node.extra['metadata'])
@@ -306,7 +306,7 @@ def main():
         multi_nodes = gce.ex_create_multiple_nodes(base_name, size, image,
                                                    number,
                                                    ex_tags=['libcloud'],
-                                                   ex_disk_auto_delete=False)
+                                                   ex_disk_auto_delete=True)
         for node in multi_nodes:
             print('   Node %s created.' % node.name)
 
@@ -341,9 +341,6 @@ def main():
     addresses = gce.ex_list_addresses()
     display('Addresses', addresses)
 
-    volumes = gce.list_volumes()
-    display('Volumes', volumes)
-
     firewalls = gce.ex_list_firewalls()
     display('Firewalls', firewalls)
 
@@ -356,7 +353,9 @@ def main():
     if CLEANUP:
         print('Cleaning up %s resources created.' % DEMO_BASE_NAME)
         clean_up(gce, DEMO_BASE_NAME, nodes,
-                 addresses + volumes + firewalls + networks + snapshots)
+                 addresses + firewalls + networks + snapshots)
+        volumes = gce.list_volumes()
+        clean_up(gce, DEMO_BASE_NAME, None, volumes)
 
 if __name__ == '__main__':
     main()

--- a/libcloud/test/compute/fixtures/gce/zones_us-central1-a_diskTypes_pd_standard.json
+++ b/libcloud/test/compute/fixtures/gce/zones_us-central1-a_diskTypes_pd_standard.json
@@ -1,0 +1,10 @@
+{
+ "kind": "compute#diskType",
+ "creationTimestamp": "2014-06-02T11:07:28.529-07:00",
+ "name": "pd-standard",
+ "description": "Standard Persistent Disk",
+ "validDiskSize": "10GB-10240GB",
+ "zone": "https://content.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a",
+ "selfLink": "https://content.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/diskTypes/pd-standard",
+ "defaultDiskSizeGb": "500"
+}


### PR DESCRIPTION
Back in #391, a new `GCEDiskType` resource was added to the GCE driver. This is a follow-up that updates the rest of the driver to allow the use of this new libcloud object vs the initial string-only support.

Tests added along with updates to the `demos/gce_demo.py` script.

/cc @verb
