### PR TITLE
Support diskSizeGb and local SSD when creating an instance on GCE

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -2216,11 +2216,12 @@ n
                 ex_disks_gce_struct[0]['initializeParams']['diskSizeGb'] = \
                     ex_boot_disk_size_gb
             if ex_with_local_ssd:
-                disk_type_local_ssd = self.ex_get_disktype('local-ssd', zone=location)
+                disk_type_local_ssd = self.ex_get_disktype('local-ssd',
+                                                           zone=location)
                 ex_disks_gce_struct.append(
                     {
                         "type": "SCRATCH",
-                        "initializeParams":{
+                        "initializeParams": {
                             "diskType": disk_type_local_ssd.extra['selfLink']
                         },
                         "autoDelete": True,

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -2049,7 +2049,7 @@ class GCENodeDriver(NodeDriver):
     def create_node(self, name, size, image, location=None,
                     ex_network='default', ex_tags=None, ex_metadata=None,
                     ex_boot_disk=None, use_existing_disk=True,
-                    ex_boot_disk_size_gb=None, ex_with_local_ssd=False,
+                    ex_boot_disk_size_gb=None, ex_with_local_ssd=None,
                     external_ip='ephemeral', ex_disk_type='pd-standard',
                     ex_disk_auto_delete=True, ex_service_accounts=None,
                     description=None, ex_can_ip_forward=None,
@@ -2178,6 +2178,9 @@ n
                              "'image', existing 'ex_boot_disk', or use the "
                              "'ex_disks_gce_struct'.")
 
+        if ex_with_local_ssd not in {None, 'SCSI', 'NVME'}:
+            raise ValueError("ex_with_local_ssd must be one of SCSI or NVME")
+
         location = location or self.zone
         if not hasattr(location, 'name'):
             location = self.ex_get_zone(location)
@@ -2217,7 +2220,8 @@ n
                             "diskType": disk_type_local_ssd.extra['selfLink']
                         },
                         "autoDelete": True,
-                        "interface": "NVME"
+                        "interface": ex_with_local_ssd
+
                     }
 
                 )

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -2049,6 +2049,7 @@ class GCENodeDriver(NodeDriver):
     def create_node(self, name, size, image, location=None,
                     ex_network='default', ex_tags=None, ex_metadata=None,
                     ex_boot_disk=None, use_existing_disk=True,
+                    ex_boot_disk_size_gb=10,
                     external_ip='ephemeral', ex_disk_type='pd-standard',
                     ex_disk_auto_delete=True, ex_service_accounts=None,
                     description=None, ex_can_ip_forward=None,
@@ -2087,6 +2088,10 @@ class GCENodeDriver(NodeDriver):
                                      same name/location is found, use that
                                      disk instead of creating a new one.
         :type     use_existing_disk: ``bool``
+
+        :keyword  ex_boot_disk_size_gb: The size of the boot disk when creating
+                                        a new one.
+        :type     ex_boot_disk_size_gb: ``int`` or ``None``
 
         :keyword  external_ip: The external IP address to use.  If 'ephemeral'
                                (default), a new non-static address will be
@@ -2196,7 +2201,8 @@ n
                 'initializeParams': {
                     'diskName': name,
                     'diskType': ex_disk_type.extra['selfLink'],
-                    'sourceImage': image.extra['selfLink']
+                    'sourceImage': image.extra['selfLink'],
+                    'diskSizeGb': ex_boot_disk_size_gb
                 }
             }]
 

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -2204,8 +2204,7 @@ n
                 'initializeParams': {
                     'diskName': name,
                     'diskType': ex_disk_type.extra['selfLink'],
-                    'sourceImage': image.extra['selfLink'],
-                    'diskSizeGb': ex_boot_disk_size_gb
+                    'sourceImage': image.extra['selfLink']
                 }
             }]
             if ex_boot_disk_size_gb:

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -2049,7 +2049,7 @@ class GCENodeDriver(NodeDriver):
     def create_node(self, name, size, image, location=None,
                     ex_network='default', ex_tags=None, ex_metadata=None,
                     ex_boot_disk=None, use_existing_disk=True,
-                    ex_boot_disk_size_gb=10,
+                    ex_boot_disk_size_gb=None, ex_with_local_ssd=False,
                     external_ip='ephemeral', ex_disk_type='pd-standard',
                     ex_disk_auto_delete=True, ex_service_accounts=None,
                     description=None, ex_can_ip_forward=None,
@@ -2205,6 +2205,22 @@ n
                     'diskSizeGb': ex_boot_disk_size_gb
                 }
             }]
+            if ex_boot_disk_size_gb:
+                ex_disks_gce_struct[0]['initializeParams']['diskSizeGb'] = \
+                    ex_boot_disk_size_gb
+            if ex_with_local_ssd:
+                disk_type_local_ssd = self.ex_get_disktype('local-ssd', zone=location)
+                ex_disks_gce_struct.append(
+                    {
+                        "type": "SCRATCH",
+                        "initializeParams":{
+                            "diskType": disk_type_local_ssd
+                        },
+                        "autoDelete": True,
+                        "interface": "NVME"
+                    }
+
+                )
 
         request, node_data = self._create_node_req(name, size, image,
                                                    location, ex_network,

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -2093,6 +2093,11 @@ class GCENodeDriver(NodeDriver):
                                         a new one.
         :type     ex_boot_disk_size_gb: ``int`` or ``None``
 
+        :keyword  ex_with_local_ssd: If set, specify to attach a local SSD to
+                                     the instance and which interface ot use:
+                                     'SCSI' or 'NVME'.
+        :type     ex_with_local_ssd: ``str`` or ``None``
+
         :keyword  external_ip: The external IP address to use.  If 'ephemeral'
                                (default), a new non-static address will be
                                used.  If 'None', then no external address will

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -2214,7 +2214,7 @@ n
                     {
                         "type": "SCRATCH",
                         "initializeParams":{
-                            "diskType": disk_type_local_ssd
+                            "diskType": disk_type_local_ssd.extra['selfLink']
                         },
                         "autoDelete": True,
                         "interface": "NVME"

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -2183,7 +2183,7 @@ n
                              "'image', existing 'ex_boot_disk', or use the "
                              "'ex_disks_gce_struct'.")
 
-        if ex_with_local_ssd and ex_with_local_ssd not in {'SCSI', 'NVME'}:
+        if ex_with_local_ssd and ex_with_local_ssd not in ['SCSI', 'NVME']:
             raise ValueError("ex_with_local_ssd must be one of SCSI or NVME")
 
         location = location or self.zone

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -2178,7 +2178,7 @@ n
                              "'image', existing 'ex_boot_disk', or use the "
                              "'ex_disks_gce_struct'.")
 
-        if ex_with_local_ssd not in {None, 'SCSI', 'NVME'}:
+        if ex_with_local_ssd and ex_with_local_ssd not in {'SCSI', 'NVME'}:
             raise ValueError("ex_with_local_ssd must be one of SCSI or NVME")
 
         location = location or self.zone


### PR DESCRIPTION
GCE has options to specify the size of boot disk when creating an instance, as well as adding a local SSD to the instance.
This pull request adds 2 new options in create_node:
- ex_boot_disk_size_gb to specify the size of the boot disk to create. If not set the default GCE was is used.
- ex_with_local_ssd to attach a local SSD and specify which interface to use.
