### PR TITLE
Replaced 'utf8' in ET.tostring with 'utf-8', invalid XML (400) otherwise

### DIFF
--- a/libcloud/compute/drivers/azure.py
+++ b/libcloud/compute/drivers/azure.py
@@ -1709,7 +1709,8 @@ class AzureNodeDriver(NodeDriver):
         root = ET.Element()
         doc = self._construct_element_tree(source, root)
 
-        result = ensure_string(ET.tostring(doc, encoding='utf8', method='xml'))
+        result = ensure_string(ET.tostring(doc, encoding='utf-8',
+                                           method='xml'))
         return result
 
     def _construct_element_tree(self, source, etree):
@@ -2108,7 +2109,7 @@ class AzureXmlSerializer(object):
             'RestartRoleOperation',
             xml
         )
-        result = ensure_string(ET.tostring(doc, encoding='utf8'))
+        result = ensure_string(ET.tostring(doc, encoding='utf-8'))
         return result
 
     @staticmethod
@@ -2119,7 +2120,7 @@ class AzureXmlSerializer(object):
             'ShutdownRoleOperation',
             xml
         )
-        result = ensure_string(ET.tostring(doc, encoding='utf8'))
+        result = ensure_string(ET.tostring(doc, encoding='utf-8'))
         return result
 
     @staticmethod
@@ -2130,7 +2131,7 @@ class AzureXmlSerializer(object):
             'StartRoleOperation',
             xml
         )
-        result = ensure_string(ET.tostring(doc, encoding='utf8'))
+        result = ensure_string(ET.tostring(doc, encoding='utf-8'))
         return result
 
     @staticmethod
@@ -2520,7 +2521,7 @@ class AzureXmlSerializer(object):
             system_configuration_set,
             doc
         )
-        result = ensure_string(ET.tostring(xml, encoding='utf8'))
+        result = ensure_string(ET.tostring(xml, encoding='utf-8'))
         return result
 
     @staticmethod
@@ -2547,7 +2548,7 @@ class AzureXmlSerializer(object):
             doc
         )
 
-        result = ensure_string(ET.tostring(doc, encoding='utf8'))
+        result = ensure_string(ET.tostring(doc, encoding='utf-8'))
         return result
 
     @staticmethod
@@ -2587,7 +2588,7 @@ class AzureXmlSerializer(object):
             xml
         )
         doc = AzureXmlSerializer.doc_from_xml('CaptureRoleOperation', xml)
-        result = ensure_string(ET.tostring(doc, encoding='utf8'))
+        result = ensure_string(ET.tostring(doc, encoding='utf-8'))
         return result
 
     @staticmethod
@@ -2638,7 +2639,7 @@ class AzureXmlSerializer(object):
                 )
             )
 
-        result = ensure_string(ET.tostring(doc, encoding='utf8'))
+        result = ensure_string(ET.tostring(doc, encoding='utf-8'))
         return result
 
     @staticmethod
@@ -2707,7 +2708,7 @@ class AzureXmlSerializer(object):
                 )
             )
 
-        result = ensure_string(ET.tostring(doc, encoding='utf8'))
+        result = ensure_string(ET.tostring(doc, encoding='utf-8'))
         return result
 
     @staticmethod


### PR DESCRIPTION
The XML that is generated by the Azure driver contains `encoding='utf8'`, which doesn't work, the Azure API returns a 400 response. If this is changed to `utf-8`, it does work. Adjusting the `encoding` argument passed to `ET.tostring` solved the 400 responses I was getting when using `ex_create_cloud_service`.
