### PR TITLE
[LIBCLOUD-766] Unique node.public_ips returned by CloudStack ex_get_nodes and list_nodes

### DIFF
--- a/libcloud/compute/drivers/cloudstack.py
+++ b/libcloud/compute/drivers/cloudstack.py
@@ -4653,7 +4653,8 @@ class CloudStackNodeDriver(CloudStackDriverMixIn, NodeDriver):
             extra['tags'] = self._get_resource_tags(data['tags'])
 
         node = CloudStackNode(id=id, name=name, state=state,
-                              public_ips=public_ips, private_ips=private_ips,
+                              public_ips=list(set(public_ips)),
+                              private_ips=private_ips,
                               driver=self, extra=extra)
         return node
 

--- a/libcloud/test/compute/test_cloudstack.py
+++ b/libcloud/test/compute/test_cloudstack.py
@@ -583,6 +583,8 @@ class CloudStackCommonTestCase(TestCaseMixin):
         self.assertEqual('2600', nodes[0].id)
         self.assertEqual([], nodes[0].extra['security_group'])
         self.assertEqual(None, nodes[0].extra['key_name'])
+        self.assertEqual(1, len(nodes[0].public_ips))
+        self.assertEqual('1.1.1.116', nodes[0].public_ips[0])
 
     def test_ex_get_node(self):
         node = self.driver.ex_get_node(2600)
@@ -590,6 +592,8 @@ class CloudStackCommonTestCase(TestCaseMixin):
         self.assertEqual('2600', node.id)
         self.assertEqual([], node.extra['security_group'])
         self.assertEqual(None, node.extra['key_name'])
+        self.assertEqual(1, len(node.public_ips))
+        self.assertEqual('1.1.1.116', node.public_ips[0])
         self.assertEqual(1, len(node.extra['ip_addresses']))
         self.assertEqual(34000, node.extra['ip_addresses'][0].id)
 


### PR DESCRIPTION
This fixes the issue node's public_ips have duplicate values.

https://issues.apache.org/jira/browse/LIBCLOUD-766
