### PR TITLE
GCE: Update generic auth error message

### DIFF
--- a/docs/compute/drivers/gce.rst
+++ b/docs/compute/drivers/gce.rst
@@ -41,7 +41,9 @@ Which one should I use?
   authorization is your Project ID.
 
 Once you have set up the authentication as described below, you pass the
-authentication information to the driver as described in `Examples`_
+authentication information to the driver as described in `Examples`_. Also
+bear in mind that large clock drift (difference in time) between authenticating
+host and google will cause authentication to fail.
 
 
 Service Account

--- a/libcloud/common/google.py
+++ b/libcloud/common/google.py
@@ -354,7 +354,7 @@ class GoogleBaseAuthConnection(ConnectionUserAndKey):
                                     data=data)
         except AttributeError:
             raise GoogleAuthError('Invalid authorization response, please '
-                                  'check your credentials.')
+                                  'check your credentials and time drift.')
         token_info = response.object
         if 'expires_in' in token_info:
             expire_time = now + datetime.timedelta(


### PR DESCRIPTION
Google authentication will fail if your time drift (difference between your local time and time on google servers) is bigger than 5 minutes. This often happens on the VM instances running in various cloud providers. Google itself doesn't provide any helpful indication of the issue, the response is just `{u'error': u'invalid_grant'}`.

There is also problem in the `_get_error(self, body)`, line 205: the error response returned by google above will mean that err is a string, not a dictionary. `err.get` will then throw attribute error, which displays generic error message. I think it is better to display the generic error message than not so helpful 'invalid_grant' response from google. You might decide to fix or change that later, but for now I think it's important to hint about time drift to the user, as this happens quite often and it's hard to find, if you only check whether your credentials are correct (which they can be, but you'll still fail auth with big time drift).
