### PR TITLE
Gandi Compute Driver improvement

### DIFF
--- a/docs/compute/drivers/gandi.rst
+++ b/docs/compute/drivers/gandi.rst
@@ -1,0 +1,36 @@
+Gandi Computer Driver Documentation
+===================================
+
+`Gandi SAS`_ is a registrar, web hosting and private and `public cloud`_
+provider based in France with data centers in France, Luxembourg and USA.
+
+.. figure:: /_static/images/provider_logos/gandi.png
+    :align: center
+    :width: 300
+    :target: https://www.gandi.net/
+
+Instantiating a driver
+----------------------
+
+When you instantiate a driver you need to pass the API key and activate
+the API platforms. See this `Gandi's documentation`_ for how to do it.
+
+Examples
+--------
+
+Create instance
+~~~~~~~~~~~~~~~
+
+.. literalinclude:: /examples/compute/gandi/create_node.py
+
+
+.. _`Gandi SAS`: https://www.gandi.net/ 
+.. _`public cloud`: https://www.gandi.net/hebergement/serveur
+.. _`Gandi's documentation`: https://wiki.gandi.net/en/xml-api/activate
+
+API Docs
+--------
+
+.. autoclass:: libcloud.compute.drivers.gandi.GandiNodeDriver
+    :members:
+    :inherited-members:

--- a/docs/examples/compute/gandi/create_node.py
+++ b/docs/examples/compute/gandi/create_node.py
@@ -1,0 +1,12 @@
+from libcloud.compute.types import Provider
+from libcloud.compute.providers import get_driver
+
+Gandi = get_driver(Provider.GANDI)
+driver = Gandi('api_key')
+
+image = [i for i in driver.list_images() if 'Debian 8 64' in i.name][0]
+size = [s for s in driver.list_sizes() if s.name == 'Medium instance'][0]
+location = [l for l in driver.list_locations() if l.name == 'Equinix Paris'][0]
+
+node = driver.create_node(name='yournode', size=size, image=image,
+                          location=location, login="youruser", password="pass")

--- a/libcloud/compute/drivers/cloudstack.py
+++ b/libcloud/compute/drivers/cloudstack.py
@@ -2260,6 +2260,14 @@ class CloudStackNodeDriver(CloudStackDriverMixIn, NodeDriver):
         return key_pairs
 
     def get_key_pair(self, name):
