### PR TITLE
Handle case where Cloudstack can return Unlimited instead of int

### DIFF
--- a/libcloud/compute/drivers/cloudstack.py
+++ b/libcloud/compute/drivers/cloudstack.py
@@ -194,7 +194,7 @@ RESOURCE_EXTRA_ATTRIBUTES_MAP = {
         },
         'device_id': {
             'key_name': 'deviceid',
-            'transform_func': int
+            'transform_func': transform_int_or_unlimited
         },
         'instance_id': {
             'key_name': 'virtualmachineid',
@@ -232,7 +232,7 @@ RESOURCE_EXTRA_ATTRIBUTES_MAP = {
         },
         'domain_id': {
             'key_name': 'domainid',
-            'transform_func': int
+            'transform_func': transform_int_or_unlimited
         },
         'network_domain': {
             'key_name': 'networkdomain',
@@ -257,55 +257,55 @@ RESOURCE_EXTRA_ATTRIBUTES_MAP = {
     },
     'project': {
         'account': {'key_name': 'account', 'transform_func': str},
-        'cpuavailable': {'key_name': 'cpuavailable', 'transform_func': int},
-        'cpulimit': {'key_name': 'cpulimit', 'transform_func': int},
-        'cputotal': {'key_name': 'cputotal', 'transform_func': int},
+        'cpuavailable': {'key_name': 'cpuavailable', 'transform_func': transform_int_or_unlimited},
+        'cpulimit': {'key_name': 'cpulimit', 'transform_func': transform_int_or_unlimited},
+        'cputotal': {'key_name': 'cputotal', 'transform_func': transform_int_or_unlimited},
         'domain': {'key_name': 'domain', 'transform_func': str},
         'domainid': {'key_name': 'domainid', 'transform_func': str},
-        'ipavailable': {'key_name': 'ipavailable', 'transform_func': int},
-        'iplimit': {'key_name': 'iplimit', 'transform_func': int},
-        'iptotal': {'key_name': 'iptotal', 'transform_func': int},
+        'ipavailable': {'key_name': 'ipavailable', 'transform_func': transform_int_or_unlimited},
+        'iplimit': {'key_name': 'iplimit', 'transform_func': transform_int_or_unlimited},
+        'iptotal': {'key_name': 'iptotal', 'transform_func': transform_int_or_unlimited},
         'memoryavailable': {'key_name': 'memoryavailable',
-                            'transform_func': int},
-        'memorylimit': {'key_name': 'memorylimit', 'transform_func': int},
-        'memorytotal': {'key_name': 'memorytotal', 'transform_func': int},
+                            'transform_func': transform_int_or_unlimited},
+        'memorylimit': {'key_name': 'memorylimit', 'transform_func': transform_int_or_unlimited},
+        'memorytotal': {'key_name': 'memorytotal', 'transform_func': transform_int_or_unlimited},
         'networkavailable': {'key_name': 'networkavailable',
-                             'transform_func': int},
-        'networklimit': {'key_name': 'networklimit', 'transform_func': int},
-        'networktotal': {'key_name': 'networktotal', 'transform_func': int},
+                             'transform_func': transform_int_or_unlimited},
+        'networklimit': {'key_name': 'networklimit', 'transform_func': transform_int_or_unlimited},
+        'networktotal': {'key_name': 'networktotal', 'transform_func': transform_int_or_unlimited},
         'primarystorageavailable': {'key_name': 'primarystorageavailable',
-                                    'transform_func': int},
+                                    'transform_func': transform_int_or_unlimited},
         'primarystoragelimit': {'key_name': 'primarystoragelimit',
-                                'transform_func': int},
+                                'transform_func': transform_int_or_unlimited},
         'primarystoragetotal': {'key_name': 'primarystoragetotal',
-                                'transform_func': int},
+                                'transform_func': transform_int_or_unlimited},
         'secondarystorageavailable': {'key_name': 'secondarystorageavailable',
-                                      'transform_func': int},
+                                      'transform_func': transform_int_or_unlimited},
         'secondarystoragelimit': {'key_name': 'secondarystoragelimit',
-                                  'transform_func': int},
+                                  'transform_func': transform_int_or_unlimited},
         'secondarystoragetotal': {'key_name': 'secondarystoragetotal',
-                                  'transform_func': int},
+                                  'transform_func': transform_int_or_unlimited},
         'snapshotavailable': {'key_name': 'snapshotavailable',
-                              'transform_func': int},
-        'snapshotlimit': {'key_name': 'snapshotlimit', 'transform_func': int},
-        'snapshottotal': {'key_name': 'snapshottotal', 'transform_func': int},
+                              'transform_func': transform_int_or_unlimited},
+        'snapshotlimit': {'key_name': 'snapshotlimit', 'transform_func': transform_int_or_unlimited},
+        'snapshottotal': {'key_name': 'snapshottotal', 'transform_func': transform_int_or_unlimited},
         'state': {'key_name': 'state', 'transform_func': str},
         'tags': {'key_name': 'tags', 'transform_func': str},
         'templateavailable': {'key_name': 'templateavailable',
-                              'transform_func': int},
-        'templatelimit': {'key_name': 'templatelimit', 'transform_func': int},
-        'templatetotal': {'key_name': 'templatetotal', 'transform_func': int},
-        'vmavailable': {'key_name': 'vmavailable', 'transform_func': int},
-        'vmlimit': {'key_name': 'vmlimit', 'transform_func': int},
-        'vmrunning': {'key_name': 'vmrunning', 'transform_func': int},
-        'vmtotal': {'key_name': 'vmtotal', 'transform_func': int},
+                              'transform_func': transform_int_or_unlimited},
+        'templatelimit': {'key_name': 'templatelimit', 'transform_func': transform_int_or_unlimited},
+        'templatetotal': {'key_name': 'templatetotal', 'transform_func': transform_int_or_unlimited},
+        'vmavailable': {'key_name': 'vmavailable', 'transform_func': transform_int_or_unlimited},
+        'vmlimit': {'key_name': 'vmlimit', 'transform_func': transform_int_or_unlimited},
+        'vmrunning': {'key_name': 'vmrunning', 'transform_func': transform_int_or_unlimited},
+        'vmtotal': {'key_name': 'vmtotal', 'transform_func': transform_int_or_unlimited},
         'volumeavailable': {'key_name': 'volumeavailable',
-                            'transform_func': int},
-        'volumelimit': {'key_name': 'volumelimit', 'transform_func': int},
-        'volumetotal': {'key_name': 'volumetotal', 'transform_func': int},
-        'vpcavailable': {'key_name': 'vpcavailable', 'transform_func': int},
-        'vpclimit': {'key_name': 'vpclimit', 'transform_func': int},
-        'vpctotal': {'key_name': 'vpctotal', 'transform_func': int}
+                            'transform_func': transform_int_or_unlimited},
+        'volumelimit': {'key_name': 'volumelimit', 'transform_func': transform_int_or_unlimited},
+        'volumetotal': {'key_name': 'volumetotal', 'transform_func': transform_int_or_unlimited},
+        'vpcavailable': {'key_name': 'vpcavailable', 'transform_func': transform_int_or_unlimited},
+        'vpclimit': {'key_name': 'vpclimit', 'transform_func': transform_int_or_unlimited},
+        'vpctotal': {'key_name': 'vpctotal', 'transform_func': transform_int_or_unlimited}
     },
     'nic': {
         'secondary_ip': {
@@ -350,11 +350,11 @@ RESOURCE_EXTRA_ATTRIBUTES_MAP = {
         },
         'esp_lifetime': {
             'key_name': 'esplifetime',
-            'transform_func': int
+            'transform_func': transform_int_or_unlimited
         },
         'ike_lifetime': {
             'key_name': 'ikelifetime',
-            'transform_func': int
+            'transform_func': transform_int_or_unlimited
         },
         'name': {
             'key_name': 'name',
@@ -388,6 +388,14 @@ RESOURCE_EXTRA_ATTRIBUTES_MAP = {
         }
     }
 }
+
+def transform_int_or_unlimited(value):
+    try:
+        return int(value)
+    except ValueError as e:
+        if value == 'Unlimited':
+            return -1
+        raise e
 
 
 class CloudStackNode(Node):

--- a/libcloud/compute/drivers/cloudstack.py
+++ b/libcloud/compute/drivers/cloudstack.py
@@ -34,6 +34,16 @@ from libcloud.utils.networking import is_private_subnet
 """
 Define the extra dictionary for specific resources
 """
+
+def transform_int_or_unlimited(value):
+    try:
+        return int(value)
+    except ValueError as e:
+        if value == 'Unlimited':
+            return -1
+        raise e
+
+
 RESOURCE_EXTRA_ATTRIBUTES_MAP = {
     'network': {
         'broadcast_domain_type': {
@@ -388,14 +398,6 @@ RESOURCE_EXTRA_ATTRIBUTES_MAP = {
         }
     }
 }
-
-def transform_int_or_unlimited(value):
-    try:
-        return int(value)
-    except ValueError as e:
-        if value == 'Unlimited':
-            return -1
-        raise e
 
 
 class CloudStackNode(Node):


### PR DESCRIPTION
Sometimes the Cloudstack API returns 'Unlimited' instead of an int. For instance, this is a sample output of listProjects()

```
{
    'primarystorageavailable': 'Unlimited',
    'domain': 'demo',
    'domainid': '6ee35be2-8002-46a3-8736-b071aa059fd6',
    'vpclimit': 'Unlimited',
    'iplimit': 'Unlimited',
    'volumelimit': 'Unlimited',
    'memorytotal': 14336,
    'secondarystorageavailable': 'Unlimited',
    'vmtotal': 7,
    'displaytext': 'DefaultEnv.',
    'vpctotal': 1,
    'id': '7862b2ed-5204-45e4-b036-b2237db40cde',
    'cpuavailable': 'Unlimited',
    'networklimit': 'Unlimited',
    'iptotal': 2,
    'volumetotal': 14,
    'snapshotlimit': 'Unlimited'....
}
```

 This change uses a  transform function to check for the `Unlimited` case . I am using -1 to mean unlimited.
