### PR TITLE
Make azure driver create_node use kwargs

### DIFF
--- a/libcloud/compute/drivers/azure.py
+++ b/libcloud/compute/drivers/azure.py
@@ -513,12 +513,7 @@ class AzureNodeDriver(NodeDriver):
         volumes = [self._to_volume(volume=v, node=node) for v in data]
         return volumes
 
-    def create_node(self, name, size, image, ex_cloud_service_name,
-                    ex_storage_service_name=None, ex_new_deployment=False,
-                    ex_deployment_slot="Production", ex_deployment_name=None,
-                    ex_admin_user_id="azureuser", ex_custom_data=None,
-                    ex_virtual_network_name=None, ex_network_config=None,
-                    auth=None, **kwargs):
+    def create_node(self, **kwargs):
         """
         Create Azure Virtual Machine
 
@@ -591,6 +586,21 @@ class AzureNodeDriver(NodeDriver):
         """
         # TODO: Refactor this method to make it more readable, split it into
         # multiple smaller methods
+
+        name = kwargs["name"]
+        size = kwargs["size"]
+        image = kwargs["image"]
+        ex_cloud_service_name = kwargs["ex_cloud_service_name"]
+        ex_storage_service_name = kwargs.get("ex_storage_service_name", None)
+        ex_new_deployment = kwargs.get("ex_storage_service_name", False)
+        ex_deployment_slot = kwargs.get("ex_deployment_slot", "Production")
+        ex_deployment_name = kwargs.get("ex_deployment_name", None)
+        ex_admin_user_id = kwargs.get("ex_admin_user_id", "azureuser")
+        ex_custom_data = kwargs.get("ex_custom_data", None)
+        ex_virtual_network_name = kwargs.get("ex_virtual_network_name", None)
+        ex_network_config = kwargs.get("ex_network_config", None)
+        auth = kwargs.get("auth", None)
+
         auth = self._get_and_check_auth(auth)
         password = auth.password
 

--- a/libcloud/compute/drivers/azure.py
+++ b/libcloud/compute/drivers/azure.py
@@ -592,7 +592,7 @@ class AzureNodeDriver(NodeDriver):
         image = kwargs["image"]
         ex_cloud_service_name = kwargs["ex_cloud_service_name"]
         ex_storage_service_name = kwargs.get("ex_storage_service_name", None)
-        ex_new_deployment = kwargs.get("ex_storage_service_name", False)
+        ex_new_deployment = kwargs.get("ex_new_deployment", False)
         ex_deployment_slot = kwargs.get("ex_deployment_slot", "Production")
         ex_deployment_name = kwargs.get("ex_deployment_name", None)
         ex_admin_user_id = kwargs.get("ex_admin_user_id", "azureuser")

--- a/libcloud/compute/drivers/azure.py
+++ b/libcloud/compute/drivers/azure.py
@@ -407,7 +407,7 @@ class AzureNodeDriver(NodeDriver):
 
         return [self._to_location(l) for l in data]
 
-    def list_nodes(self, ex_cloud_service_name):
+    def list_nodes(self, **kwargs):
         """
         List all nodes
 
@@ -421,6 +421,8 @@ class AzureNodeDriver(NodeDriver):
 
         :rtype: ``list`` of :class:`Node`
         """
+        ex_cloud_service_name = kwargs["ex_cloud_service_name"]
+
         response = self._perform_get(
             self._get_hosted_service_path(ex_cloud_service_name) +
             '?embed-detail=True',


### PR DESCRIPTION
Make AzureNodeDriver create_node use only **kwargs. That should
allow the use of the debloy_node from the base class to work.
## Motivation

Prior that change, one cannot use a deploy_node as deploy_node (defined on the libcloud.compute.base.NodeDriver) call the create_node of the driver with only keyword arguments.
