### PR TITLE
[LIBCLOUD-712] Use get() to take signature version

### DIFF
--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -5659,7 +5659,7 @@ class EC2NodeDriver(BaseEC2NodeDriver):
         self.region_name = region
         self.api_name = details['api_name']
         self.country = details['country']
-        self.signature_version = details.pop('signature_version',
+        self.signature_version = details.get('signature_version',
                                              DEFAULT_SIGNATURE_VERSION)
 
         host = host or details['endpoint']


### PR DESCRIPTION
The pop() call will remove the field from the REGION_DETAILS dictionary,
causing subsequent calls to use the default value.

Fixes https://issues.apache.org/jira/browse/LIBCLOUD-712
