### PR TITLE
Add VolumeSnapshot.created attribute

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,13 @@ General
 Compute
 ~~~~~~~
 
+- VolumeSnapshots now have a `created` attribute that is a `datetime`
+  field showing the creation datetime of the snapshot. The field in
+  VolumeSnapshot.extra containing the original string is maintained, so
+  this is a backwards-compatible change.
+  (GITHUB-473)
+  [Allard Hoeve]
+
 - Improve GCE create_node, make sure ex_get_disktype function
   (GITHUB-448)
   [Markos Gogoulos]

--- a/docs/upgrade_notes.rst
+++ b/docs/upgrade_notes.rst
@@ -5,6 +5,15 @@ This page describes how to upgrade from a previous version to a new version
 which contains backward incompatible or semi-incompatible changes and how to
 preserve the old behavior when this is possible.
 
+Development
+-----------
+
+* VolumeSnapshots now have a `created` attribute that is a `datetime`
+  field showing the creation datetime of the snapshot. The field in
+  VolumeSnapshot.extra containing the original string is maintained, so
+  this is a backwards-compatible change.
+
+
 Libcloud 0.16.0
 ---------------
 

--- a/libcloud/compute/base.py
+++ b/libcloud/compute/base.py
@@ -545,12 +545,6 @@ class VolumeSnapshot(object):
     """
     A base VolumeSnapshot class to derive from.
     """
-    id = None
-    driver = None
-    size = None
-    extra = None
-    created = None
-
     def __init__(self, id, driver, size=None, extra=None, created=None):
         """
         VolumeSnapshot constructor.

--- a/libcloud/compute/base.py
+++ b/libcloud/compute/base.py
@@ -545,23 +545,38 @@ class VolumeSnapshot(object):
     """
     A base VolumeSnapshot class to derive from.
     """
-    def __init__(self, id, driver, size=None, extra=None):
+    id = None
+    driver = None
+    size = None
+    extra = None
+    created = None
+
+    def __init__(self, id, driver, size=None, extra=None, created=None):
         """
         VolumeSnapshot constructor.
 
         :param      id: Snapshot ID.
         :type       id: ``str``
 
+        :param      driver: The driver that represents a connection to the
+                            provider
+        :type       driver: `NodeDriver`
+
         :param      size: A snapshot size in GB.
         :type       size: ``int``
 
         :param      extra: Provider depends parameters for snapshot.
         :type       extra: ``dict``
+
+        :param      created: A datetime object that represents when the
+                             snapshot was created
+        :type       created: ``datetime.datetime``
         """
         self.id = id
         self.driver = driver
         self.size = size
         self.extra = extra or {}
+        self.created = created
 
     def destroy(self):
         """

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -4690,6 +4690,8 @@ class BaseEC2NodeDriver(NodeDriver):
                           namespace=NAMESPACE)
         size = findtext(element=element, xpath='volumeSize',
                         namespace=NAMESPACE)
+        created = parse_date(findtext(element=element, xpath='startTime',
+                             namespace=NAMESPACE))
 
         # Get our tags
         tags = self._get_resource_tags(element)
@@ -4707,7 +4709,7 @@ class BaseEC2NodeDriver(NodeDriver):
         extra['name'] = name
 
         return VolumeSnapshot(snapId, size=int(size),
-                              driver=self, extra=extra)
+                              driver=self, extra=extra, created=created)
 
     def _to_key_pairs(self, elems):
         key_pairs = [self._to_key_pair(elem=elem) for elem in elems]

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -33,6 +33,7 @@ from libcloud.compute.base import NodeSize, StorageVolume, VolumeSnapshot
 from libcloud.compute.base import UuidMixin
 from libcloud.compute.providers import Provider
 from libcloud.compute.types import NodeState
+from libcloud.utils.iso8601 import parse_date
 
 API_VERSION = 'v1'
 DEFAULT_TASK_COMPLETION_TIMEOUT = 180
@@ -485,10 +486,11 @@ class GCERegion(UuidMixin):
 
 
 class GCESnapshot(VolumeSnapshot):
-    def __init__(self, id, name, size, status, driver, extra=None):
+    def __init__(self, id, name, size, status, driver, extra=None,
+                 created=None):
         self.name = name
         self.status = status
-        super(GCESnapshot, self).__init__(id, driver, size, extra)
+        super(GCESnapshot, self).__init__(id, driver, size, extra, created)
 
 
 class GCETargetHttpProxy(UuidMixin):
@@ -5203,10 +5205,15 @@ n
             lic_objs = self._licenses_from_urls(licenses=snapshot['licenses'])
             extra['licenses'] = lic_objs
 
