### PR TITLE
GCE: Fix check_node indentation to match check_disk

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -4899,15 +4899,11 @@ class GCENodeDriver(NodeDriver):
             return
         if response['status'] == 'DONE':
             status['node_response'] = None
-        if error:
-            status['node'] = GCEFailedNode(status['name'],
-                                           error, code)
-        else:
-            try:
+            if error:
+                status['node'] = GCEFailedNode(status['name'], error, code)
+            else:
                 status['node'] = self.ex_get_node(status['name'],
                                                   node_attrs['location'])
-            except ResourceNotFoundError:
-                return
 
     def _create_vol_req(self, size, name, location=None, snapshot=None,
                         image=None, ex_disk_type='pd-standard'):


### PR DESCRIPTION
The _multi_check_node later if statements were somehow indented incorrectly and a try except was inserted to work around the issue. This fixes the indentation problem so that the self.ex_get_node call is only made when the original create_node call has finished creating the node.

The code now also matches the _multi_disk_node function which has the proper indentation.
