### PR TITLE
[LIBCLOUD-605] Support HTTP-LB in GCE NodeDriver

### DIFF
--- a/libcloud/common/google.py
+++ b/libcloud/common/google.py
@@ -730,7 +730,7 @@ class GoogleBaseConnection(ConnectionUserAndKey, PollingConnection):
 
         In many places, the Google API returns a full URL to a resource.
         This will strip the scheme and host off of the path and just return
-        the request.  Otherwise, it will append the base request_path to
+        the request.  Otherwise, it will prepend the base request_path to
         the action.
 
         :param  action: The action to be called in the http request

--- a/libcloud/test/compute/fixtures/gce/global_backendServices-empty.json
+++ b/libcloud/test/compute/fixtures/gce/global_backendServices-empty.json
@@ -1,0 +1,5 @@
+{
+ "kind": "compute#backendServiceList",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/backendServices",
+ "id": "projects/project_name/global/backendServices"
+}

--- a/libcloud/test/compute/fixtures/gce/global_backendServices-web-service.json
+++ b/libcloud/test/compute/fixtures/gce/global_backendServices-web-service.json
@@ -1,0 +1,38 @@
+{
+ "kind": "compute#backendServiceList",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/backendServices",
+ "id": "projects/project_name/global/backendServices",
+ "items": [
+  {
+   "kind": "compute#backendService",
+   "id": "12158223670162062306",
+   "creationTimestamp": "2014-08-14T14:37:36.728-07:00",
+   "name": "web-service",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/backendServices/web-service",
+   "backends": [
+    {
+     "description": "",
+     "group": "https://www.googleapis.com/resourceviews/v1beta1/projects/project_name/zones/us-central1-b/resourceViews/us-resources",
+     "balancingMode": "RATE",
+     "maxRate": 100,
+     "capacityScaler": 1.0
+    },
+    {
+     "description": "",
+     "group": "https://www.googleapis.com/resourceviews/v1beta1/projects/project_name/zones/europe-west1-b/resourceViews/eu-resources",
+     "balancingMode": "RATE",
+     "maxRate": 100,
+     "capacityScaler": 1.0
+    }
+   ],
+   "healthChecks": [
+    "https://www.googleapis.com/compute/v1/projects/project_name/global/httpHealthChecks/basic-check"
+   ],
+   "timeoutSec": 30,
+   "port": 80,
+   "protocol": "HTTP",
+   "fingerprint": "Do4_wUywpJU=",
+   "portName": ""
+  }
+ ]
+}

--- a/libcloud/test/compute/fixtures/gce/global_backendServices_no_backends.json
+++ b/libcloud/test/compute/fixtures/gce/global_backendServices_no_backends.json
@@ -1,0 +1,15 @@
+{
+ "kind": "compute#backendService",
+ "id": "12158223690162062306",
+ "creationTimestamp": "2014-08-14T14:37:36.728-07:00",
+ "name": "web-service",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/backendServices/web-service",
+ "healthChecks": [
+  "https://www.googleapis.com/compute/v1/projects/project_name/global/httpHealthChecks/basic-check"
+ ],
+ "timeoutSec": 30,
+ "port": 80,
+ "protocol": "HTTP",
+ "fingerprint": "5qm-QyYGyzw=",
+ "portName": ""
+}

--- a/libcloud/test/compute/fixtures/gce/global_backendServices_post.json
+++ b/libcloud/test/compute/fixtures/gce/global_backendServices_post.json
@@ -1,0 +1,13 @@
+{
+ "kind": "compute#operation",
+ "id": "8150500075597870926",
+ "name": "operation-global_backendServices_post",
+ "operationType": "insert",
+ "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/backendServices/web-service",
+ "status": "PENDING",
+ "user": "user@developer.gserviceaccount.com",
+ "progress": 0,
+ "insertTime": "2014-10-10T16:39:17.206-07:00",
+ "startTime": "2014-10-10T16:39:17.613-07:00",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/operations/operation-global_backendServices_post"
+}

--- a/libcloud/test/compute/fixtures/gce/global_backendServices_web_service.json
+++ b/libcloud/test/compute/fixtures/gce/global_backendServices_web_service.json
@@ -1,0 +1,31 @@
+{
+ "kind": "compute#backendService",
+ "id": "1814698108461677231",
+ "creationTimestamp": "2014-08-15T16:14:43.729-07:00",
+ "name": "web-service",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/backendServices/web-service",
+ "backends": [
+  {
+   "description": "",
+   "group": "https://www.googleapis.com/resourceviews/v1beta1/projects/project_name/zones/us-central1-b/resourceViews/us-resources",
+   "balancingMode": "RATE",
+   "maxRate": 100,
+   "capacityScaler": 1.0
+  },
+  {
+   "description": "",
+   "group": "https://www.googleapis.com/resourceviews/v1beta1/projects/project_name/zones/europe-west1-b/resourceViews/eu-resources",
+   "balancingMode": "RATE",
+   "maxRate": 150,
+   "capacityScaler": 1.0
+  }
+ ],
+ "healthChecks": [
+  "https://www.googleapis.com/compute/v1/projects/project_name/global/httpHealthChecks/basic-check"
+ ],
+ "timeoutSec": 30,
+ "port": 80,
+ "protocol": "HTTP",
+ "fingerprint": "ha9VAg-MJ5M=",
+ "portName": ""
+}

