### PR TITLE
[compute] s/self.assertTrue(True)/pass/

### DIFF
--- a/libcloud/test/compute/test_dreamhost.py
+++ b/libcloud/test/compute/test_dreamhost.py
@@ -51,7 +51,7 @@ class DreamhostTest(unittest.TestCase, TestCaseMixin):
             self.assertTrue(
                 False)  # Above command should have thrown an InvalidCredsException
         except InvalidCredsError:
-            self.assertTrue(True)
+            pass
 
     def test_list_nodes(self):
         """

--- a/libcloud/test/compute/test_gridspot.py
+++ b/libcloud/test/compute/test_gridspot.py
@@ -51,7 +51,7 @@ class GridspotTest(unittest.TestCase, TestCaseMixin):
             # Above command should have thrown an InvalidCredsException
             self.assertTrue(False)
         except InvalidCredsError:
-            self.assertTrue(True)
+            pass
 
     def test_list_nodes(self):
         nodes = self.driver.list_nodes()
@@ -90,7 +90,7 @@ class GridspotTest(unittest.TestCase, TestCaseMixin):
         """
         Gridspot does not implement this functionality
         """
-        self.assertTrue(True)
+        pass
 
     def test_destroy_node(self):
         """
@@ -104,85 +104,85 @@ class GridspotTest(unittest.TestCase, TestCaseMixin):
         Gridspot does not fail a destroy node unless the parameters are bad, in
         which case it 404s
         """
-        self.assertTrue(True)
+        pass
 
     def test_reboot_node(self):
         """
         Gridspot does not implement this functionality
         """
-        self.assertTrue(True)
+        pass
 
     def test_reboot_node_failure(self):
         """
         Gridspot does not implement this functionality
         """
-        self.assertTrue(True)
+        pass
 
     def test_resize_node(self):
         """
         Gridspot does not implement this functionality
         """
-        self.assertTrue(True)
+        pass
 
     def test_reboot_node_response(self):
         """
         Gridspot does not implement this functionality
         """
-        self.assertTrue(True)
+        pass
 
     def test_list_images_response(self):
         """
         Gridspot does not implement this functionality
         """
-        self.assertTrue(True)
+        pass
 
     def test_create_node_response(self):
         """
         Gridspot does not implement this functionality
         """
-        self.assertTrue(True)
+        pass
 
     def test_destroy_node_response(self):
         """
         Gridspot does not implement this functionality
         """
-        self.assertTrue(True)
+        pass
 
     def test_list_sizes_response(self):
         """
         Gridspot does not implement this functionality
         """
-        self.assertTrue(True)
+        pass
 
     def test_resize_node_failure(self):
         """
         Gridspot does not implement this functionality
         """
-        self.assertTrue(True)
+        pass
 
     def test_list_images(self):
         """
         Gridspot does not implement this functionality
         """
-        self.assertTrue(True)
+        pass
 
     def test_list_sizes(self):
         """
         Gridspot does not implement this functionality
         """
-        self.assertTrue(True)
+        pass
 
     def test_list_locations(self):
         """
         Gridspot does not implement this functionality
         """
-        self.assertTrue(True)
+        pass
 
     def test_list_locations_response(self):
         """
         Gridspot does not implement this functionality
         """
-        self.assertTrue(True)
+        pass
 
 
 class GridspotMockHttp(MockHttp):

--- a/libcloud/test/compute/test_opsource.py
+++ b/libcloud/test/compute/test_opsource.py
@@ -42,7 +42,7 @@ class OpsourceTests(unittest.TestCase, TestCaseMixin):
             self.assertTrue(
                 False)  # Above command should have thrown an InvalidCredsException
         except InvalidCredsError:
-            self.assertTrue(True)
+            pass
 
     def test_list_sizes_response(self):
         OpsourceMockHttp.type = None
@@ -66,7 +66,7 @@ class OpsourceTests(unittest.TestCase, TestCaseMixin):
             self.assertTrue(
                 False)  # above command should have thrown OpsourceAPIException
         except OpsourceAPIException:
-            self.assertTrue(True)
+            pass
 
     def test_destroy_node_response(self):
         node = Node(id='11', name=None, state=None,
@@ -83,7 +83,7 @@ class OpsourceTests(unittest.TestCase, TestCaseMixin):
             self.assertTrue(
                 False)  # above command should have thrown OpsourceAPIException
         except OpsourceAPIException:
-            self.assertTrue(True)
+            pass
 
     def test_create_node_response(self):
         rootPw = NodeAuthPassword('pass123')
@@ -110,7 +110,7 @@ class OpsourceTests(unittest.TestCase, TestCaseMixin):
             self.assertTrue(
                 False)  # above command should have thrown OpsourceAPIException
         except OpsourceAPIException:
-            self.assertTrue(True)
+            pass
 
     def test_ex_start_node(self):
         node = Node(id='11', name=None, state=None,
@@ -127,7 +127,7 @@ class OpsourceTests(unittest.TestCase, TestCaseMixin):
             self.assertTrue(
                 False)  # above command should have thrown OpsourceAPIException
         except OpsourceAPIException:
-            self.assertTrue(True)
+            pass
 
     def test_ex_power_off(self):
         node = Node(id='11', name=None, state=None,
@@ -144,7 +144,7 @@ class OpsourceTests(unittest.TestCase, TestCaseMixin):
             self.assertTrue(
                 False)  # above command should have thrown OpsourceAPIException
         except OpsourceAPIException:
-            self.assertTrue(True)
+            pass
 
     def test_ex_list_networks(self):
         nets = self.driver.ex_list_networks()


### PR DESCRIPTION
The idiomatic "noop" for a Python block is `pass`, including unit tests.
