### PR TITLE
[google compute] raise notfound on images that are not found

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -3810,7 +3810,7 @@ n
 
         :return:  GCENodeImage object based on provided information or None if
                   an image with that name is not found.
-        :rtype:   :class:`GCENodeImage` or ``None``
+        :rtype:   :class:`GCENodeImage` or raise ``ResourceNotFoundError``
         """
         if partial_name.startswith('https://'):
             response = self.connection.request(partial_name, method='GET')
@@ -3821,6 +3821,10 @@ n
                 for short_name in short_list:
                     if partial_name.startswith(short_name):
                         image = self._match_images(img_proj, partial_name)
+
+        if not image:
+            raise ResourceNotFoundError('Could not find image \'%s\'' % (
+                                        partial_name), None, None)
         return image
 
     def ex_get_route(self, name):

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -858,6 +858,11 @@ class GCENodeDriverTest(LibcloudTestCase, TestCaseMixin):
         self.assertTrue(destroyed)
 
     def test_ex_delete_image(self):
+        self.assertRaises(ResourceNotFoundError,
+                          self.driver.ex_get_image, 'missing-image')
+        self.assertRaises(ResourceNotFoundError,
+                          self.driver.ex_delete_image, 'missing-image')
+
         image = self.driver.ex_get_image('debian-7')
         deleted = self.driver.ex_delete_image(image)
         self.assertTrue(deleted)


### PR DESCRIPTION
If a user tried to delete an image by name (string) and the image was not found, the code would fail with a `NoneType` does not contain `name` attribute error.

This fixes the case where if an image can't be found by string name, it will raise a `ResourceNotFoundError`.

/cc @tanpeter - if you think this will work and is good, I can merge it in.
