### PR TITLE
GoogleStorageDriver can now use either our S3 authentication or other…

### DIFF
--- a/libcloud/common/base.py
+++ b/libcloud/common/base.py
@@ -520,9 +520,7 @@ class Connection(object):
             (self.host, self.port, self.secure,
              self.request_path) = self._tuple_from_url(url)
 
-        if timeout is None:
-            timeout = self.__class__.timeout
-        self.timeout = timeout
+        self.timeout = timeout or self.timeout
         self.retry_delay = retry_delay
         self.backoff = backoff
         self.proxy_url = proxy_url

--- a/libcloud/common/google.py
+++ b/libcloud/common/google.py
@@ -104,11 +104,24 @@ except ImportError:
 TIMESTAMP_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 
 
+def _now():
+    return datetime.datetime.utcnow()
+
+
 def _is_gce():
     http_code, http_reason, body = _get_gce_metadata()
     if http_code == httplib.OK and body:
         return True
     return False
+
+
+def _is_gcs_s3(user_id):
+    """Checks S3 key format: 20 alphanumeric chars starting with GOOG."""
+    return len(user_id) == 20 and user_id.startswith('GOOG')
+
+
+def _is_sa(user_id):
+    return user_id.endswith('@developer.gserviceaccount.com')
 
 
 def _get_gce_metadata(path=''):
@@ -328,9 +341,6 @@ class GoogleBaseAuthConnection(ConnectionUserAndKey):
 
         super(GoogleBaseAuthConnection, self).__init__(user_id, key, **kwargs)
 
-    def _now(self):
-        return datetime.datetime.utcnow()
-
     def add_default_headers(self, headers):
         headers['Content-Type'] = "application/x-www-form-urlencoded"
         headers['Host'] = self.host
@@ -348,7 +358,7 @@ class GoogleBaseAuthConnection(ConnectionUserAndKey):
         :rtype:   ``dict``
         """
         data = urlencode(request_body)
-        now = self._now()
+        now = _now()
         try:
             response = self.request('/o/oauth2/token', method='POST',
                                     data=data)
@@ -545,10 +555,41 @@ class GoogleGCEServiceAcctAuthConnection(GoogleBaseAuthConnection):
                              "'%s'" % str(http_reason))
         token_info = json.loads(token_info)
         if 'expires_in' in token_info:
-            expire_time = self._now() + datetime.timedelta(
+            expire_time = _now() + datetime.timedelta(
                 seconds=token_info['expires_in'])
             token_info['expire_time'] = expire_time.strftime(TIMESTAMP_FORMAT)
         return token_info
+
+
+class GoogleAuthType(object):
+    """
+    SA (Service Account),
+    IA (Installed Application),
+    GCE (Auth from a GCE instance with service account enabled)
+    GCS_S3 (Cloud Storage S3 interoperability authentication)
+    """
+    SA = 'SA'
+    IA = 'IA'
+    GCE = 'GCE'
+    GCS_S3 = 'GCS_S3'
+
+    ALL_TYPES = [SA, IA, GCE, GCS_S3]
+    OAUTH2_TYPES = [SA, IA, GCE]
+
+    @classmethod
+    def guess_type(cls, user_id):
+        if _is_sa(user_id):
+            return cls.SA
+        elif _is_gce():
+            return cls.GCE
+        elif _is_gcs_s3(user_id):
+            return cls.GCS_S3
+        else:
+            return cls.IA
+
+    @classmethod
+    def is_oauth2(cls, auth_type):
+        return auth_type in cls.OAUTH2_TYPES
 
 
 class GoogleBaseConnection(ConnectionUserAndKey, PollingConnection):
@@ -558,6 +599,7 @@ class GoogleBaseConnection(ConnectionUserAndKey, PollingConnection):
     host = 'www.googleapis.com'
     poll_interval = 2.0
     timeout = 180
+    credential_file = '~/.google_libcloud_auth'
 
     def __init__(self, user_id, key=None, auth_type=None,
                  credential_file=None, scopes=None, **kwargs):
@@ -574,13 +616,8 @@ class GoogleBaseConnection(ConnectionUserAndKey, PollingConnection):
                      authentication.
         :type   key: ``str``
 
-        :keyword  auth_type: Accepted values are "SA" or "IA" or "GCE"
-                             ("Service Account" or "Installed Application" or
-                             "GCE" if libcloud is being used on a GCE instance
-                             with service account enabled).
-                             If not supplied, auth_type will be guessed based
-                             on value of user_id or if the code is being
-                             executed in a GCE instance.).
+        :keyword  auth_type: See GoogleAuthType class for list and description
+                             of accepted values.
                              If not supplied, auth_type will be guessed based
                              on value of user_id or if the code is running
                              on a GCE instance.
@@ -594,49 +631,24 @@ class GoogleBaseConnection(ConnectionUserAndKey, PollingConnection):
                           read/write access to Compute, Storage, and DNS.
         :type     scopes: ``list``
         """
