### PR TITLE
[LIBCLOUD-724] Added storage service create and delete methods to Azu…

### DIFF
--- a/libcloud/test/compute/fixtures/azure/_3761b98b_673d_526c_8d55_fee918758e6e_services_storageservices_dss123.xml
+++ b/libcloud/test/compute/fixtures/azure/_3761b98b_673d_526c_8d55_fee918758e6e_services_storageservices_dss123.xml
@@ -1,0 +1,1 @@
+<Error xmlns="http://schemas.microsoft.com/windowsazure" xmlns:i="http://www.w3.org/2001/XMLSchema-instance"><Code>ResourceNotFound</Code><Message>The storage account \'dss123\' was not found.</Message></Error>

--- a/libcloud/test/compute/test_azure.py
+++ b/libcloud/test/compute/test_azure.py
@@ -294,6 +294,25 @@ class AzureNodeDriverTests(LibcloudTestCase):
         with self.assertRaises(LibcloudError):
             self.driver.ex_destroy_cloud_service(name="testdc1234")
 
+    def test_ex_create_storage_service(self):
+        result = self.driver.ex_create_storage_service(name="testdss123", location="East US")
+        self.assertTrue(result)
+
+    def test_ex_create_storage_service_service_exists(self):
+        with self.assertRaises(LibcloudError):
+            self.driver.ex_create_storage_service(
+                name="dss123",
+                location="East US"
+            )
+
+    def test_ex_destroy_storage_service(self):
+        result = self.driver.ex_destroy_storage_service(name="testdss123")
+        self.assertTrue(result)
+
+    def test_ex_destroy_storage_service_service_does_not_exist(self):
+        with self.assertRaises(LibcloudError):
+            self.driver.ex_destroy_storage_service(name="dss123")
+
     def test_create_node_and_deployment_one_node(self):
         kwargs = {
             "ex_storage_service_name": "mtlytics",
@@ -507,6 +526,22 @@ class AzureMockHttp(MockHttp):
 
     def _3761b98b_673d_526c_8d55_fee918758e6e_services_hostedservices_testdc123(self, method, url, body, headers):
         return (httplib.OK, body, headers, httplib.responses[httplib.OK])
+
+    def _3761b98b_673d_526c_8d55_fee918758e6e_services_storageservices(self, method, url, body, headers):
+        # request url is the same irrespective of serviceName, only way to differentiate
+        if "<ServiceName>testdss123</ServiceName>" in body:
+            return (httplib.ACCEPTED, body, headers, httplib.responses[httplib.ACCEPTED])
+        elif "<ServiceName>dss123</ServiceName>" in body:
+            return (httplib.CONFLICT, body, headers, httplib.responses[httplib.CONFLICT])
+
+    def _3761b98b_673d_526c_8d55_fee918758e6e_services_storageservices_testdss123(self, method, url, body, headers):
+        return (httplib.OK, body, headers, httplib.responses[httplib.OK])
+
+    def _3761b98b_673d_526c_8d55_fee918758e6e_services_storageservices_dss123(self, method, url, body, headers):
+        if method == "GET":
+            body = self.fixtures.load('_3761b98b_673d_526c_8d55_fee918758e6e_services_storageservices_dss123.xml')
+
+        return (httplib.NOT_FOUND, body, headers, httplib.responses[httplib.NOT_FOUND])
 
     def _3761b98b_673d_526c_8d55_fee918758e6e_services_hostedservices_testdc1234(self, method, url, body, headers):
         if method == "GET":


### PR DESCRIPTION
Added methods to create and destroy storage services in Azure and the appropriate tests. I believe this is necessary because when you use the create_node method to create a node, it will automatically create a storage service, and when you call destroy_node, it does not delete that storage service. Consequently, you must use another tool or the GUI to clean up after node creation (or to set up for it), so providing this functionality through libcloud enhances the role libcloud can play in Azure usage. Also, I think these methods belong in the compute driver rather than in the storage driver for two reasons:
1) These are higher level functions than is accessible through the current Azure storage driver (you must specify an already-created storage service to instantiate the driver)
2) The Azure API lumps these functions in with other compute functions, specifically separating them from object storage functions.
