### PR TITLE
Proxy_url & connection object fixes

### DIFF
--- a/libcloud/common/abiquo.py
+++ b/libcloud/common/abiquo.py
@@ -187,7 +187,8 @@ class AbiquoConnection(ConnectionUserAndKey, PollingConnection):
                                                host=host, port=port,
                                                url=url, timeout=timeout,
                                                retry_delay=retry_delay,
-                                               backoff=backoff, proxy_url=proxy_url)
+                                               backoff=backoff,
+                                               proxy_url=proxy_url)
 
         # This attribute stores data cached across multiple request
         self.cache = {}

--- a/libcloud/common/abiquo.py
+++ b/libcloud/common/abiquo.py
@@ -181,13 +181,13 @@ class AbiquoConnection(ConnectionUserAndKey, PollingConnection):
 
     def __init__(self, user_id, key, secure=True, host=None, port=None,
                  url=None, timeout=None,
-                 retry_delay=None, backoff=None):
+                 retry_delay=None, backoff=None, proxy_url=None):
         super(AbiquoConnection, self).__init__(user_id=user_id, key=key,
                                                secure=secure,
                                                host=host, port=port,
                                                url=url, timeout=timeout,
                                                retry_delay=retry_delay,
-                                               backoff=backoff)
+                                               backoff=backoff, proxy_url=proxy_url)
 
         # This attribute stores data cached across multiple request
         self.cache = {}

--- a/libcloud/common/aws.py
+++ b/libcloud/common/aws.py
@@ -128,14 +128,14 @@ class AWSGenericResponse(AWSBaseResponse):
 
 class AWSTokenConnection(ConnectionUserAndKey):
     def __init__(self, user_id, key, secure=True,
-                 host=None, port=None, url=None, timeout=None, token=None,
+                 host=None, port=None, url=None, timeout=None, proxy_url=None, token=None,
                  retry_delay=None, backoff=None):
         self.token = token
         super(AWSTokenConnection, self).__init__(user_id, key, secure=secure,
                                                  host=host, port=port, url=url,
                                                  timeout=timeout,
                                                  retry_delay=retry_delay,
-                                                 backoff=backoff)
+                                                 backoff=backoff, proxy_url=proxy_url)
 
     def add_default_params(self, params):
         # Even though we are adding it to the headers, we need it here too
@@ -328,14 +328,14 @@ class AWSRequestSignerAlgorithmV4(AWSRequestSigner):
 
 class SignedAWSConnection(AWSTokenConnection):
     def __init__(self, user_id, key, secure=True, host=None, port=None,
-                 url=None, timeout=None, token=None, retry_delay=None,
+                 url=None, timeout=None, proxy_url=None, token=None, retry_delay=None,
                  backoff=None, signature_version=DEFAULT_SIGNATURE_VERSION):
         super(SignedAWSConnection, self).__init__(user_id=user_id, key=key,
                                                   secure=secure, host=host,
                                                   port=port, url=url,
                                                   timeout=timeout, token=token,
                                                   retry_delay=retry_delay,
-                                                  backoff=backoff)
+                                                  backoff=backoff, proxy_url=proxy_url)
         self.signature_version = str(signature_version)
 
         if self.signature_version == '2':

--- a/libcloud/common/aws.py
+++ b/libcloud/common/aws.py
@@ -128,14 +128,15 @@ class AWSGenericResponse(AWSBaseResponse):
 
 class AWSTokenConnection(ConnectionUserAndKey):
     def __init__(self, user_id, key, secure=True,
-                 host=None, port=None, url=None, timeout=None, proxy_url=None, token=None,
-                 retry_delay=None, backoff=None):
+                 host=None, port=None, url=None, timeout=None, proxy_url=None,
+                 token=None, retry_delay=None, backoff=None):
         self.token = token
         super(AWSTokenConnection, self).__init__(user_id, key, secure=secure,
                                                  host=host, port=port, url=url,
                                                  timeout=timeout,
                                                  retry_delay=retry_delay,
-                                                 backoff=backoff, proxy_url=proxy_url)
+                                                 backoff=backoff,
+                                                 proxy_url=proxy_url)
 
     def add_default_params(self, params):
         # Even though we are adding it to the headers, we need it here too
