### PR TITLE
Cache locations to improve list_images performance

### DIFF
--- a/libcloud/compute/drivers/dimensiondata.py
+++ b/libcloud/compute/drivers/dimensiondata.py
@@ -536,10 +536,13 @@ class DimensionDataNodeDriver(NodeDriver):
 
         :rtype: :class:`NodeLocation`
         """
+        if not hasattr(self, '_cached_locations_'):
+            self._cached_locations_ = self.list_locations()
+
         location = None
         if id is not None:
             location = list(
-                filter(lambda x: x.id == id, self.list_locations()))[0]
+                filter(lambda x: x.id == id, self._cached_locations_))[0]
         return location
 
     def _to_networks(self, object):


### PR DESCRIPTION
This change caches the locations in a private attribute to avoid
repeated calls for the same result set. The number of calls made is
directly proportional to the number of images returned. For a 223
result set, this can reach as high as 99.990 seconds. Caching the
locations reduces it to around 2.001 seconds. The risk of stale location
data during execution is negligible.
