### PR TITLE
Added support for vCloud 5.5 and snapshot operations

### DIFF
--- a/libcloud/compute/drivers/vcloud.py
+++ b/libcloud/compute/drivers/vcloud.py
@@ -1996,7 +1996,15 @@ class VCloud_1_5_NodeDriver(VCloudNodeDriver):
         return isinstance(node_or_image, Node)
 
     def _to_node(self, node_elm):
-        # Parse VMs as extra field
+        # Parse snapshots and VMs as extra fields
+        snapshots = []
+        for snapshot_elem in node_elm.findall(fixxpath(node_elm, 'SnapshotSection/Snapshot')):
+            snapshots.append({
+                "created": snapshot_elem.get("created"),
+                "poweredOn": snapshot_elem.get("poweredOn"),
+                "size": snapshot_elem.get("size"),
+            })
+
         vms = []
         for vm_elem in node_elm.findall(fixxpath(node_elm, 'Children/Vm')):
             public_ips = []
@@ -2053,7 +2061,7 @@ class VCloud_1_5_NodeDriver(VCloudNodeDriver):
                     public_ips=public_ips,
                     private_ips=private_ips,
                     driver=self.connection.driver,
-                    extra={'vdc': vdc.name, 'vms': vms})
+                    extra={'vdc': vdc.name, 'vms': vms, 'snapshots': snapshots})
         return node
 
     def _to_vdc(self, vdc_elm):
