### PR TITLE
Add snapshotid to ec2 and os volumes extra

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,11 @@ General
 Compute
 ~~~~~~~
 
+- StorageVolume objects on EC2 and OpenStack now have a key called snapshot_id
+  in their extra dicts containing the snapshot ID the volume was based on.
+  (GITHUB-479)
+  [Allard Hoeve]
+
 - Add support for creating volumes based on snapshots to EC2 and OS drivers.
   Also modify signature of base NodeDriver.create_volume to reflect the fact
   that all drivers expect a StorageSnapshot object as the snapshot argument.

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -1563,6 +1563,10 @@ RESOURCE_EXTRA_ATTRIBUTES_MAP = {
             'xpath': 'attachmentSet/item/device',
             'transform_func': str
         },
+        'snapshot_id': {
+            'xpath': 'snapshotId',
+            'transform_func': lambda v: str(v) or None
+        },
         'iops': {
             'xpath': 'iops',
             'transform_func': int

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -2064,6 +2064,7 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
                 'description': api_node['displayDescription'],
                 'attachments': [att for att in api_node['attachments'] if att],
                 'state': api_node.get('status', None),
+                'snapshot_id': api_node.get('snapshotId', None),
                 'location': api_node.get('availabilityZone', None),
                 'volume_type': api_node.get('volumeType', None),
                 'metadata': api_node.get('metadata', None),

--- a/libcloud/test/compute/fixtures/openstack_v1.1/_os_volumes.json
+++ b/libcloud/test/compute/fixtures/openstack_v1.1/_os_volumes.json
@@ -31,7 +31,7 @@
             "id": "cfcec3bc-b736-4db5-9535-4c24112691b5",
             "metadata": {},
             "size": 50,
-            "snapshotId": null,
+            "snapshotId": "01f48111-7866-4cd2-986a-e92683c4a363",
             "status": "available",
             "volumeType": "None"
         }

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -776,12 +776,14 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
         self.assertEqual('vol-v24bfh75', volumes[1].id)
         self.assertEqual(11, volumes[1].size)
         self.assertEqual('available', volumes[1].extra['state'])
+        self.assertIsNone(volumes[1].extra['snapshot_id'])
 
         self.assertEqual('vol-b6c851ec', volumes[2].id)
         self.assertEqual(8, volumes[2].size)
         self.assertEqual('in-use', volumes[2].extra['state'])
         self.assertEqual('i-d334b4b3', volumes[2].extra['instance_id'])
         self.assertEqual('/dev/sda1', volumes[2].extra['device'])
+        self.assertEqual('snap-30d37269', volumes[2].extra['snapshot_id'])
 
     def test_create_volume(self):
         location = self.driver.list_locations()[0]

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -803,6 +803,7 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
                 "serverId": "12065",
                 "volumeId": "cd76a3a1-c4ce-40f6-9b9f-07a61508938d",
             }],
+            'snapshot_id': None,
             'state': 'available',
             'location': 'nova',
             'volume_type': 'None',
@@ -817,6 +818,7 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
         self.assertEqual(volume.extra, {
             'description': 'some description',
             'attachments': [],
+            'snapshot_id': '01f48111-7866-4cd2-986a-e92683c4a363',
             'state': 'available',
             'location': 'nova',
             'volume_type': 'None',


### PR DESCRIPTION
Add snapshot_id to `extra` dicts for StorageVolumes on EC2 and OpenStack.
