### PR TITLE
Add "ttl" attribute to the libcloud.dns.base.Record class

### DIFF
--- a/docs/upgrade_notes.rst
+++ b/docs/upgrade_notes.rst
@@ -5,8 +5,19 @@ This page describes how to upgrade from a previous version to a new version
 which contains backward incompatible or semi-incompatible changes and how to
 preserve the old behavior when this is possible.
 
-Development
------------
+In development
+--------------
+
+* New optional ``ttl`` argument has been added to ``libcloud.dns.base.Record``
+  class constructor before the existing ``extra`` argument.
+
+  If you have previously manually instantiated this class and didn't use
+  keyword arguments, you need to update your code to correctly pass arguments
+  to the constructor (you are encouraged to use keyword arguments to avoid such
+  issues in the future).
+
+Libcloud 0.19.0
+---------------
 
 * The base signature of NodeDriver.create_volume has changed. The snapshot
   argument is now expected to be a VolumeSnapshot instead of a string.

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -2318,7 +2318,6 @@ class BaseEC2NodeDriver(NodeDriver):
             attributes = copy.deepcopy(attributes)
             price = self._get_size_price(size_id=instance_type)
             attributes.update({'price': price})
-            print attributes
             sizes.append(NodeSize(driver=self, **attributes))
         return sizes
 

--- a/libcloud/dns/base.py
+++ b/libcloud/dns/base.py
@@ -91,7 +91,8 @@ class Record(object):
     Zone record / resource.
     """
 
-    def __init__(self, id, name, type, data, zone, driver, extra=None):
+    def __init__(self, id, name, type, data, zone, driver, ttl=None,
+                 extra=None):
         """
         :param id: Record id
         :type id: ``str``
@@ -111,6 +112,9 @@ class Record(object):
         :param driver: DNSDriver instance.
         :type driver: :class:`DNSDriver`
 