--- a/libcloud/test/compute/fixtures/gce/global_backendServices_web_service_delete.json
+++ b/libcloud/test/compute/fixtures/gce/global_backendServices_web_service_delete.json
@@ -1,0 +1,14 @@
+{
+ "kind": "compute#operation",
+ "id": "3333333333333333333",
+ "name": "operation_global_backendServices_web_service_delete",
+ "operationType": "delete",
+ "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/backendServices/web-service",
+ "targetId": "15555555555223232737",
+ "status": "PENDING",
+ "user": "user@developer.gserviceaccount.com",
+ "progress": 0,
+ "insertTime": "2014-10-28T12:51:20.402-07:00",
+ "startTime": "2014-10-28T12:51:20.623-07:00",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/operations/operation_global_backendServices_web_service_delete"
+}

--- a/libcloud/test/compute/fixtures/gce/global_forwardingRules.json
+++ b/libcloud/test/compute/fixtures/gce/global_forwardingRules.json
@@ -1,0 +1,29 @@
+{
+ "kind": "compute#forwardingRuleList",
+ "id": "projects/project_name/global/forwardingRules",
+ "items": [
+  {
+   "kind": "compute#forwardingRule",
+   "id": "16224943838916174114",
+   "creationTimestamp": "2014-08-22T11:15:26.174-07:00",
+   "name": "http-rule",
+   "IPAddress": "192.0.2.1",
+   "IPProtocol": "TCP",
+   "portRange": "80-80",
+   "target": "https://www.googleapis.com/compute/v1/projects/project_name/global/targetHttpProxies/web-proxy",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/forwardingRules/http-rule"
+  },
+  {
+   "kind": "compute#forwardingRule",
+   "id": "16224943838916174115",
+   "creationTimestamp": "2014-08-22T11:15:26.174-07:00",
+   "name": "http-rule2",
+   "IPAddress": "192.0.2.2",
+   "IPProtocol": "TCP",
+   "portRange": "80-80",
+   "target": "https://www.googleapis.com/compute/v1/projects/project_name/global/targetHttpProxies/web-proxy",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/forwardingRules/http-rule2"
+  }
+ ],
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/forwardingRules"
+}

--- a/libcloud/test/compute/fixtures/gce/global_forwardingRules_http_rule.json
+++ b/libcloud/test/compute/fixtures/gce/global_forwardingRules_http_rule.json
@@ -1,0 +1,12 @@
+{
+ "kind": "compute#forwardingRule",
+ "id": "16224243838919174114",
+ "creationTimestamp": "2014-08-22T11:15:26.174-07:00",
+ "name": "http-rule",
+ "IPAddress": "192.0.2.1",
+ "IPProtocol": "TCP",
+ "portRange": "80-80",
+ "target": "https://www.googleapis.com/compute/v1/projects/project_name/global/targetHttpProxies/web-proxy",
+ "description": "global forwarding rule",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/forwardingRules/http-rule"
+}

--- a/libcloud/test/compute/fixtures/gce/global_forwardingRules_http_rule_delete.json
+++ b/libcloud/test/compute/fixtures/gce/global_forwardingRules_http_rule_delete.json
@@ -1,0 +1,14 @@
+{
+ "kind": "compute#operation",
+ "id": "3333333333333333333",
+ "name": "operation_global_forwardingRules_http_rule_delete",
+ "operationType": "delete",
+ "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/forwardingRules/http-rule-test",
+ "targetId": "16224243838919174114",
+ "status": "PENDING",
+ "user": "user@developer.gserviceaccount.com",
+ "progress": 0,
+ "insertTime": "2014-10-28T10:53:13.433-07:00",
+ "startTime": "2014-10-28T10:53:13.723-07:00",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/operations/operation_global_forwardingRules_http_rule_delete"
+}

--- a/libcloud/test/compute/fixtures/gce/global_forwardingRules_post.json
+++ b/libcloud/test/compute/fixtures/gce/global_forwardingRules_post.json
@@ -1,0 +1,13 @@
+{
+ "kind": "compute#operation",
+ "id": "33333333333333333333",
+ "name": "operation_global_forwardingRules_post",
+ "operationType": "insert",
+ "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/forwardingRules/http-rule",
+ "status": "PENDING",
+ "user": "user@developer.gserviceaccount.com",
+ "progress": 0,
+ "insertTime": "2014-10-27T17:10:54.102-07:00",
+ "startTime": "2014-10-27T17:10:54.531-07:00",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/operations/operation_global_forwardingRules_post"
+}

--- a/libcloud/test/compute/fixtures/gce/global_targetHttpProxies.json
+++ b/libcloud/test/compute/fixtures/gce/global_targetHttpProxies.json
@@ -1,0 +1,23 @@
+{
+ "kind": "compute#targetHttpProxyList",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/targetHttpProxies",
+ "id": "projects/project_name/global/targetHttpProxies",
+ "items": [
+  {
+   "kind": "compute#targetHttpProxy",
+   "id": "2276970411930672658",
+   "creationTimestamp": "2014-08-22T09:47:35.425-07:00",
+   "name": "web-proxy",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/targetHttpProxies/web-proxy",
+   "urlMap": "https://www.googleapis.com/compute/v1/projects/project_name/global/urlMaps/web-map"
+  },
+  {
+   "kind": "compute#targetHttpProxy",
+   "id": "2276970411930672659",
+   "creationTimestamp": "2014-08-22T09:47:35.425-07:00",
+   "name": "web-proxy2",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/targetHttpProxies/web-proxy2",
+   "urlMap": "https://www.googleapis.com/compute/v1/projects/project_name/global/urlMaps/web-map"
+  }
+ ]
+}

