### PR TITLE
Fixed error when proxy_url is None.

### DIFF
--- a/libcloud/compute/drivers/vcloud.py
+++ b/libcloud/compute/drivers/vcloud.py
@@ -848,7 +848,8 @@ class VCloud_1_5_Connection(VCloudConnection):
                      'application/vnd.vmware.vcloud.orgList+xml')).get('href')
             )
 
-            self.connection.set_http_proxy(self.proxy_url)
+            if self.proxy_url:
+                self.connection.set_http_proxy(self.proxy_url)
             self.connection.request(method='GET', url=org_list_url,
                                     headers=self.add_default_headers({}))
             body = ET.XML(self.connection.getresponse().read())

--- a/libcloud/compute/drivers/vcloud.py
+++ b/libcloud/compute/drivers/vcloud.py
@@ -848,7 +848,7 @@ class VCloud_1_5_Connection(VCloudConnection):
                      'application/vnd.vmware.vcloud.orgList+xml')).get('href')
             )
 
-            if self.proxy_url:
+            if self.proxy_url is not None:
                 self.connection.set_http_proxy(self.proxy_url)
             self.connection.request(method='GET', url=org_list_url,
                                     headers=self.add_default_headers({}))


### PR DESCRIPTION
A recently added change (https://github.com/apache/libcloud/commit/3fa2e1b4f70ed472ba39c74322915412f2d44f36) contains an error when proxy_url is None. This small change fixes it. 