+        :param ttl: Record TTL.
+        :type ttl: ``int``
+
         :param extra: (optional) Extra attributes (driver specific).
         :type extra: ``dict``
         """
@@ -120,6 +124,7 @@ class Record(object):
         self.data = data
         self.zone = zone
         self.driver = driver
+        self.ttl = ttl
         self.extra = extra or {}
 
     def update(self, name=None, type=None, data=None, extra=None):
@@ -138,10 +143,10 @@ class Record(object):
         return record_id
 
     def __repr__(self):
-        return ('<Record: zone=%s, name=%s, type=%s, data=%s, provider=%s '
-                '...>' %
+        return ('<Record: zone=%s, name=%s, type=%s, data=%s, provider=%s, '
+                'ttl=%s ...>' %
                 (self.zone.id, self.name, self.type, self.data,
-                 self.driver.name))
+                 self.driver.name, self.ttl))
 
 
 class DNSDriver(BaseDriver):

--- a/libcloud/dns/drivers/auroradns.py
+++ b/libcloud/dns/drivers/auroradns.py
@@ -237,7 +237,7 @@ class AuroraDNSDriver(DNSDriver):
 
         return Record(id=record['id'], name=name, type=record['type'],
                       data=record['content'], zone=zone, driver=self,
-                      extra=extra)
+                      ttl=record['ttl'], extra=extra)
 
     def __res_to_zone(self, zone):
         return Zone(id=zone['id'], domain=zone['name'], type=DEFAULT_ZONE_TYPE,

--- a/libcloud/dns/drivers/dnsimple.py
+++ b/libcloud/dns/drivers/dnsimple.py
@@ -290,4 +290,5 @@ class DNSimpleDNSDriver(DNSDriver):
                  'updated_at': record.get('updated_at'),
                  'domain_id': record.get('domain_id'),
                  'priority': record.get('prio')}
-        return Record(id, name, type, data, zone, self, extra=extra)
+        return Record(id=id, name=name, type=type, data=data, zone=zone,
+                      driver=self, ttl=record.get('ttl', None), extra=extra)

--- a/libcloud/dns/drivers/durabledns.py
+++ b/libcloud/dns/drivers/durabledns.py
@@ -648,7 +648,7 @@ class DurableDNSDriver(DNSDriver):
         extra = {'aux': int(item.get('aux')), 'ttl': int(item.get('ttl'))}
         record = Record(id=item.get('id'), type=item.get('type'), zone=zone,
                         name=item.get('name'), data=item.get('data'),
-                        driver=self, extra=extra)
+                        driver=self, ttl=item.get('ttl', None), extra=extra)
 
         return record
 

--- a/libcloud/dns/drivers/gandi.py
+++ b/libcloud/dns/drivers/gandi.py
@@ -154,6 +154,7 @@ class GandiDNSDriver(BaseGandiDriver, DNSDriver):
             data=record['value'],
             zone=zone,
             driver=self,
+            ttl=record['ttl'],
             extra={'ttl': record['ttl']}
         )
 

--- a/libcloud/dns/drivers/google.py
+++ b/libcloud/dns/drivers/google.py
@@ -372,7 +372,8 @@ class GoogleDNSDriver(DNSDriver):
         record_id = '%s:%s' % (r['type'], r['name'])
         return Record(id=record_id, name=r['name'],
                       type=r['type'], data=r, zone=zone,
-                      driver=self, extra={})
+                      driver=self, ttl=r.get('ttl', None),
+                      extra={})
 
     def _cleanup_domain(self, domain):
         # name can only contain lower case alphanumeric characters and hyphens

--- a/libcloud/dns/drivers/hostvirtual.py
+++ b/libcloud/dns/drivers/hostvirtual.py
@@ -108,7 +108,8 @@ class HostVirtualDNSDriver(DNSDriver):
         name = item['name'][:-len(zone.domain) - 1]
         record = Record(id=item['id'], name=name,
                         type=type, data=item['content'],
-                        zone=zone, driver=self, extra=extra)
+                        zone=zone, driver=self, ttl=item['ttl'],
+                        extra=extra)
         return record
 
     def list_zones(self):
@@ -222,7 +223,9 @@ class HostVirtualDNSDriver(DNSDriver):
             data=json.dumps(params), method='POST').object
         record = Record(id=result['id'], name=name,
                         type=type, data=data,
-                        extra=merged, zone=zone, driver=self)
+                        extra=merged, zone=zone,
+                        ttl=merged.get('ttl', None),
+                        driver=self)
         return record
 
     def update_record(self, record, name=None, type=None,

--- a/libcloud/dns/drivers/linode.py
+++ b/libcloud/dns/drivers/linode.py
@@ -174,7 +174,8 @@ class LinodeDNSDriver(DNSDriver):
 
         result = self.connection.request(API_ROOT, params=params).objects[0]
         record = Record(id=result['ResourceID'], name=name, type=type,
-                        data=data, extra=merged, zone=zone, driver=self)
+                        data=data, extra=merged, zone=zone, driver=self,
+                        ttl=merged.get('TTL_sec', None))
         return record
 
     def update_record(self, record, name=None, type=None, data=None,
@@ -268,5 +269,5 @@ class LinodeDNSDriver(DNSDriver):
         type = self._string_to_record_type(item['TYPE'])
         record = Record(id=item['RESOURCEID'], name=item['NAME'], type=type,
                         data=item['TARGET'], zone=zone, driver=self,
-                        extra=extra)
+                        ttl=item['TTL_SEC'], extra=extra)
         return record

--- a/libcloud/dns/drivers/pointdns.py
+++ b/libcloud/dns/drivers/pointdns.py
@@ -751,7 +751,8 @@ class PointDNSDriver(DNSDriver):
         extra = {'ttl': record.get('ttl'),
                  'zone_id': record.get('zone_id'),
                  'aux': record.get('aux')}
-        return Record(id, name, type, data, zone, self, extra=extra)
+        return Record(id=id, name=name, type=type, data=data, zone=zone,
+                      driver=self, ttl=record.get('ttl', None), extra=extra)
 
     def _to_redirects(self, data, zone):
         redirects = []

--- a/libcloud/dns/drivers/rackspace.py
+++ b/libcloud/dns/drivers/rackspace.py
@@ -373,7 +373,8 @@ class RackspaceDNSDriver(DNSDriver, OpenStackDriverMixin):
                 extra[key] = data[key]
 
         record = Record(id=str(id), name=name, type=type, data=record_data,
-                        zone=zone, driver=self, extra=extra)
+                        zone=zone, driver=self, ttl=extra.get('ttl', None),
+                        extra=extra)
         return record
 
     def _to_full_record_name(self, domain, name):

--- a/libcloud/dns/drivers/route53.py
+++ b/libcloud/dns/drivers/route53.py
@@ -189,7 +189,7 @@ class Route53DNSDriver(DNSDriver):
         self._post_changeset(zone, batch)
         id = ':'.join((self.RECORD_TYPE_MAP[type], name))
         return Record(id=id, name=name, type=type, data=data, zone=zone,
-                      driver=self, extra=extra)
+                      driver=self, ttl=extra.get('ttl', None), extra=extra)
 
     def update_record(self, record, name=None, type=None, data=None,
                       extra=None):
@@ -216,7 +216,7 @@ class Route53DNSDriver(DNSDriver):
 
         id = ':'.join((self.RECORD_TYPE_MAP[type], name))
         return Record(id=id, name=name, type=type, data=data, zone=record.zone,
-                      driver=self, extra=extra)
+                      driver=self, ttl=extra.get('ttl', None), extra=extra)
 
     def delete_record(self, record):
         try:
@@ -270,7 +270,8 @@ class Route53DNSDriver(DNSDriver):
         records = []
         for value in values:
             record = Record(id=id, name=name, type=type, data=value, zone=zone,
-                            driver=self, extra=extra)
+                            driver=self, ttl=extra.get('ttl', None),
+                            extra=extra)
             records.append(record)
 
         return records
@@ -505,7 +506,7 @@ class Route53DNSDriver(DNSDriver):
 
         id = ':'.join((self.RECORD_TYPE_MAP[type], name))
         record = Record(id=id, name=name, type=type, data=data, zone=zone,
-                        driver=self, extra=extra)
+                        driver=self, ttl=extra.get('ttl', None), extra=extra)
         return record
 
     def _get_more(self, rtype, **kwargs):

--- a/libcloud/dns/drivers/softlayer.py
+++ b/libcloud/dns/drivers/softlayer.py
@@ -208,6 +208,7 @@ class SoftLayerDNSDriver(DNSDriver):
             data=item['data'],
             zone=zone,
             driver=self,
+            ttl=item['ttl'],
             extra=extra
         )
         return record

--- a/libcloud/dns/drivers/vultr.py
+++ b/libcloud/dns/drivers/vultr.py
@@ -369,7 +369,6 @@ class VultrDNSDriver(DNSDriver):
         return zones
 
     def _to_record(self, item, zone):
-
         extra = {}
 
         if item.get('priority'):

--- a/libcloud/dns/drivers/worldwidedns.py
+++ b/libcloud/dns/drivers/worldwidedns.py
@@ -532,4 +532,5 @@ class WorldWideDNSDriver(DNSDriver):
         return records
 
     def _to_record(self, _id, subdomain, type, data, zone):
-        return Record(_id, subdomain, type, data, zone, zone.driver)
+        return Record(id=_id, name=subdomain, type=type, data=data, zone=zone,
+                      driver=zone.driver)

--- a/libcloud/dns/drivers/zerigo.py
+++ b/libcloud/dns/drivers/zerigo.py
@@ -438,7 +438,7 @@ class ZerigoDNSDriver(DNSDriver):
                  'priority': priority, 'ttl': ttl}
 
         record = Record(id=id, name=name, type=type, data=data,
-                        zone=zone, driver=self, extra=extra)
+                        zone=zone, driver=self, ttl=ttl, extra=extra)
         return record
 
     def _get_more(self, rtype, **kwargs):

--- a/libcloud/dns/drivers/zonomi.py
+++ b/libcloud/dns/drivers/zonomi.py
@@ -327,6 +327,8 @@ class ZonomiDNSDriver(DNSDriver):
     def _to_record(self, item, zone):
         if len(item.get('ttl')) > 0:
             ttl = item.get('ttl').split(' ')[0]
+        else:
+            ttl = None
         extra = {'ttl': ttl,
                  'prio': item.get('prio')}
         if len(item['name']) > len(zone.domain):
@@ -337,7 +339,7 @@ class ZonomiDNSDriver(DNSDriver):
             record_name = zone.domain
         record = Record(id=record_name, name=record_name,
                         data=item['content'], type=item['type'], zone=zone,
-                        driver=self, extra=extra)
+                        driver=self, ttl=ttl, extra=extra)
 
         return record
 


### PR DESCRIPTION
This pull request adds new `ttl` attribute to the `libcloud.dns.base.Record` class. Class constructor has also been updated to reflect this change - this attribute has been added as an optional argument before `extra`.

Next step will be updating `{create,update}_record` methods so they also accept `ttl` argument. This way user doesn't need to mess with `extra['ttl']` and we provide a stronger and better API (something we should have done from the beginning).

As mentioned in the upgrade notes - this change is backward incompatible if the user manually instantiated `Record` class without using keyword arguments.