-        self.credential_file = credential_file or '~/.gce_libcloud_auth'
+        self.user_id = user_id
+        self.key = key
+        if auth_type and auth_type not in GoogleAuthType.ALL_TYPES:
+            raise GoogleAuthError('Invalid auth type: %s' % auth_type)
+        self.auth_type = auth_type or GoogleAuthType.guess_type(user_id)
 
-        if auth_type is None:
-            # Try to guess.
-            if '@' in user_id:
-                auth_type = 'SA'
-            elif _is_gce():
-                auth_type = 'GCE'
-            else:
-                auth_type = 'IA'
-
-        # Default scopes to read/write for compute, storage, and dns.  Can
-        # override this when calling get_driver() or setting in secrets.py
+        # OAuth2 stuff and placeholders
         self.scopes = scopes
-        if not self.scopes:
-            self.scopes = [
-                'https://www.googleapis.com/auth/compute',
-                'https://www.googleapis.com/auth/devstorage.full_control',
-                'https://www.googleapis.com/auth/ndev.clouddns.readwrite',
-            ]
-        self.token_info = self._get_token_info_from_file()
+        self.auth_conn = None
+        self.token_expire_time = None
+        self.token_info = None
+        if credential_file:
+            self.credential_file = credential_file
+        elif self.auth_type == GoogleAuthType.SA:
+            self.credential_file += '.' + user_id
 
-        if auth_type == 'GCE':
-            self.auth_conn = GoogleGCEServiceAcctAuthConnection(
-                user_id, self.scopes, **kwargs)
-        elif auth_type == 'SA':
-            if '@' not in user_id:
-                raise GoogleAuthError('Service Account auth requires a '
-                                      'valid email address')
-            self.auth_conn = GoogleServiceAcctAuthConnection(
-                user_id, key, self.scopes, **kwargs)
-        elif auth_type == 'IA':
-            self.auth_conn = GoogleInstalledAppAuthConnection(
-                user_id, key, self.scopes, **kwargs)
-        else:
-            raise GoogleAuthError('Invalid auth_type: %s' % str(auth_type))
-
-        if self.token_info is None:
-            self.token_info = self.auth_conn.get_new_token()
-            self._write_token_info_to_file()
-
-        self.token_expire_time = datetime.datetime.strptime(
-            self.token_info['expire_time'], TIMESTAMP_FORMAT)
+        if GoogleAuthType.is_oauth2(self.auth_type):
+            self._setup_oauth2(**kwargs)
 
         super(GoogleBaseConnection, self).__init__(user_id, key, **kwargs)
 
@@ -645,14 +657,11 @@ class GoogleBaseConnection(ConnectionUserAndKey, PollingConnection):
         ver_platform = 'Python %s/%s' % (python_ver, sys.platform)
         self.user_agent_append(ver_platform)
 
-    def _now(self):
-        return datetime.datetime.utcnow()
-
     def add_default_headers(self, headers):
         """
         @inherits: :class:`Connection.add_default_headers`
         """
-        headers['Content-Type'] = "application/json"
+        headers['Content-Type'] = 'application/json'
         headers['Host'] = self.host
         return headers
 
