### PR TITLE
Implemented LazyObject class, which provides a 'lazy' class method to create instances with lazy initialization. Th…

### DIFF
--- a/libcloud/common/base.py
+++ b/libcloud/common/base.py
@@ -76,6 +76,41 @@ __all__ = [
 RETRY_FAILED_HTTP_REQUESTS = False
 
 
+class LazyObject(object):
+    """An object that doesn't get initialized until accessed."""
+
+    @classmethod
+    def _proxy(cls, *lazy_init_args, **lazy_init_kwargs):
+        class Proxy(cls, object):
+            _lazy_obj = None
+
+            def __init__(self):
+                # Must override the lazy_cls __init__
+                pass
+
+            def __getattribute__(self, attr):
+                lazy_obj = object.__getattribute__(self, '_get_lazy_obj')()
+                return getattr(lazy_obj, attr)
+
+            def __setattr__(self, attr, value):
+                lazy_obj = object.__getattribute__(self, '_get_lazy_obj')()
+                setattr(lazy_obj, attr, value)
+
+            def _get_lazy_obj(self):
+                lazy_obj = object.__getattribute__(self, '_lazy_obj')
+                if lazy_obj is None:
+                    lazy_obj = cls(*lazy_init_args, **lazy_init_kwargs)
+                    object.__setattr__(self, '_lazy_obj', lazy_obj)
+                return lazy_obj
+
+        return Proxy()
+
+    @classmethod
+    def lazy(cls, *lazy_init_args, **lazy_init_kwargs):
+        """Create a lazily instantiated instance of the subclass, cls."""
+        return cls._proxy(*lazy_init_args, **lazy_init_kwargs)
+
+
 class HTTPResponse(httplib.HTTPResponse):
     # On python 2.6 some calls can hang because HEAD isn't quite properly
     # supported.

--- a/libcloud/test/common/test_base.py
+++ b/libcloud/test/common/test_base.py
@@ -1,0 +1,44 @@
+import unittest
+import sys
+
+import mock
+
+from libcloud.common.base import LazyObject
+from libcloud.test import LibcloudTestCase
+
+
+class LazyObjectTest(LibcloudTestCase):
+
+    class A(LazyObject):
+        def __init__(self, x, y=None):
+            self.x = x
+            self.y = y
+
+    def test_lazy_init(self):
+        # Test normal init
+        a = self.A(1, y=2)
+        self.assertTrue(isinstance(a, self.A))
+
+        # Test lazy init
+        with mock.patch.object(self.A,
+                               '__init__', return_value=None) as mock_init:
+            a = self.A.lazy(3, y=4)
+            self.assertTrue(isinstance(a, self.A))  # Proxy is a subclass of A
+            mock_init.assert_not_called()
+
+            # Since we have a mock init, an A object doesn't actually get
+            # created. But, we can still call __dict__ on the proxy, which will
+            # init the lazy object.
+            self.assertEqual(a.__dict__, {})
+            mock_init.assert_called_once_with(3, y=4)
+
+    def test_setattr(self):
+        a = self.A.lazy('foo', y='bar')
+        a.z = 'baz'
+        wrapped_lazy_obj = object.__getattribute__(a, '_lazy_obj')
+        self.assertEqual(a.z, 'baz')
+        self.assertEqual(wrapped_lazy_obj.z, 'baz')
+
+
+if __name__ == '__main__':
+    sys.exit(unittest.main())


### PR DESCRIPTION
…e lazy class method returns a Proxy object that subclasses the target object class. Upon accessing the proxy object in any way, the object is initialized.

Modified Google Compute Engine License objects, GCELicense, to be such a lazy object. This addresses https://issues.apache.org/jira/browse/LIBCLOUD-786.

Tests/Verification:
  tox -e lint
  python setup.py test
  Added test/common/test_base.py which has LazyObjectTest