--- a/libcloud/test/compute/fixtures/gce/global_targetHttpProxies_post.json
+++ b/libcloud/test/compute/fixtures/gce/global_targetHttpProxies_post.json
@@ -1,0 +1,13 @@
+{
+ "kind": "compute#operation",
+ "id": "3333333333333333333",
+ "name": "operation_global_targetHttpProxies_post",
+ "operationType": "insert",
+ "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/targetHttpProxies/web-proxy",
+ "status": "PENDING",
+ "user": "user@developer.gserviceaccount.com",
+ "progress": 0,
+ "insertTime": "2014-10-27T16:22:40.726-07:00",
+ "startTime": "2014-10-27T16:22:41.027-07:00",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/operations/operation_global_targetHttpProxies_post"
+}

--- a/libcloud/test/compute/fixtures/gce/global_targetHttpProxies_web_proxy.json
+++ b/libcloud/test/compute/fixtures/gce/global_targetHttpProxies_web_proxy.json
@@ -1,0 +1,8 @@
+{
+ "kind": "compute#targetHttpProxy",
+ "id": "2276970411950672658",
+ "creationTimestamp": "2014-08-22T09:47:35.425-07:00",
+ "name": "web-proxy",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/targetHttpProxies/web-proxy",
+ "urlMap": "https://www.googleapis.com/compute/v1/projects/project_name/global/urlMaps/web-map"
+}

--- a/libcloud/test/compute/fixtures/gce/global_targetHttpProxies_web_proxy_delete.json
+++ b/libcloud/test/compute/fixtures/gce/global_targetHttpProxies_web_proxy_delete.json
@@ -1,0 +1,14 @@
+{
+ "kind": "compute#operation",
+ "id": "33333333333333333333",
+ "name": "operation_global_targetHttpProxies_web_proxy_delete",
+ "operationType": "delete",
+ "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/targetHttpProxies/web-proxy",
+ "targetId": "5243939392541625113",
+ "status": "PENDING",
+ "user": "user@developer.gserviceaccount.com",
+ "progress": 0,
+ "insertTime": "2014-10-28T12:21:47.406-07:00",
+ "startTime": "2014-10-28T12:21:47.666-07:00",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/operations/operation_global_targetHttpProxies_web_proxy_delete"
+}

--- a/libcloud/test/compute/fixtures/gce/global_urlMaps.json
+++ b/libcloud/test/compute/fixtures/gce/global_urlMaps.json
@@ -1,0 +1,16 @@
+{
+ "kind": "compute#urlMapList",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/urlMaps",
+ "id": "projects/project_name/global/urlMaps",
+ "items": [
+  {
+   "kind": "compute#urlMap",
+   "id": "4266107551250249032",
+   "creationTimestamp": "2014-08-15T16:16:54.084-07:00",
+   "name": "web-map",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/urlMaps/web-map",
+   "defaultService": "https://www.googleapis.com/compute/v1/projects/project_name/global/backendServices/web-service",
+   "fingerprint": "JiV2ACVOAlg="
+  }
+ ]
+}

--- a/libcloud/test/compute/fixtures/gce/global_urlMaps_post.json
+++ b/libcloud/test/compute/fixtures/gce/global_urlMaps_post.json
@@ -1,0 +1,13 @@
+{
+ "kind": "compute#operation",
+ "id": "14014132704089638847",
+ "name": "operation-global_urlMaps_post",
+ "operationType": "insert",
+ "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/urlMaps/test-map2",
+ "status": "PENDING",
+ "user": "user@developer.gserviceaccount.com",
+ "progress": 0,
+ "insertTime": "2014-10-27T15:21:17.438-07:00",
+ "startTime": "2014-10-27T15:21:17.631-07:00",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/operations/operation-global_urlMaps_post"
+}

--- a/libcloud/test/compute/fixtures/gce/global_urlMaps_web_map.json
+++ b/libcloud/test/compute/fixtures/gce/global_urlMaps_web_map.json
@@ -1,0 +1,9 @@
+{
+ "kind": "compute#urlMap",
+ "id": "4266107551250249032",
+ "creationTimestamp": "2014-08-15T16:16:54.084-07:00",
+ "name": "web-map",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/urlMaps/web-map",
+ "defaultService": "https://www.googleapis.com/compute/v1/projects/project_name/global/backendServices/web-service",
+ "fingerprint": "JiV2ACVOAlg="
+}

--- a/libcloud/test/compute/fixtures/gce/global_urlMaps_web_map_delete.json
+++ b/libcloud/test/compute/fixtures/gce/global_urlMaps_web_map_delete.json
@@ -1,0 +1,14 @@
+{
+ "kind": "compute#operation",
+ "id": "3333333333333333333",
+ "name": "operation_global_urlMaps_web_map_delete",
+ "operationType": "delete",
+ "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/urlMaps/web-map",
+ "targetId": "1955555555986139870",
+ "status": "PENDING",
+ "user": "user@developer.gserviceaccount.com",
+ "progress": 0,
+ "insertTime": "2014-10-28T12:36:28.927-07:00",
+ "startTime": "2014-10-28T12:36:29.146-07:00",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/operations/operation_global_urlMaps_web_map_delete"
+}