@@ -328,14 +329,16 @@ class AWSRequestSignerAlgorithmV4(AWSRequestSigner):
 
 class SignedAWSConnection(AWSTokenConnection):
     def __init__(self, user_id, key, secure=True, host=None, port=None,
-                 url=None, timeout=None, proxy_url=None, token=None, retry_delay=None,
-                 backoff=None, signature_version=DEFAULT_SIGNATURE_VERSION):
+                 url=None, timeout=None, proxy_url=None, token=None,
+                 retry_delay=None, backoff=None,
+                 signature_version=DEFAULT_SIGNATURE_VERSION):
         super(SignedAWSConnection, self).__init__(user_id=user_id, key=key,
                                                   secure=secure, host=host,
                                                   port=port, url=url,
                                                   timeout=timeout, token=token,
                                                   retry_delay=retry_delay,
-                                                  backoff=backoff, proxy_url=proxy_url)
+                                                  backoff=backoff,
+                                                  proxy_url=proxy_url)
         self.signature_version = str(signature_version)
 
         if self.signature_version == '2':

--- a/libcloud/common/base.py
+++ b/libcloud/common/base.py
@@ -1099,7 +1099,8 @@ class BaseDriver(object):
         conn_kwargs = self._ex_connection_class_kwargs()
         conn_kwargs.update({'timeout': kwargs.pop('timeout', None),
                             'retry_delay': kwargs.pop('retry_delay', None),
-                            'backoff': kwargs.pop('backoff', None)})
+                            'backoff': kwargs.pop('backoff', None),
+                            'proxy_url': kwargs.pop('proxy_url', None)})
         self.connection = self.connectionCls(*args, **conn_kwargs)
 
         self.connection.driver = self

--- a/libcloud/common/base.py
+++ b/libcloud/common/base.py
@@ -1006,8 +1006,8 @@ class CertificateConnection(Connection):
     """
     Base connection class which accepts a single ``cert_file`` argument.
     """
-    def __init__(self, cert_file, secure=True, host=None, port=None, url=None, proxy_url=None,
-                 timeout=None, backoff=None, retry_delay=None):
+    def __init__(self, cert_file, secure=True, host=None, port=None, url=None,
+                 proxy_url=None, timeout=None, backoff=None, retry_delay=None):
         """
         Initialize `cert_file`; set `secure` to an ``int`` based on
         passed value.
@@ -1016,7 +1016,8 @@ class CertificateConnection(Connection):
                                                     port=port, url=url,
                                                     timeout=timeout,
                                                     backoff=backoff,
-                                                    retry_delay=retry_delay, proxy_url=proxy_url)
+                                                    retry_delay=retry_delay,
+                                                    proxy_url=proxy_url)
 
         self.cert_file = cert_file
 

--- a/libcloud/common/base.py
+++ b/libcloud/common/base.py
@@ -1006,7 +1006,7 @@ class CertificateConnection(Connection):
     """
     Base connection class which accepts a single ``cert_file`` argument.
     """
-    def __init__(self, cert_file, secure=True, host=None, port=None, url=None,
+    def __init__(self, cert_file, secure=True, host=None, port=None, url=None, proxy_url=None,
                  timeout=None, backoff=None, retry_delay=None):
         """
         Initialize `cert_file`; set `secure` to an ``int`` based on
@@ -1016,7 +1016,7 @@ class CertificateConnection(Connection):
                                                     port=port, url=url,
                                                     timeout=timeout,
                                                     backoff=backoff,
-                                                    retry_delay=retry_delay)
+                                                    retry_delay=retry_delay, proxy_url=proxy_url)
 
         self.cert_file = cert_file
 

--- a/libcloud/common/gandi.py
+++ b/libcloud/common/gandi.py
@@ -58,7 +58,7 @@ class GandiConnection(XMLRPCConnection, ConnectionKey):
     endpoint = '/xmlrpc/'
 
     def __init__(self, key, secure=True, timeout=None,
-                 retry_delay=None, backoff=None):
+                 retry_delay=None, backoff=None, proxy_url=None):
         # Note: Method resolution order in this case is
         # XMLRPCConnection -> Connection and Connection doesn't take key as the
         # first argument so we specify a keyword argument instead.
