### PR TITLE
LIBCLOUD-719: AuroraObjects storage driver

### DIFF
--- a/docs/storage/drivers/auroraobjects.rst
+++ b/docs/storage/drivers/auroraobjects.rst
@@ -1,0 +1,57 @@
+AuroraObjects Storage Driver Documentation
+======================================
+
+`PCextreme B.V.`_ is a Dutch cloud provider. It provides a public cloud offering
+under the name AuroraCompute. All cloud services are under the family name Aurora.
+
+All data is stored on servers in the European Union.
+
+.. figure:: /_static/images/provider_logos/pcextreme.png
+    :align: center
+    :width: 300
+    :target: https://www.pcextreme.nl/en/aurora/objects
+
+Protocol
+------------------
+
+AuroraObjects talks the Amazon S3 protocol and thus supports almost all functions
+which the Amazon S3 storage driver supports.
+
+It however does not support CDN support. Calling any of the CDN functions will raise
+a LibcloudError.
+
+As a backend AuroraObjects uses `Ceph`_ for storage.
+
+Multipart uploads
+------------------
+
+AuroraObjects storage driver supports multipart uploads which means you can
+upload objects with a total size of up to 5 TB.
+
+Multipart upload works similar to Amazon S3. After uploading all the parts the
+AuroraObjects servers combine the parts into one large object.
+
+If you use
+:meth:`libcloud.storage.base.StorageDriver.upload_object_via_stream` method,
+Libcloud transparently handles all the splitting and uploading of the parts
+for you.
+
+By default, to prevent excessive buffering and use of memory, each part is
+5 MB in size. This is also the smallest size of a part you can use with the
+multi part upload.
+
+Examples
+--------
+
+Please refer to the Amazon S3 storage driver documentation for examples.
+
+
+API Docs
+--------
+
+.. autoclass:: libcloud.compute.drivers.auroraobjects.AuroraObjectsStorageDriver
+    :members:
+    :inherited-members:
+
+.. _`PCextreme B.V.`: https://www.pcextreme.nl/
+.. _`Ceph`: https://ceph.com/

--- a/libcloud/storage/drivers/auroraobjects.py
+++ b/libcloud/storage/drivers/auroraobjects.py
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from libcloud.common.types import LibcloudError
+from libcloud.storage.providers import Provider
+from libcloud.storage.drivers.s3 import BaseS3StorageDriver, BaseS3Connection
+
+__all__ = [
+    'AuroraObjectsStorageDriver'
+]
+
+AURORA_OBJECTS_EU_HOST = 'o.auroraobjects.eu'
+
+NO_CDN_SUPPORT_ERROR = 'CDN is not supported by AuroraObjects'
+
+
+class BaseAuroraObjectsConnection(BaseS3Connection):
+    host = AURORA_OBJECTS_EU_HOST
+
+
+class BaseAuroraObjectsStorageDriver(BaseS3StorageDriver):
+    type = Provider.AURORAOBJECTS
+    name = 'PCextreme AuroraObjects'
+    website = 'https://www.pcextreme.nl/en/aurora/objects'
+
+
+class AuroraObjectsStorageDriver(BaseAuroraObjectsStorageDriver):
+    connectionCls = BaseAuroraObjectsConnection
+
+    def enable_container_cdn(self, *argv):
+        raise LibcloudError(NO_CDN_SUPPORT_ERROR, driver=self)
+
+    def enable_object_cdn(self, *argv):
+        raise LibcloudError(NO_CDN_SUPPORT_ERROR, driver=self)
+
+    def get_container_cdn_url(self, *argv):
+        raise LibcloudError(NO_CDN_SUPPORT_ERROR, driver=self)
+
+    def get_object_cdn_url(self, *argv):
+        raise LibcloudError(NO_CDN_SUPPORT_ERROR, driver=self)

--- a/libcloud/storage/providers.py
+++ b/libcloud/storage/providers.py
@@ -48,6 +48,8 @@ DRIVERS = {
     ('libcloud.storage.drivers.azure_blobs', 'AzureBlobsStorageDriver'),
     Provider.KTUCLOUD:
     ('libcloud.storage.drivers.ktucloud', 'KTUCloudStorageDriver'),
+    Provider.AURORAOBJECTS:
+    ('libcloud.storage.drivers.auroraobjects', 'AuroraObjectsStorageDriver'),
 
     # Deprecated
     Provider.CLOUDFILES_US:

--- a/libcloud/storage/types.py
+++ b/libcloud/storage/types.py
@@ -42,6 +42,7 @@ class Provider(object):
     :cvar S3_US_WEST_OREGON: Amazon S3 US West 2 (Oregon)
     :cvar NIMBUS: Nimbus.io driver
     :cvar LOCAL: Local storage driver
+    :cvar AURORAOBJECTS: AuroraObjects storage driver
     """
     DUMMY = 'dummy'
     S3 = 's3'
@@ -58,6 +59,7 @@ class Provider(object):
     CLOUDFILES = 'cloudfiles'
     AZURE_BLOBS = 'azure_blobs'
     KTUCLOUD = 'ktucloud'
+    AURORAOBJECTS = 'auroraobjects'
 
     # Deperecated
     CLOUDFILES_US = 'cloudfiles_us'


### PR DESCRIPTION
AuroraObjects is a object store compatible with Amazon S3.

The driver extends the Amazon S3 driver and overwrites the host pointing
it towards the AuroraObjects servers in the European Union.
