### PR TITLE
Clarify DreamHost provider is for VPS product

### DIFF
--- a/libcloud/compute/drivers/dreamhost.py
+++ b/libcloud/compute/drivers/dreamhost.py
@@ -126,7 +126,7 @@ class DreamhostNodeDriver(NodeDriver):
     """
     type = Provider.DREAMHOST
     api_name = 'dreamhost'
-    name = "Dreamhost"
+    name = "DreamHost VPS"
     website = 'http://dreamhost.com/'
     connectionCls = DreamhostConnection
 


### PR DESCRIPTION
DreamHost has a VPS product and a cloud product, based on OpenStack.
This patch clarifies that the libcloud provider for DreamHost is for
the VPS product, not for DreamCloud.

Signed-off-by: Stefano Maffulli stefano.maffulli@dreamhost.com
