### PR TITLE
[LIBCLOUD-720] GCE job timeout modification.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -659,6 +659,10 @@ Compute
   (GITHUB-371)
   [Jeroen de Korte]
 
+- Allow setting job timeout in GENodeDriver.
+  (LIBCLOUD-720)
+  [Gabi Kazav]
+
 Storage
 ~~~~~~~
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -659,7 +659,7 @@ Compute
   (GITHUB-371)
   [Jeroen de Korte]
 
-- Allow setting job timeout in GENodeDriver.
+- Allow setting job timeout in GCENodeDriver.
   (LIBCLOUD-720)
   [Gabi Kazav]
 

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -1037,7 +1037,8 @@ class GCENodeDriver(NodeDriver):
         :type     timeout: ``int``
         """
         if timeout is not None:
-            self.connectionCls.timeout=timeout
+            if timeout > 0:
+                self.connectionCls.timeout = timeout
 
         if not project:
             raise ValueError('Project name must be specified using '

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -997,7 +997,8 @@ class GCENodeDriver(NodeDriver):
     }
 
     def __init__(self, user_id, key=None, datacenter=None, project=None,
-                 auth_type=None, scopes=None, credential_file=None, **kwargs):
+                 auth_type=None, scopes=None, credential_file=None,
+                 timeout=None, **kwargs):
         """
         :param  user_id: The email address (for service accounts) or Client ID
                          (for installed apps) to be used for authentication.
@@ -1031,7 +1032,13 @@ class GCENodeDriver(NodeDriver):
         :keyword  credential_file: Path to file for caching authentication
                                    information used by GCEConnection.
         :type     credential_file: ``str``
+
+        :keyword  timeout: Jobs timeout in seconds.
+        :type     timeout: ``int``
         """
+        if timeout is not None:
+            self.connectionCls.timeout=timeout
+
         if not project:
             raise ValueError('Project name must be specified using '
                              '"project" keyword.')


### PR DESCRIPTION
Google jobs timeout hardcoded to be 180 seconds.
There is no access to this property from the Node class.
Added timeout argument to the _init_ of GCENodeDriver.

https://issues.apache.org/jira/browse/LIBCLOUD-720
