### PR TITLE
GCE[ex_create_route] By default let's assume if next_hop is not a string it's a Node object

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -2187,7 +2187,7 @@ class GCENodeDriver(NodeDriver):
         elif isinstance(next_hop, str):
             route_data['nextHopIp'] = next_hop
         else:
-            route_data['nextHopInstance'] = node.extra['selfLink']
+            route_data['nextHopInstance'] = next_hop.extra['selfLink']
 
         request = '/global/routes'
         self.connection.async_request(request, method='POST',

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -2187,7 +2187,6 @@ class GCENodeDriver(NodeDriver):
         elif isinstance(next_hop, str):
             route_data['nextHopIp'] = next_hop
         else:
-            node = self.ex_get_node(next_hop)
             route_data['nextHopInstance'] = node.extra['selfLink']
 
         request = '/global/routes'


### PR DESCRIPTION
As far my knowledge is concerned it is impossible to reach the else part of the whole next_hop in a sensible way.
For example (commented):

```
        if next_hop is None:
            url = 'https://www.googleapis.com/compute/%s/projects/%s/%s' % (
                  API_VERSION, self.project,
                  "global/gateways/default-internet-gateway")
            route_data['nextHopGateway'] = url
        elif isinstance(next_hop, str): # if it is string, assume it's an IP address
            route_data['nextHopIp'] = next_hop
        else: # what object is expected here? next_hop param there should be string or sth that evaluates to string
            node = self.ex_get_node(next_hop)
            route_data['nextHopInstance'] = node.extra['selfLink']
```

Even if you pass `Node` object to `next_hop` param it evaluates to object representation not the node name itself what is expected.
Even tried to pass some Dummy node object that evaluates to a node name in a string context but it failed on finding proper zone `_find_zone_or_region` because `name` param is a string explicitly needed here `if res['name'] == name:`. When change to `str(name)` worked properly.

In my opinion more sensible choice would be to assume that when `next_hop` is not a string it is a `Node` object and it can be achieved with deleting just one line and changing `node` to `next_hop`.
