### PR TITLE
[LIBCLOUD-780] Add Rackspace RDNS support

### DIFF
--- a/libcloud/test/dns/fixtures/rackspace/create_ptr_record_success.json
+++ b/libcloud/test/dns/fixtures/rackspace/create_ptr_record_success.json
@@ -1,0 +1,21 @@
+{
+   "request":"{\"recordsList\": {\"records\": [{\"data\": \"127.1.1.1\", \"type\": \"PTR\", \"name\": \"www.foo4.bar.com\"}]}, \"link\": {\"content\": \"\", \"href\": \"https://ord.servers.api.rackspacecloud.com/v2/905546514/servers/370b0ff8-3f57-4e10-ac84-e9145ce00584\", \"rel\": \"cloudServersOpenStack\"}}",
+   "response":{
+      "records":[
+         {
+            "name":"www.foo4.bar.com",
+            "id":"PTR-7423317",
+            "type":"PTR",
+            "data":"127.1.1.1",
+            "updated":"2011-10-29T20:50:41.000+0000",
+            "ttl":3600,
+            "created":"2011-10-29T20:50:41.000+0000"
+         }
+      ]
+   },
+   "status":"COMPLETED",
+   "verb":"POST",
+   "jobId":"12345678-5739-43fb-8939-f3a2c4c0e99c",
+   "callbackUrl":"https://dns.api.rackspacecloud.com/v1.0/546514/status/12345678-5739-43fb-8939-f3a2c4c0e99c",
+   "requestUrl":"http://dns.api.rackspacecloud.com/v1.0/546514/rdns"
+}

--- a/libcloud/test/dns/fixtures/rackspace/delete_ptr_record_success.json
+++ b/libcloud/test/dns/fixtures/rackspace/delete_ptr_record_success.json
@@ -1,0 +1,8 @@
+{
+   "status":"COMPLETED",
+   "verb":"DELETE",
+   "jobId":"12345678-2e5d-490f-bb6e-fdc65d1118a9",
+   "callbackUrl":"https://dns.api.rackspacecloud.com/v1.0/11111/status/12345678-2e5d-490f-bb6e-fdc65d1118a9",
+   "requestUrl":"http://dns.api.rackspacecloud.com/v1.0/11111/rdns/cloudServersOpenStack"
+}
+

--- a/libcloud/test/dns/fixtures/rackspace/list_ptr_records_success.json
+++ b/libcloud/test/dns/fixtures/rackspace/list_ptr_records_success.json
@@ -1,0 +1,14 @@
+{
+   "records":[
+      {
+         "name":"test3.foo4.bar.com",
+         "id":"PTR-7423034",
+         "type":"PTR",
+         "comment":"lulz",
+         "data":"127.7.7.7",
+         "updated":"2011-10-29T18:42:28.000+0000",
+         "ttl":777,
+         "created":"2011-10-29T15:29:29.000+0000"
+      }
+   ]
+}


### PR DESCRIPTION
New DNS driver methods:
- ex_iterate_ptr_records
- ex_get_ptr_record
- ex_create_ptr_record
- ex_update_ptr_record
- ex_delete_ptr_record

This should cover all of the functionality offered by the Rackspace
DNS API in regards to RDNS.