@@ -66,7 +66,7 @@ class GandiConnection(XMLRPCConnection, ConnectionKey):
         super(GandiConnection, self).__init__(key=key, secure=secure,
                                               timeout=timeout,
                                               retry_delay=retry_delay,
-                                              backoff=backoff)
+                                              backoff=backoff, proxy_url=proxy_url)
         self.driver = BaseGandiDriver
 
     def request(self, method, *args):

--- a/libcloud/common/gandi.py
+++ b/libcloud/common/gandi.py
@@ -66,7 +66,8 @@ class GandiConnection(XMLRPCConnection, ConnectionKey):
         super(GandiConnection, self).__init__(key=key, secure=secure,
                                               timeout=timeout,
                                               retry_delay=retry_delay,
-                                              backoff=backoff, proxy_url=proxy_url)
+                                              backoff=backoff,
+                                              proxy_url=proxy_url)
         self.driver = BaseGandiDriver
 
     def request(self, method, *args):

--- a/libcloud/common/openstack.py
+++ b/libcloud/common/openstack.py
@@ -122,7 +122,7 @@ class OpenStackBaseConnection(ConnectionUserAndKey):
     _auth_version = None
 
     def __init__(self, user_id, key, secure=True,
-                 host=None, port=None, timeout=None,
+                 host=None, port=None, timeout=None, proxy_url=None,
                  ex_force_base_url=None,
                  ex_force_auth_url=None,
                  ex_force_auth_version=None,
@@ -134,7 +134,7 @@ class OpenStackBaseConnection(ConnectionUserAndKey):
                  retry_delay=None, backoff=None):
         super(OpenStackBaseConnection, self).__init__(
             user_id, key, secure=secure, timeout=timeout,
-            retry_delay=retry_delay, backoff=backoff)
+            retry_delay=retry_delay, backoff=backoff, proxy_url=proxy_url)
 
         if ex_force_auth_version:
             self._auth_version = ex_force_auth_version