@@ -663,7 +672,7 @@ class GoogleBaseConnection(ConnectionUserAndKey, PollingConnection):
 
         @inherits: :class:`Connection.pre_connect_hook`
         """
-        now = self._now()
+        now = _now()
         if self.token_expire_time < now:
             self.token_info = self.auth_conn.refresh_token(self.token_info)
             self.token_expire_time = datetime.datetime.strptime(
@@ -698,33 +707,6 @@ class GoogleBaseConnection(ConnectionUserAndKey, PollingConnection):
                     raise e
         # One more time, then give up.
         return super(GoogleBaseConnection, self).request(*args, **kwargs)
-
-    def _get_token_info_from_file(self):
-        """
-        Read credential file and return token information.
-
-        :return:  Token information dictionary, or None
-        :rtype:   ``dict`` or ``None``
-        """
-        token_info = None
-        filename = os.path.realpath(os.path.expanduser(self.credential_file))
-
-        try:
-            with open(filename, 'r') as f:
-                data = f.read()
-            token_info = json.loads(data)
-        except IOError:
-            pass
-        return token_info
-
-    def _write_token_info_to_file(self):
-        """
-        Write token_info to credential file.
-        """
-        filename = os.path.realpath(os.path.expanduser(self.credential_file))
-        data = json.dumps(self.token_info)
-        with open(filename, 'w') as f:
-            f.write(data)
 
     def has_completed(self, response):
         """
@@ -768,3 +750,61 @@ class GoogleBaseConnection(ConnectionUserAndKey, PollingConnection):
         else:
             request = self.request_path + action
         return request
+
+    def _setup_oauth2(self, **kwargs):
+        # Default scopes to read/write for compute, storage, and dns.  Can
+        # override this when calling get_driver() or setting in secrets.py
+        if not self.scopes:
+            self.scopes = [
+                'https://www.googleapis.com/auth/compute',
+                'https://www.googleapis.com/auth/devstorage.full_control',
+                'https://www.googleapis.com/auth/ndev.clouddns.readwrite',
+            ]
+        self.token_info = self._get_token_info_from_file()
+
+        if self.auth_type == GoogleAuthType.GCE:
+            self.auth_conn = GoogleGCEServiceAcctAuthConnection(
+                self.user_id, self.scopes, **kwargs)
+        elif self.auth_type == GoogleAuthType.SA:
+            self.auth_conn = GoogleServiceAcctAuthConnection(
+                self.user_id, self.key, self.scopes, **kwargs)
+        elif self.auth_type == GoogleAuthType.IA:
+            self.auth_conn = GoogleInstalledAppAuthConnection(
+                self.user_id, self.key, self.scopes, **kwargs)
+        else:
+            raise GoogleAuthError('Invalid auth_type: %s' %
+                                  str(self.auth_type))
+
+        if self.token_info is None:
+            self.token_info = self.auth_conn.get_new_token()
+            self._write_token_info_to_file()
+
+        self.token_expire_time = datetime.datetime.strptime(
+            self.token_info['expire_time'], TIMESTAMP_FORMAT)
+
+    def _get_token_info_from_file(self):
+        """
+        Read credential file and return token information.
+
+        :return:  Token information dictionary, or None
+        :rtype:   ``dict`` or ``None``
+        """
+        token_info = None
+        filename = os.path.realpath(os.path.expanduser(self.credential_file))
+
+        try:
+            with open(filename, 'r') as f:
+                data = f.read()
+            token_info = json.loads(data)
+        except IOError:
+            pass
+        return token_info
+
+    def _write_token_info_to_file(self):
+        """
+        Write token_info to credential file.
+        """
+        filename = os.path.realpath(os.path.expanduser(self.credential_file))
+        data = json.dumps(self.token_info)
+        with open(filename, 'w') as f:
+            f.write(data)

--- a/libcloud/compute/base.py
+++ b/libcloud/compute/base.py
@@ -668,12 +668,6 @@ class NodeDriver(BaseDriver):
 
     NODE_STATE_MAP = {}
 
-    def __init__(self, key, secret=None, secure=True, host=None, port=None,
-                 api_version=None, **kwargs):
-        super(NodeDriver, self).__init__(key=key, secret=secret, secure=secure,
-                                         host=host, port=port,
-                                         api_version=api_version, **kwargs)
-
     def list_nodes(self):
         """
         List all nodes.

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -1047,7 +1047,7 @@ class GCENodeDriver(NodeDriver):
         self.project = project
         self.scopes = scopes
         self.credential_file = credential_file or \
-            '~/.gce_libcloud_auth' + '.' + self.project
+            GCEConnection.credential_file + '.' + self.project
 
         super(GCENodeDriver, self).__init__(user_id, key, **kwargs)
 

--- a/libcloud/storage/base.py
+++ b/libcloud/storage/base.py
@@ -190,12 +190,6 @@ class StorageDriver(BaseDriver):
     # provided and none can be detected when uploading an object
     strict_mode = False
 
-    def __init__(self, key, secret=None, secure=True, host=None, port=None,
-                 **kwargs):
-        super(StorageDriver, self).__init__(key=key, secret=secret,
-                                            secure=secure, host=host,
-                                            port=port, **kwargs)
-
     def iterate_containers(self):
         """
         Return a generator of containers for the given account

