### PR TITLE
Include 'service_name' support in _parse_service_catalog_auth_v3 for Openstack Drivers

### DIFF
--- a/libcloud/common/openstack_identity.py
+++ b/libcloud/common/openstack_identity.py
@@ -419,6 +419,7 @@ class OpenStackServiceCatalog(object):
 
         for item in service_catalog:
             service_type = item['type']
+            service_name = item.get('name', None)
 
             entry_endpoints = []
             for endpoint in item['endpoints']:
@@ -438,6 +439,7 @@ class OpenStackServiceCatalog(object):
                 entry_endpoints.append(entry_endpoint)
 
             entry = OpenStackServiceCatalogEntry(service_type=service_type,
+                                                 service_name=service_name,
                                                  endpoints=entry_endpoints)
             entries.append(entry)
 


### PR DESCRIPTION
The 'service_name' attribute was being left out when parsing the v3 ServiceCatalog returned by OpenStack. As a result, this error would occur: `LibcloudError: <LibcloudError in None 'Could not find specified endpoint'>`

The solution is to parse and add the service_name to the `OpenStackServiceCatalogEntry` similar to how it was done in `_parse_service_catalog_auth_v2`.
