### PR TITLE
Route53 creating/updating records fixes

### DIFF
--- a/libcloud/dns/drivers/route53.py
+++ b/libcloud/dns/drivers/route53.py
@@ -372,6 +372,8 @@ class Route53DNSDriver(DNSDriver):
 
             rrecs = ET.SubElement(rrs, 'ResourceRecords')
             rrec = ET.SubElement(rrecs, 'ResourceRecord')
+            if 'priority' in extra:
+                data = '{0} {1}'.format(extra['priority'], data)
             ET.SubElement(rrec, 'Value').text = data
 
         uri = API_ROOT + 'hostedzone/' + zone.id + '/rrset'

--- a/libcloud/dns/drivers/route53.py
+++ b/libcloud/dns/drivers/route53.py
@@ -315,7 +315,7 @@ class Route53DNSDriver(DNSDriver):
 
         rrs = ET.SubElement(change, 'ResourceRecordSet')
         ET.SubElement(rrs, 'Name').text = record.name + '.' + \
-            record.zone.domain
+            record.zone.domain if record.name else record.zone.domain
         ET.SubElement(rrs, 'Type').text = self.RECORD_TYPE_MAP[record.type]
         ET.SubElement(rrs, 'TTL').text = str(record.extra.get('ttl', '0'))
 
@@ -334,7 +334,8 @@ class Route53DNSDriver(DNSDriver):
         ET.SubElement(change, 'Action').text = 'CREATE'
 
         rrs = ET.SubElement(change, 'ResourceRecordSet')
-        ET.SubElement(rrs, 'Name').text = name + '.' + record.zone.domain
+        ET.SubElement(rrs, 'Name').text = name + '.' + \
+            record.zone.domain if name else record.zone.domain
         ET.SubElement(rrs, 'Type').text = self.RECORD_TYPE_MAP[type]
         ET.SubElement(rrs, 'TTL').text = str(extra.get('ttl', '0'))
 
@@ -364,7 +365,8 @@ class Route53DNSDriver(DNSDriver):
             ET.SubElement(change, 'Action').text = action
 
             rrs = ET.SubElement(change, 'ResourceRecordSet')
-            ET.SubElement(rrs, 'Name').text = name + '.' + zone.domain
+            ET.SubElement(rrs, 'Name').text = name + '.' + \
+                zone.domain if name else zone.domain
             ET.SubElement(rrs, 'Type').text = self.RECORD_TYPE_MAP[type_]
             ET.SubElement(rrs, 'TTL').text = str(extra.get('ttl', '0'))
 

--- a/libcloud/test/dns/test_route53.py
+++ b/libcloud/test/dns/test_route53.py
@@ -155,6 +155,20 @@ class Route53Tests(unittest.TestCase):
         self.assertEqual(record.type, RecordType.A)
         self.assertEqual(record.data, '127.0.0.1')
 
+    def test_create_record_zone_name(self):
+        zone = self.driver.list_zones()[0]
+        record = self.driver.create_record(
+            name='', zone=zone,
+            type=RecordType.A, data='127.0.0.1',
+            extra={'ttl': 0}
+        )
+
+        self.assertEqual(record.id, 'A:')
+        self.assertEqual(record.name, '')
+        self.assertEqual(record.zone, zone)
+        self.assertEqual(record.type, RecordType.A)
+        self.assertEqual(record.data, '127.0.0.1')
+
     def test_create_multi_value_record(self):
         zone = self.driver.list_zones()[0]
         records = self.driver.ex_create_multi_value_record(


### PR DESCRIPTION
-  Before it was not possible to set an A record that points directly to domain zone name. Fixed it with correctly parsing empty name.
-  MX records priority was not handled correctly.