--- a/libcloud/test/secrets.py-dist
+++ b/libcloud/test/secrets.py-dist
@@ -54,7 +54,8 @@ PACKET_PARAMS = ('api_key')
 
 # Storage
 STORAGE_S3_PARAMS = ('key', 'secret')
-STORAGE_GOOGLE_STORAGE_PARAMS = ('key', 'secret')
+# Google key = 20 char alphanumeric string starting with GOOG
+STORAGE_GOOGLE_STORAGE_PARAMS = ('GOOG0123456789ABCXYZ', 'secret')
 
 # Azure key is b64 encoded and must be decoded before signing requests
 STORAGE_AZURE_BLOBS_PARAMS = ('account', 'cGFzc3dvcmQ=')

--- a/libcloud/test/storage/test_google_storage.py
+++ b/libcloud/test/storage/test_google_storage.py
@@ -13,16 +13,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
+import mock
 import sys
 import unittest
 
-from libcloud.utils.py3 import httplib
+import email.utils
 
-from libcloud.storage.drivers.google_storage import GoogleStorageDriver
-from libcloud.test.storage.test_s3 import S3Tests, S3MockHttp
-
+from libcloud.common.google import GoogleAuthType
+from libcloud.storage.drivers import google_storage
+from libcloud.test import LibcloudTestCase
 from libcloud.test.file_fixtures import StorageFileFixtures
 from libcloud.test.secrets import STORAGE_GOOGLE_STORAGE_PARAMS
+from libcloud.test.storage.test_s3 import S3Tests, S3MockHttp
+from libcloud.utils.py3 import httplib
+
+CONN_CLS = google_storage.GoogleStorageConnection
+STORAGE_CLS = google_storage.GoogleStorageDriver
+
+TODAY = email.utils.formatdate(usegmt=True)
+
+OAUTH2_MOCK = mock.patch(
+    'libcloud.common.google.GoogleBaseConnection._setup_oauth2', spec=True)
 
 
 class GoogleStorageMockHttp(S3MockHttp):
@@ -32,23 +44,230 @@ class GoogleStorageMockHttp(S3MockHttp):
         # test_get_object
         # Google uses a different HTTP header prefix for meta data
         body = self.fixtures.load('list_containers.xml')
-        headers = {'content-type': 'application/zip',
-                   'etag': '"e31208wqsdoj329jd"',
-                   'x-goog-meta-rabbits': 'monkeys',
-                   'content-length': 12345,
-                   'last-modified': 'Thu, 13 Sep 2012 07:13:22 GMT'
-                   }
+        headers = {
+            'content-type': 'application/zip',
+            'etag': '"e31208wqsdoj329jd"',
+            'x-goog-meta-rabbits': 'monkeys',
+            'content-length': 12345,
+            'last-modified': 'Thu, 13 Sep 2012 07:13:22 GMT'
+        }
 
