### PR TITLE
Implement create_ and destroy_volume_snapshot for OS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,10 +25,17 @@ Compute
   (GITHUB-479)
   [Allard Hoeve]
 
+- OpenStack driver: deprecated ex_create_snapshot and ex_delete_snapshot in 
+  favor of create_volume_snapshot and destroy_volume_snapshot. Updated base 
+  driver method create_storage_volume argument name to be optional.
+  (GITHUB-478)
+  [Allard Hoeve]
+
 - Add support for creating volumes based on snapshots to EC2 and OS drivers.
   Also modify signature of base NodeDriver.create_volume to reflect the fact
   that all drivers expect a StorageSnapshot object as the snapshot argument.
   (GITHUB-467, LIBCLOUD-672)
+  [Allard Hoeve]
 
 - VolumeSnapshots now have a `created` attribute that is a `datetime`
   field showing the creation datetime of the snapshot. The field in

--- a/docs/upgrade_notes.rst
+++ b/docs/upgrade_notes.rst
@@ -20,6 +20,16 @@ Development
   VolumeSnapshot.extra containing the original string is maintained, so
   this is a backwards-compatible change.
 
+* The OpenStack compute driver methods ex_create_snapshot and
+  ex_delete_snapshot are now deprecated by the standard methods
+  create_volume_snapshot and destroy_volume_snapshot. You should update your
+  code.
+
+* The compute base driver now considers the name argument to
+  create_volume_snapshot to be optional. All official implementations of this
+  methods already considered it optional. You should update any custom
+  drivers if they rely on the name being mandatory.
+
 Libcloud 0.16.0
 ---------------
 

--- a/libcloud/compute/base.py
+++ b/libcloud/compute/base.py
@@ -1016,9 +1016,15 @@ class NodeDriver(BaseDriver):
         raise NotImplementedError(
             'create_volume not implemented for this driver')
 
-    def create_volume_snapshot(self, volume, name):
+    def create_volume_snapshot(self, volume, name=None):
         """
         Creates a snapshot of the storage volume.
+
+        :param volume: The StorageVolume to create a VolumeSnapshot from
+        :type volume: :class:`.VolumeSnapshot`
+
+        :param name: Name of created snapshot (optional)
+        :type name: `str`
 
         :rtype: :class:`VolumeSnapshot`
         """
@@ -1070,6 +1076,9 @@ class NodeDriver(BaseDriver):
     def destroy_volume_snapshot(self, snapshot):
         """
         Destroys a snapshot.
+
+        :param snapshot: The snapshot to delete
+        :type snapshot: :class:`VolumeSnapshot`
 
         :rtype: :class:`bool`
         """

--- a/libcloud/compute/drivers/cloudstack.py
+++ b/libcloud/compute/drivers/cloudstack.py
@@ -3577,12 +3577,16 @@ class CloudStackNodeDriver(CloudStackDriverMixIn, NodeDriver):
             list_snapshots.append(self._to_snapshot(snap))
         return list_snapshots
 
-    def create_volume_snapshot(self, volume):
+    def create_volume_snapshot(self, volume, name=None):
         """
         Create snapshot from volume
 
         :param      volume: Instance of ``StorageVolume``
         :type       volume: ``StorageVolume``
+
+        :param      name: The name of the snapshot is disregarded
+                          by CloudStack drivers
+        :type       name: `str`
 
         :rtype: :class:`VolumeSnapshot`
         """
@@ -3592,14 +3596,6 @@ class CloudStackNodeDriver(CloudStackDriverMixIn, NodeDriver):
         return self._to_snapshot(snapshot['snapshot'])
 
     def destroy_volume_snapshot(self, snapshot):
-        """
-        Destroy snapshot
-
-        :param      snapshot: Instance of ``VolumeSnapshot``
-        :type       volume: ``VolumeSnapshot``
-
-        :rtype: ``bool``
-        """
         self._async_request(command='deleteSnapshot',
                             params={'id': snapshot.id},
                             method='GET')

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -2422,7 +2422,7 @@ class BaseEC2NodeDriver(NodeDriver):
         :param      volume: Instance of ``StorageVolume``
         :type       volume: ``StorageVolume``
 
-        :param      name: Name of snapshot
+        :param      name: Name of snapshot (optional)
         :type       name: ``str``
 
         :rtype: :class:`VolumeSnapshot`
@@ -3445,7 +3445,8 @@ class BaseEC2NodeDriver(NodeDriver):
         Create tags for a resource (Node or StorageVolume).
 
         :param resource: Resource to be tagged
-        :type resource: :class:`Node` or :class:`StorageVolume`
+        :type resource: :class:`Node` or :class:`StorageVolume` or
+                        :class:`VolumeSnapshot`
 
         :param tags: A dictionary or other mapping of strings to strings,
                      associating tag names with tag values.

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -1433,6 +1433,18 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
         self.assertEqual(len(snapshots), 1)
         self.assertEqual(snapshots[0].id, '4fbbdccf-e058-6502-8844-6feeffdf4cb5')
 
+    def test_create_volume_snapshot(self):
+        volume = self.driver.list_volumes()[0]
+        if self.driver_type.type == 'rackspace':
+            self.conn_classes[0].type = 'RACKSPACE'
+            self.conn_classes[1].type = 'RACKSPACE'
+
+        ret = self.driver.create_volume_snapshot(volume,
+                                                 'Test Volume',
+                                                 ex_description='This is a test',
+                                                 ex_force=True)
+        self.assertEqual(ret.id, '3fbbcccf-d058-4502-8844-6feeffdf4cb5')
+
     def test_ex_create_snapshot(self):
         volume = self.driver.list_volumes()[0]
         if self.driver_type.type == 'rackspace':
@@ -1441,8 +1453,18 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
 
         ret = self.driver.ex_create_snapshot(volume,
                                              'Test Volume',
-                                             'This is a test')
+                                             description='This is a test',
+                                             force=True)
         self.assertEqual(ret.id, '3fbbcccf-d058-4502-8844-6feeffdf4cb5')
+
+    def test_destroy_volume_snapshot(self):
+        if self.driver_type.type == 'rackspace':
+            self.conn_classes[0].type = 'RACKSPACE'
+            self.conn_classes[1].type = 'RACKSPACE'
+
+        snapshot = self.driver.ex_list_snapshots()[0]
+        ret = self.driver.destroy_volume_snapshot(snapshot)
+        self.assertTrue(ret)
 
     def test_ex_delete_snapshot(self):
         if self.driver_type.type == 'rackspace':


### PR DESCRIPTION
The OS driver currently implements `ex_create_snapshot` and `ex_delete_snapshot` instead of `create_volume_snapshot` and `delete_volume_snapshot`. This PR fixes that.
- Add `libcloud.compute.drivers.openstack.create_volume_snapshot`.
- Add `libcloud.compute.drivers.openstack.destroy_volume_snapshot`.
- Clean up base signature to match current implementations: the name argument is considered optional by all drivers that use the signature.
- The CloudStack signature was breaking contract by not accepting the `name` argument.
- Documented that CloudStack disregards any name given to a new snapshot even though it accepts the argument.
- Fixed a lot of docstrings.
- Removes superfluous docstrings that matched the base docstring.
