### PR TITLE
[LIBCLOUD-730]Add instance fault to OpenStack_NodeDriver

### DIFF
--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -2113,6 +2113,7 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
                 vm_state=api_node.get("OS-EXT-STS:vm_state", None),
                 power_state=api_node.get("OS-EXT-STS:power_state", None),
                 progress=api_node.get("progress", None),
+                fault=api_node.get('fault')
             ),
         )
 

--- a/libcloud/test/compute/fixtures/openstack_v1.1/_servers_detail.json
+++ b/libcloud/test/compute/fixtures/openstack_v1.1/_servers_detail.json
@@ -85,6 +85,14 @@
                     }
                 ]
             },
+            "fault": {
+                "id": 1234,
+                "instance_uuid": "ec53630b-e4fb-442a-a748-c376f5c4345b",
+                "code": "500",
+                "message": "test message",
+                "details": "No valid host was found.",
+                "host": "912566d83a13fbb357ea3f13c629363d9f7e1ba3f925b49f3d2ab725"
+            },
             "config_drive": "",
             "id": 12065,
             "metadata": {},

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -788,6 +788,7 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
         self.assertEqual(node.extra.get('vm_state'), 'active')
         self.assertEqual(node.extra.get('power_state'), 1)
         self.assertEqual(node.extra.get('progress'), 25)
+        self.assertEqual(node.extra.get('fault')['id'], 1234)
 
     def test_list_nodes_no_image_id_attribute(self):
         # Regression test for LIBCLOD-455


### PR DESCRIPTION
`InstanceFault` is returned by the API but is not saved in the `OpenStack_1_1_NodeDriver.extra` field. Adding `fault` to the `extra` field.
[LIBCLOUD-730](https://issues.apache.org/jira/browse/LIBCLOUD-730)
