### PR TITLE
[WIP] [LIBCLOUD-692] Run tox tests in a vagrant box

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ apache_libcloud.egg-info/
 .project
 .pydevproject
 .settings
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,38 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+VAGRANTFILE_API_VERSION = "2"
+
+$provision_script = <<SCRIPT
+add-apt-repository ppa:fkrull/deadsnakes
+apt-get update
+
+apt-get -y install python2.5 python2.6 python2.7 python3.2 python3.3 python3.4
+apt-get -y install python-dev python2.5-dev python2.6-dev python2.7-dev python3.2-dev python3.3-dev python3.4-dev
+apt-get -y install python-pip
+
+wget https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.0-linux64.tar.bz2
+tar xf ./pypy-2.5.0-linux64.tar.bz2 -C /opt
+ln -s /opt/pypy-2.5.0-linux64/bin/pypy /usr/local/bin/pypy
+
+cp -r /vagrant /home/vagrant/libcloud
+cd /home/vagrant/libcloud
+
+pip install tox
+pip install mock
+pip install lockfile
+pip install coverage
+SCRIPT
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "ubuntu/trusty64"
+
+  config.vm.define "tests" do |db|
+    config.vm.provision :shell, :inline => $provision_script
+  end
+
+  config.vm.provider :virtualbox do |vb|
+    vb.customize ["modifyvm", :id, "--memory", "2048"]
+  end
+
+end

--- a/contrib/run_tests.sh
+++ b/contrib/run_tests.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+#
+# Script which spawns a virtual instance using vagrant and a
+# backend provider i.e. VirtualBox, install pypy, pip,
+# python versions 2.5, 2.6, 2.7, 3.2, 3.3, 3.4 (corresponding
+# dev packages as well) and run tox tests in the virtual instance
+
+cd ../
+vagrant up tests
+vagrant ssh tests -c "cd /home/vagrant/libcloud; sudo tox"
+vagrant destroy -f


### PR DESCRIPTION
WIP:
still working on an alternative: run the tests using a docker image.

Corresponding issue:
https://issues.apache.org/jira/browse/LIBCLOUD-692
