### PR TITLE
CloudStack: fix in parsing of an empty body

### DIFF
--- a/libcloud/common/cloudstack.py
+++ b/libcloud/common/cloudstack.py
@@ -44,10 +44,14 @@ class CloudStackResponse(JsonResponse):
         if value is None:
             value = self.body
 
+        if not value:
+            value = 'WARNING: error message text sent by provider was empty.'
+
         error = ProviderError(value=value, http_code=self.status,
                               driver=self.connection.driver)
         raise error
 
+    def _get_provider_error
 
 class CloudStackConnection(ConnectionUserAndKey, PollingConnection):
     responseCls = CloudStackResponse

--- a/libcloud/common/cloudstack.py
+++ b/libcloud/common/cloudstack.py
@@ -35,12 +35,13 @@ class CloudStackResponse(JsonResponse):
         if self.status == httplib.UNAUTHORIZED:
             raise InvalidCredsError('Invalid provider credentials')
 
+        value = None
         body = self.parse_body()
-        values = list(body.values())[0]
-
-        if 'errortext' in values:
-            value = values['errortext']
-        else:
+        if hasattr(body, 'values'):
+            values = list(body.values())[0]
+            if 'errortext' in values:
+                value = values['errortext']
+        if value is None:
             value = self.body
 
         error = ProviderError(value=value, http_code=self.status,

--- a/libcloud/common/cloudstack.py
+++ b/libcloud/common/cloudstack.py
@@ -51,7 +51,6 @@ class CloudStackResponse(JsonResponse):
                               driver=self.connection.driver)
         raise error
 
-    def _get_provider_error
 
 class CloudStackConnection(ConnectionUserAndKey, PollingConnection):
     responseCls = CloudStackResponse


### PR DESCRIPTION
Fix for the issue when `AttributeError: 'str' object has no attribute 'values'` gets thrown in case of an empty body is retuned by the provider.

```
Traceback (most recent call last):
...
  File "/usr/lib/python2.6/site-packages/libcloud/compute/drivers/cloudstack.py", line 1089, in list_sizes
    method='GET')
  File "/usr/lib/python2.6/site-packages/libcloud/common/cloudstack.py", line 188, in _sync_request
    headers=headers, method=method)
  File "/usr/lib/python2.6/site-packages/libcloud/common/cloudstack.py", line 152, in _sync_request
    data=data, headers=headers, method=method)
  File "/usr/lib/python2.6/site-packages/libcloud/common/base.py", line 736, in request
    response = responseCls(**kwargs)
  File "/usr/lib/python2.6/site-packages/libcloud/common/base.py", line 117, in __init__
    raise Exception(self.parse_error())
  File "/usr/lib/python2.6/site-packages/libcloud/common/cloudstack.py", line 39, in parse_error
    values = list(body.values())[0]
AttributeError: 'str' object has no attribute 'values'
```

Exception after the change:

```
  File "/usr/lib/python2.6/site-packages/libcloud/common/cloudstack.py", line 188, in _sync_request
    headers=headers, method=method)
  File "/usr/lib/python2.6/site-packages/libcloud/common/cloudstack.py", line 152, in _sync_request
    data=data, headers=headers, method=method)
  File "/usr/lib/python2.6/site-packages/libcloud/common/base.py", line 736, in request
    response = responseCls(**kwargs)
  File "/usr/lib/python2.6/site-packages/libcloud/common/base.py", line 117, in __init__
    raise Exception(self.parse_error())
  File "/usr/lib/python2.6/site-packages/libcloud/common/cloudstack.py", line 48, in parse_error
    raise error
libcloud.common.types.ProviderError: 'WARNING: error message text sent by provider was empty.'
```