--- a/libcloud/test/compute/fixtures/gce/operations_operation_global_backendServices_post.json
+++ b/libcloud/test/compute/fixtures/gce/operations_operation_global_backendServices_post.json
@@ -1,0 +1,15 @@
+{
+ "kind": "compute#operation",
+ "id": "8150500072597970926",
+ "name": "operation_global_backendServices_post",
+ "operationType": "insert",
+ "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/backendServices/web-service",
+ "targetId": "4582947879210482708",
+ "status": "DONE",
+ "user": "user@developer.gserviceaccount.com",
+ "progress": 100,
+ "insertTime": "2014-10-10T16:39:17.206-07:00",
+ "startTime": "2014-10-10T16:39:17.613-07:00",
+ "endTime": "2014-10-10T16:39:18.330-07:00",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/operations/operation_global_backendServices_post"
+}

--- a/libcloud/test/compute/fixtures/gce/operations_operation_global_backendServices_web_service_delete.json
+++ b/libcloud/test/compute/fixtures/gce/operations_operation_global_backendServices_web_service_delete.json
@@ -1,0 +1,15 @@
+{
+ "kind": "compute#operation",
+ "id": "3333333333333333333",
+ "name": "operation_global_backendServices_web_service_delete",
+ "operationType": "delete",
+ "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/backendServices/web-service",
+ "targetId": "15555555555223232737",
+ "status": "DONE",
+ "user": "user@developer.gserviceaccount.com",
+ "progress": 100,
+ "insertTime": "2014-10-28T12:51:20.402-07:00",
+ "startTime": "2014-10-28T12:51:20.623-07:00",
+ "endTime": "2014-10-28T12:51:21.218-07:00",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/operations/operation_global_backendServices_web_service_delete"
+}

--- a/libcloud/test/compute/fixtures/gce/operations_operation_global_forwardingRules_http_rule_delete.json
+++ b/libcloud/test/compute/fixtures/gce/operations_operation_global_forwardingRules_http_rule_delete.json
@@ -1,0 +1,15 @@
+{
+ "kind": "compute#operation",
+ "id": "4444444444444444444",
+ "name": "operation_global_forwardingRules_http_rule_delete",
+ "operationType": "delete",
+ "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/forwardingRules/http-rule-test",
+ "targetId": "16224243838919174114",
+ "status": "DONE",
+ "user": "user@developer.gserviceaccount.com",
+ "progress": 100,
+ "insertTime": "2014-10-28T10:53:13.433-07:00",
+ "startTime": "2014-10-28T10:53:13.723-07:00",
+ "endTime": "2014-10-28T10:53:16.304-07:00",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/operations/operation_global_forwardingRules_http_rule_delete"
+}

--- a/libcloud/test/compute/fixtures/gce/operations_operation_global_forwardingRules_post.json
+++ b/libcloud/test/compute/fixtures/gce/operations_operation_global_forwardingRules_post.json
@@ -1,0 +1,15 @@
+{
+ "kind": "compute#operation",
+ "id": "44444444444444444444",
+ "name": "operation_global_forwardingRules_post",
+ "operationType": "insert",
+ "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/forwardingRules/http-rule",
+ "targetId": "16224243838919174114",
+ "status": "DONE",
+ "user": "user@developer.gserviceaccount.com",
+ "progress": 100,
+ "insertTime": "2014-10-27T17:10:54.102-07:00",
+ "startTime": "2014-10-27T17:10:54.531-07:00",
+ "endTime": "2014-10-27T17:10:59.466-07:00",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/operations/operation_global_forwardingRules_post"
+}

--- a/libcloud/test/compute/fixtures/gce/operations_operation_global_targetHttpProxies_post.json
+++ b/libcloud/test/compute/fixtures/gce/operations_operation_global_targetHttpProxies_post.json
@@ -1,0 +1,15 @@
+{
+ "kind": "compute#operation",
+ "id": "7514147734702416613",
+ "name": "operation_global_targetHttpProxies_post",
+ "operationType": "insert",
+ "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/targetHttpProxies/web-proxy",
+ "targetId": "5242670162541625113",
+ "status": "DONE",
+ "user": "user@developer.gserviceaccount.com",
+ "progress": 100,
+ "insertTime": "2014-10-27T16:22:40.726-07:00",
+ "startTime": "2014-10-27T16:22:41.027-07:00",
+ "endTime": "2014-10-27T16:22:41.657-07:00",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/operations/operation_global_targetHttpProxies_post"
+}

--- a/libcloud/test/compute/fixtures/gce/operations_operation_global_targetHttpProxies_web_proxy_delete.json
+++ b/libcloud/test/compute/fixtures/gce/operations_operation_global_targetHttpProxies_web_proxy_delete.json
@@ -1,0 +1,15 @@
+{
+ "kind": "compute#operation",
+ "id": "12025659947133083605",
+ "name": "operation_global_targetHttpProxies_web_proxy_delete",
+ "operationType": "delete",
+ "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/targetHttpProxies/web-proxy",
+ "targetId": "5243939392541625113",
+ "status": "DONE",
+ "user": "user@developer.gserviceaccount.com",
+ "progress": 100,
+ "insertTime": "2014-10-28T12:21:47.406-07:00",
+ "startTime": "2014-10-28T12:21:47.666-07:00",
+ "endTime": "2014-10-28T12:21:48.419-07:00",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/operations/operation_global_targetHttpProxies_web_proxy_delete"
+}

