### PR TITLE
compute: Documentation update for AuroraCompute

### DIFF
--- a/docs/compute/drivers/auroracompute.rst
+++ b/docs/compute/drivers/auroracompute.rst
@@ -4,12 +4,19 @@ AuroraCompute Computer Driver Documentation
 `PCextreme B.V.`_ is a Dutch cloud provider. It provides a public cloud offering
 under the name AuroraCompute. All cloud services are under the family name Aurora.
 
-The datacenters are located in Amsterdam and Rotterdam, The Netherlands.
+The datacenters / availability zones are located in:
+
+- Amsterdam (NL)
+- Rotterdam (NL)
+- Miami (US)
+- Los Angelos (US)
+- Tokyo (JP)
+
 
 .. figure:: /_static/images/provider_logos/pcextreme.png
     :align: center
     :width: 300
-    :target: https://www.pcextreme.nl/aurora
+    :target: https://www.pcextreme.nl/en/aurora/compute
 
 The AuroraCompute driver is based on the CloudStack driver. Please refer to
 :doc:`CloudStack Compute Driver Documentation <cloudstack>` page for more

--- a/libcloud/compute/drivers/auroracompute.py
+++ b/libcloud/compute/drivers/auroracompute.py
@@ -24,6 +24,6 @@ __all__ = [
 class AuroraComputeNodeDriver(CloudStackNodeDriver):
     type = Provider.AURORACOMPUTE
     name = 'PCextreme AuroraCompute'
-    website = 'https://www.pcextreme.nl/aurora/'
+    website = 'https://www.pcextreme.nl/en/aurora/compute'
     host = 'cloud.pcextreme.nl'
     path = '/api'


### PR DESCRIPTION
This is mainly a URL update pointing directly to the English version
of the website.
