### PR TITLE
Fix a bug in consuming streams in Paramiko ssh client 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,13 @@ General
   ``LIBCLOUD_RETRY_FAILED_HTTP_REQUESTS`` environment variable.
   (GITHUB-515, LIBCLOUD-360, LIBCLOUD-709)
 
+- Fix a bug in consuming stdout and stderr strams in Paramiko SSH client.
+
+  In some cases (like connecting to localhost via SSH), exit_status_ready
+  gets set immediately even before the while loop to consume the streams
+  kicks in. In those cases, we will not have consumed the streams at all.
+  [Lakshmi Kannan]
+
 Compute
 ~~~~~~~
 

--- a/libcloud/test/compute/test_ssh_client.py
+++ b/libcloud/test/compute/test_ssh_client.py
@@ -30,7 +30,7 @@ from libcloud.compute.ssh import have_paramiko
 
 from libcloud.utils.py3 import StringIO
 
-from mock import patch, Mock
+from mock import patch, Mock, MagicMock
 
 if not have_paramiko:
     ParamikoSSHClient = None  # NOQA
@@ -192,6 +192,10 @@ class ParamikoSSHClientTests(LibcloudTestCase):
                          'port': 22}
         mock.client.connect.assert_called_once_with(**expected_conn)
 
+    @patch.object(ParamikoSSHClient, '_consume_stdout',
+                  MagicMock(return_value=StringIO('')))
+    @patch.object(ParamikoSSHClient, '_consume_stderr',
+                  MagicMock(return_value=StringIO('')))
     def test_basic_usage_absolute_path(self):
         """
         Basic execution.


### PR DESCRIPTION
I wrote a wrapper to that wraps the SSH client to test. See https://github.com/lakshmi-kannan/st2/pull/2 and specifically https://github.com/lakshmi-kannan/st2/commit/1f0e025f8ff378eff7dd00a929cffce035e63a4b.

```
(virtualenv)/m/s/s/st2 git:paramiko_parallel_ssh ❯❯❯ st2common/bin/paramiko_ssh_evenlets_tester.py --hosts=localhost,127.0.0.1 --user=lakshmi --private-key="/home/vagrant/.ssh/id_rsa" --cmd="pwd"
"cmd results: \n{'127.0.0.1': [u'/home/lakshmi\\n', '', 0, True], 'localhost': [u'/home/lakshmi\\n', '', 0, True]}"
(virtualenv)/m/s/s/st2 git:paramiko_parallel_ssh ❯❯❯
```
