### PR TITLE
Update docs for EC2 region change in 0.14

### DIFF
--- a/docs/compute/drivers/ec2.rst
+++ b/docs/compute/drivers/ec2.rst
@@ -10,12 +10,13 @@ platform, Amazon Web Services (AWS).
     :width: 300
     :target: https://aws.amazon.com/ec2/
 
-It allows users to rent virtual servers in more than 8 regions such as:
+It allows users to rent virtual servers in more than 9 regions such as:
 
 * US East (Northern Virginia) Region
 * US West (Oregon) Region
 * US West (Northern California) Region
-* EU (Ireland) Region
+* EU West (Ireland) Region
+* EU Central (Frankfurt) Region
 * Asia Pacific (Singapore) Region
 * Asia Pacific (Sydney) Region
 * Asia Pacific (Tokyo) Region

--- a/docs/examples/compute/create_ec2_node.py
+++ b/docs/examples/compute/create_ec2_node.py
@@ -7,8 +7,8 @@ SECRET_KEY = 'your secret key'
 IMAGE_ID = 'ami-c8052d8d'
 SIZE_ID = 't1.micro'
 
-cls = get_driver(Provider.EC2_US_WEST)
-driver = cls(ACCESS_ID, SECRET_KEY)
+cls = get_driver(Provider.EC2)
+driver = cls(ACCESS_ID, SECRET_KEY, region="us-west-1")
 
 # Here we select size and image
 sizes = driver.list_sizes()

--- a/docs/examples/compute/create_ec2_node_and_associate_elastic_ip.py
+++ b/docs/examples/compute/create_ec2_node_and_associate_elastic_ip.py
@@ -7,8 +7,8 @@ SECRET_KEY = 'your secret key'
 IMAGE_ID = 'ami-c8052d8d'
 SIZE_ID = 't1.micro'
 
-cls = get_driver(Provider.EC2_US_WEST)
-driver = cls(ACCESS_ID, SECRET_KEY)
+cls = get_driver(Provider.EC2)
+driver = cls(ACCESS_ID, SECRET_KEY, region="us-west-1")
 
 sizes = driver.list_sizes()
 images = driver.list_images()

--- a/docs/examples/compute/create_ec2_node_custom_ami.py
+++ b/docs/examples/compute/create_ec2_node_custom_ami.py
@@ -13,8 +13,8 @@ SIZE_ID = 't1.micro'
 
 # 'us-west-1' region is available in Libcloud under EC2_US_WEST provider
 # constant
-cls = get_driver(Provider.EC2_US_WEST)
-driver = cls(ACCESS_ID, SECRET_KEY)
+cls = get_driver(Provider.EC2)
+driver = cls(ACCESS_ID, SECRET_KEY, region="us-west-1")
 
 # Here we select
 sizes = driver.list_sizes()

--- a/docs/examples/compute/create_ec2_node_iam.py
+++ b/docs/examples/compute/create_ec2_node_iam.py
@@ -7,8 +7,8 @@ IAM_PROFILE = 'your IAM profile arn or IAM profile name'
 
 IMAGE_ID = 'ami-c8052d8d'
 SIZE_ID = 't1.micro'
-cls = get_driver(Provider.EC2_US_WEST)
-driver = cls(ACCESS_ID, SECRET_KEY)
+cls = get_driver(Provider.EC2)
+driver = cls(ACCESS_ID, SECRET_KEY, region="us-west-1")
 
 # Here we select size and image
 sizes = driver.list_sizes()

--- a/docs/examples/compute/create_ec2_node_manual_instantiation.py
+++ b/docs/examples/compute/create_ec2_node_manual_instantiation.py
@@ -8,8 +8,8 @@ SECRET_KEY = 'your secret key'
 IMAGE_ID = 'ami-c8052d8d'
 SIZE_ID = 't1.micro'
 
-cls = get_driver(Provider.EC2_US_WEST)
-driver = cls(ACCESS_ID, SECRET_KEY)
+cls = get_driver(Provider.EC2)
+driver = cls(ACCESS_ID, SECRET_KEY, region="us-west-1")
 
 size = NodeSize(id=SIZE_ID, name=None, ram=None, disk=None, bandwidth=None,
                 price=None, driver=driver)

--- a/docs/examples/compute/ec2/temporary_credentials.py
+++ b/docs/examples/compute/ec2/temporary_credentials.py
@@ -1,6 +1,6 @@
 from libcloud.compute.types import Provider
 from libcloud.compute.providers import get_driver
 
-cls = get_driver(Provider.EC2_US_WEST)
+cls = get_driver(Provider.EC2)
 driver = cls('temporary access key', 'temporary secret key',
-             token='temporary session token')
+             token='temporary session token', region="us-west-1")


### PR DESCRIPTION
In 0.14 the API for selecting an EC2 region changed, but was
never reflected in the examples. This change fixes the code
snippets to use the up-to-date region selection API.
