### PR TITLE
key_file should be azure_cert.pem

### DIFF
--- a/docs/examples/compute/azure/instantiate.py
+++ b/docs/examples/compute/azure/instantiate.py
@@ -3,4 +3,4 @@ from libcloud.compute.providers import get_driver
 
 cls = get_driver(Provider.AZURE)
 driver = cls(subscription_id='subscription-id',
-             key_file='/path/to/azure_cert.cer')
+             key_file='/path/to/azure_cert.pem')


### PR DESCRIPTION
According to https://azure.microsoft.com/en-us/documentation/articles/cloud-services-python-how-to-use-service-management/ key_file should be '/path/to/azure_cert.pem'
azure_cert.cer raises ssl.SSLError: [SSL] PEM lib (_ssl.c:2580) error.
