### PR TITLE
[LIBCLOUD-768] UnicodeDecodeError occurs when LIBCLOUD_DEBUG is set

### DIFF
--- a/libcloud/common/base.py
+++ b/libcloud/common/base.py
@@ -373,7 +373,8 @@ class LoggingConnection():
         rv += ("\n# -------- end %d:%d response ----------\n"
                % (id(self), id(r)))
 
-        rv = rv.decode('utf-8')
+        if not PY3:
+            rv = rv.decode('utf-8')
         rr._original_data = body
         return (rr, rv)
 

--- a/libcloud/common/base.py
+++ b/libcloud/common/base.py
@@ -373,6 +373,7 @@ class LoggingConnection():
         rv += ("\n# -------- end %d:%d response ----------\n"
                % (id(self), id(r)))
 
+        rv = rv.decode('utf-8')
         rr._original_data = body
         return (rr, rv)
 


### PR DESCRIPTION
This fixes UnicodeDecodeError when LIBCLOUD_DEBUG is set and non-ascii character is included in response.

https://issues.apache.org/jira/browse/LIBCLOUD-768
