### PR TITLE
Add state attribute to StorageVolume

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,18 @@ Compute
   (GITHUB-488, LIBCLOUD-682)
   [Greg Hill]
 
+- StorageVolume objects now have an attribute `state` that holds a
+  state variable that is standardized state across drivers. Drivers that
+  currently support the `state` attribute are OpenStack and EC2.
+  StorageVolume objects returned by drivers that do not support the
+  attribute will have a `state` of `None`. When a provider returns a state
+  that is unknown to the driver, the state will be `UNKNOWN`. Please report
+  such states. A couple of drivers already put state fields in the `extra`
+  fields of StorageVolumes. These fields were kept for
+  backwards-compatibility and for reference.
+  (GITHUB-476)
+  [Allard Hoeve]
+
 - StorageVolume objects on EC2 and OpenStack now have a key called snapshot_id
   in their extra dicts containing the snapshot ID the volume was based on.
   (GITHUB-479)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,10 +25,17 @@ Compute
   (GITHUB-479)
   [Allard Hoeve]
 
+- OpenStack driver: deprecated ex_create_snapshot and ex_delete_snapshot in 
+  favor of create_volume_snapshot and destroy_volume_snapshot. Updated base 
+  driver method create_storage_volume argument name to be optional.
+  (GITHUB-478)
+  [Allard Hoeve]
+
 - Add support for creating volumes based on snapshots to EC2 and OS drivers.
   Also modify signature of base NodeDriver.create_volume to reflect the fact
   that all drivers expect a StorageSnapshot object as the snapshot argument.
   (GITHUB-467, LIBCLOUD-672)
+  [Allard Hoeve]
 
 - VolumeSnapshots now have a `created` attribute that is a `datetime`
   field showing the creation datetime of the snapshot. The field in

--- a/docs/upgrade_notes.rst
+++ b/docs/upgrade_notes.rst
@@ -20,6 +20,16 @@ Development
   VolumeSnapshot.extra containing the original string is maintained, so
   this is a backwards-compatible change.
 
+* The OpenStack compute driver methods ex_create_snapshot and
+  ex_delete_snapshot are now deprecated by the standard methods
+  create_volume_snapshot and destroy_volume_snapshot. You should update your
+  code.
+
+* The compute base driver now considers the name argument to
+  create_volume_snapshot to be optional. All official implementations of this
+  methods already considered it optional. You should update any custom
+  drivers if they rely on the name being mandatory.
+
 Libcloud 0.16.0
 ---------------
 

--- a/libcloud/compute/base.py
+++ b/libcloud/compute/base.py
@@ -1016,9 +1016,15 @@ class NodeDriver(BaseDriver):
         raise NotImplementedError(
             'create_volume not implemented for this driver')
 
-    def create_volume_snapshot(self, volume, name):
+    def create_volume_snapshot(self, volume, name=None):
         """
         Creates a snapshot of the storage volume.
+
+        :param volume: The StorageVolume to create a VolumeSnapshot from
+        :type volume: :class:`.VolumeSnapshot`
+
+        :param name: Name of created snapshot (optional)
+        :type name: `str`
 
         :rtype: :class:`VolumeSnapshot`
         """
@@ -1070,6 +1076,9 @@ class NodeDriver(BaseDriver):
     def destroy_volume_snapshot(self, snapshot):
         """
         Destroys a snapshot.
+
+        :param snapshot: The snapshot to delete
+        :type snapshot: :class:`VolumeSnapshot`
 
         :rtype: :class:`bool`
         """

--- a/libcloud/compute/base.py
+++ b/libcloud/compute/base.py
@@ -30,7 +30,8 @@ from libcloud.utils.py3 import b
 
 import libcloud.compute.ssh
 from libcloud.pricing import get_size_price
-from libcloud.compute.types import NodeState, DeploymentError
+from libcloud.compute.types import NodeState, StorageVolumeState,\
+    DeploymentError
 from libcloud.compute.ssh import SSHClient
 from libcloud.common.base import ConnectionKey
 from libcloud.common.base import BaseDriver
