### PR TITLE
[LIBCLOUD-726] Added support for custom data in create_node function …

### DIFF
--- a/libcloud/compute/drivers/azure.py
+++ b/libcloud/compute/drivers/azure.py
@@ -579,6 +579,10 @@ class AzureNodeDriver(NodeDriver):
         auth = self._get_and_check_auth(auth)
         password = auth.password
 
+        # Check for custom data
+        custom_data = None
+        if 'custom_data' in kwargs:
+            custom_data = kwargs['custom_data']
         if not isinstance(size, NodeSize):
             raise ValueError('Size must be an instance of NodeSize')
 
@@ -663,7 +667,8 @@ class AzureNodeDriver(NodeDriver):
                 name,
                 ex_admin_user_id,
                 password,
-                False
+                False,
+                custom_data
             )
 
         network_config.input_endpoints.items.append(endpoint)
@@ -2300,6 +2305,12 @@ class AzureXmlSerializer(object):
                 )
                 AzureXmlSerializer.data_to_xml([('Path', key.path)], kpair)
 
+        if configuration.custom_data is not None:
+            AzureXmlSerializer.data_to_xml(
+                [('CustomData', configuration.custom_data)],
+                xml
+            )
+
         return xml
 
     @staticmethod
@@ -2781,7 +2792,8 @@ class LinuxConfigurationSet(WindowsAzureData):
                  host_name=None,
                  user_name=None,
                  user_password=None,
-                 disable_ssh_password_authentication=None):
+                 disable_ssh_password_authentication=None,
+                 custom_data=None):
         self.configuration_set_type = 'LinuxProvisioningConfiguration'
         self.host_name = host_name
         self.user_name = user_name
@@ -2789,6 +2801,7 @@ class LinuxConfigurationSet(WindowsAzureData):
         self.disable_ssh_password_authentication = \
             disable_ssh_password_authentication
         self.ssh = SSH()
+        self.custom_data = custom_data
 
 
 class WindowsConfigurationSet(WindowsAzureData):


### PR DESCRIPTION
Azure has support for Custom Data (i.e. "User Data") in base64 format to be included on node creation (https://msdn.microsoft.com/en-us/library/azure/jj157194.aspx). I have implemented this in the create_node function for Linux VMs. This is an important feature for any workflows that rely on cloud-init.
