### PR TITLE
Use native match_hostname functionality from ssl module in Python >= 3.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,14 @@ Changelog
 Changes with Apache Libcloud in development
 -------------------------------------------
 
+General
+~~~~~~~
+
+- Use native ``ssl.match_hostname`` functionality when running on Python >=
+  3.2 and only require ``backports.ssl_match_hostname`` dependency on Python
+  versions < 3.2.
+  [Tomaz Muraus]
+
 Compute
 ~~~~~~~
 

--- a/libcloud/httplib_ssl.py
+++ b/libcloud/httplib_ssl.py
@@ -23,13 +23,13 @@ import ssl
 import base64
 import warnings
 
-from backports.ssl_match_hostname import match_hostname, CertificateError
-
 import libcloud.security
 from libcloud.utils.py3 import b
 from libcloud.utils.py3 import httplib
 from libcloud.utils.py3 import urlparse
 from libcloud.utils.py3 import urlunquote
+from libcloud.utils.py3 import match_hostname
+from libcloud.utils.py3 import CertificateError
 
 
 __all__ = [

--- a/libcloud/utils/py3.py
+++ b/libcloud/utils/py3.py
@@ -53,6 +53,13 @@ if sys.version_info >= (3, 0):
 if sys.version_info >= (3, 2) and sys.version_info < (3, 3):
     PY32 = True
 
+if sys.version_info >= (3, 2):
+    # ssl module in Python >= 3.2 includes match hostname function
+    from ssl import match_hostname, CertificateError  # NOQA
+else:
+    from backports.ssl_match_hostname import match_hostname, CertificateError  # NOQA
+
+
 if PY3:
     import http.client as httplib
     from io import StringIO

--- a/setup.py
+++ b/setup.py
@@ -23,14 +23,13 @@ from glob import glob
 from os.path import splitext, basename, join as pjoin
 
 try:
-    import epydoc
+    import epydoc  # NOQA
     has_epydoc = True
 except ImportError:
     has_epydoc = False
 
 import libcloud.utils.misc
 from libcloud.utils.dist import get_packages, get_data_files
-from libcloud.utils.py3 import unittest2_required
 
 libcloud.utils.misc.SHOW_DEPRECATION_WARNING = False
 
@@ -47,9 +46,18 @@ DOC_TEST_MODULES = ['libcloud.compute.drivers.dummy',
 SUPPORTED_VERSIONS = ['2.5', '2.6', '2.7', 'PyPy', '3.x']
 
 TEST_REQUIREMENTS = [
-    'backports.ssl_match_hostname',
     'mock'
 ]
+
+if sys.version_info < (3, 2):
+    TEST_REQUIREMENTS.append('backports.ssl_match_hostname')
+
+# Note: we can't use libcloud.utils.py3 here because it relies on backports
+# dependency being installed / available
+if sys.version_info >= (2, 7):
+    unittest2_required = False
+else:
+    unittest2_required = True
 
 if sys.version_info <= (2, 4):
     version = '.'.join([str(x) for x in sys.version_info[:3]])
@@ -222,9 +230,12 @@ class CoverageCommand(Command):
 
 forbid_publish()
 
-install_requires = ['backports.ssl_match_hostname']
+install_requires = []
 if pre_python26:
     install_requires.extend(['ssl', 'simplejson'])
+
+if sys.version_info < (3, 2):
+    install_requires.append('backports.ssl_match_hostname')
 
 setup(
     name='apache-libcloud',

--- a/tox.ini
+++ b/tox.ini
@@ -29,20 +29,17 @@ deps = backports.ssl_match_hostname
        lockfile
 
 [testenv:py32]
-deps = backports.ssl_match_hostname
-       mock
+deps = mock
        lockfile
 
 [testenv:py33]
-deps = backports.ssl_match_hostname
-       mock
+deps = mock
        lockfile
 
 [testenv:py34]
 # At some point we can switch to use the stdlib provided mock module on
 # Python3.4+
-deps = backports.ssl_match_hostname
-       mock
+deps = mock
        lockfile
 
 [testenv:docs]


### PR DESCRIPTION
Python >= 3.2 provides `match_hostname` functionality in the `ssl` module starting from Python 3.2.

With this change we now use native functionality on those versions and only require and use `backports.ssl_match_hostname` on Python < 3.2.
