### PR TITLE
CloudSigma - add Honolulu, HI endpoint data

### DIFF
--- a/libcloud/common/cloudsigma.py
+++ b/libcloud/common/cloudsigma.py
@@ -55,7 +55,13 @@ API_ENDPOINTS_2_0 = {
         'name': 'Washington, DC',
         'country': 'United States',
         'host': 'wdc.cloudsigma.com'
-    }
+    },
+    'hnl': {
+        'name': 'Honolulu, HI',
+        'country': 'United States',
+        'host': 'hnl.cloudsigma.com'
+    },
+
 }
 
 DEFAULT_REGION = 'zrh'


### PR DESCRIPTION
The recently added Honolulu, HI endpoint has not found its way into libcloud yet.  There are no associated JIRA tickets with this change.
Here it is.
