### PR TITLE
Vultr ssh key support

### DIFF
--- a/libcloud/compute/drivers/digitalocean.py
+++ b/libcloud/compute/drivers/digitalocean.py
@@ -125,6 +125,12 @@ class DigitalOceanNodeDriver(NodeDriver):
         data = self.connection.request('/droplets/new', params=params).object
         return self._to_node(data=data['droplet'])
 
+    def create_image(self, node, name, description=None):
+        params = {'name': name}
+        res = self.connection.request('/droplets/%s/snapshot/' % (node.id),
+                                      params=params)
+        return res.status == httplib.OK
+
     def reboot_node(self, node):
         res = self.connection.request('/droplets/%s/reboot/' % (node.id))
         return res.status == httplib.OK


### PR DESCRIPTION
Added in support for vultr to get the ssh keys list similar to the DigitalOcean driver method ex_list_ssh_keys().

Also updated the create_node() method to accept a key id for creating vultr nodes with those keys.
