### PR TITLE
docs typofix

### DIFF
--- a/docs/examples/compute/ec2/create_general_purpose_ssd_volume.py
+++ b/docs/examples/compute/ec2/create_general_purpose_ssd_volume.py
@@ -5,4 +5,4 @@ cls = get_driver(Provider.EC2, region='us-east-i1')
 driver = cls('access key', 'secret key')
 
 volume = driver.create_volume(size=100, name='Test GP volume',
-                              ex_volume_type='g2')
+                              ex_volume_type='gp2')


### PR DESCRIPTION
From what I can tell, the proper volume type is `gp2`, not just `gp`.
