### PR TITLE
LIBCLOUD-717 Implement v2 API request speed optimization and other ch…

### DIFF
--- a/docs/compute/drivers/digital_ocean.rst
+++ b/docs/compute/drivers/digital_ocean.rst
@@ -16,7 +16,7 @@ Instantiating a driver
 DigitalOcean driver supports two API versions - old API v1.0 and the new API
 v2.0. Since trunk (to be libcloud v0.18.0), the driver uses the correct API
 based on the initialization with the Client ID (key) and Access Token (secret)
-for v1.0 or the Personal Access Token (key) in v2.0 and will through an
+for v1.0 or the Personal Access Token (key) in v2.0 and will throw an
 exception if the `api_version` is set explicitly without the proper arguments.
 
 Instantiating a driver using API v2.0

--- a/docs/compute/drivers/digital_ocean.rst
+++ b/docs/compute/drivers/digital_ocean.rst
@@ -16,7 +16,8 @@ Instantiating a driver
 DigitalOcean driver supports two API versions - old API v1.0 and the new API
 v2.0. Since trunk (to be libcloud v0.18.0), the driver uses the correct API
 based on the initialization with the Client ID (key) and Access Token (secret)
-for v1.0 or the Personal Access Token (key) in v2.0.
+for v1.0 or the Personal Access Token (key) in v2.0 and will through an
+exception if the `api_version` is set explicitly without the proper arguments.
 
 Instantiating a driver using API v2.0
 -------------------------------------
@@ -28,6 +29,12 @@ Instantiating a driver using API v1.0
 -------------------------------------
 
 .. literalinclude:: /examples/compute/digitalocean/instantiate_api_v1.0.py
+   :language: python
+
+Creating a droplet using API v2.0
+---------------------------------
+
+.. literalinclude:: /examples/compute/digitalocean/create_api_v2.0.py
    :language: python
 
 API Docs

--- a/docs/examples/compute/digitalocean/create_api_v2.0.py
+++ b/docs/examples/compute/digitalocean/create_api_v2.0.py
@@ -1,0 +1,18 @@
+from libcloud.compute.types import Provider
+from libcloud.compute.providers import get_driver
+
+cls = get_driver(Provider.DIGITAL_OCEAN)
+
+driver = cls('access token', api_version='v2')
+
+options = {'backups': True,
+           'private_networking': True,
+           'ssh_keys': [123456, 123457]}
+
+name = 'test.domain.tld'
+size = driver.list_sizes()[0]
+image = driver.list_images()[0]
+location = driver.list_locations()[0]
+
+node = driver.create_node(name, size, image, location,
+                          ex_create_attr=options)

--- a/libcloud/compute/drivers/digitalocean.py
+++ b/libcloud/compute/drivers/digitalocean.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Digital Ocean Driver
+DigitalOcean Driver
 """
 import json
 import warnings
@@ -24,8 +24,8 @@ from libcloud.common.digitalocean import DigitalOcean_v1_BaseDriver
 from libcloud.common.digitalocean import DigitalOcean_v2_BaseDriver
 from libcloud.common.types import InvalidCredsError
 from libcloud.compute.types import Provider, NodeState
-from libcloud.compute.base import NodeDriver, Node
 from libcloud.compute.base import NodeImage, NodeSize, NodeLocation, KeyPair
+from libcloud.compute.base import Node, NodeDriver
 
 __all__ = [
     'DigitalOceanNodeDriver',
@@ -320,38 +320,77 @@ class DigitalOcean_v2_NodeDriver(DigitalOcean_v2_BaseDriver,
                       'active': NodeState.RUNNING,
                       'archive': NodeState.TERMINATED}
 
-    def list_nodes(self):
-        data = self._paginated_request('/v2/droplets', 'droplets')
-        return list(map(self._to_node, data))
-
-    def list_locations(self):
-        data = self.connection.request('/v2/regions').object['regions']
-        return list(map(self._to_location, data))
+    EX_CREATE_ATTRIBUTES = ['backups',
+                            'ipv6',
+                            'private_networking',
+                            'user_data',
+                            'ssh_keys']
 
     def list_images(self):
         data = self._paginated_request('/v2/images', 'images')
         return list(map(self._to_image, data))
 
+    def list_key_pairs(self):
+        """
+        List all the available SSH keys.
+
+        :return: Available SSH keys.
+        :rtype: ``list`` of :class:`KeyPair`
+        """
+        data = self._paginated_request('/v2/account/keys', 'ssh_keys')
+        return list(map(self._to_key_pair, data))
+
+    def list_locations(self):
+        data = self._paginated_request('/v2/regions', 'regions')
+        return list(map(self._to_location, data))
+
+    def list_nodes(self):
+        data = self._paginated_request('/v2/droplets', 'droplets')
+        return list(map(self._to_node, data))
+
     def list_sizes(self):
-        data = self.connection.request('/v2/sizes').object['sizes']
+        data = self._paginated_request('/v2/sizes', 'sizes')
         return list(map(self._to_size, data))
 
-    def create_node(self, name, size, image, location, ex_ssh_key_ids=None):
+    def create_node(self, name, size, image, location,
+                    ex_create_attr={}, ex_ssh_key_ids=None):
         """
         Create a node.
 