+        """
+        Retrieve a single key pair.
+
+        :param name: Name of the key pair to retrieve.
+        :type name: ``str``
+
+        :rtype: :class:`.KeyPair`
+        """
         params = {'name': name}
         res = self._sync_request(command='listSSHKeyPairs',
                                  params=params,

--- a/libcloud/compute/drivers/gandi.py
+++ b/libcloud/compute/drivers/gandi.py
@@ -461,6 +461,19 @@ class GandiNodeDriver(BaseGandiDriver, NodeDriver):
         res = self.connection.request('hosting.disk.list', {})
         return self._to_volumes(res.object)
 
+    def ex_get_volume(self, volume_id):
+        """
+        Return a Volume object based on a volume ID.
+
+        :param  volume_id: The ID of the volume
+        :type   volume_id: ``int``
+
+        :return:  A StorageVolume object for the volume
+        :rtype:   :class:`StorageVolume`
+        """
+        res = self.connection.request('hosting.disk.info', volume_id)
+        return self._to_volume(res.object)
+
     def create_volume(self, size, name, location=None, snapshot=None):
         """
         Create a volume (disk).

--- a/libcloud/test/compute/fixtures/gandi/ssh_delete.xml
+++ b/libcloud/test/compute/fixtures/gandi/ssh_delete.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<methodResponse>
+<params>
+<param>
+<value><boolean>1</boolean></value>
+</param>
+</params>
+</methodResponse>

--- a/libcloud/test/compute/fixtures/gandi/ssh_info.xml
+++ b/libcloud/test/compute/fixtures/gandi/ssh_info.xml
@@ -1,0 +1,25 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<methodResponse>
+<params>
+<param>
+<value><struct>
+<member>
+<name>fingerprint</name>
+<value><string>a6:1f:b8:b4:19:91:99:d8:af:ab:d6:17:72:8b:d1:6c</string></value>
+</member>
+<member>
+<name>name</name>
+<value><string>testkey</string></value>
+</member>
+<member>
+<name>value</name>
+<value><string>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaCXFxl0cPZa+PkXSaux/9Sfn4J81eNJ4f/ZkjdIlmLJVYFUKbpC16eEwXYEfw/QBAZFPODCDQOFAZdgajO572y9scp09F7L7Rhwrw7DYu8STMIBz0XBIO8eOUyu5hVRpxaZGDih9B99e1hITTGFg+BveAmrdB8CPtygKo/fUmaamrocZBrD1betaLTC0i6/DVz7YAbR0CleZLlaBogqVhqmS0TB4J67aG2vvq1MjyOixQY5Ab4aXo4Dz1jd7oqCGCKCO9oKAG0ok94foxkfnCmfRrnfWzOA7SFWjUs65SOrGYZghspDcbJ9vA4ZkUuWJXPPvLVgsI8aHwkezJPD8Th root@testhost</string></value>
+</member>
+<member>
+<name>id</name>
+<value><int>10</int></value>
+</member>
+</struct></value>
+</param>
+</params>
+</methodResponse>

--- a/libcloud/test/compute/fixtures/gandi/ssh_list.xml
+++ b/libcloud/test/compute/fixtures/gandi/ssh_list.xml
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<methodResponse>
+<params>
+<param>
+<value><array><data>
+<value><struct>
+<member>
+<name>fingerprint</name>
+<value><string>a6:1f:b8:b4:19:91:99:d8:af:ab:d6:17:72:8b:d1:6c</string></value>
+</member>
+<member>
+<name>id</name>
+<value><int>10</int></value>
+</member>
+<member>
+<name>name</name>
+<value><string>testkey</string></value>
+</member>
+</struct></value>
+</data></array></value>
+</param>
+</params>
+</methodResponse>

--- a/libcloud/test/compute/test_gandi.py
+++ b/libcloud/test/compute/test_gandi.py
@@ -171,6 +171,10 @@ class GandiTests(unittest.TestCase):
         response = self.driver.delete_key_pair(10)
         self.assertTrue(response)
 
+    def test_ex_get_node(self):
+        node = self.driver.ex_get_node(34951)
+        self.assertEqual(node.name, "test2")
+
 
 class GandiRatingTests(unittest.TestCase):
 

--- a/libcloud/test/compute/test_gandi.py
+++ b/libcloud/test/compute/test_gandi.py
@@ -156,7 +156,7 @@ class GandiTests(unittest.TestCase):
 
     def test_list_key_pairs(self):
         keys = self.driver.list_key_pairs()
-        self.assertGreater(len(keys), 0)
+        self.assertTrue(len(keys) > 0)
 
     def test_get_key_pair(self):
         key = self.driver.get_key_pair(10)

--- a/libcloud/test/compute/test_gandi.py
+++ b/libcloud/test/compute/test_gandi.py
@@ -154,6 +154,23 @@ class GandiTests(unittest.TestCase):
         disks = self.driver.list_volumes()
         self.assertTrue(self.driver.ex_update_disk(disks[0], new_size=4096))
 
+    def test_list_key_pairs(self):
+        keys = self.driver.list_key_pairs()
+        self.assertGreater(len(keys), 0)
+
+    def test_get_key_pair(self):
+        key = self.driver.get_key_pair(10)
+        self.assertEqual(key.name, 'testkey')
+
+    def test_import_key_pair_from_string(self):
+        key = self.driver.import_key_pair_from_string('testkey', '12345')
+        self.assertEqual(key.name, 'testkey')
+        self.assertEqual(key.extra['id'], 10)
+
+    def test_delete_key_pair(self):
+        response = self.driver.delete_key_pair(10)
+        self.assertTrue(response)
+
 
 class GandiRatingTests(unittest.TestCase):
 
@@ -283,6 +300,22 @@ class GandiMockHttp(BaseGandiMockHttp):
 
     def _xmlrpc__hosting_disk_delete(self, method, url, body, headers):
         body = self.fixtures.load('disk_delete.xml')
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+
+    def _xmlrpc__hosting_ssh_info(self, method, url, body, headers):
+        body = self.fixtures.load('ssh_info.xml')
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+
+    def _xmlrpc__hosting_ssh_list(self, method, url, body, headers):
+        body = self.fixtures.load('ssh_list.xml')
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+
+    def _xmlrpc__hosting_ssh_create(self, method, url, body, headers):
+        body = self.fixtures.load('ssh_info.xml')
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+
+    def _xmlrpc__hosting_ssh_delete(self, method, url, body, headers):
+        body = self.fixtures.load('ssh_delete.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
 

--- a/libcloud/test/compute/test_gandi.py
+++ b/libcloud/test/compute/test_gandi.py
@@ -175,6 +175,10 @@ class GandiTests(unittest.TestCase):
         node = self.driver.ex_get_node(34951)
         self.assertEqual(node.name, "test2")
 
+    def test_ex_get_volume(self):
+        volume = self.driver.ex_get_volume(1263)
+        self.assertEqual(volume.name, "libcloud")
+
 
 class GandiRatingTests(unittest.TestCase):
 


### PR DESCRIPTION
- Added sphinx documentation with example of node creation
- Added docstring for all public methods
- Added SSH keypair management: list, get, import, delete
- Change authentification initialisation in create_node: User must choose between login/password, SSH keys or both
- Added ex_get_node and ex_get_volume
- Added tests for all commit