@@ -68,6 +69,7 @@ __all__ = [
     'NodeDriver',
 
     'StorageVolume',
+    'StorageVolumeState',
     'VolumeSnapshot',
 
     # Deprecated, moved to libcloud.utils.networking
@@ -460,7 +462,8 @@ class StorageVolume(UuidMixin):
     A base StorageVolume class to derive from.
     """
 
-    def __init__(self, id, name, size, driver, extra=None):
+    def __init__(self, id, name, size, driver,
+                 state=None, extra=None):
         """
         :param id: Storage volume ID.
         :type id: ``str``
@@ -474,6 +477,10 @@ class StorageVolume(UuidMixin):
         :param driver: Driver this image belongs to.
         :type driver: :class:`.NodeDriver`
 
+        :param state: Optional state of the StorageVolume. If not
+                      provided, will default to UNKNOWN.
+        :type state: :class:`.StorageVolumeState`
+
         :param extra: Optional provider specific attributes.
         :type extra: ``dict``
         """
@@ -482,6 +489,7 @@ class StorageVolume(UuidMixin):
         self.size = size
         self.driver = driver
         self.extra = extra
+        self.state = state
         UuidMixin.__init__(self)
 
     def list_snapshots(self):

--- a/libcloud/compute/drivers/cloudstack.py
+++ b/libcloud/compute/drivers/cloudstack.py
@@ -3577,12 +3577,16 @@ class CloudStackNodeDriver(CloudStackDriverMixIn, NodeDriver):
             list_snapshots.append(self._to_snapshot(snap))
         return list_snapshots
 
-    def create_volume_snapshot(self, volume):
+    def create_volume_snapshot(self, volume, name=None):
         """
         Create snapshot from volume
 
         :param      volume: Instance of ``StorageVolume``
         :type       volume: ``StorageVolume``
+
+        :param      name: The name of the snapshot is disregarded
+                          by CloudStack drivers
+        :type       name: `str`
 
         :rtype: :class:`VolumeSnapshot`
         """
@@ -3592,14 +3596,6 @@ class CloudStackNodeDriver(CloudStackDriverMixIn, NodeDriver):
         return self._to_snapshot(snapshot['snapshot'])
 
     def destroy_volume_snapshot(self, snapshot):
-        """
-        Destroy snapshot
-
-        :param      snapshot: Instance of ``VolumeSnapshot``
-        :type       volume: ``VolumeSnapshot``
-
-        :rtype: ``bool``
-        """
         self._async_request(command='deleteSnapshot',
                             params={'id': snapshot.id},
                             method='GET')

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -2422,7 +2422,7 @@ class BaseEC2NodeDriver(NodeDriver):
         :param      volume: Instance of ``StorageVolume``
         :type       volume: ``StorageVolume``
 
-        :param      name: Name of snapshot
+        :param      name: Name of snapshot (optional)
         :type       name: ``str``
 
         :rtype: :class:`VolumeSnapshot`
@@ -3445,7 +3445,8 @@ class BaseEC2NodeDriver(NodeDriver):
         Create tags for a resource (Node or StorageVolume).
 
         :param resource: Resource to be tagged
-        :type resource: :class:`Node` or :class:`StorageVolume`
+        :type resource: :class:`Node` or :class:`StorageVolume` or
+                        :class:`VolumeSnapshot`
 
         :param tags: A dictionary or other mapping of strings to strings,
                      associating tag names with tag values.

--- a/libcloud/compute/drivers/ibm_sce.py
+++ b/libcloud/compute/drivers/ibm_sce.py
@@ -711,7 +711,7 @@ class IBMNodeDriver(NodeDriver):
                              object.findtext('Name'),
                              object.findtext('Size'),
                              self.connection.driver,
-                             extra)
+                             extra=extra)
 
     def _to_volume_offerings(self, object):
         return [self._to_volume_offering(iType) for iType in

--- a/libcloud/compute/types.py
+++ b/libcloud/compute/types.py
@@ -223,6 +223,21 @@ class NodeState(object):
         return getattr(cls, value.upper(), None)
 
 
+class StorageVolumeState(object):
+    """
+    Standard states of a StorageVolume
+    """
+    AVAILABLE = 0
+    ERROR = 1
+    INUSE = 2
+    CREATING = 3
+    DELETING = 4
+    DELETED = 5
+    BACKUP = 6
+    ATTACHING = 7
+    UNKNOWN = 8
+
+
 class Architecture(object):
     """
     Image and size architectures.

--- a/libcloud/test/compute/fixtures/ec2/describe_volumes.xml
+++ b/libcloud/test/compute/fixtures/ec2/describe_volumes.xml
@@ -15,7 +15,7 @@
             <size>11</size>
             <snapshotId/>
             <availabilityZone>us-east-1c</availabilityZone>
-            <status>available</status>
+            <status>in-use</status>
             <createTime>2013-10-08T19:36:49.000Z</createTime>
             <attachmentSet/>
         </item>
@@ -24,7 +24,7 @@
             <size>8</size>
             <snapshotId>snap-30d37269</snapshotId>
             <availabilityZone>us-east-1d</availabilityZone>
-            <status>in-use</status>
+            <status>some-unknown-status</status>
             <createTime>2013-06-25T02:04:12.000Z</createTime>
             <attachmentSet>
                 <item>

--- a/libcloud/test/compute/fixtures/openstack_v1.1/_os_volumes.json
+++ b/libcloud/test/compute/fixtures/openstack_v1.1/_os_volumes.json
@@ -32,7 +32,7 @@
             "metadata": {},
             "size": 50,
             "snapshotId": "01f48111-7866-4cd2-986a-e92683c4a363",
-            "status": "available",
+            "status": "some-unknown-state",
             "volumeType": "None"
         }
     ]

--- a/libcloud/test/compute/test_base.py
+++ b/libcloud/test/compute/test_base.py
@@ -18,8 +18,9 @@ import unittest
 from libcloud.common.base import Response
 from libcloud.common.base import Connection, ConnectionKey, ConnectionUserAndKey
 from libcloud.common.types import LibcloudError
-from libcloud.compute.base import Node, NodeSize, NodeImage, NodeDriver
+from libcloud.compute.base import Node, NodeSize, NodeImage, NodeDriver, StorageVolume
 from libcloud.compute.base import NodeAuthSSHKey, NodeAuthPassword
