### PR TITLE
[LIBCLOUD-683] add optional extra fields to Openstack Node responses

### DIFF
--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -2083,9 +2083,11 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
             extra=dict(
                 hostId=api_node['hostId'],
                 access_ip=api_node.get('accessIPv4'),
+                access_ipv6=api_node.get('accessIPv6', None),
                 # Docs says "tenantId", but actual is "tenant_id". *sigh*
                 # Best handle both.
                 tenantId=api_node.get('tenant_id') or api_node['tenantId'],
+                userId=api_node.get('user_id', None),
                 imageId=image_id,
                 flavorId=api_node['flavor']['id'],
                 uri=next(link['href'] for link in api_node['links'] if
@@ -2099,6 +2101,10 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
                 config_drive=config_drive,
                 availability_zone=api_node.get('OS-EXT-AZ:availability_zone'),
                 volumes_attached=volumes_attached,
+                task_state=api_node.get("OS-EXT-STS:task_state", None),
+                vm_state=api_node.get("OS-EXT-STS:vm_state", None),
+                power_state=api_node.get("OS-EXT-STS:power_state", None),
+                progress=api_node.get("progress", None),
             ),
         )
 

--- a/libcloud/test/compute/fixtures/openstack_v1.1/_servers_detail.json
+++ b/libcloud/test/compute/fixtures/openstack_v1.1/_servers_detail.json
@@ -88,7 +88,10 @@
             "config_drive": "",
             "id": 12065,
             "metadata": {},
-            "OS-DCF:diskConfig": "AUTO"
+            "OS-DCF:diskConfig": "AUTO",
+            "OS-EXT-STS:task_state": "spawning",
+            "OS-EXT-STS:vm_state": "active",
+            "OS-EXT-STS:power_state": 1
         },
         {
             "status": "ACTIVE",
@@ -156,7 +159,10 @@
             "config_drive": "",
             "id": 12064,
             "metadata": {},
-            "OS-DCF:diskConfig": "AUTO"
+            "OS-DCF:diskConfig": "AUTO",
+            "OS-EXT-STS:task_state": "spawning",
+            "OS-EXT-STS:vm_state": "active",
+            "OS-EXT-STS:power_state": 1
         }
     ]
 }

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -237,6 +237,7 @@ class OpenStack_1_0_Tests(unittest.TestCase, TestCaseMixin):
         self.assertEqual(node.extra.get('flavorId'), '1')
         self.assertEqual(node.extra.get('imageId'), '11')
         self.assertEqual(type(node.extra.get('metadata')), type(dict()))
+
         OpenStackMockHttp.type = 'METADATA'
         ret = self.driver.list_nodes()
         self.assertEqual(len(ret), 1)
@@ -778,6 +779,15 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
         self.assertEqual(node.extra.get('metadata'), {})
         self.assertEqual(node.extra['updated'], '2011-10-11T00:50:04Z')
         self.assertEqual(node.extra['created'], '2011-10-11T00:51:39Z')
+        self.assertEqual(node.extra.get('userId'), 'rs-reach')
+        self.assertEqual(node.extra.get('hostId'), '912566d83a13fbb357ea'
+                                                   '3f13c629363d9f7e1ba3f'
+                                                   '925b49f3d2ab725')
+        self.assertEqual(node.extra.get('disk_config'), 'AUTO')
+        self.assertEqual(node.extra.get('task_state'), 'spawning')
+        self.assertEqual(node.extra.get('vm_state'), 'active')
+        self.assertEqual(node.extra.get('power_state'), 1)
+        self.assertEqual(node.extra.get('progress'), 25)
 
     def test_list_nodes_no_image_id_attribute(self):
         # Regression test for LIBCLOD-455


### PR DESCRIPTION
Several fields utilized by Rackspace Public Cloud were
not being returned.  A few of them are from Openstack
core, and some are from extensions used by Rackspace.
