### PR TITLE
Give SSL unverified context to httplib.HTTPSConnection when relevant

### DIFF
--- a/libcloud/httplib_ssl.py
+++ b/libcloud/httplib_ssl.py
@@ -208,6 +208,9 @@ class LibcloudHTTPSConnection(httplib.HTTPSConnection, LibcloudBaseConnection):
         proxy_url_env = os.environ.get(HTTP_PROXY_ENV_VARIABLE_NAME, None)
         proxy_url = kwargs.pop('proxy_url', proxy_url_env)
 
+        if not self.verify and hasattr(ssl, '_create_unverified_context'):
+            kwargs['context'] = ssl._create_unverified_context()
+
         super(LibcloudHTTPSConnection, self).__init__(*args, **kwargs)
 
         if proxy_url:


### PR DESCRIPTION
Since certificate verification is enabled by default for stdlib http clients (PEP 0476) libcloud.security.VERIFY_SSL_CERT does not work as expected, raising the following exception:

`File "/opt/normalizer/local/lib/python2.7/site-packages/libcloud/common/base.py", line 725, in request
    raise ssl.SSLError(str(e))
ssl.SSLError: ('[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:590)',)`