-        :keyword    ex_ssh_key_ids: A list of ssh key ids which will be added
-                                   to the server. (optional)
-        :type       ex_ssh_key_ids: ``list`` of ``str``
+        The `ex_create_attr` parameter can include the following dictionary
+        key and value pairs:
+
+        * `backups`: ``bool`` defaults to False
+        * `ipv6`: ``bool`` defaults to False
+        * `private_networking`: ``bool`` defaults to False
+        * `user_data`: ``str`` for cloud-config data
+        * `ssh_keys`: ``list`` of ``int`` key ids or ``str`` fingerprints
+
+        `ex_create_attr['ssh_keys']` will override `ex_ssh_key_ids` assignment.
+
+        :keyword ex_create_attr: A dictionary of optional attributes for
+                                 droplet creation
+        :type ex_create_attr: ``dict``
+
+        :keyword ex_ssh_key_ids: A list of ssh key ids which will be added
+                                 to the server. (optional)
+        :type ex_ssh_key_ids: ``list`` of ``int`` key ids or ``str``
+                              key fingerprints
 
         :return: The newly created node.
         :rtype: :class:`Node`
         """
         attr = {'name': name, 'size': size.name, 'image': image.id,
                 'region': location.id}
-
+        # Maintained for backward compatibilty
         if ex_ssh_key_ids:
+            warnings.warn("The ex_ssh_key_ids parameter has been deprecated in"
+                          " favor of the ex_create_attr parameter.")
             attr['ssh_keys'] = ex_ssh_key_ids
+
+        for key in ex_create_attr.keys():
+            if key in self.EX_CREATE_ATTRIBUTES:
+                attr[key] = ex_create_attr[key]
 
         res = self.connection.request('/v2/droplets',
                                       data=json.dumps(attr), method='POST')
@@ -366,36 +405,20 @@ class DigitalOcean_v2_NodeDriver(DigitalOcean_v2_BaseDriver,
 
         return self._to_node(data=data)
 
+    def destroy_node(self, node):
+        res = self.connection.request('/v2/droplets/%s' % (node.id),
+                                      method='DELETE')
+        return res.status == httplib.NO_CONTENT
+
     def reboot_node(self, node):
         attr = {'type': 'reboot'}
         res = self.connection.request('/v2/droplets/%s/actions' % (node.id),
                                       data=json.dumps(attr), method='POST')
         return res.status == httplib.CREATED
 
-    def destroy_node(self, node):
-        res = self.connection.request('/v2/droplets/%s' % (node.id),
-                                      method='DELETE')
-        return res.status == httplib.NO_CONTENT
-
-    def get_image(self, image_id):
-        """
-        Get an image based on an image_id
-
-        @inherits: :class:`NodeDriver.get_image`
-
-        :param image_id: Image identifier
-        :type image_id: ``int``
-
-        :return: A NodeImage object
-        :rtype: :class:`NodeImage`
-        """
-        res = self.connection.request('/v2/images/%s' % (image_id))
-        data = res.object['image']
-        return self._to_image(data)
-
     def create_image(self, node, name):
         """
-        Create an image fron a Node.
+        Create an image from a Node.
 
         @inherits: :class:`NodeDriver.create_image`
 
@@ -426,6 +449,21 @@ class DigitalOcean_v2_NodeDriver(DigitalOcean_v2_BaseDriver,
                                       method='DELETE')
         return res.status == httplib.NO_CONTENT
 
