### PR TITLE
[LIBCLOUD-656] adding the tok02 region for softlayer compute.

### DIFF
--- a/libcloud/compute/drivers/softlayer.py
+++ b/libcloud/compute/drivers/softlayer.py
@@ -47,6 +47,7 @@ DATACENTERS = {
     'sjc01': {'country': 'US', 'name': 'San Jose - West Coast U.S.'},
     'sng01': {'country': 'SG', 'name': 'Singapore - Southeast Asia'},
     'ams01': {'country': 'NL', 'name': 'Amsterdam - Western Europe'},
+    'tok02': {'country': 'JP', 'name': 'Tokyo - Japan'},
 }
 
 NODE_STATE_MAP = {


### PR DESCRIPTION
This is a simple one liner that adds the tok02 region to the softlayer compute driver. When the driver was originally created the region did not exist, which would explain why it wasnt present. Let me know if you need any more info.
