### PR TITLE
[LIBCLOUD-738] Update Rackspace AUTH_URL

### DIFF
--- a/libcloud/common/rackspace.py
+++ b/libcloud/common/rackspace.py
@@ -21,4 +21,4 @@ __all__ = [
     'AUTH_URL'
 ]
 
-AUTH_URL = 'https://auth.api.rackspacecloud.com'
+AUTH_URL = 'https://identity.api.rackspacecloud.com'


### PR DESCRIPTION
Rackspace is phasing out the https://auth.api.rackspace.com endpoint in favor of https://identity.api.rackspace.com.

The identity.api endpoint has been available for several years now, and there's no exact timeline on the removal of the auth.api endpoint. I had a conversation with our Identity team and they wanted to make sure we have all of the various SDKs pointing to identity.api earlier than later in order to make the transition easier.

This passes unit tests as they don't really do anything with the AUTH_URL. I checked a few things manually as a functional test and they worked fine as well.
