### PR TITLE
Ensure rackspace lbs and servers know their uri and service_name

### DIFF
--- a/libcloud/common/openstack.py
+++ b/libcloud/common/openstack.py
@@ -219,6 +219,18 @@ class OpenStackBaseConnection(ConnectionUserAndKey):
 
         return self.service_catalog
 
+    def get_service_name(self):
+        """
+        Gets the service name used to look up the endpoint in the service
+        catalog.
+
+        :return: name of the service in the catalog
+        """
+        if self._ex_force_service_name:
+            return self._ex_force_service_name
+
+        return self.service_name
+
     def get_endpoint(self):
         """
         Selects the endpoint to use based on provider specific values,

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -862,6 +862,7 @@ class OpenStack_1_0_NodeDriver(OpenStackNodeDriver):
                      'uri': "https://%s%s/servers/%s" % (
                          self.connection.host,
                          self.connection.request_path, el.get('id')),
+                     'service_name': self.connection.get_service_name(),
                      'metadata': metadata})
         return n
 
@@ -2116,6 +2117,7 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
                 flavorId=api_node['flavor']['id'],
                 uri=next(link['href'] for link in api_node['links'] if
                          link['rel'] == 'self'),
+                service_name=self.connection.get_service_name(),
                 metadata=api_node['metadata'],
                 password=api_node.get('adminPass', None),
                 created=api_node['created'],

--- a/libcloud/compute/drivers/rackspace.py
+++ b/libcloud/compute/drivers/rackspace.py
@@ -24,25 +24,27 @@ from libcloud.compute.drivers.openstack import OpenStack_1_1_Connection,\
 from libcloud.common.rackspace import AUTH_URL
 from libcloud.utils.iso8601 import parse_date
 
-
+SERVICE_TYPE = 'compute'
+SERVICE_NAME_GEN1 = 'cloudServers'
+SERVICE_NAME_GEN2 = 'cloudServersOpenStack'
 ENDPOINT_ARGS_MAP = {
-    'dfw': {'service_type': 'compute',
-            'name': 'cloudServersOpenStack',
+    'dfw': {'service_type': SERVICE_TYPE,
+            'name': SERVICE_NAME_GEN2,
             'region': 'DFW'},
-    'ord': {'service_type': 'compute',
-            'name': 'cloudServersOpenStack',
+    'ord': {'service_type': SERVICE_TYPE,
+            'name': SERVICE_NAME_GEN2,
             'region': 'ORD'},
-    'iad': {'service_type': 'compute',
-            'name': 'cloudServersOpenStack',
+    'iad': {'service_type': SERVICE_TYPE,
+            'name': SERVICE_NAME_GEN2,
             'region': 'IAD'},
-    'lon': {'service_type': 'compute',
-            'name': 'cloudServersOpenStack',
+    'lon': {'service_type': SERVICE_TYPE,
+            'name': SERVICE_NAME_GEN2,
             'region': 'LON'},
-    'syd': {'service_type': 'compute',
-            'name': 'cloudServersOpenStack',
+    'syd': {'service_type': SERVICE_TYPE,
+            'name': SERVICE_NAME_GEN2,
             'region': 'SYD'},
-    'hkg': {'service_type': 'compute',
-            'name': 'cloudServersOpenStack',
+    'hkg': {'service_type': SERVICE_TYPE,
+            'name': SERVICE_NAME_GEN2,
             'region': 'HKG'},
 
 }
@@ -64,8 +66,8 @@ class RackspaceFirstGenConnection(OpenStack_1_0_Connection):
 
     def get_endpoint(self):
         if '2.0' in self._auth_version:
-            ep = self.service_catalog.get_endpoint(service_type='compute',
-                                                   name='cloudServers')
+            ep = self.service_catalog.get_endpoint(service_type=SERVICE_TYPE,
+                                                   name=SERVICE_NAME_GEN1)
         else:
             raise LibcloudError(
                 'Auth version "%s" not supported' % (self._auth_version))
@@ -90,6 +92,9 @@ class RackspaceFirstGenConnection(OpenStack_1_0_Connection):
                                             'https://lon.servers.api')
 
         return public_url
+
+    def get_service_name(self):
+        return SERVICE_NAME_GEN1
 
 
 class RackspaceFirstGenNodeDriver(OpenStack_1_0_NodeDriver):
@@ -152,6 +157,13 @@ class RackspaceConnection(OpenStack_1_1_Connection):
         self.region = kwargs.pop('region', None)
         self.get_endpoint_args = kwargs.pop('get_endpoint_args', None)
         super(RackspaceConnection, self).__init__(*args, **kwargs)
+
+    def get_service_name(self):
+        if not self.get_endpoint_args:
+            # if they used ex_force_base_url, assume the Rackspace default
+            return SERVICE_NAME_GEN2
+
+        return self.get_endpoint_args.get('name', SERVICE_NAME_GEN2)
 
     def get_endpoint(self):
         if not self.get_endpoint_args:

--- a/libcloud/loadbalancer/drivers/rackspace.py
+++ b/libcloud/loadbalancer/drivers/rackspace.py
@@ -1336,6 +1336,9 @@ class RackspaceLBDriver(Driver, OpenStackDriverMixin):
             "ipv6PublicSource": sourceAddresses.get("ipv6Public"),
             "ipv4PublicSource": sourceAddresses.get("ipv4Public"),
             "ipv4PrivateSource": sourceAddresses.get("ipv4Servicenet"),
+            "service_name": self.connection.get_service_name(),
+            "uri": "https://%s%s/loadbalancers/%s" % (
+                self.connection.host, self.connection.request_path, el["id"]),
         }
 
         if 'virtualIps' in el:

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -790,6 +790,8 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
         self.assertEqual(node.extra.get('power_state'), 1)
         self.assertEqual(node.extra.get('progress'), 25)
         self.assertEqual(node.extra.get('fault')['id'], 1234)
+        self.assertTrue(node.extra.get('service_name') is not None)
+        self.assertTrue(node.extra.get('uri') is not None)
 
     def test_list_nodes_no_image_id_attribute(self):
         # Regression test for LIBCLOD-455

--- a/libcloud/test/loadbalancer/test_rackspace.py
+++ b/libcloud/test/loadbalancer/test_rackspace.py
@@ -135,6 +135,8 @@ class RackspaceLBTests(unittest.TestCase):
         self.assertEqual(balancers[0].id, "8155")
         self.assertEqual(balancers[0].port, 80)
         self.assertEqual(balancers[0].ip, "1.1.1.25")
+        self.assertTrue(balancers[0].extra.get('service_name') is not None)
+        self.assertTrue(balancers[0].extra.get('uri') is not None)
         self.assertEqual(balancers[1].name, "test1")
         self.assertEqual(balancers[1].id, "8156")
 


### PR DESCRIPTION
This is a precursor to adding Rackspace RDNS support.  It lets you
set PTR records for loadbalancers and servers, but it needs these
two pieces of information to do so.
