### PR TITLE
[LIBCLOUD-774] Add preemptible instance creation for GCENodeDriver

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -2235,7 +2235,8 @@ class GCENodeDriver(NodeDriver):
                     ex_disk_auto_delete=True, ex_service_accounts=None,
                     description=None, ex_can_ip_forward=None,
                     ex_disks_gce_struct=None, ex_nic_gce_struct=None,
-                    ex_on_host_maintenance=None, ex_automatic_restart=None):
+                    ex_on_host_maintenance=None, ex_automatic_restart=None,
+                    ex_preemptible=None):
         """
         Create a new node and return a node object for the node.
 
@@ -2343,6 +2344,11 @@ class GCENodeDriver(NodeDriver):
                                         default value for the instance type.)
         :type     ex_automatic_restart: ``bool`` or ``None``
 
+        :keyword  ex_preemptible: Defines whether the instance is preemptible.
+                                        (If not supplied, the instance will
+                                         not be preemptible)
+        :type     ex_preemptible: ``bool`` or ``None``
+
         :return:  A Node object for the new node.
         :rtype:   :class:`Node`
         """
@@ -2396,7 +2402,8 @@ class GCENodeDriver(NodeDriver):
                                                    ex_disks_gce_struct,
                                                    ex_nic_gce_struct,
                                                    ex_on_host_maintenance,
-                                                   ex_automatic_restart)
+                                                   ex_automatic_restart,
+                                                   ex_preemptible)
         self.connection.async_request(request, method='POST', data=node_data)
         return self.ex_get_node(name, location.name)
 
@@ -4528,7 +4535,8 @@ class GCENodeDriver(NodeDriver):
                          description=None, ex_can_ip_forward=None,
                          ex_disks_gce_struct=None, ex_nic_gce_struct=None,
                          ex_on_host_maintenance=None,
-                         ex_automatic_restart=None):
+                         ex_automatic_restart=None,
+                         ex_preemptible=None):
         """
         Returns a request and body to create a new node.  This is a helper
         method to support both :class:`create_node` and
@@ -4633,6 +4641,11 @@ class GCENodeDriver(NodeDriver):
                                         supplied, value will be set to the GCE
                                         default value for the instance type.)
         :type     ex_automatic_restart: ``bool`` or ``None``
+
+        :keyword  ex_preemptible: Defines whether the instance is preemptible.
+                                        (If not supplied, the instance will
+                                         not be preemptible)
+        :type     ex_preemptible: ``bool`` or ``None``
 
         :return:  A tuple containing a request string and a node_data dict.
         :rtype:   ``tuple`` of ``str`` and ``dict``
@@ -4764,6 +4777,8 @@ class GCENodeDriver(NodeDriver):
                 scheduling['onHostMaintenance'] = 'MIGRATE'
         if ex_automatic_restart is not None:
             scheduling['automaticRestart'] = ex_automatic_restart
+        if ex_preemptible is not None:
+            scheduling['preemptible'] = ex_preemptible
         if scheduling:
             node_data['scheduling'] = scheduling
 


### PR DESCRIPTION
Added another argument to GCENodeDriver.create_node method to allow for creation of preemptible instances on Google Compute Engine.  Modeled after other arguments passed to 'scheduling' dictionary.  Small change, no tests provided. 

https://issues.apache.org/jira/browse/LIBCLOUD-774