-        return (httplib.OK,
-                body,
-                headers,
-                httplib.responses[httplib.OK])
+        return (
+            httplib.OK,
+            body,
+            headers,
+            httplib.responses[httplib.OK]
+        )
+
+
+class GoogleStorageConnectionTest(LibcloudTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(LibcloudTestCase, cls).setUpClass()
+        OAUTH2_MOCK.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        super(LibcloudTestCase, cls).tearDownClass()
+        OAUTH2_MOCK.stop()
+
+    @mock.patch('email.utils.formatdate')
+    @mock.patch('libcloud.common.google.'
+                'GoogleBaseConnection.add_default_headers')
+    def test_add_default_headers(self, mock_base_method, mock_formatdate):
+        mock_formatdate.return_value = TODAY
+        starting_headers = {'starting': 'headers'}
+        changed_headers = {'changed': 'headers'}
+        project = 'foo-project'
+
+        # Should use base add_default_headers
+        mock_base_method.return_value = dict(changed_headers)
+        conn = CONN_CLS('foo_user', 'bar_key', secure=True,
+                        auth_type=GoogleAuthType.GCE)
+        conn.get_project = lambda: None
+        self.assertEqual(
+            conn.add_default_headers(dict(starting_headers)),
+            dict(changed_headers)
+        )
+        mock_base_method.assert_called_once_with(dict(starting_headers))
+        mock_base_method.reset_mock()
+
+        # Base add_default_headers with project
+        mock_base_method.return_value = dict(changed_headers)
+        conn = CONN_CLS('foo_user', 'bar_key', secure=True,
+                        auth_type=GoogleAuthType.GCE)
+        conn.get_project = lambda: project
+        headers = dict(changed_headers)
+        headers[CONN_CLS.PROJECT_ID_HEADER] = project
+        self.assertEqual(
+            conn.add_default_headers(dict(starting_headers)),
+            headers
+        )
+        mock_base_method.assert_called_once_with(dict(starting_headers))
+        mock_base_method.reset_mock()
+
+        # Should use S3 add_default_headers
+        conn = CONN_CLS('foo_user', 'bar_key', secure=True,
+                        auth_type=GoogleAuthType.GCS_S3)
+        conn.get_project = lambda: None
+        headers = dict(starting_headers)
+        headers['Date'] = TODAY
+        self.assertEqual(conn.add_default_headers(dict(starting_headers)),
+                         headers)
+        mock_base_method.assert_not_called()
+
+        # S3 add_default_headers with project
+        conn = CONN_CLS('foo_user', 'bar_key', secure=True,
+                        auth_type=GoogleAuthType.GCS_S3)
+        conn.get_project = lambda: project
+        headers = dict(starting_headers)
+        headers['Date'] = TODAY
+        headers[CONN_CLS.PROJECT_ID_HEADER] = project
+        self.assertEqual(conn.add_default_headers(dict(starting_headers)),
+                         headers)
+        mock_base_method.assert_not_called()
+
+    @mock.patch('libcloud.common.google.GoogleBaseConnection.encode_data')
+    def test_encode_data(self, mock_base_method):
+        old_data = 'old data!'
+        new_data = 'new data!'
+
+        # Should use Base encode_data
+        mock_base_method.return_value = new_data
+        conn = CONN_CLS('foo_user', 'bar_key', secure=True,
+                        auth_type=GoogleAuthType.GCE)
+        self.assertEqual(conn.encode_data(old_data), new_data)
+        mock_base_method.assert_called_once_with(old_data)
+        mock_base_method.reset_mock()
+
+        # Should use S3 encode_data (which does nothing)
+        conn = CONN_CLS('foo_user', 'bar_key', secure=True,
+                        auth_type=GoogleAuthType.GCS_S3)
+        self.assertEqual(conn.encode_data(old_data), old_data)
+        mock_base_method.assert_not_called()
+
+    @mock.patch('libcloud.storage.drivers.s3.'
+                'BaseS3Connection.get_auth_signature')
+    def test_get_s3_auth_signature(self, mock_s3_auth_sig_method):
+        # Check that the S3 HMAC signature method is used.
+        # Check that headers are copied and modified before calling the method.
+        mock_s3_auth_sig_method.return_value = 'mock signature!'
+        starting_params = {}
+        starting_headers = {
+            'Date': TODAY,
+            'x-goog-foo': 'MAINTAIN UPPERCASE!',
+            'x-Goog-bar': 'Header should be lowered',
+            'Other': 'LOWER THIS!'
+        }
+        modified_headers = {
+            'date': TODAY,
+            'x-goog-foo': 'MAINTAIN UPPERCASE!',
+            'x-goog-bar': 'Header should be lowered',
+            'other': 'lower this!'
+        }
+
+        conn = CONN_CLS('foo_user', 'bar_key', secure=True,
+                        auth_type=GoogleAuthType.GCS_S3)
+        conn.method = 'GET'
+        conn.action = '/path'
+        result = conn._get_s3_auth_signature(starting_params, starting_headers)
+        self.assertNotEqual(starting_headers, modified_headers)
+        self.assertEqual(result, 'mock signature!')
+        mock_s3_auth_sig_method.assert_called_once_with(
+            method='GET',
+            headers=modified_headers,
+            params=starting_params,
+            expires=None,
+            secret_key='bar_key',
+            path='/path',
+            vendor_prefix='x-goog'
+        )
+
+    @mock.patch('libcloud.common.google.GoogleBaseConnection.pre_connect_hook')
+    def test_pre_connect_hook_oauth2(self, mock_base_hook):
+        # Should use BaseGoogleConnection pre_connect_hook
+        # Check that the base hook is called.
+        starting_params = {'starting': 'params'}
+        changed_params = {'changed': 'params'}
+        starting_headers = {'starting': 'headers'}
+        changed_headers = {'changed': 'headers'}
+
+        mock_base_hook.return_value = (dict(changed_params),
+                                       dict(changed_headers))
+        conn = CONN_CLS('foo_user', 'bar_key', secure=True,
+                        auth_type=GoogleAuthType.GCE)
+        result = conn.pre_connect_hook(
+            dict(starting_params),
+            dict(starting_headers)
+        )
+        self.assertEqual(
+            result,
+            (dict(changed_params), dict(changed_headers))
+        )
+        mock_base_hook.assert_called_once_with(
+            dict(starting_params),
+            dict(starting_headers)
+        )
+        mock_base_hook.reset_mock()
+
+    @mock.patch('libcloud.common.google.GoogleBaseConnection.pre_connect_hook')
+    def test_pre_connect_hook_hmac(self, mock_base_hook):
+        # Check that we call for a HMAC signature, passing params and headers
+        # Check that we properly apply the HMAC signature.
+        # Check that we don't use the BaseGoogleConnection pre_connect_hook.
+        starting_params = {'starting': 'params'}
+        starting_headers = {'starting': 'headers'}
+
+        def fake_hmac_method(params, headers):
+            # snapshot the params and headers passed (they are modified later)
+            fake_hmac_method.params_passed = copy.deepcopy(params)
+            fake_hmac_method.headers_passed = copy.deepcopy(headers)
+            return 'fake signature!'
+
+        conn = CONN_CLS('foo_user', 'bar_key', secure=True,
+                        auth_type=GoogleAuthType.GCS_S3)
+        conn._get_s3_auth_signature = fake_hmac_method
+        conn.action = 'GET'
+        conn.method = '/foo'
+        expected_headers = dict(starting_headers)
+        expected_headers['Authorization'] = (
+            '%s %s:%s' % (google_storage.SIGNATURE_IDENTIFIER, 'foo_user',
+                          'fake signature!')
+        )
+        result = conn.pre_connect_hook(
+            dict(starting_params),
+            dict(starting_headers)
+        )
+        self.assertEqual(
+            result,
+            (dict(starting_params), expected_headers)
+        )
+        mock_base_hook.assert_not_called()
+        self.assertEqual(
+            fake_hmac_method.params_passed,
+            starting_params
+        )
+        self.assertEqual(
+            fake_hmac_method.headers_passed,
+            starting_headers
+        )
 
 
 class GoogleStorageTests(S3Tests):
-    driver_type = GoogleStorageDriver
+    driver_type = STORAGE_CLS
     driver_args = STORAGE_GOOGLE_STORAGE_PARAMS
     mock_response_klass = GoogleStorageMockHttp
+
+    @classmethod
+    def setUpClass(cls):
+        super(S3Tests, cls).setUpClass()
+        OAUTH2_MOCK.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        super(S3Tests, cls).tearDownClass()
+        OAUTH2_MOCK.stop()
 
     def test_billing_not_enabled(self):
         # TODO


### PR DESCRIPTION
… Cloud OAuth2 authentication methods.

GoogleBaseConnection allows for a GCS_S3 auth type now, but does not handle creating the S3 HMAC header. GoogleBaseConnection still handles OAuth2  for GCE, IA, and SA auth types.

GoogleStorageConnection contains the logic for creating an S3 HMAC auth header and the logic for switching between the oauth2 auth or the S3 HMAC auth.

Changed an InvalidContainerNameError to ContainerError in S3 create_container. The exception was being raised on ANY 400 error, which can be returned for things other than an invalid name. In other words, the exception was a misnomer.

Added tests for new logic.

Did other minor cleanup.

Tests run:
Some manual tests putting, getting, and deleting objects/buckets. I used a Service Account, Installed App creds, and S3 interoperability creds.
libcloud.test.common.test_google
libcloud.test.compute.test_gce (to make sure changes to the GoogleBaseConnection didn't break it)
libcloud.test.storage.test_google_storage
libcloud.test.storage.test_s3