+from libcloud.compute.types import StorageVolumeState
 
 from libcloud.test import MockResponse           # pylint: disable-msg=E0611
 
@@ -40,6 +41,9 @@ class BaseTests(unittest.TestCase):
 
     def test_base_node_image(self):
         NodeImage(id=0, name=0, driver=FakeDriver())
+
+    def test_base_storage_volume(self):
+        StorageVolume(id="0", name="0", size=10, driver=FakeDriver(), state=StorageVolumeState.AVAILABLE)
 
     def test_base_response(self):
         Response(MockResponse(status=200, body='foo'), ConnectionKey('foo'))

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -1433,6 +1433,18 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
         self.assertEqual(len(snapshots), 1)
         self.assertEqual(snapshots[0].id, '4fbbdccf-e058-6502-8844-6feeffdf4cb5')
 
+    def test_create_volume_snapshot(self):
+        volume = self.driver.list_volumes()[0]
+        if self.driver_type.type == 'rackspace':
+            self.conn_classes[0].type = 'RACKSPACE'
+            self.conn_classes[1].type = 'RACKSPACE'
+
+        ret = self.driver.create_volume_snapshot(volume,
+                                                 'Test Volume',
+                                                 ex_description='This is a test',
+                                                 ex_force=True)
+        self.assertEqual(ret.id, '3fbbcccf-d058-4502-8844-6feeffdf4cb5')
+
     def test_ex_create_snapshot(self):
         volume = self.driver.list_volumes()[0]
         if self.driver_type.type == 'rackspace':
@@ -1441,8 +1453,18 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
 
         ret = self.driver.ex_create_snapshot(volume,
                                              'Test Volume',
-                                             'This is a test')
+                                             description='This is a test',
+                                             force=True)
         self.assertEqual(ret.id, '3fbbcccf-d058-4502-8844-6feeffdf4cb5')
+
+    def test_destroy_volume_snapshot(self):
+        if self.driver_type.type == 'rackspace':
+            self.conn_classes[0].type = 'RACKSPACE'
+            self.conn_classes[1].type = 'RACKSPACE'
+
+        snapshot = self.driver.ex_list_snapshots()[0]
+        ret = self.driver.destroy_volume_snapshot(snapshot)
+        self.assertTrue(ret)
 
     def test_ex_delete_snapshot(self):
         if self.driver_type.type == 'rackspace':

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -34,7 +34,7 @@ from libcloud.utils.py3 import u
 
 from libcloud.common.types import InvalidCredsError, MalformedResponseError, \
     LibcloudError
-from libcloud.compute.types import Provider, KeyPairDoesNotExistError
+from libcloud.compute.types import Provider, KeyPairDoesNotExistError, StorageVolumeState
 from libcloud.compute.providers import get_driver
 from libcloud.compute.drivers.openstack import (
     OpenStack_1_0_NodeDriver, OpenStack_1_0_Response,
@@ -794,6 +794,7 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
 
         self.assertEqual('cd76a3a1-c4ce-40f6-9b9f-07a61508938d', volume.id)
         self.assertEqual('test_volume_2', volume.name)
+        self.assertEqual(StorageVolumeState.AVAILABLE, volume.state)
         self.assertEqual(2, volume.size)
         self.assertEqual(volume.extra, {
             'description': '',
@@ -811,15 +812,17 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
             'created_at': '2013-06-24T11:20:13.000000',
         })
 
+        # also test that unknown state resolves to StorageVolumeState.UNKNOWN
         volume = volumes[1]
         self.assertEqual('cfcec3bc-b736-4db5-9535-4c24112691b5', volume.id)
         self.assertEqual('test_volume', volume.name)
         self.assertEqual(50, volume.size)
+        self.assertEqual(StorageVolumeState.UNKNOWN, volume.state)
         self.assertEqual(volume.extra, {
             'description': 'some description',
             'attachments': [],
             'snapshot_id': '01f48111-7866-4cd2-986a-e92683c4a363',
-            'state': 'available',
+            'state': 'some-unknown-state',
             'location': 'nova',
             'volume_type': 'None',
             'metadata': {},


### PR DESCRIPTION
1. Currently, volume state is defined by the driver in a key in `extra`. This key varies between drivers. Also, the value varies between drivers.
2. However, it is a commonly accessed attribute that should be unified across drivers, just as `Node` state is unified in `NodeState`.
3. This PR does exactly that.

Some caveats:
1. Except for OS and EC2, all other drivers return StorageVolume objects with state `UNKNOWN`.
   1. I have no access to GCE.
   2. I could find no exhaustive list of GCE disk states.
   3. The same holds for all the other drivers.
   4. I do not think this is a problem, because the instance variable does not currently exist at all :wink: 

UPDATE: GCE list is here: https://cloud.google.com/compute/docs/reference/latest/disks#resource

```
Acceptable values are:
"CREATING": The disk is being created.
"FAILED": The disk failed to be created.
"READY": The disk is ready to use.
"RESTORING": The disk is being restored from either a snapshot or an image.
```
