### PR TITLE
[LIBCLOUD-679] Add virtualmachine_id to CloudStackAddress

### DIFF
--- a/libcloud/compute/drivers/cloudstack.py
+++ b/libcloud/compute/drivers/cloudstack.py
@@ -474,15 +474,20 @@ class CloudStackAddress(object):
 
     :param      vpc_id: VPC the ip belongs to
     :type       vpc_id: ``str``
+
+    :param      virtualmachine_id: The ID of virutal machine this address
+                                   is assigned to
+    :type       virtualmachine_id: ``str``
     """
 
     def __init__(self, id, address, driver, associated_network_id=None,
-                 vpc_id=None):
+                 vpc_id=None, virtualmachine_id=None):
         self.id = id
         self.address = address
         self.driver = driver
         self.associated_network_id = associated_network_id
         self.vpc_id = vpc_id
+        self.virtualmachine_id = virtualmachine_id
 
     def release(self):
         self.driver.ex_release_public_ip(address=self)
@@ -2200,7 +2205,9 @@ class CloudStackNodeDriver(CloudStackDriverMixIn, NodeDriver):
             ips.append(CloudStackAddress(ip['id'],
                                          ip['ipaddress'],
                                          self,
-                                         ip.get('associatednetworkid', [])))
+                                         ip.get('associatednetworkid', []),
+                                         ip.get('vpcid'),
+                                         ip.get('virtualmachineid')))
 
         return ips
 

--- a/libcloud/test/compute/test_cloudstack.py
+++ b/libcloud/test/compute/test_cloudstack.py
@@ -774,6 +774,7 @@ class CloudStackCommonTestCase(TestCaseMixin):
     def test_ex_list_public_ips(self):
         ips = self.driver.ex_list_public_ips()
         self.assertEqual(ips[0].address, '1.1.1.116')
+        self.assertEqual(ips[0].virtualmachine_id, '2600')
 
     def test_ex_allocate_public_ip(self):
         addr = self.driver.ex_allocate_public_ip()


### PR DESCRIPTION
This patch adds virtualmachine_id attribute to CloudStackAddress class.
The virtualmachine_id can be used to point virtual machine the address is assigned to (ex. static nat).
