### PR TITLE
Fix bug LIBCLOUD-635 - openstack-swift auth v2

### DIFF
--- a/libcloud/storage/drivers/cloudfiles.py
+++ b/libcloud/storage/drivers/cloudfiles.py
@@ -138,8 +138,8 @@ class OpenStackSwiftConnection(OpenStackBaseConnection):
             endpoint = self.service_catalog.get_endpoint(
                 name=self._service_name, region=self._service_region)
 
-        if PUBLIC_ENDPOINT_KEY in endpoint:
-            return endpoint[PUBLIC_ENDPOINT_KEY]
+        if endpoint:
+            return endpoint.url
         else:
             raise LibcloudError('Could not find specified endpoint')
 


### PR DESCRIPTION
As reported by James in LIBCLOUD-635
https://issues.apache.org/jira/browse/LIBCLOUD-635

OpenStack-Swift authentication is broken from at least
 0.16. I confirmed the bug in 0.17 and master.

the code here tries to perform operations on a
OpenStackServiceCatalogEntryEndpoint that cannot
be performed on this class.

Since get_endpoint() will return an endpoint with
a URL (not 3 different URLs: publicURL/internalURL/
adminURL) or error, it should be safe to test for
existence and use the url. However, review very
welcome!

This fix has been tested against OpenStack Juno.