+    def get_image(self, image_id):
+        """
+        Get an image based on an image_id
+
+        @inherits: :class:`NodeDriver.get_image`
+
+        :param image_id: Image identifier
+        :type image_id: ``int``
+
+        :return: A NodeImage object
+        :rtype: :class:`NodeImage`
+        """
+        data = self._paginated_request('/v2/images/%s' % (image_id), 'image')
+        return self._to_image(data)
+
     def ex_rename_node(self, node, name):
         attr = {'type': 'rename', 'name': name}
         res = self.connection.request('/v2/droplets/%s/actions' % (node.id),
@@ -444,31 +482,7 @@ class DigitalOcean_v2_NodeDriver(DigitalOcean_v2_BaseDriver,
                                       data=json.dumps(attr), method='POST')
         return res.status == httplib.CREATED
 
-    def list_key_pairs(self):
-        """
-        List all the available SSH keys.
-
-        :return: Available SSH keys.
-        :rtype: ``list`` of :class:`KeyPair`
-        """
-        data = self._paginated_request('/v2/account/keys', 'ssh_keys')
-        return list(map(self._to_key_pair, data))
-
-    def get_key_pair(self, name):
-        """
-        Retrieve a single key pair.
-
-        :param name: Name of the key pair to retrieve.
-        :type name: ``str``
-
-        :rtype: :class:`.KeyPair`
-        """
-        qkey = [k for k in self.list_key_pairs() if k.name == name][0]
-        data = self.connection.request('/v2/account/keys/%s' %
-                                       qkey.extra['id']).object['ssh_key']
-        return self._to_key_pair(data=data)
-
-    def create_key_pair(self, name, public_key):
+    def create_key_pair(self, name, public_key=''):
         """
         Create a new SSH key.
 
@@ -498,28 +512,19 @@ class DigitalOcean_v2_NodeDriver(DigitalOcean_v2_BaseDriver,
                                       method='DELETE')
         return res.status == httplib.NO_CONTENT
 
-    def _paginated_request(self, url, obj):
+    def get_key_pair(self, name):
         """
-            Perform multiple calls in order to have a full list of elements
-            when the API are paginated.
+        Retrieve a single key pair.
+
+        :param name: Name of the key pair to retrieve.
+        :type name: ``str``
+
+        :rtype: :class:`.KeyPair`
         """
-        params = {}
-        data = self.connection.request(url)
-        try:
-            pages = data.object['links']['pages']['last'].split('=')[-1]
-            values = data.object[obj]
-            for page in range(2, int(pages) + 1):
-                params.update({'page': page})
-                new_data = self.connection.request(url, params=params)
-
-                more_values = new_data.object[obj]
-                for value in more_values:
-                    values.append(value)
-            data = values
-        except KeyError:  # No pages.
-            data = data.object[obj]
-
-        return data
+        qkey = [k for k in self.list_key_pairs() if k.name == name][0]
+        data = self.connection.request('/v2/account/keys/%s' %
+                                       qkey.extra['id']).object['ssh_key']
+        return self._to_key_pair(data=data)
 
     def _to_node(self, data):
         extra_keys = ['memory', 'vcpus', 'disk', 'region', 'image',
@@ -547,7 +552,7 @@ class DigitalOcean_v2_NodeDriver(DigitalOcean_v2_BaseDriver,
 
         node = Node(id=data['id'], name=data['name'], state=state,
                     public_ips=public_ips, private_ips=private_ips,
-                    extra=extra, driver=self)
+                    driver=self, extra=extra)
         return node
 
     def _to_image(self, data):
@@ -557,8 +562,8 @@ class DigitalOcean_v2_NodeDriver(DigitalOcean_v2_BaseDriver,
                  'regions': data['regions'],
                  'min_disk_size': data['min_disk_size'],
                  'created_at': data['created_at']}
-        return NodeImage(id=data['id'], name=data['name'], extra=extra,
-                         driver=self)
+        return NodeImage(id=data['id'], name=data['name'], driver=self,
+                         extra=extra)
 
     def _to_location(self, data):
         return NodeLocation(id=data['slug'], name=data['name'], country=None,


### PR DESCRIPTION
…anges
- Increased pagination to API maximum
- Added create_node parameter to support droplet features (backups, ipv6, user_data, etc )
- Reorganized method groups for style
- Converted all list_\* to paginated request

In large result sets, the API request was returning the default 25 results per request, making it very slow in large sets.

https://issues.apache.org/jira/browse/LIBCLOUD-717

I have some doubts about the ex_create_attr, but this was done to support selecting features. The prior parameter for ssh key selection/assignment was kept, but updated to throw a deprecation warning.

I've also added an example of how the create_node is called with the options.

I'm not sure about the rest documentation of the ex_create_attr dictionary values, but I look foward to the review.