--- a/libcloud/compute/drivers/cloudframes.py
+++ b/libcloud/compute/drivers/cloudframes.py
@@ -117,7 +117,7 @@ class CloudFramesConnection(XMLRPCConnection, ConnectionKey):
 
     def __init__(self, key=None, secret=None, secure=True,
                  host=None, port=None, url=None, timeout=None,
-                 retry_delay=None, backoff=None):
+                 retry_delay=None, backoff=None, proxy_url=None):
         """
         :param    key:    The username to connect with to the cloudapi
         :type     key:    ``str``
@@ -142,7 +142,7 @@ class CloudFramesConnection(XMLRPCConnection, ConnectionKey):
                                                     host=host, port=port,
                                                     url=url, timeout=timeout,
                                                     retry_delay=retry_delay,
-                                                    backoff=backoff)
+                                                    backoff=backoff, proxy_url=proxy_url)
         self._auth = base64.b64encode(
             b('%s:%s' % (key, secret))).decode('utf-8')
         self.endpoint = url

--- a/libcloud/compute/drivers/cloudframes.py
+++ b/libcloud/compute/drivers/cloudframes.py
@@ -142,7 +142,8 @@ class CloudFramesConnection(XMLRPCConnection, ConnectionKey):
                                                     host=host, port=port,
                                                     url=url, timeout=timeout,
                                                     retry_delay=retry_delay,
-                                                    backoff=backoff, proxy_url=proxy_url)
+                                                    backoff=backoff,
+                                                    proxy_url=proxy_url)
         self._auth = base64.b64encode(
             b('%s:%s' % (key, secret))).decode('utf-8')
         self.endpoint = url

--- a/libcloud/compute/drivers/vcloud.py
+++ b/libcloud/compute/drivers/vcloud.py
@@ -851,7 +851,7 @@ class VCloud_1_5_Connection(VCloudConnection):
             self.connection.set_http_proxy ( self.proxy_url )
             self.connection.request(method='GET', url=org_list_url,
                                     headers=self.add_default_headers({}))
-            body = ET.XML(conn.getresponse().read())
+            body = ET.XML(self.connection.getresponse().read())
             self.driver.org = get_url_path(
                 next((org for org in body.findall(fixxpath(body, 'Org'))
                      if org.get('name') == self.org_name)).get('href')

--- a/libcloud/compute/drivers/vcloud.py
+++ b/libcloud/compute/drivers/vcloud.py
@@ -848,7 +848,7 @@ class VCloud_1_5_Connection(VCloudConnection):
                      'application/vnd.vmware.vcloud.orgList+xml')).get('href')
             )
 
-            self.connection.set_http_proxy ( self.proxy_url )
+            self.connection.set_http_proxy(self.proxy_url)
             self.connection.request(method='GET', url=org_list_url,
                                     headers=self.add_default_headers({}))
             body = ET.XML(self.connection.getresponse().read())

--- a/libcloud/compute/drivers/vcloud.py
+++ b/libcloud/compute/drivers/vcloud.py
@@ -335,12 +335,10 @@ class VCloudConnection(ConnectionUserAndKey):
 
     def _get_auth_token(self):
         if not self.token:
-            conn = self.conn_classes[self.secure](self.host,
-                                                  self.port)
-            conn.request(method='POST', url='/api/v0.8/login',
-                         headers=self._get_auth_headers())
+            self.connection.request(method='POST', url='/api/v0.8/login',
+                                    headers=self._get_auth_headers())
 
-            resp = conn.getresponse()
+            resp = self.connection.getresponse()
             headers = dict(resp.getheaders())
             body = ET.XML(resp.read())
 
@@ -829,12 +827,10 @@ class VCloud_1_5_Connection(VCloudConnection):
     def _get_auth_token(self):
         if not self.token:
             # Log In
-            conn = self.conn_classes[self.secure](self.host,
-                                                  self.port)
-            conn.request(method='POST', url='/api/sessions',
-                         headers=self._get_auth_headers())
+            self.connection.request(method='POST', url='/api/sessions',
+                                    headers=self._get_auth_headers())
 
-            resp = conn.getresponse()
+            resp = self.connection.getresponse()
             headers = dict(resp.getheaders())
 
             # Set authorization token
@@ -852,8 +848,9 @@ class VCloud_1_5_Connection(VCloudConnection):
                      'application/vnd.vmware.vcloud.orgList+xml')).get('href')
             )
 
-            conn.request(method='GET', url=org_list_url,
-                         headers=self.add_default_headers({}))
+            self.connection.set_http_proxy ( self.proxy_url )
+            self.connection.request(method='GET', url=org_list_url,
+                                    headers=self.add_default_headers({}))
             body = ET.XML(conn.getresponse().read())
             self.driver.org = get_url_path(
                 next((org for org in body.findall(fixxpath(body, 'Org'))

--- a/libcloud/test/__init__.py
+++ b/libcloud/test/__init__.py
@@ -166,6 +166,8 @@ class MockHttp(BaseMockHttpObject):
 
     test = None  # TestCase instance which is using this mock
 
+    proxy_url = None
+
     def __init__(self, host, port, *args, **kwargs):
         self.host = host
         self.port = port
@@ -200,6 +202,9 @@ class MockHttp(BaseMockHttpObject):
 
     def close(self):
         pass
+
+    def set_http_proxy (self, proxy_url):
+        self.proxy_url = proxy_url
 
     # Mock request/response example
     def _example(self, method, url, body, headers):

--- a/libcloud/test/__init__.py
+++ b/libcloud/test/__init__.py
@@ -203,7 +203,7 @@ class MockHttp(BaseMockHttpObject):
     def close(self):
         pass
 
-    def set_http_proxy (self, proxy_url):
+    def set_http_proxy(self, proxy_url):
         self.proxy_url = proxy_url
 
     # Mock request/response example


### PR DESCRIPTION
I have a use case that requires explicitly setting the proxy_url for accessing a vCloud API (as opposed to the default environment proxy). I noticed that the proxy_url was not being passed to the base Connection class by the base NodeDriver. I fixed this by adding the proxy_url into the constructor call where the connection class is created.

Also, within the vCouldNodeDriver a new connection class we being created with
no custom variables rather than re-using the existing connection class. Any custom values, such as the proxy_url, were not being passed to this new instance. By swapping to the self.connection class these variables are set.

I could not find any unit tests that would demonstrate this issue (I would assume that they would be integration tests anyway). So apologies that this fix does not have supporting tests.
