### PR TITLE
fixing missing parameter exception for ex_add_access_config function

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -899,7 +899,8 @@ class GCENodeDriver(NodeDriver):
         else:
             self.region = None
 
-    def ex_add_access_config(self, node, name, nat_ip=None, config_type=None):
+    def ex_add_access_config(self, node, name, nic, nat_ip=None,
+                             config_type=None):
         """
         Add a network interface access configuration to a node.
 
@@ -934,10 +935,11 @@ class GCENodeDriver(NodeDriver):
 
         if nat_ip is not None:
             config['natIP'] = nat_ip
-
+        params = {'networkInterface': nic}
         request = '/zones/%s/instances/%s/addAccessConfig' % (zone_name,
                                                               node_name)
-        self.connection.async_request(request, method='POST', data=config)
+        self.connection.async_request(request, method='POST',
+                                      data=config, params=params)
         return True
 
     def ex_delete_access_config(self, node, name, nic):

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -1093,9 +1093,9 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
 
     def test_ex_add_access_config(self):
         self.assertRaises(ValueError, self.driver.ex_add_access_config,
-                          'node', 'name')
+                          'node', 'name', 'nic')
         node = self.driver.ex_get_node('node-name', 'us-central1-a')
-        self.assertTrue(self.driver.ex_add_access_config(node, 'foo'))
+        self.assertTrue(self.driver.ex_add_access_config(node, 'foo', 'bar'))
 
     def test_ex_delete_access_config(self):
         self.assertRaises(ValueError, self.driver.ex_add_access_config,


### PR DESCRIPTION
Missing nic parameter throws exception in gce.ex_add_access_config

```
stderr: Traceback (most recent call last):
  File "/Users/pmoosh/.ansible/tmp/ansible-tmp-1421538564.46-10999847043196/gce_setip.py", line 139, in <module>
    main(sys.argv[1:])
  File "/Users/pmoosh/.ansible/tmp/ansible-tmp-1421538564.46-10999847043196/gce_setip.py", line 128, in main
    gce.ex_add_access_config(node = my_instance, name = ACC_CNF_NM, nat_ip = item.address)
  File "/Users/pmoosh/src/apache-libcloud/libcloud/compute/drivers/gce.py", line 941, in ex_add_access_config
    self.connection.async_request(request, method='POST', data=config)
  File "/Users/pmoosh/src/apache-libcloud/libcloud/common/base.py", line 866, in async_request
    response = request(**kwargs)
  File "/Users/pmoosh/src/apache-libcloud/libcloud/common/google.py", line 669, in request
    *args, **kwargs)
  File "/Users/pmoosh/src/apache-libcloud/libcloud/common/base.py", line 736, in request
    response = responseCls(**kwargs)
  File "/Users/pmoosh/src/apache-libcloud/libcloud/common/base.py", line 119, in __init__
    self.object = self.parse_body()
  File "/Users/pmoosh/src/apache-libcloud/libcloud/common/google.py", line 267, in parse_body
    raise InvalidRequestError(message, self.status, code)
libcloud.common.google.InvalidRequestError: {'locationType': 'parameter', 'domain': 'global', 'message': 'Required parameter: networkInterface', 'reason': 'required', 'location': 'networkInterface'}
```
