### PR TITLE
Hostvirtual delete_zone and record_name fixes

### DIFF
--- a/libcloud/dns/drivers/hostvirtual.py
+++ b/libcloud/dns/drivers/hostvirtual.py
@@ -105,7 +105,8 @@ class HostVirtualDNSDriver(DNSDriver):
     def _to_record(self, item, zone=None):
         extra = {'ttl': item['ttl']}
         type = self._string_to_record_type(item['type'])
-        record = Record(id=item['id'], name=item['name'],
+        name = item['name'][:-len(zone.domain) - 1]
+        record = Record(id=item['id'], name=name,
                         type=type, data=item['content'],
                         zone=zone, driver=self, extra=extra)
         return record

--- a/libcloud/dns/drivers/hostvirtual.py
+++ b/libcloud/dns/drivers/hostvirtual.py
@@ -153,7 +153,7 @@ class HostVirtualDNSDriver(DNSDriver):
         return record
 
     def delete_zone(self, zone):
-        params = {'zone_id': zone.id}
+        params = {'id': zone.id}
         self.connection.set_context({'resource': 'zone', 'id': zone.id})
         result = self.connection.request(
             API_ROOT + '/dns/zone/', params=params, method='DELETE').object

--- a/libcloud/test/dns/test_hostvirtual.py
+++ b/libcloud/test/dns/test_hostvirtual.py
@@ -54,7 +54,7 @@ class HostVirtualTests(unittest.TestCase):
         self.assertEqual(len(records), 3)
 
         record = records[1]
-        self.assertEqual(record.name, 'www.t.com')
+        self.assertEqual(record.name, 'www')
         self.assertEqual(record.id, '300719')
         self.assertEqual(record.type, RecordType.A)
         self.assertEqual(record.data, '208.111.35.173')
@@ -77,7 +77,7 @@ class HostVirtualTests(unittest.TestCase):
     def test_get_record(self):
         record = self.driver.get_record(zone_id='47234', record_id='300377')
         self.assertEqual(record.id, '300377')
-        self.assertEqual(record.name, '*.t.com')
+        self.assertEqual(record.name, '*')
         self.assertEqual(record.type, RecordType.CNAME)
         self.assertEqual(record.data, 't.com')
 
@@ -139,6 +139,19 @@ class HostVirtualTests(unittest.TestCase):
         self.assertEqual(updated_zone.domain, 'tt.com')
         self.assertEqual(updated_zone.type, zone.type)
         self.assertEqual(updated_zone.ttl, '3600')
+
+    def test_create_record_no_name(self):
+        zone = self.driver.list_zones()[0]
+        record = self.driver.create_record(
+            name='', zone=zone,
+            type=RecordType.A, data='127.0.0.1'
+        )
+
+        self.assertEqual(record.id, '300377')
+        self.assertEqual(record.name, '')
+        self.assertEqual(record.zone, zone)
+        self.assertEqual(record.type, RecordType.A)
+        self.assertEqual(record.data, '127.0.0.1')
 
     def test_create_record(self):
         zone = self.driver.list_zones()[0]


### PR DESCRIPTION
-  Fix 'delete_zone` params that were set incorrectly
-  Fix name parsing, so that getting records returns only name, without domain included.
