### PR TITLE
[LIBCLOUD-767] Fixed CloudStackAddress parameters

### DIFF
--- a/libcloud/compute/drivers/cloudstack.py
+++ b/libcloud/compute/drivers/cloudstack.py
@@ -1454,8 +1454,8 @@ class CloudStackNodeDriver(CloudStackDriverMixIn, NodeDriver):
 
         node = self._to_node(data=vm, public_ips=list(public_ips.keys()))
 
-        addresses = public_ips.items()
-        addresses = [CloudStackAddress(node, v, k) for k, v in addresses]
+        addresses = [CloudStackAddress(address_id, address, node.driver)
+                     for address, address_id in public_ips.items()]
         node.extra['ip_addresses'] = addresses
 
         rules = []

--- a/libcloud/test/compute/test_cloudstack.py
+++ b/libcloud/test/compute/test_cloudstack.py
@@ -590,6 +590,8 @@ class CloudStackCommonTestCase(TestCaseMixin):
         self.assertEqual('2600', node.id)
         self.assertEqual([], node.extra['security_group'])
         self.assertEqual(None, node.extra['key_name'])
+        self.assertEqual(1, len(node.extra['ip_addresses']))
+        self.assertEqual(34000, node.extra['ip_addresses'][0].id)
 
     def test_ex_get_node_doesnt_exist(self):
         self.assertRaises(Exception, self.driver.ex_get_node(26), node_id=26)


### PR DESCRIPTION
This fixes the parameters of CloudStackAddress of node.extra['ip_addresses'].

https://issues.apache.org/jira/browse/LIBCLOUD-767
