### PR TITLE
improve GCE create_node, make sure ex_get_disktype function will not fail

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -2160,7 +2160,7 @@ n
         if image and not hasattr(image, 'name'):
             image = self.ex_get_image(image)
         if not hasattr(ex_disk_type, 'name'):
-            ex_disk_type = self.ex_get_disktype(ex_disk_type)
+            ex_disk_type = self.ex_get_disktype(ex_disk_type, zone=location)
 
         # Use disks[].initializeParams to auto-create the boot disk
         if not ex_disks_gce_struct and not ex_boot_disk:
@@ -2346,7 +2346,7 @@ n
         if image and not hasattr(image, 'name'):
             image = self.ex_get_image(image)
         if not hasattr(ex_disk_type, 'name'):
-            ex_disk_type = self.ex_get_disktype(ex_disk_type)
+            ex_disk_type = self.ex_get_disktype(ex_disk_type, zone=location)
 
         node_attrs = {'size': size,
                       'image': image,

--- a/libcloud/test/compute/fixtures/gce/zones_europe-west1-a_diskTypes_pd_standard.json
+++ b/libcloud/test/compute/fixtures/gce/zones_europe-west1-a_diskTypes_pd_standard.json
@@ -1,0 +1,10 @@
+{
+"creationTimestamp": "2014-06-02T11:07:28.530-07:00",
+ "defaultDiskSizeGb": "500",
+ "description": "Standard Persistent Disk",
+ "kind": "compute#diskType",
+ "name": "pd-standard",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/gifted-electron-225/zones/europe-west1-a/diskTypes/pd-standard",
+ "validDiskSize": "10GB-10240GB",
+ "zone": "https://www.googleapis.com/compute/v1/projects/gifted-electron-225/zones/europe-west1-a"
+}

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -2259,6 +2259,10 @@ class GCEMockHttp(MockHttpTestCase):
             body = self.fixtures.load('zones_europe-west1-a_instances.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
+    def _zones_europe_west1_a_diskTypes_pd_standard(self, method, url, body, headers):
+        body = self.fixtures.load('zones_europe-west1-a_diskTypes_pd_standard.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
     def _zones_us_central1_a_instances(self, method, url, body, headers):
         if method == 'POST':
             body = self.fixtures.load(


### PR DESCRIPTION
create_node supports passing ex_disk_type as either str or GCEDiskType. If you pass an str, or if you don't pass anything -most usual case I believe- it gets an str value of 'pd-standard' since it is a kwarg,  then the function will fail because self.ex_get_disktype is called without the location, and line 
      request = '/zones/%s/diskTypes/%s' % (zone.name, name)

will break with a 'NoneType' object has no attribute 'name'

This can easily be fixed with this commit (also applies to ex_create_multiple_nodes). 

Then nodes with ssh key deployed are easily created:

```
from libcloud.compute.providers import get_driver; from libcloud.compute.types import Provider; driver = get_driver('gce')
conn = driver('email', 'key', project='project')
node = conn.create_node(
                name=machine_name, # str
                image=image, # NodeImage
                size=size, # NodeSize
                location=location, # NodeLocation
                ex_metadata=metadata # {'sshKeys': 'user:%s' % public_ssh_rsa_key}
            )
```