@@ -2101,3 +2109,57 @@ class VCloud_5_5_NodeDriver(VCloud_5_1_NodeDriver):
     Accept headers
     '''
     connectionCls = VCloud_5_5_Connection
+
+    def ex_create_snapshot(self, node):
+        """
+        Creates new snapshot of a virtual machine or of all the virtual machines in a vApp.
+        Prior to creation of the new snapshots, any existing user created snapshots
+        associated with the virtual machines are removed.
+
+        :param  node: node
+        :type   node: :class:`Node`
+
+        :rtype: :class:`Node`
+        """
+        snapshot_xml = ET.Element("CreateSnapshotParams",
+                                  { 'memory': 'true', 'name': 'name', 'quiesce': 'true',
+                                    'xmlns': "http://www.vmware.com/vcloud/v1.5",
+                                    'xmlns:xsi': "http://www.w3.org/2001/XMLSchema-instance"}
+                                  )
+        ET.SubElement(snapshot_xml, 'Description').text = 'Description'
+        headers = {
+            'Content-Type': 'application/vnd.vmware.vcloud.createSnapshotParams+xml'
+        }
+        return self._perform_snapshot_operation(node, "createSnapshot", snapshot_xml, headers)
+
+    def ex_remove_snapshots(self, node):
+        """
+        Removes all user created snapshots for a vApp or virtual machine.
+
+        :param  node: node
+        :type   node: :class:`Node`
+
+        :rtype: :class:`Node`
+        """
+        return self._perform_snapshot_operation(node, "removeAllSnapshots", None, None)
+
+    def ex_revert_to_snapshot(self, node):
+        """
+        Reverts a vApp or virtual machine to the current snapshot, if any.
+
+        :param  node: node
+        :type   node: :class:`Node`
+
+        :rtype: :class:`Node`
+        """
+        return self._perform_snapshot_operation(node, "revertToCurrentSnapshot", None, None)
+
+    def _perform_snapshot_operation(self, node, operation, xml_data, headers):
+        res = self.connection.request(
+            '%s/action/%s' % (get_url_path(node.id), operation),
+            data=ET.tostring(xml_data) if xml_data else None,
+            method='POST',
+            headers=headers)
+        self._wait_for_task_completion(res.object.get('href'))
+        res = self.connection.request(get_url_path(node.id))
+        return self._to_node(res.object)

--- a/libcloud/compute/drivers/vcloud.py
+++ b/libcloud/compute/drivers/vcloud.py
@@ -2132,11 +2132,11 @@ class VCloud_5_5_NodeDriver(VCloud_5_1_NodeDriver):
         """
         snapshot_xml = ET.Element(
             "CreateSnapshotParams",
-            { 'memory': 'true',
-              'name': 'name',
-              'quiesce': 'true',
-              'xmlns': "http://www.vmware.com/vcloud/v1.5",
-              'xmlns:xsi': "http://www.w3.org/2001/XMLSchema-instance"}
+            {'memory': 'true',
+             'name': 'name',
+             'quiesce': 'true',
+             'xmlns': "http://www.vmware.com/vcloud/v1.5",
+             'xmlns:xsi': "http://www.w3.org/2001/XMLSchema-instance"}
         )
         ET.SubElement(snapshot_xml, 'Description').text = 'Description'
         content_type = 'application/vnd.vmware.vcloud.createSnapshotParams+xml'

--- a/libcloud/compute/drivers/vcloud.py
+++ b/libcloud/compute/drivers/vcloud.py
@@ -387,6 +387,8 @@ class VCloudNodeDriver(NodeDriver):
                 cls = VCloud_1_5_NodeDriver
             elif api_version == '5.1':
                 cls = VCloud_5_1_NodeDriver
+            elif api_version == '5.5':
+                cls = VCloud_5_5_NodeDriver
             else:
                 raise NotImplementedError(
                     "No VCloudNodeDriver found for API version %s" %
@@ -859,6 +861,13 @@ class VCloud_1_5_Connection(VCloudConnection):
 
     def add_default_headers(self, headers):
         headers['Accept'] = 'application/*+xml;version=1.5'
+        headers['x-vcloud-authorization'] = self.token
+        return headers
+
+
+class VCloud_5_5_Connection(VCloud_1_5_Connection):
+    def add_default_headers(self, headers):
+        headers['Accept'] = 'application/*+xml;version=5.5'
         headers['x-vcloud-authorization'] = self.token
         return headers
 
@@ -2085,3 +2094,10 @@ class VCloud_5_1_NodeDriver(VCloud_1_5_NodeDriver):
             # MB
             raise ValueError(
                 '%s is not a valid vApp VM memory value' % (vm_memory))
+
+
+class VCloud_5_5_NodeDriver(VCloud_5_1_NodeDriver):
+    '''Use 5.5 Connection class to explicitly set 5.5 for the version in
+    Accept headers
+    '''
+    connectionCls = VCloud_5_5_Connection

--- a/libcloud/compute/drivers/vcloud.py
+++ b/libcloud/compute/drivers/vcloud.py
@@ -2001,7 +2001,8 @@ class VCloud_1_5_NodeDriver(VCloudNodeDriver):
             snapshots = None
         else:
             snapshots = []
-            for snapshot_elem in node_elm.findall(fixxpath(node_elm, 'SnapshotSection/Snapshot')):
+            for snapshot_elem in node_elm.findall(
+                    fixxpath(node_elm, 'SnapshotSection/Snapshot')):
                 snapshots.append({
                     "created": snapshot_elem.get("created"),
                     "poweredOn": snapshot_elem.get("poweredOn"),
@@ -2119,25 +2120,33 @@ class VCloud_5_5_NodeDriver(VCloud_5_1_NodeDriver):
 
     def ex_create_snapshot(self, node):
         """
-        Creates new snapshot of a virtual machine or of all the virtual machines in a vApp.
-        Prior to creation of the new snapshots, any existing user created snapshots
-        associated with the virtual machines are removed.
+        Creates new snapshot of a virtual machine or of all
+        the virtual machines in a vApp. Prior to creation of the new
+        snapshots, any existing user created snapshots associated
+        with the virtual machines are removed.
 
         :param  node: node
         :type   node: :class:`Node`
 
         :rtype: :class:`Node`
         """
-        snapshot_xml = ET.Element("CreateSnapshotParams",
-                                  { 'memory': 'true', 'name': 'name', 'quiesce': 'true',
-                                    'xmlns': "http://www.vmware.com/vcloud/v1.5",
-                                    'xmlns:xsi': "http://www.w3.org/2001/XMLSchema-instance"}
-                                  )
+        snapshot_xml = ET.Element(
+            "CreateSnapshotParams",
+            { 'memory': 'true',
+              'name': 'name',
+              'quiesce': 'true',
+              'xmlns': "http://www.vmware.com/vcloud/v1.5",
+              'xmlns:xsi': "http://www.w3.org/2001/XMLSchema-instance"}
+        )
         ET.SubElement(snapshot_xml, 'Description').text = 'Description'
+        content_type = 'application/vnd.vmware.vcloud.createSnapshotParams+xml'
         headers = {
-            'Content-Type': 'application/vnd.vmware.vcloud.createSnapshotParams+xml'
+            'Content-Type': content_type
         }
-        return self._perform_snapshot_operation(node, "createSnapshot", snapshot_xml, headers)
+        return self._perform_snapshot_operation(node,
+                                                "createSnapshot",
+                                                snapshot_xml,
+                                                headers)
 
     def ex_remove_snapshots(self, node):
         """
@@ -2148,7 +2157,10 @@ class VCloud_5_5_NodeDriver(VCloud_5_1_NodeDriver):
 
         :rtype: :class:`Node`
         """
-        return self._perform_snapshot_operation(node, "removeAllSnapshots", None, None)
+        return self._perform_snapshot_operation(node,
+                                                "removeAllSnapshots",
+                                                None,
+                                                None)
 
     def ex_revert_to_snapshot(self, node):
         """
@@ -2159,7 +2171,10 @@ class VCloud_5_5_NodeDriver(VCloud_5_1_NodeDriver):
 
         :rtype: :class:`Node`
         """
-        return self._perform_snapshot_operation(node, "revertToCurrentSnapshot", None, None)
+        return self._perform_snapshot_operation(node,
+                                                "revertToCurrentSnapshot",
+                                                None,
+                                                None)
 
     def _perform_snapshot_operation(self, node, operation, xml_data, headers):
         res = self.connection.request(

--- a/libcloud/test/compute/fixtures/vcloud_1_5/api_task_2518935e_b315_4d8e_9e99_9275f751877c.xml
+++ b/libcloud/test/compute/fixtures/vcloud_1_5/api_task_2518935e_b315_4d8e_9e99_9275f751877c.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?><Task
+    xmlns="http://www.vmware.com/vcloud/v1.5"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    cancelRequested="false"
+    expiryTime="2013-05-15T13:10:25.449+03:00"
+    href="https://vcloud.example.com/api/task/2518935e-b315-4d8e-9e99-9275f751877c"
+    id="urn:vcloud:task:2518935e-b315-4d8e-9e99-9275f751877c"
+    name="task"
+    operation="Removing Snapshot Virtual Machine (ec94079b-3071-4a72-b95c-4154acb12c38)"
+    operationName="vappRemoveAllSnapshots"
+    serviceNamespace="com.vmware.vcloud"
+    startTime="2013-02-14T13:10:25.449+02:00"
+    status="success"
+    type="application/vnd.vmware.vcloud.task+xml"
+    xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://https://vcloud.example.com/api/v1.5/schema/master.xsd">
+    <Link
+        href="https://vcloud.example.com/api/task/2518935e-b315-4d8e-9e99-9275f751877c/action/cancel"
+        rel="task:cancel"/>
+    <Owner
+        href="https://vcloud.example.com/api/vApp/vm-ec94079b-3071-4a72-b95c-4154acb12c38"
+        name=""
+        type="application/vnd.vmware.vcloud.vm+xml"/>
+    <User
+        href="https://vcloud.example.com/api/admin/user/1260efee-6915-494c-8afa-84e7e6d8a310"
+        name="system"
+        type="application/vnd.vmware.admin.user+xml"/>
+    <Organization
+        href="https://vcloud.example.com/api/org/7b832bc5-3d65-45a2-8d35-da28388ab80a"
+        name="Default"
+        type="application/vnd.vmware.vcloud.org+xml"/>
+    <Details/>
+</Task>

--- a/libcloud/test/compute/fixtures/vcloud_1_5/api_task_fab4b26f_4f2e_4d49_ad01_ae9324bbfe48.xml
+++ b/libcloud/test/compute/fixtures/vcloud_1_5/api_task_fab4b26f_4f2e_4d49_ad01_ae9324bbfe48.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?><Task
+    xmlns="http://www.vmware.com/vcloud/v1.5"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    cancelRequested="false"
+    expiryTime="2013-05-15T13:10:11.652+03:00"
+    href="https://vcloud.example.com/api/task/fab4b26f-4f2e-4d49-ad01-ae9324bbfe48"
+    id="urn:vcloud:task:fab4b26f-4f2e-4d49-ad01-ae9324bbfe48"
+    name="task"
+    operation="Creating Snapshot Virtual Machine (ec94079b-3071-4a72-b95c-4154acb12c38)"
+    operationName="vappCreateSnapshot"
+    serviceNamespace="com.vmware.vcloud"
+    startTime="2013-02-14T13:10:11.652+02:00"
+    status="success"
+    type="application/vnd.vmware.vcloud.task+xml"
+    xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://https://vcloud.example.com/api/v1.5/schema/master.xsd">
+    <Link
+        href="https://vcloud.example.com/api/task/fab4b26f-4f2e-4d49-ad01-ae9324bbfe48/action/cancel"
+        rel="task:cancel"/>
+    <Owner
+        href="https://vcloud.example.com/api/vApp/vm-ec94079b-3071-4a72-b95c-4154acb12c38"
+        name=""
+        type="application/vnd.vmware.vcloud.vm+xml"/>
+    <User
+        href="https://vcloud.example.com/api/admin/user/1260efee-6915-494c-8afa-84e7e6d8a310"
+        name="system"
+        type="application/vnd.vmware.admin.user+xml"/>
+    <Organization
+        href="https://vcloud.example.com/api/org/7b832bc5-3d65-45a2-8d35-da28388ab80a"
+        name="Default"
+        type="application/vnd.vmware.vcloud.org+xml"/>
+    <Details/>
+</Task>

--- a/libcloud/test/compute/fixtures/vcloud_1_5/api_task_fe75d3af_f5a3_44a5_b016_ae0bdadfc32b.xml
+++ b/libcloud/test/compute/fixtures/vcloud_1_5/api_task_fe75d3af_f5a3_44a5_b016_ae0bdadfc32b.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?><Task
+    xmlns="http://www.vmware.com/vcloud/v1.5"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    cancelRequested="false"
+    expiryTime="2013-05-15T13:10:20.999+03:00"
+    href="https://vcloud.example.com/api/task/fe75d3af-f5a3-44a5-b016-ae0bdadfc32b"
+    id="urn:vcloud:task:fe75d3af-f5a3-44a5-b016-ae0bdadfc32b"
+    name="task"
+    operation="Reverting to Snapshot Virtual Machine (ec94079b-3071-4a72-b95c-4154acb12c38)"
+    operationName="vappRevertToCurrentSnapshot"
+    serviceNamespace="com.vmware.vcloud"
+    startTime="2013-02-14T13:10:20.999+02:00"
+    status="success"
+    type="application/vnd.vmware.vcloud.task+xml"
+    xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://https://vcloud.example.com/api/v1.5/schema/master.xsd">
+    <Link
+        href="https://vcloud.example.com/api/task/fe75d3af-f5a3-44a5-b016-ae0bdadfc32b/action/cancel"
+        rel="task:cancel"/>
+    <Owner
+        href="https://vcloud.example.com/api/vApp/vm-ec94079b-3071-4a72-b95c-4154acb12c38"
+        name=""
+        type="application/vnd.vmware.vcloud.vm+xml"/>
+    <User
+        href="https://vcloud.example.com/api/admin/user/1260efee-6915-494c-8afa-84e7e6d8a310"
+        name="system"
+        type="application/vnd.vmware.admin.user+xml"/>
+    <Organization
+        href="https://vcloud.example.com/api/org/7b832bc5-3d65-45a2-8d35-da28388ab80a"
+        name="Default"
+        type="application/vnd.vmware.vcloud.org+xml"/>
+    <Details/>
+</Task>

--- a/libcloud/test/compute/fixtures/vcloud_1_5/api_vApp_vapp_8c57a5b6_e61b_48ca_8a78_3b70ee65ef6b_create_snapshot.xml
+++ b/libcloud/test/compute/fixtures/vcloud_1_5/api_vApp_vapp_8c57a5b6_e61b_48ca_8a78_3b70ee65ef6b_create_snapshot.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?><Task
+    xmlns="http://www.vmware.com/vcloud/v1.5"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    cancelRequested="false"
+    expiryTime="2013-05-15T13:10:11.652+03:00"
+    href="https://vcloud.example.com/api/task/fab4b26f-4f2e-4d49-ad01-ae9324bbfe48"
+    id="urn:vcloud:task:fab4b26f-4f2e-4d49-ad01-ae9324bbfe48"
+    name="task"
+    operation="Creating Snapshot Virtual Machine (ec94079b-3071-4a72-b95c-4154acb12c38)"
+    operationName="vappCreateSnapshot"
+    serviceNamespace="com.vmware.vcloud"
+    startTime="2013-02-14T13:10:11.652+02:00"
+    status="running"
+    type="application/vnd.vmware.vcloud.task+xml"
+    xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://https://vcloud.example.com/api/v1.5/schema/master.xsd">
+    <Link
+        href="https://vcloud.example.com/api/task/fab4b26f-4f2e-4d49-ad01-ae9324bbfe48/action/cancel"
+        rel="task:cancel"/>
+    <Owner
+        href="https://vcloud.example.com/api/vApp/vm-ec94079b-3071-4a72-b95c-4154acb12c38"
+        name=""
+        type="application/vnd.vmware.vcloud.vm+xml"/>
+    <User
+        href="https://vcloud.example.com/api/admin/user/1260efee-6915-494c-8afa-84e7e6d8a310"
+        name="system"
+        type="application/vnd.vmware.admin.user+xml"/>
+    <Organization
+        href="https://vcloud.example.com/api/org/7b832bc5-3d65-45a2-8d35-da28388ab80a"
+        name="Default"
+        type="application/vnd.vmware.vcloud.org+xml"/>
+    <Details/>
+</Task>

--- a/libcloud/test/compute/fixtures/vcloud_1_5/api_vApp_vapp_8c57a5b6_e61b_48ca_8a78_3b70ee65ef6b_remove_snapshots.xml
+++ b/libcloud/test/compute/fixtures/vcloud_1_5/api_vApp_vapp_8c57a5b6_e61b_48ca_8a78_3b70ee65ef6b_remove_snapshots.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?><Task
+    xmlns="http://www.vmware.com/vcloud/v1.5"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    cancelRequested="false"
+    expiryTime="2013-05-15T13:10:25.449+03:00"
+    href="https://vcloud.example.com/api/task/2518935e-b315-4d8e-9e99-9275f751877c"
+    id="urn:vcloud:task:2518935e-b315-4d8e-9e99-9275f751877c"
+    name="task"
+    operation="Removing Snapshot Virtual Machine (ec94079b-3071-4a72-b95c-4154acb12c38)"
+    operationName="vappRemoveAllSnapshots"
+    serviceNamespace="com.vmware.vcloud"
+    startTime="2013-02-14T13:10:25.449+02:00"
+    status="running"
+    type="application/vnd.vmware.vcloud.task+xml"
+    xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://https://vcloud.example.com/api/v1.5/schema/master.xsd">
+    <Link
+        href="https://vcloud.example.com/api/task/2518935e-b315-4d8e-9e99-9275f751877c/action/cancel"
+        rel="task:cancel"/>
+    <Owner
+        href="https://vcloud.example.com/api/vApp/vm-ec94079b-3071-4a72-b95c-4154acb12c38"
+        name=""
+        type="application/vnd.vmware.vcloud.vm+xml"/>
+    <User
+        href="https://vcloud.example.com/api/admin/user/1260efee-6915-494c-8afa-84e7e6d8a310"
+        name="system"
+        type="application/vnd.vmware.admin.user+xml"/>
+    <Organization
+        href="https://vcloud.example.com/api/org/7b832bc5-3d65-45a2-8d35-da28388ab80a"
+        name="Default"
+        type="application/vnd.vmware.vcloud.org+xml"/>
+    <Details/>
+</Task>

--- a/libcloud/test/compute/fixtures/vcloud_1_5/api_vApp_vapp_8c57a5b6_e61b_48ca_8a78_3b70ee65ef6b_revert_snapshot.xml
+++ b/libcloud/test/compute/fixtures/vcloud_1_5/api_vApp_vapp_8c57a5b6_e61b_48ca_8a78_3b70ee65ef6b_revert_snapshot.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?><Task
+    xmlns="http://www.vmware.com/vcloud/v1.5"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    cancelRequested="false"
+    expiryTime="2013-05-15T13:10:20.999+03:00"
+    href="https://vcloud.example.com/api/task/fe75d3af-f5a3-44a5-b016-ae0bdadfc32b"
+    id="urn:vcloud:task:fe75d3af-f5a3-44a5-b016-ae0bdadfc32b"
+    name="task"
+    operation="Reverting to Snapshot Virtual Machine (ec94079b-3071-4a72-b95c-4154acb12c38)"
+    operationName="vappRevertToCurrentSnapshot"
+    serviceNamespace="com.vmware.vcloud"
+    startTime="2013-02-14T13:10:20.999+02:00"
+    status="success"
+    type="application/vnd.vmware.vcloud.task+xml"
+    xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://https://vcloud.example.com/api/v1.5/schema/master.xsd">
+    <Link
+        href="https://vcloud.example.com/api/task/fe75d3af-f5a3-44a5-b016-ae0bdadfc32b/action/cancel"
+        rel="task:cancel"/>
+    <Owner
+        href="https://vcloud.example.com/api/vApp/vm-ec94079b-3071-4a72-b95c-4154acb12c38"
+        name=""
+        type="application/vnd.vmware.vcloud.vm+xml"/>
+    <User
+        href="https://vcloud.example.com/api/admin/user/1260efee-6915-494c-8afa-84e7e6d8a310"
+        name="system"
+        type="application/vnd.vmware.admin.user+xml"/>
+    <Organization
+        href="https://vcloud.example.com/api/org/7b832bc5-3d65-45a2-8d35-da28388ab80a"
+        name="Default"
+        type="application/vnd.vmware.vcloud.org+xml"/>
+    <Details/>
+</Task>

--- a/libcloud/test/compute/test_vcloud.py
+++ b/libcloud/test/compute/test_vcloud.py
@@ -26,6 +26,7 @@ from libcloud.utils.py3 import httplib, b
 from libcloud.compute.drivers.vcloud import TerremarkDriver, VCloudNodeDriver, Subject
 from libcloud.compute.drivers.vcloud import VCloud_1_5_NodeDriver, ControlAccess
 from libcloud.compute.drivers.vcloud import VCloud_5_1_NodeDriver
+from libcloud.compute.drivers.vcloud import VCloud_5_5_NodeDriver
 from libcloud.compute.drivers.vcloud import Vdc
 from libcloud.compute.base import Node, NodeImage
 from libcloud.compute.types import NodeState
@@ -392,6 +393,37 @@ class VCloud_5_1_Tests(unittest.TestCase, TestCaseMixin):
             'https://vm-vcloud/api/vAppTemplate/vappTemplate-ac1bc027-bf8c-4050-8643-4971f691c158', ret[0].id)
 
 
+class VCloud_5_5_Tests(unittest.TestCase, TestCaseMixin):
+
+    def setUp(self):
+        VCloudNodeDriver.connectionCls.host = 'test'
+        VCloudNodeDriver.connectionCls.conn_classes = (
+            None, VCloud_5_5_MockHttp)
+        VCloud_5_5_MockHttp.type = None
+        self.driver = VCloudNodeDriver(
+            *VCLOUD_PARAMS, **{'api_version': '5.5'})
+
+        self.assertTrue(isinstance(self.driver, VCloud_5_5_NodeDriver))
+
+    def test_ex_create_snapshot(self):
+        node = Node(
+            'https://vm-vcloud/api/vApp/vapp-8c57a5b6-e61b-48ca-8a78-3b70ee65ef6b',
+            'testNode', NodeState.RUNNING, [], [], self.driver)
+        self.driver.ex_create_snapshot(node)
+
+    def test_ex_remove_snapshots(self):
+        node = Node(
+            'https://vm-vcloud/api/vApp/vapp-8c57a5b6-e61b-48ca-8a78-3b70ee65ef6b',
+            'testNode', NodeState.RUNNING, [], [], self.driver)
+        self.driver.ex_remove_snapshots(node)
+
+    def test_ex_revert_to_snapshot(self):
+        node = Node(
+            'https://vm-vcloud/api/vApp/vapp-8c57a5b6-e61b-48ca-8a78-3b70ee65ef6b',
+            'testNode', NodeState.RUNNING, [], [], self.driver)
+        self.driver.ex_revert_to_snapshot(node)
+
+
 class TerremarkMockHttp(MockHttp):
 
     fixtures = ComputeFileFixtures('terremark')
@@ -710,6 +742,43 @@ class VCloud_1_5_MockHttp(MockHttp, unittest.TestCase):
     def _api_admin_group_b8202c48_7151_4e61_9a6c_155474c7d413(self, method, url, body, headers):
         body = self.fixtures.load(
             'api_admin_group_b8202c48_7151_4e61_9a6c_155474c7d413.xml')
+        return httplib.OK, body, headers, httplib.responses[httplib.OK]
+
+
+class VCloud_5_5_MockHttp(VCloud_1_5_MockHttp):
+    # TODO: Move 5.5 fixtures to their own folder
+
+    def _api_vApp_vapp_8c57a5b6_e61b_48ca_8a78_3b70ee65ef6b_action_createSnapshot(self, method, url, body, headers):
+        assert method == 'POST'
+        body = self.fixtures.load(
+            'api_vApp_vapp_8c57a5b6_e61b_48ca_8a78_3b70ee65ef6b_create_snapshot.xml')
+        return httplib.OK, body, headers, httplib.responses[httplib.OK]
+
+    def _api_task_fab4b26f_4f2e_4d49_ad01_ae9324bbfe48(self, method, url, body, headers):
+        body = self.fixtures.load(
+            'api_task_b034df55_fe81_4798_bc81_1f0fd0ead450.xml')
+        return httplib.OK, body, headers, httplib.responses[httplib.OK]
+
+    def _api_vApp_vapp_8c57a5b6_e61b_48ca_8a78_3b70ee65ef6b_action_removeAllSnapshots(self, method, url, body, headers):
+        assert method == 'POST'
+        body = self.fixtures.load(
+            'api_vApp_vapp_8c57a5b6_e61b_48ca_8a78_3b70ee65ef6b_remove_snapshots.xml')
+        return httplib.OK, body, headers, httplib.responses[httplib.OK]
+
+    def _api_task_2518935e_b315_4d8e_9e99_9275f751877c(self, method, url, body, headers):
+        body = self.fixtures.load(
+            'api_task_2518935e_b315_4d8e_9e99_9275f751877c.xml')
+        return httplib.OK, body, headers, httplib.responses[httplib.OK]
+
+    def _api_vApp_vapp_8c57a5b6_e61b_48ca_8a78_3b70ee65ef6b_action_revertToCurrentSnapshot(self, method, url, body, headers):
+        assert method == 'POST'
+        body = self.fixtures.load(
+            'api_vApp_vapp_8c57a5b6_e61b_48ca_8a78_3b70ee65ef6b_revert_snapshot.xml')
+        return httplib.OK, body, headers, httplib.responses[httplib.OK]
+
+    def _api_task_fe75d3af_f5a3_44a5_b016_ae0bdadfc32b(self, method, url, body, headers):
+        body = self.fixtures.load(
+            'api_task_fe75d3af_f5a3_44a5_b016_ae0bdadfc32b.xml')
         return httplib.OK, body, headers, httplib.responses[httplib.OK]
 
 


### PR DESCRIPTION
The vCloud 5.5 commit cames from Philip Kershaw (philip.kershaw@stfc.ac.uk), although it seems he never sent it to upstream. He talks about it here http://mail-archives.apache.org/mod_mbox/libcloud-dev/201403.mbox/%3C836226893590734FA88B31162359477F5F7FFE90@EXCHMBX01.fed.cclrc.ac.uk%3E.

The second commit adds snapshot management (create, delete, restore) methods. It also adds 'snapshots' as new field in the 'extra' dict.
