### PR TITLE
[google] fix pricing script and test; fix build

### DIFF
--- a/contrib/update_google_prices.py
+++ b/contrib/update_google_prices.py
@@ -19,10 +19,8 @@ Loads Google Cloud Platform prices and updates the `pricing.json` data file.
 """
 
 import os
-try:
-    import simplejson as json
-except ImportError:
-    import json
+import json
+import simplejson
 import sys
 import time
 import urllib2
@@ -80,7 +78,7 @@ def main(argv):
 
     # Write updated price list.
     with open(PRICING_FILE_PATH, 'w') as libcloud_out:
-        json_str = json.dumps(libcloud_data, indent=4 * ' ',
+        json_str = simplejson.dumps(libcloud_data, indent=4 * ' ',
                                     item_sort_key=utils.sortKeysNumerically)
         libcloud_out.write(json_str)
 

--- a/contrib/utils_test.py
+++ b/contrib/utils_test.py
@@ -16,10 +16,7 @@
 #
 ################################################################################
 
-try:
-    import simplejson as json
-except ImportError:
-    import json
+import simplejson
 import unittest
 import utils
 
@@ -59,7 +56,7 @@ class SortKeysNumericallyTest(unittest.TestCase):
 }\
 """
         self.assertEqual(
-            json.dumps(input, indent=4 * ' ',
+            simplejson.dumps(input, indent=4 * ' ',
                              item_sort_key=utils.sortKeysNumerically),
             output)
 


### PR DESCRIPTION
Revert conditional import of simplejson to unconditional: the code as
implemented only works with simplejson and not the standard json library because
it relies on the `item_sort_key` functionality which only simplejson provides
and json does not.

Also fixes indentation which breaks the build since the linter is part of the
tests.

Fixes the issues seen here:
- https://travis-ci.org/apache/libcloud/builds/90117628
- https://travis-ci.org/apache/libcloud/jobs/90117643

/cc: @erjohnso to review and merge.
