### PR TITLE
[google] Set GCENodeDriver api_name to `google`.

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -945,7 +945,7 @@ class GCENodeDriver(NodeDriver):
     result in additional GCE API calls.
     """
     connectionCls = GCEConnection
-    api_name = 'googleapis'
+    api_name = 'google'
     name = "Google Compute Engine"
     type = Provider.GCE
     website = 'https://cloud.google.com/'


### PR DESCRIPTION
/cc: @davidwilson2038