--- a/libcloud/test/compute/fixtures/gce/operations_operation_global_urlMaps_post.json
+++ b/libcloud/test/compute/fixtures/gce/operations_operation_global_urlMaps_post.json
@@ -1,0 +1,15 @@
+{
+ "kind": "compute#operation",
+ "id": "14014131794489638887",
+ "name": "operation-global_urlMaps_post",
+ "operationType": "insert",
+ "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/urlMaps/web-map",
+ "targetId": "4266107551250249032",
+ "status": "DONE",
+ "user": "user@developer.gserviceaccount.com",
+ "progress": 100,
+ "insertTime": "2014-10-27T15:21:17.438-07:00",
+ "startTime": "2014-10-27T15:21:17.631-07:00",
+ "endTime": "2014-10-27T15:21:18.422-07:00",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/operations/operation-global_urlMaps_post"
+}

--- a/libcloud/test/compute/fixtures/gce/operations_operation_global_urlMaps_web_map_delete.json
+++ b/libcloud/test/compute/fixtures/gce/operations_operation_global_urlMaps_web_map_delete.json
@@ -1,0 +1,15 @@
+{
+ "kind": "compute#operation",
+ "id": "3333333333333333333",
+ "name": "operation_global_urlMaps_web_map_delete",
+ "operationType": "delete",
+ "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/urlMaps/web-map",
+ "targetId": "1955555555986139870",
+ "status": "DONE",
+ "user": "user@developer.gserviceaccount.com",
+ "progress": 100,
+ "insertTime": "2014-10-28T12:36:28.927-07:00",
+ "startTime": "2014-10-28T12:36:29.146-07:00",
+ "endTime": "2014-10-28T12:36:29.693-07:00",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/operations/operation_global_urlMaps_web_map_delete"
+}

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -22,12 +22,12 @@ import datetime
 from libcloud.utils.py3 import httplib
 from libcloud.compute.drivers.gce import (GCENodeDriver, API_VERSION,
                                           timestamp_to_datetime,
-                                          GCEAddress, GCEHealthCheck,
+                                          GCEAddress, GCEBackendService,
                                           GCEFirewall, GCEForwardingRule,
-                                          GCENetwork,
-                                          GCEZone,
-                                          GCENodeImage,
-                                          GCERoute)
+                                          GCEHealthCheck, GCENetwork,
+                                          GCENodeImage, GCERoute,
+                                          GCETargetHttpProxy, GCEUrlMap,
+                                          GCEZone)
 from libcloud.common.google import (GoogleBaseAuthConnection,
                                     GoogleInstalledAppAuthConnection,
                                     GoogleBaseConnection,
@@ -77,6 +77,16 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         datetime2 = datetime.datetime(2013, 6, 26, 17, 43, 15)
         self.assertEqual(timestamp_to_datetime(timestamp2), datetime2)
 
+    def test_get_object_by_kind(self):
+        obj = self.driver._get_object_by_kind(None)
+        self.assertIsNone(obj)
+        obj = self.driver._get_object_by_kind('')
+        self.assertIsNone(obj)
+        obj = self.driver._get_object_by_kind(
+            'https://www.googleapis.com/compute/v1/projects/project_name/'
+            'global/targetHttpProxies/web-proxy')
+        self.assertEquals(obj.name, 'web-proxy')
+
     def test_get_region_from_zone(self):
         zone1 = self.driver.ex_get_zone('us-central1-a')
         expected_region1 = 'us-central1'
@@ -125,6 +135,18 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         names = [a.name for a in address_list_all]
         self.assertTrue('libcloud-demo-address' in names)
 
+    def test_ex_list_backendservices(self):
+        self.backendservices_mock = 'empty'
+        backendservices_list = self.driver.ex_list_backendservices()
+        self.assertListEqual(backendservices_list, [])
+
+        self.backendservices_mock = 'web-service'
+        backendservices_list = self.driver.ex_list_backendservices()
+        web_service = backendservices_list[0]
+        self.assertEqual(web_service.name, 'web-service')
+        self.assertEqual(len(web_service.healthchecks), 1)
+        self.assertEqual(len(web_service.backends), 2)
+
     def test_ex_list_healthchecks(self):
         healthchecks = self.driver.ex_list_healthchecks()
         self.assertEqual(len(healthchecks), 3)
@@ -146,6 +168,13 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         self.assertEqual(forwarding_rules_uc1[0].name, 'lcforwardingrule')
         names = [f.name for f in forwarding_rules_all]
         self.assertTrue('lcforwardingrule' in names)
+
+    def test_ex_list_forwarding_rules_global(self):
+        forwarding_rules = self.driver.ex_list_forwarding_rules(global_rules=True)
+        self.assertEqual(len(forwarding_rules), 2)
+        self.assertEqual(forwarding_rules[0].name, 'http-rule')
+        names = [f.name for f in forwarding_rules]
+        self.assertListEqual(names, ['http-rule', 'http-rule2'])
 
     def test_list_images(self):
         local_images = self.driver.list_images()
@@ -195,6 +224,13 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         snapshots = self.driver.ex_list_snapshots()
         self.assertEqual(len(snapshots), 2)
         self.assertEqual(snapshots[0].name, 'lcsnapshot')
+
+    def test_ex_list_targethttpproxies(self):
+        target_proxies = self.driver.ex_list_targethttpproxies()
+        self.assertEqual(len(target_proxies), 2)
+        self.assertEqual(target_proxies[0].name, 'web-proxy')
+        names = [t.name for t in target_proxies]
+        self.assertListEqual(names, ['web-proxy', 'web-proxy2'])
 
     def test_ex_list_targetinstances(self):
         target_instances = self.driver.ex_list_targetinstances()
@@ -248,6 +284,14 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         self.assertTrue('pd-standard' in names)
         self.assertTrue('local-ssd' in names)
 
+    def test_ex_list_urlmaps(self):
+        urlmaps_list = self.driver.ex_list_urlmaps()
+        web_map = urlmaps_list[0]
+        self.assertEqual(web_map.name, 'web-map')
+        self.assertEqual(len(web_map.host_rules), 0)
+        self.assertEqual(len(web_map.path_matchers), 0)
+        self.assertEqual(len(web_map.tests), 0)
+
     def test_list_volumes(self):
         volumes = self.driver.list_volumes()
         volumes_all = self.driver.list_volumes('all')
@@ -277,6 +321,14 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         address = self.driver.ex_create_address(address_name)
         self.assertTrue(isinstance(address, GCEAddress))
         self.assertEqual(address.name, address_name)
+
+    def test_ex_create_backendservice(self):
+        backendservice_name = 'web-service'
+        backendservice = self.driver.ex_create_backendservice(
+            name=backendservice_name,
+            healthchecks=['lchealthcheck'])
+        self.assertTrue(isinstance(backendservice, GCEBackendService))
+        self.assertEqual(backendservice.name, backendservice_name)
 
     def test_ex_create_healthcheck(self):
         healthcheck_name = 'lchealthcheck'
@@ -317,10 +369,51 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         fwr_name = 'lcforwardingrule'
         targetpool = 'lctargetpool'
         region = 'us-central1'
+        address = 'lcaddress'
         port_range = '8000-8500'
         description = 'test forwarding rule'
         fwr = self.driver.ex_create_forwarding_rule(fwr_name, targetpool,
                                                     region=region,
+                                                    address=address,
+                                                    port_range=port_range,
+                                                    description=description)
+        self.assertTrue(isinstance(fwr, GCEForwardingRule))
+        self.assertEqual(fwr.name, fwr_name)
+        self.assertEqual(fwr.region.name, region)
+        self.assertEqual(fwr.protocol, 'TCP')
+        self.assertEqual(fwr.extra['portRange'], port_range)
+        self.assertEqual(fwr.extra['description'], description)
+
+    def test_ex_create_forwarding_rule_global(self):
+        fwr_name = 'http-rule'
+        target_name = 'web-proxy'
+        address = 'lcaddressglobal'
+        port_range = '80-80'
+        description = 'global forwarding rule'
+        for target in (target_name,
+                       self.driver.ex_get_targethttpproxy(target_name)):
+            fwr = self.driver.ex_create_forwarding_rule(fwr_name, target,
+                                                        global_rule=True,
+                                                        address=address,
+                                                        port_range=port_range,
+                                                        description=description)
+            self.assertTrue(isinstance(fwr, GCEForwardingRule))
+            self.assertEqual(fwr.name, fwr_name)
+            self.assertEqual(fwr.extra['portRange'], port_range)
+            self.assertEqual(fwr.extra['description'], description)
+
+    def test_ex_create_forwarding_rule_targetpool_keyword(self):
+        """Test backwards compatibility with the targetpool kwarg."""
+        fwr_name = 'lcforwardingrule'
+        targetpool = 'lctargetpool'
+        region = 'us-central1'
+        address = self.driver.ex_get_address('lcaddress')
+        port_range = '8000-8500'
+        description = 'test forwarding rule'
+        fwr = self.driver.ex_create_forwarding_rule(fwr_name,
+                                                    targetpool=targetpool,
+                                                    region=region,
+                                                    address=address,
                                                     port_range=port_range,
                                                     description=description)
         self.assertTrue(isinstance(fwr, GCEForwardingRule))
@@ -520,6 +613,14 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         self.assertEqual(nodes[0].name, '%s-000' % base_name)
         self.assertEqual(nodes[1].name, '%s-001' % base_name)
 
+    def test_ex_create_targethttpproxy(self):
+        proxy_name = 'web-proxy'
+        urlmap_name = 'web-map'
+        for urlmap in (urlmap_name, self.driver.ex_get_urlmap(urlmap_name)):
+            proxy = self.driver.ex_create_targethttpproxy(proxy_name, urlmap)
+            self.assertTrue(isinstance(proxy, GCETargetHttpProxy))
+            self.assertEqual(proxy_name, proxy.name)
+
     def test_ex_create_targetinstance(self):
         targetinstance_name = 'lctargetinstance'
         zone = 'us-central1-a'
@@ -555,6 +656,14 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         self.assertEqual(targetpool.name, targetpool_name)
         self.assertEqual(targetpool.extra.get('sessionAffinity'),
                          session_affinity)
+
+    def test_ex_create_urlmap(self):
+        urlmap_name = 'web-map'
+        for service in ('web-service',
+                        self.driver.ex_get_backendservice('web-service')):
+            urlmap = self.driver.ex_create_urlmap(urlmap_name, service)
+            self.assertTrue(isinstance(urlmap, GCEUrlMap))
+            self.assertEqual(urlmap_name, urlmap.name)
 
     def test_ex_create_volume_snapshot(self):
         snapshot_name = 'lcsnapshot'
@@ -696,6 +805,11 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         destroyed = address.destroy()
         self.assertTrue(destroyed)
 
+    def test_ex_destroy_backendservice(self):
+        backendservice = self.driver.ex_get_backendservice('web-service')
+        destroyed = backendservice.destroy()
+        self.assertTrue(destroyed)
+
     def test_ex_destroy_healthcheck(self):
         hc = self.driver.ex_get_healthcheck('lchealthcheck')
         destroyed = hc.destroy()
@@ -730,6 +844,11 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         destroyed = fwr.destroy()
         self.assertTrue(destroyed)
 
+    def test_ex_destroy_forwarding_rule_global(self):
+        fwr = self.driver.ex_get_forwarding_rule('http-rule', global_rule=True)
+        destroyed = fwr.destroy()
+        self.assertTrue(destroyed)
+
     def test_ex_destroy_route(self):
         route = self.driver.ex_get_route('lcdemoroute')
         destroyed = route.destroy()
@@ -753,6 +872,11 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         for d in destroyed:
             self.assertTrue(d)
 
+    def test_destroy_targethttpproxy(self):
+        proxy = self.driver.ex_get_targethttpproxy('web-proxy')
+        destroyed = proxy.destroy()
+        self.assertTrue(destroyed)
+
     def test_destroy_targetinstance(self):
         targetinstance = self.driver.ex_get_targetinstance('lctargetinstance')
         self.assertEqual(targetinstance.name, 'lctargetinstance')
@@ -762,6 +886,11 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
     def test_destroy_targetpool(self):
         targetpool = self.driver.ex_get_targetpool('lctargetpool')
         destroyed = targetpool.destroy()
+        self.assertTrue(destroyed)
+
+    def test_destroy_urlmap(self):
+        urlmap = self.driver.ex_get_urlmap('web-map')
+        destroyed = urlmap.destroy()
         self.assertTrue(destroyed)
 
     def test_destroy_volume(self):
@@ -797,6 +926,26 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         self.assertEqual(address.region.name, 'us-central1')
         self.assertEqual(address.extra['status'], 'RESERVED')
 
+    def test_ex_get_backendservice(self):
+        web_service = self.driver.ex_get_backendservice('web-service')
+        self.assertEqual(web_service.name, 'web-service')
+        self.assertEqual(web_service.protocol, 'HTTP')
+        self.assertEqual(web_service.port, 80)
+        self.assertEqual(web_service.timeout, 30)
+        self.assertEqual(web_service.healthchecks[0].name, 'basic-check')
+        self.assertEqual(len(web_service.healthchecks), 1)
+        backends = web_service.backends
+        self.assertEqual(len(backends), 2)
+        self.assertEqual(backends[0]['balancingMode'], 'RATE')
+        self.assertEqual(backends[0]['maxRate'], 100)
+        self.assertEqual(backends[0]['capacityScaler'], 1.0)
+
+        web_service = self.driver.ex_get_backendservice('no-backends')
+        self.assertEqual(web_service.name, 'web-service')
+        self.assertEqual(web_service.healthchecks[0].name, 'basic-check')
+        self.assertEqual(len(web_service.healthchecks), 1)
+        self.assertEqual(len(web_service.backends), 0)
+
     def test_ex_get_healthcheck(self):
         healthcheck_name = 'lchealthcheck'
         healthcheck = self.driver.ex_get_healthcheck(healthcheck_name)
@@ -818,6 +967,16 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         self.assertEqual(fwr.extra['portRange'], '8000-8500')
         self.assertEqual(fwr.targetpool.name, 'lctargetpool')
         self.assertEqual(fwr.protocol, 'TCP')
+
+    def test_ex_get_forwarding_rule_global(self):
+        fwr_name = 'http-rule'
+        fwr = self.driver.ex_get_forwarding_rule(fwr_name, global_rule=True)
+        self.assertEqual(fwr.name, fwr_name)
+        self.assertEqual(fwr.extra['portRange'], '80-80')
+        self.assertEqual(fwr.targetpool.name, 'web-proxy')
+        self.assertEqual(fwr.protocol, 'TCP')
+        self.assertEqual(fwr.address, '192.0.2.1')
+        self.assertEqual(fwr.targetpool.name, 'web-proxy')
 
     def test_ex_get_image_license(self):
         image = self.driver.ex_get_image('sles-12-v20141023')
@@ -1021,6 +1180,13 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         self.assertEqual(size.ram, 3840)
         self.assertEqual(size.extra['guestCpus'], 1)
 
+    def test_ex_get_targethttpproxy(self):
+        targethttpproxy_name = 'web-proxy'
+        targethttpproxy = self.driver.ex_get_targethttpproxy(
+            targethttpproxy_name)
+        self.assertEqual(targethttpproxy.name, targethttpproxy_name)
+        self.assertEqual(targethttpproxy.urlmap.name, 'web-map')
+
     def test_ex_get_targetinstance(self):
         targetinstance_name = 'lctargetinstance'
         targetinstance = self.driver.ex_get_targetinstance(targetinstance_name)
@@ -1040,6 +1206,12 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         self.assertEqual(snapshot.name, snapshot_name)
         self.assertEqual(snapshot.size, '10')
         self.assertEqual(snapshot.status, 'READY')
+
+    def test_ex_get_urlmap(self):
+        urlmap_name = 'web-map'
+        urlmap = self.driver.ex_get_urlmap(urlmap_name)
+        self.assertEqual(urlmap.name, urlmap_name)
+        self.assertEqual(urlmap.default_service.name, 'web-service')
 
     def test_ex_get_volume(self):
         volume_name = 'lcdisk'
@@ -1134,6 +1306,40 @@ class GCEMockHttp(MockHttpTestCase):
 
     def _aggregated_targetPools(self, method, url, body, headers):
         body = self.fixtures.load('aggregated_targetPools.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _global_backendServices(self, method, url, body, headers):
+        if method == 'POST':
+            body = self.fixtures.load('global_backendServices_post.json')
+        else:
+            body = self.fixtures.load('global_backendServices-%s.json' %
+                                      self.test.backendservices_mock)
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _global_backendServices_no_backends(self, method, url, body, headers):
+        body = self.fixtures.load('global_backendServices_no_backends.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _global_backendServices_web_service(self, method, url, body, headers):
+        if method == 'DELETE':
+            body = self.fixtures.load(
+                'global_backendServices_web_service_delete.json')
+        else:
+            body = self.fixtures.load('global_backendServices_web_service.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _global_forwardingRules(self, method, url, body, headers):
+        if method == 'POST':
+            body = self.fixtures.load('global_forwardingRules_post.json')
+        else:
+            body = self.fixtures.load('global_forwardingRules.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _global_forwardingRules_http_rule(self, method, url, body, headers):
+        if method == 'DELETE':
+            body = self.fixtures.load('global_forwardingRules_http_rule_delete.json')
+        else:
+            body = self.fixtures.load('global_forwardingRules_http_rule.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
     def _global_httpHealthChecks(self, method, url, body, headers):
@@ -1271,6 +1477,31 @@ class GCEMockHttp(MockHttpTestCase):
             'operations_operation_setCommonInstanceMetadata.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
+    def _global_operations_operation_global_backendServices_post(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'operations_operation_global_backendServices_post.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _global_operations_operation_global_backendServices_web_service_delete(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'operations_operation_global_backendServices_web_service_delete'
+            '.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _global_operations_operation_global_forwardingRules_http_rule_delete(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'operations_operation_global_forwardingRules_http_rule_delete.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _global_operations_operation_global_forwardingRules_post(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'operations_operation_global_forwardingRules_post.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
     def _global_operations_operation_global_httpHealthChecks_lchealthcheck_delete(
             self, method, url, body, headers):
         body = self.fixtures.load(
@@ -1353,6 +1584,60 @@ class GCEMockHttp(MockHttpTestCase):
             self, method, url, body, headers):
         body = self.fixtures.load(
             'operations_operation_global_addresses_lcaddressglobal_delete.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _global_operations_operation_global_targetHttpProxies_post(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'operations_operation_global_targetHttpProxies_post.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _global_operations_operation_global_targetHttpProxies_web_proxy_delete(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'operations_operation_global_targetHttpProxies_web_proxy_delete'
+            '.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _global_operations_operation_global_urlMaps_post(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'operations_operation_global_urlMaps_post.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _global_operations_operation_global_urlMaps_web_map_delete(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'operations_operation_global_urlMaps_web_map_delete.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _global_targetHttpProxies(self, method, url, body, headers):
+        if method == 'POST':
+            body = self.fixtures.load('global_targetHttpProxies_post.json')
+        else:
+            body = self.fixtures.load('global_targetHttpProxies.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _global_targetHttpProxies_web_proxy(self, method, url, body, headers):
+        if method == 'DELETE':
+            body = self.fixtures.load(
+                'global_targetHttpProxies_web_proxy_delete.json')
+        else:
+            body = self.fixtures.load('global_targetHttpProxies_web_proxy.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _global_urlMaps(self, method, url, body, headers):
+        if method == 'POST':
+            body = self.fixtures.load('global_urlMaps_post.json')
+        else:
+            body = self.fixtures.load('global_urlMaps.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _global_urlMaps_web_map(self, method, url, body, headers):
+        if method == 'DELETE':
+            body = self.fixtures.load('global_urlMaps_web_map_delete.json')
+        else:
+            body = self.fixtures.load('global_urlMaps_web_map.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
     def _regions_us_central1_operations_operation_regions_us_central1_addresses_lcaddress_delete(


### PR DESCRIPTION
This change adds coverage for GCE's HTTP-LB features via ex_\* functions
in the GCE NodeDriver.

Also, this updates the existing ex_create_forwarding_rule to use a
more generic 'target' parameter.  Previously this was 'targetpool', but
the GCE API has changed this to 'target' because it can be a targetPool,
targetInstance or targetHttpProxy.  This update is backwards compatible.

@erjohnso This replaces PR #427 