+        try:
+            created = parse_date(snapshot.get('creationTimestamp'))
+        except ValueError:
+            created = None
+
         return GCESnapshot(id=snapshot['id'], name=snapshot['name'],
                            size=snapshot['diskSizeGb'],
                            status=snapshot.get('status'), driver=self,
-                           extra=extra)
+                           extra=extra, created=created)
 
     def _to_storage_volume(self, volume):
         """

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -15,6 +15,7 @@
 """
 OpenStack driver
 """
+from libcloud.utils.iso8601 import parse_date
 
 try:
     import simplejson as json
@@ -2066,8 +2067,14 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
                  'description': description,
                  'status': status}
 
+        try:
+            created_dt = parse_date(created_at)
+        except ValueError:
+            created_dt = None
+
         snapshot = VolumeSnapshot(id=data['id'], driver=self,
-                                  size=data['size'], extra=extra)
+                                  size=data['size'], extra=extra,
+                                  created=created_dt)
         return snapshot
 
     def _to_size(self, api_flavor, price=None, bandwidth=None):

--- a/libcloud/compute/drivers/rackspace.py
+++ b/libcloud/compute/drivers/rackspace.py
@@ -22,6 +22,7 @@ from libcloud.compute.drivers.openstack import OpenStack_1_1_Connection,\
     OpenStack_1_1_NodeDriver
 
 from libcloud.common.rackspace import AUTH_URL
+from libcloud.utils.iso8601 import parse_date
 
 
 ENDPOINT_ARGS_MAP = {
@@ -215,9 +216,14 @@ class RackspaceNodeDriver(OpenStack_1_1_NodeDriver):
                  'description': api_node['displayDescription'],
                  'status': api_node['status']}
 
+        try:
+            created_td = parse_date(api_node['createdAt'])
+        except ValueError:
+            created_td = None
+
         snapshot = VolumeSnapshot(id=api_node['id'], driver=self,
                                   size=api_node['size'],
-                                  extra=extra)
+                                  extra=extra, created=created_td)
         return snapshot
 
     def _ex_connection_class_kwargs(self):

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -18,6 +18,7 @@ from __future__ import with_statement
 import os
 import sys
 from datetime import datetime
+from libcloud.utils.iso8601 import UTC
 
 from libcloud.utils.py3 import httplib
 
@@ -824,6 +825,8 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
         self.assertEqual('Test snapshot', snap.extra['name'])
         self.assertEqual(vol.id, snap.extra['volume_id'])
         self.assertEqual('pending', snap.extra['state'])
+        # 2013-08-15T16:22:30.000Z
+        self.assertEqual(datetime(2013, 8, 15, 16, 22, 30, tzinfo=UTC), snap.created)
 
     def test_list_snapshots(self):
         snaps = self.driver.list_snapshots()

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -19,6 +19,7 @@ import os
 import sys
 import unittest
 import datetime
+from libcloud.utils.iso8601 import UTC
 
 try:
     import simplejson as json
@@ -1396,7 +1397,12 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
 
         snapshots = self.driver.ex_list_snapshots()
         self.assertEqual(len(snapshots), 3)
+        self.assertEqual(snapshots[0].created, datetime.datetime(2012, 2, 29, 3, 50, 7, tzinfo=UTC))
+        self.assertEqual(snapshots[0].extra['created'], "2012-02-29T03:50:07Z")
         self.assertEqual(snapshots[0].extra['name'], 'snap-001')
+
+        # invalid date is parsed as None
+        assert snapshots[2].created is None
 
     def test_list_volume_snapshots(self):
         volume = self.driver.list_volumes()[0]

--- a/libcloud/test/compute/test_rackspace.py
+++ b/libcloud/test/compute/test_rackspace.py
@@ -117,6 +117,7 @@ class RackspaceNovaLonMockHttp(RackspaceNovaMockHttp):
                 httplib.responses[httplib.OK])
 
 
+# Does not derive from TestCase because it should not be used by setup.py test
 class BaseRackspaceNovaTestCase(object):
     conn_classes = (RackspaceNovaMockHttp, RackspaceNovaMockHttp)
     auth_url = 'https://auth.api.example.com'


### PR DESCRIPTION
One very important aspect of snapshots is when they are made, especially when used as historical backups. The field in VolumeSnapshot.extra that is used to represent this data varies between OS, EC2, GCE and Rackspace. Also, EC2 boasts a `datetime` value in `extra`, while OpenStack and derivatives use a plain string.

This PR adds a `created` attribute to VolumeSnapshot, that is a parsed date. This unified all implementations.
