### PR TITLE
Consistent logic for dependencies resolution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,16 @@ from libcloud.utils.dist import get_packages, get_data_files
 
 libcloud.utils.misc.SHOW_DEPRECATION_WARNING = False
 
+# Different versions of python have different requirements.  We can't use
+# libcloud.utils.py3 here because it relies on backports dependency being
+# installed / available
+PY2 = sys.version_info.major == 2
+PY3 = sys.version_info.major == 3
+pre_PY25 = PY2 and sys.version_info < (2, 5)
+pre_PY26 = PY2 and sys.version_info < (2, 6)
+pre_PY279 = PY2 and sys.version_info < (2, 7, 9)
+pre_PY32 = PY3 and sys.version_info < (3, 2)
+post_PY27 = PY2 and sys.version_info >= (2, 7)
 
 HTML_VIEWSOURCE_BASE = 'https://svn.apache.org/viewvc/libcloud/trunk'
 PROJECT_BASE_DIR = 'http://libcloud.apache.org'
@@ -49,25 +59,19 @@ TEST_REQUIREMENTS = [
     'mock'
 ]
 
-if sys.version_info < (3, 2):
+if pre_PY279 or pre_PY32:
     TEST_REQUIREMENTS.append('backports.ssl_match_hostname')
 
-# Note: we can't use libcloud.utils.py3 here because it relies on backports
-# dependency being installed / available
-if sys.version_info >= (2, 7):
+if post_PY27 or PY3:
     unittest2_required = False
 else:
     unittest2_required = True
 
-if sys.version_info <= (2, 4):
+if pre_PY25:
     version = '.'.join([str(x) for x in sys.version_info[:3]])
     print('Version ' + version + ' is not supported. Supported versions are ' +
           ', '.join(SUPPORTED_VERSIONS))
     sys.exit(1)
-
-# pre-2.6 will need the ssl PyPI package
-pre_python26 = (sys.version_info[0] == 2 and sys.version_info[1] < 6)
-
 
 def read_version_string():
     version = None
@@ -146,7 +150,7 @@ class TestCommand(Command):
             print("Please copy the new secrets.py-dist file over otherwise" +
                   " tests might fail")
 
-        if pre_python26:
+        if pre_PY26:
             missing = []
             # test for dependencies
             try:
@@ -231,10 +235,10 @@ class CoverageCommand(Command):
 forbid_publish()
 
 install_requires = []
-if pre_python26:
+if pre_PY26:
     install_requires.extend(['ssl', 'simplejson'])
 
-if sys.version_info < (3, 2):
+if pre_PY279 or pre_PY32:
     install_requires.append('backports.ssl_match_hostname')
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -38,11 +38,11 @@ libcloud.utils.misc.SHOW_DEPRECATION_WARNING = False
 # installed / available
 PY2 = sys.version_info.major == 2
 PY3 = sys.version_info.major == 3
-pre_PY25 = PY2 and sys.version_info < (2, 5)
-pre_PY26 = PY2 and sys.version_info < (2, 6)
-pre_PY279 = PY2 and sys.version_info < (2, 7, 9)
-pre_PY32 = PY3 and sys.version_info < (3, 2)
-post_PY27 = PY2 and sys.version_info >= (2, 7)
+PY2_pre_25 = PY2 and sys.version_info < (2, 5)
+PY2_pre_26 = PY2 and sys.version_info < (2, 6)
+PY2_pre_27 = PY2 and sys.version_info < (2, 7)
+PY2_pre_279 = PY2 and sys.version_info < (2, 7, 9)
+PY3_pre_32 = PY3 and sys.version_info < (3, 2)
 
 HTML_VIEWSOURCE_BASE = 'https://svn.apache.org/viewvc/libcloud/trunk'
 PROJECT_BASE_DIR = 'http://libcloud.apache.org'
@@ -59,15 +59,15 @@ TEST_REQUIREMENTS = [
     'mock'
 ]
 
-if pre_PY279 or pre_PY32:
+if PY2_pre_279 or PY3_pre_32:
     TEST_REQUIREMENTS.append('backports.ssl_match_hostname')
 
-if post_PY27 or PY3:
-    unittest2_required = False
-else:
+if PY2_pre_27:
     unittest2_required = True
+else:
+    unittest2_required = False
 
-if pre_PY25:
+if PY2_pre_25:
     version = '.'.join([str(x) for x in sys.version_info[:3]])
     print('Version ' + version + ' is not supported. Supported versions are ' +
           ', '.join(SUPPORTED_VERSIONS))
@@ -150,7 +150,7 @@ class TestCommand(Command):
             print("Please copy the new secrets.py-dist file over otherwise" +
                   " tests might fail")
 
-        if pre_PY26:
+        if PY2_pre_26:
             missing = []
             # test for dependencies
             try:
@@ -235,10 +235,10 @@ class CoverageCommand(Command):
 forbid_publish()
 
 install_requires = []
-if pre_PY26:
+if PY2_pre_26:
     install_requires.extend(['ssl', 'simplejson'])
 
-if pre_PY279 or pre_PY32:
+if PY2_pre_279 or PY3_pre_32:
     install_requires.append('backports.ssl_match_hostname')
 
 setup(


### PR DESCRIPTION
Different versions of Python have different dependencies.  These differences
are parsed in various ways.  This pull request establishes a consistent method
for setting dependencies per version.

In addition, the code from `backports.ssl_match_hostname` has been merged into
the standard library in Python 2.7.9.  The condition for adding that dependency
now takes into account that fact.

https://www.python.org/downloads/release/python-279/

> The entirety of Python 3.4's ssl module has been backported for Python 2.7.9.
> See PEP 466 for justification.
