### PR TITLE
cloudstack: If no volumes are found return an empty list

### DIFF
--- a/libcloud/compute/drivers/cloudstack.py
+++ b/libcloud/compute/drivers/cloudstack.py
@@ -2168,8 +2168,9 @@ class CloudStackNodeDriver(CloudStackDriverMixIn, NodeDriver):
                                          method='GET')
 
         list_volumes = []
+
         extra_map = RESOURCE_EXTRA_ATTRIBUTES_MAP['volume']
-        for vol in volumes['volume']:
+        for vol in volumes.get('volume', []):
             extra = self._get_extra_dict(vol, extra_map)
 
             if 'tags' in vol:


### PR DESCRIPTION
Otherwise we got this:

<pre>
Traceback (most recent call last):
  File "auroracompute.py", line 16, in <module>
    print(conn.list_volumes())
  File "/home/wido/repos/libcloud/libcloud/compute/drivers/cloudstack.py", line 2172, in list_volumes
    for vol in volumes['volume']:
KeyError: 'volume'
</pre>


Simply return a empty list if no volume is found
