### PR TITLE
LIBCLOUD-650: ex_create_multi_value_record only returns one record

### DIFF
--- a/libcloud/dns/drivers/route53.py
+++ b/libcloud/dns/drivers/route53.py
@@ -273,7 +273,7 @@ class Route53DNSDriver(DNSDriver):
                             driver=self, extra=extra)
             records.append(record)
 
-        return record
+        return records
 
     def ex_delete_all_records(self, zone):
         """
@@ -346,7 +346,6 @@ class Route53DNSDriver(DNSDriver):
         for other_record in other_records:
             rrec = ET.SubElement(rrecs, 'ResourceRecord')
             ET.SubElement(rrec, 'Value').text = other_record['data']
-
         uri = API_ROOT + 'hostedzone/' + record.zone.id + '/rrset'
         data = ET.tostring(changeset)
         self.connection.set_context({'zone_id': record.zone.id})

--- a/libcloud/test/dns/test_route53.py
+++ b/libcloud/test/dns/test_route53.py
@@ -155,6 +155,26 @@ class Route53Tests(unittest.TestCase):
         self.assertEqual(record.type, RecordType.A)
         self.assertEqual(record.data, '127.0.0.1')
 
+    def test_create_multi_value_record(self):
+        zone = self.driver.list_zones()[0]
+        records = self.driver.ex_create_multi_value_record(
+            name='balancer', zone=zone,
+            type=RecordType.A, data='127.0.0.1\n127.0.0.2',
+            extra={'ttl': 0}
+
+        )
+        self.assertEqual(len(records), 2)
+        self.assertEqual(records[0].id, 'A:balancer')
+        self.assertEqual(records[1].id, 'A:balancer')
+        self.assertEqual(records[0].name, 'balancer')
+        self.assertEqual(records[1].name, 'balancer')
+        self.assertEqual(records[0].zone, zone)
+        self.assertEqual(records[1].zone, zone)
+        self.assertEqual(records[0].type, RecordType.A)
+        self.assertEqual(records[1].type, RecordType.A)
+        self.assertEqual(records[0].data, '127.0.0.1')
+        self.assertEqual(records[1].data, '127.0.0.2')
+
     def test_update_record(self):
         zone = self.driver.list_zones()[0]
         record = self.driver.list_records(zone=zone)[1]


### PR DESCRIPTION
Fixes that bug and also adds tests for that function.

Bug discovery and solution by @jvrplmlmn
