### PR TITLE
Allow testing using nosetests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [wheel]
 universal = 1
+
+[nosetests]
+exclude=TestCaseMixin


### PR DESCRIPTION
Nosetests tried to execute all imported `TestCaseMixin`s. This patch lets it skip all `TestCaseMixin` base classes that are imported.

Yes, we test using tox, but nosetests is a superior test runner in that it let's you run a subset of the tests. Also, peoples preferences will vary.

Tox also allows a subset to be run by passing arguments on to `setup.py`, but our `setup.py` does not support the `-s` flag.
