### PR TITLE
Treat sphinx warnings as errors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -156,13 +156,14 @@ DNS
 ~~~
 
 - RackSpace driver - New DNS driver methods:
-    ex_iterate_ptr_records
-    ex_get_ptr_record
-    ex_create_ptr_record
-    ex_update_ptr_record
-    ex_delete_ptr_record
-    This should cover all of the functionality offered by the Rackspace
-    DNS API in regards to RDNS.
+   - ex_iterate_ptr_records
+   - ex_get_ptr_record
+   - ex_create_ptr_record
+   - ex_update_ptr_record
+   - ex_delete_ptr_record
+
+  This should cover all of the functionality offered by the Rackspace DNS API
+  in regards to RDNS.
   (LIBCLOUD-780, GITHUB-652)
   [Greg Hill]
 
@@ -628,11 +629,12 @@ Compute
   [Konstantin Skaburskas]
 
 - Various improvements in the DigitalOcean driver:
-  - Increase page size to API maximum.
-  - Add ``ex_create_attr`` kwarg to ``create_node`` method.
-  - Update all the ``list_*`` methods to use paginated requests
-  - Allow user to specify page size by passing ``ex_per_page`` argument to the
-    constructor.
+   - Increase page size to API maximum.
+   - Add ``ex_create_attr`` kwarg to ``create_node`` method.
+   - Update all the ``list_*`` methods to use paginated requests
+   - Allow user to specify page size by passing ``ex_per_page`` argument to the
+     constructor.
+
   (LIBCLOUD-717, GITHUB-537)
   [Javier Castillo II]
 

--- a/docs/compute/_supported_methods_block_storage.rst
+++ b/docs/compute/_supported_methods_block_storage.rst
@@ -13,6 +13,7 @@ Provider                              list volumes create volume destroy volume 
 `CloudStack`_                         yes          yes           yes            yes           yes           no             yes            
 `Cloudwatt`_                          yes          yes           yes            yes           yes           yes            yes            
 `DigitalOcean`_                       no           no            no             no            no            no             no             
+`DimensionData`_                      no           no            no             no            no            no             no             
 `Amazon EC2`_                         yes          yes           yes            yes           yes           yes            yes            
 `Amazon EC2 (ap-northeast-1)`_        yes          yes           yes            yes           yes           yes            yes            
 `Amazon EC2 (ap-southeast-1)`_        yes          yes           yes            yes           yes           yes            yes            
@@ -84,6 +85,7 @@ Provider                              list volumes create volume destroy volume 
 .. _`CloudStack`: http://cloudstack.org/
 .. _`Cloudwatt`: https://www.cloudwatt.com/
 .. _`DigitalOcean`: https://www.digitalocean.com
+.. _`DimensionData`: http://www.dimensiondata.com/
 .. _`Amazon EC2`: http://aws.amazon.com/ec2/
 .. _`Amazon EC2 (ap-northeast-1)`: http://aws.amazon.com/ec2/
 .. _`Amazon EC2 (ap-southeast-1)`: http://aws.amazon.com/ec2/

--- a/docs/compute/_supported_methods_image_management.rst
+++ b/docs/compute/_supported_methods_image_management.rst
@@ -13,6 +13,7 @@ Provider                              list images get image create image delete 
 `CloudStack`_                         yes         no        no           no           no        
 `Cloudwatt`_                          yes         yes       yes          yes          no        
 `DigitalOcean`_                       yes         yes       yes          yes          no        
+`DimensionData`_                      yes         no        no           no           no        
 `Amazon EC2`_                         yes         yes       yes          yes          yes       
 `Amazon EC2 (ap-northeast-1)`_        yes         yes       yes          yes          yes       
 `Amazon EC2 (ap-southeast-1)`_        yes         yes       yes          yes          yes       
@@ -84,6 +85,7 @@ Provider                              list images get image create image delete 
 .. _`CloudStack`: http://cloudstack.org/
 .. _`Cloudwatt`: https://www.cloudwatt.com/
 .. _`DigitalOcean`: https://www.digitalocean.com
+.. _`DimensionData`: http://www.dimensiondata.com/
 .. _`Amazon EC2`: http://aws.amazon.com/ec2/
 .. _`Amazon EC2 (ap-northeast-1)`: http://aws.amazon.com/ec2/
 .. _`Amazon EC2 (ap-southeast-1)`: http://aws.amazon.com/ec2/

--- a/docs/compute/_supported_methods_key_pair_management.rst
+++ b/docs/compute/_supported_methods_key_pair_management.rst
@@ -13,6 +13,7 @@ Provider                              list key pairs get key pair create key pai
 `CloudStack`_                         yes            yes          yes             yes                           no                          yes            
 `Cloudwatt`_                          yes            yes          yes             yes                           no                          yes            
 `DigitalOcean`_                       yes            yes          yes             no                            no                          yes            
+`DimensionData`_                      no             no           no              no                            no                          no             
 `Amazon EC2`_                         yes            yes          yes             yes                           no                          yes            
 `Amazon EC2 (ap-northeast-1)`_        yes            yes          yes             yes                           no                          yes            
 `Amazon EC2 (ap-southeast-1)`_        yes            yes          yes             yes                           no                          yes            
@@ -84,6 +85,7 @@ Provider                              list key pairs get key pair create key pai
 .. _`CloudStack`: http://cloudstack.org/
 .. _`Cloudwatt`: https://www.cloudwatt.com/
 .. _`DigitalOcean`: https://www.digitalocean.com
+.. _`DimensionData`: http://www.dimensiondata.com/
 .. _`Amazon EC2`: http://aws.amazon.com/ec2/
 .. _`Amazon EC2 (ap-northeast-1)`: http://aws.amazon.com/ec2/
 .. _`Amazon EC2 (ap-southeast-1)`: http://aws.amazon.com/ec2/

--- a/docs/compute/_supported_methods_main.rst
+++ b/docs/compute/_supported_methods_main.rst
@@ -13,6 +13,7 @@ Provider                              list nodes create node reboot node destroy
 `CloudStack`_                         yes        yes         yes         yes          yes         yes        yes        
 `Cloudwatt`_                          yes        yes         yes         yes          yes         yes        yes        
 `DigitalOcean`_                       yes        yes         yes         yes          yes         yes        no         
+`DimensionData`_                      yes        yes         yes         yes          yes         yes        yes        
 `Amazon EC2`_                         yes        yes         yes         yes          yes         yes        yes        
 `Amazon EC2 (ap-northeast-1)`_        yes        yes         yes         yes          yes         yes        yes        
 `Amazon EC2 (ap-southeast-1)`_        yes        yes         yes         yes          yes         yes        yes        
@@ -84,6 +85,7 @@ Provider                              list nodes create node reboot node destroy
 .. _`CloudStack`: http://cloudstack.org/
 .. _`Cloudwatt`: https://www.cloudwatt.com/
 .. _`DigitalOcean`: https://www.digitalocean.com
+.. _`DimensionData`: http://www.dimensiondata.com/
 .. _`Amazon EC2`: http://aws.amazon.com/ec2/
 .. _`Amazon EC2 (ap-northeast-1)`: http://aws.amazon.com/ec2/
 .. _`Amazon EC2 (ap-southeast-1)`: http://aws.amazon.com/ec2/

--- a/docs/compute/_supported_providers.rst
+++ b/docs/compute/_supported_providers.rst
@@ -13,6 +13,7 @@ Provider                              Documentation                             
 `CloudStack`_                         :doc:`Click </compute/drivers/cloudstack>`    CLOUDSTACK          :mod:`libcloud.compute.drivers.cloudstack`     :class:`CloudStackNodeDriver`       
 `Cloudwatt`_                          :doc:`Click </compute/drivers/cloudwatt>`     CLOUDWATT           :mod:`libcloud.compute.drivers.cloudwatt`      :class:`CloudwattNodeDriver`        
 `DigitalOcean`_                       :doc:`Click </compute/drivers/digital_ocean>` DIGITAL_OCEAN       :mod:`libcloud.compute.drivers.digitalocean`   :class:`DigitalOceanNodeDriver`     
+`DimensionData`_                      :doc:`Click </compute/drivers/dimensiondata>` DIMENSIONDATA       :mod:`libcloud.compute.drivers.dimensiondata`  :class:`DimensionDataNodeDriver`    
 `Amazon EC2`_                         :doc:`Click </compute/drivers/ec2>`           EC2                 :mod:`libcloud.compute.drivers.ec2`            :class:`EC2NodeDriver`              
 `Amazon EC2 (ap-northeast-1)`_                                                      EC2_AP_NORTHEAST    :mod:`libcloud.compute.drivers.ec2`            :class:`EC2APNENodeDriver`          
 `Amazon EC2 (ap-southeast-1)`_                                                      EC2_AP_SOUTHEAST    :mod:`libcloud.compute.drivers.ec2`            :class:`EC2APSENodeDriver`          
@@ -84,6 +85,7 @@ Provider                              Documentation                             
 .. _`CloudStack`: http://cloudstack.org/
 .. _`Cloudwatt`: https://www.cloudwatt.com/
 .. _`DigitalOcean`: https://www.digitalocean.com
+.. _`DimensionData`: http://www.dimensiondata.com/
 .. _`Amazon EC2`: http://aws.amazon.com/ec2/
 .. _`Amazon EC2 (ap-northeast-1)`: http://aws.amazon.com/ec2/
 .. _`Amazon EC2 (ap-southeast-1)`: http://aws.amazon.com/ec2/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,7 +80,7 @@ release = '0.14.0-dev'
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 exclude_patterns = [
-    'docs/apidocs/modules.rst',  # generated during build (orphan)
+    'apidocs/modules.rst',  # generated during build (orphan)
     '_build',
     '*/_*.rst'
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,7 +80,7 @@ release = '0.14.0-dev'
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 exclude_patterns = [
-    'apidocs/modules.rst',  # generated during build (orphan)
+    'apidocs/*',  # generated during build (orphans)
     '_build',
     '*/_*.rst'
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,8 +11,14 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys, os
+import os
+import sys
 import subprocess
+
+from sphinx.environment import BuildEnvironment
+
+from sphinx.ext.autodoc import AutoDirective
+from sphinx.ext.autodoc import AutodocReporter
 
 # Detect if we are running on read the docs
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
@@ -263,3 +269,29 @@ texinfo_documents = [
 intersphinx_mapping = {'http://docs.python.org/': None}
 
 autoclass_content = 'both'
+
+
+# Note: For now we ignore sphinx-autodoc warnings since there are too many
+# and we want at least documentation (not docstring) related warnings to be
+# reported, treated as errors and fixed.
+def noop(*args, **kwargs):
+    pass
+
+def mock_warning(self, *args, **kwargs):
+    # We re-write warning as info (level 1)
+    return self.system_message(1, *args, **kwargs)
+
+original_warn_node = BuildEnvironment.warn_node
+
+def ignore_more_than_one_target_found_errors(self, msg, node):
+    if "more than one target found" in msg:
+        return None
+
+    return original_warn_node(self, msg, node)
+
+
+# Monkey patch the original methods
+AutoDirective.warn = noop
+AutodocReporter.warning = mock_warning
+
+BuildEnvironment.warn_node = ignore_more_than_one_target_found_errors

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,6 +80,7 @@ release = '0.14.0-dev'
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 exclude_patterns = [
+    'docs/apidocs/modules.rst',  # generated during build (orphan)
     '_build',
     '*/_*.rst'
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -284,7 +284,7 @@ def mock_warning(self, *args, **kwargs):
 original_warn_node = BuildEnvironment.warn_node
 
 def ignore_more_than_one_target_found_errors(self, msg, node):
-    if "more than one target found" in msg:
+    if 'more than one target found' in msg:
         return None
 
     return original_warn_node(self, msg, node)

--- a/docs/examples/http_proxy/constructor_argument.py
+++ b/docs/examples/http_proxy/constructor_argument.py
@@ -1,0 +1,8 @@
+from libcloud.compute.types import Provider
+from libcloud.compute.providers import get_driver
+
+PROXY_URL_NO_AUTH_1 = 'http://<proxy hostname 1>:<proxy port 2>'
+
+cls = get_driver(Provider.RACKSPACE)
+driver = cls('username', 'api key', region='ord',
+             http_proxy=PROXY_URL_NO_AUTH_1)

--- a/libcloud/common/google.py
+++ b/libcloud/common/google.py
@@ -21,8 +21,8 @@ Information about setting up your Google OAUTH2 credentials:
 For libcloud, there are two basic methods for authenticating to Google using
 OAUTH2: Service Accounts and Client IDs for Installed Applications.
 
-Both are initially set up from the Cloud Console_
-_Console: https://cloud.google.com/console
+Both are initially set up from the Cloud Console Console -
+https://cloud.google.com/console
 
 Setting up Service Account authentication (note that you need the PyCrypto
 package installed to use this):
@@ -38,9 +38,7 @@ package installed to use this):
 - Optionally, you may choose to Generate a PKCS12 key from the Console.
   It needs to be converted to the PEM format.  Please note, the PKCS12 format
   is deprecated and may be removed in a future release.
-  - Convert the key using OpenSSL (the default password is 'notasecret'):
-    ``openssl pkcs12 -in YOURPRIVKEY.p12 -nodes -nocerts
-    -passin pass:notasecret | openssl rsa -out PRIV.pem``
+  - Convert the key using OpenSSL (the default password is 'notasecret').
   - Move the .pem file to a safe location.
 - To Authenticate, you will need to pass the Service Account's "Email
   address" in as the user_id and the path to the .pem file as the key.
@@ -66,6 +64,7 @@ Setting up Installed Application authentication:
 
 Please remember to secure your keys and access tokens.
 """
+
 from __future__ import with_statement
 
 try:

--- a/libcloud/common/onapp.py
+++ b/libcloud/common/onapp.py
@@ -35,11 +35,12 @@ class OnAppConnection(ConnectionUserAndKey):
         Add Basic Authentication header to all the requests.
         It injects the "Authorization: Basic Base64String===" header
         in each request
+
         :type  headers: ``dict``
         :param headers: Default input headers
+
         :rtype:         ``dict``
-        :return:        Default input headers with the "Authorization"
-                        header
+        :return:        Default input headers with the "Authorization" header.
         """
         b64string = b("%s:%s" % (self.user_id, self.key))
         encoded = b64encode(b64string).decode("utf-8")

--- a/libcloud/common/openstack.py
+++ b/libcloud/common/openstack.py
@@ -74,40 +74,46 @@ class OpenStackBaseConnection(ConnectionUserAndKey):
     :type secure: ``bool``
 
     :param ex_force_base_url: Base URL for connection requests.  If
-    not specified, this will be determined by authenticating.
+                              not specified, this will be determined by
+                              authenticating.
     :type ex_force_base_url: ``str``
 
     :param ex_force_auth_url: Base URL for authentication requests.
     :type ex_force_auth_url: ``str``
 
     :param ex_force_auth_version: Authentication version to use.  If
-    not specified, defaults to AUTH_API_VERSION.
+                                  not specified, defaults to AUTH_API_VERSION.
     :type ex_force_auth_version: ``str``
 
-    :param ex_force_auth_token: Authentication token to use for
-    connection requests.  If specified, the connection will not attempt
-    to authenticate, and the value of ex_force_base_url will be used to
-    determine the base request URL.  If ex_force_auth_token is passed in,
-    ex_force_base_url must also be provided.
+    :param ex_force_auth_token: Authentication token to use for connection
+                                requests.  If specified, the connection will
+                                not attempt to authenticate, and the value
+                                of ex_force_base_url will be used to
+                                determine the base request URL.  If
+                                ex_force_auth_token is passed in,
+                                ex_force_base_url must also be provided.
     :type ex_force_auth_token: ``str``
 
-    :param ex_tenant_name: When authenticating, provide this tenant
-    name to the identity service.  A scoped token will be returned.
-    Some cloud providers require the tenant name to be provided at
-    authentication time.  Others will use a default tenant if none
-    is provided.
+    :param ex_tenant_name: When authenticating, provide this tenant name to the
+                           identity service. A scoped token will be returned.
+                           Some cloud providers require the tenant name to be
+                           provided at authentication time. Others will use a
+                           default tenant if none is provided.
     :type ex_tenant_name: ``str``
 
     :param ex_force_service_type: Service type to use when selecting an
-    service.  If not specified, a provider specific default will be used.
+                                  service. If not specified, a provider
+                                  specific default will be used.
     :type ex_force_service_type: ``str``
 
     :param ex_force_service_name: Service name to use when selecting an
-    service.  If not specified, a provider specific default will be used.
+                                  service. If not specified, a provider
+                                  specific default will be used.
     :type ex_force_service_name: ``str``
 
-    :param ex_force_service_region: Region to use when selecting an
-    service.  If not specified, a provider specific default will be used.
+    :param ex_force_service_region: Region to use when selecting an service.
+                                    If not specified, a provider specific
+                                    default will be used.
     :type ex_force_service_region: ``str``
     """
 

--- a/libcloud/compute/deployment.py
+++ b/libcloud/compute/deployment.py
@@ -246,7 +246,7 @@ class MultiStepDeployment(Deployment):
         :type add: Single :class:`Deployment` or a ``list`` of
                    :class:`Deployment`
         :keyword add: Adds this deployment to the others already in this
-        object.
+                      object.
         """
         if add is not None:
             add = add if isinstance(add, (list, tuple)) else [add]

--- a/libcloud/compute/drivers/abiquo.py
+++ b/libcloud/compute/drivers/abiquo.py
@@ -328,8 +328,8 @@ class AbiquoNodeDriver(NodeDriver):
         """
         Destroy a group.
 
-        Be careful! Destroying a group means destroying all the :class:`Node`s
-        there and the group itself!
+        Be careful! Destroying a group means destroying all the :class:`Node`
+        instances there and the group itself!
 
         If there is currently any action over any :class:`Node` of the
         :class:`NodeGroup`, then the method will raise an exception.

--- a/libcloud/compute/drivers/azure.py
+++ b/libcloud/compute/drivers/azure.py
@@ -954,23 +954,25 @@ class AzureNodeDriver(NodeDriver):
 
     def ex_set_instance_endpoints(self, node, endpoints,
                                   ex_deployment_slot="Production"):
-        """
-        endpoint = ConfigurationSetInputEndpoint(
-            name='SSH',
-            protocol='tcp',
-            port=port,
-            local_port='22',
-            load_balanced_endpoint_set_name=None,
-            enable_direct_server_return=False
-        )
-        {
-            'name': 'SSH',
-            'protocol': 'tcp',
-            'port': port,
-            'local_port': '22'
-        }
-        """
 
+        """
+        For example::
+
+            endpoint = ConfigurationSetInputEndpoint(
+                name='SSH',
+                protocol='tcp',
+                port=port,
+                local_port='22',
+                load_balanced_endpoint_set_name=None,
+                enable_direct_server_return=False
+            )
+            {
+                'name': 'SSH',
+                'protocol': 'tcp',
+                'port': port,
+                'local_port': '22'
+            }
+        """
         ex_cloud_service_name = node.extra['ex_cloud_service_name']
         vm_role_name = node.name
 

--- a/libcloud/compute/drivers/cloudsigma.py
+++ b/libcloud/compute/drivers/cloudsigma.py
@@ -274,11 +274,11 @@ class CloudSigma_1_0_NodeDriver(CloudSigmaNodeDriver):
         :type       name: ``str``
 
         :keyword    smp: Number of virtual processors or None to calculate
-        based on the cpu speed
+                         based on the cpu speed.
         :type       smp: ``int``
 
         :keyword    nic_model: e1000, rtl8139 or virtio (is not specified,
-        e1000 is used)
+                               e1000 is used)
         :type       nic_model: ``str``
 
         :keyword    vnc_password: If not set, VNC access is disabled.

--- a/libcloud/compute/drivers/cloudstack.py
+++ b/libcloud/compute/drivers/cloudstack.py
@@ -818,7 +818,7 @@ class CloudStackNetworkACL(object):
         :type       id ``int``
 
         :param      protocol: the protocol for the ACL rule. Valid values are
-                    TCP/UDP/ICMP/ALL or valid protocol number
+                               TCP/UDP/ICMP/ALL or valid protocol number
         :type       protocol: ``string``
 
         :param      acl_id: Name of the network ACL List
@@ -837,7 +837,8 @@ class CloudStackNetworkACL(object):
         :type       end_port: ``str``
 
         :param      traffic_type: the traffic type for the ACL,can be Ingress
-                    or Egress, defaulted to Ingress if not specified
+                                  or Egress, defaulted to Ingress if not
+                                  specified
         :type       traffic_type: ``str``
 
         :rtype: :class:`CloudStackNetworkACL`

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -2292,7 +2292,7 @@ class GCENodeDriver(NodeDriver):
                                        list of dictionaries containing email
                                        and list of scopes, e.g.
                                        [{'email':'default',
-                                         'scopes':['compute', ...]}, ...]
+                                       'scopes':['compute', ...]}, ...]
                                        Scopes can either be full URLs or short
                                        names. If not provided, use the
                                        'default' service account email and a
@@ -2345,8 +2345,8 @@ class GCENodeDriver(NodeDriver):
         :type     ex_automatic_restart: ``bool`` or ``None``
 
         :keyword  ex_preemptible: Defines whether the instance is preemptible.
-                                        (If not supplied, the instance will
-                                         not be preemptible)
+                                  (If not supplied, the instance will not be
+                                  preemptible)
         :type     ex_preemptible: ``bool`` or ``None``
 
         :return:  A Node object for the new node.
@@ -2491,7 +2491,7 @@ class GCENodeDriver(NodeDriver):
                                        list of dictionaries containing email
                                        and list of scopes, e.g.
                                        [{'email':'default',
-                                         'scopes':['compute', ...]}, ...]
+                                       'scopes':['compute', ...]}, ...]
                                        Scopes can either be full URLs or short
                                        names. If not provided, use the
                                        'default' service account email and a
@@ -3299,7 +3299,7 @@ class GCENodeDriver(NodeDriver):
                                        list of dictionaries containing email
                                        and list of scopes, e.g.
                                        [{'email':'default',
-                                         'scopes':['compute', ...]}, ...]
+                                       'scopes':['compute', ...]}, ...]
                                        Scopes can either be full URLs or short
                                        names. If not provided, use the
                                        'default' service account email and a
@@ -4592,7 +4592,7 @@ class GCENodeDriver(NodeDriver):
                                        list of dictionaries containing email
                                        and list of scopes, e.g.
                                        [{'email':'default',
-                                         'scopes':['compute', ...]}, ...]
+                                       'scopes':['compute', ...]}, ...]
                                        Scopes can either be full URLs or short
                                        names. If not provided, use the
                                        'default' service account email and a

--- a/libcloud/compute/drivers/hostvirtual.py
+++ b/libcloud/compute/drivers/hostvirtual.py
@@ -126,8 +126,11 @@ class HostVirtualNodeDriver(NodeDriver):
         return images
 
     def create_node(self, name, image, size, **kwargs):
-        """Creates a node
-        Example of node creation with ssh key deployed
+        """
+        Creates a node
+
+        Example of node creation with ssh key deployed:
+
         >>> from libcloud.compute.base import NodeAuthSSHKey
         >>> key = open('/home/user/.ssh/id_rsa.pub').read()
         >>> auth = NodeAuthSSHKey(pubkey=key)
@@ -139,7 +142,7 @@ class HostVirtualNodeDriver(NodeDriver):
         >>> location = conn.list_locations()[1]
         >>> name = 'markos-dev'
         >>> node = conn.create_node(name, image, size, auth=auth,
-                                    location=location)
+        >>>                         location=location)
         """
 
         dc = None

--- a/libcloud/compute/drivers/ibm_sce.py
+++ b/libcloud/compute/drivers/ibm_sce.py
@@ -132,8 +132,7 @@ class Address(object):
     """
     A reserved IP address that can be attached to an instance.
     Properties: id, ip, state, options(location, type, created_time, state,
-     hostname, instance_ids, vlan, owner,
-    mode, offering_id)
+    hostname, instance_ids, vlan, owner, mode, offering_id)
     """
     def __init__(self, id, ip, state, options):
         self.id = id

--- a/libcloud/compute/drivers/linode.py
+++ b/libcloud/compute/drivers/linode.py
@@ -55,18 +55,18 @@ class LinodeNodeDriver(NodeDriver):
 
     Rough mapping of which is which:
 
-        list_nodes              linode.list
-        reboot_node             linode.reboot
-        destroy_node            linode.delete
-        create_node             linode.create, linode.update,
-                                linode.disk.createfromdistribution,
-                                linode.disk.create, linode.config.create,
-                                linode.ip.addprivate, linode.boot
-        list_sizes              avail.linodeplans
-        list_images             avail.distributions
-        list_locations          avail.datacenters
-        list_volumes            linode.disk.list
-        destroy_volume          linode.disk.delete
+    - list_nodes              linode.list
+    - reboot_node             linode.reboot
+    - destroy_node            linode.delete
+    - create_node             linode.create, linode.update,
+                              linode.disk.createfromdistribution,
+                              linode.disk.create, linode.config.create,
+                              linode.ip.addprivate, linode.boot
+    - list_sizes              avail.linodeplans
+    - list_images             avail.distributions
+    - list_locations          avail.datacenters
+    - list_volumes            linode.disk.list
+    - destroy_volume          linode.disk.delete
 
     For more information on the Linode API, be sure to read the reference:
 

--- a/libcloud/compute/drivers/nephoscale.py
+++ b/libcloud/compute/drivers/nephoscale.py
@@ -351,13 +351,13 @@ get all keys call with no arguments')
         We can also specify the location
         >>> location = conn.list_locations()[0]
         >>> node = conn.create_node(name=name,
-            ...                     size=size,
-            ...                     image=image,
-            ...                     console_key=console_key,
-            ...                     server_key=server_key,
-            ...                     connect_attempts=10,
-            ...                     nowait=True,
-            ...                     zone=location.id)
+        >>> ...                     size=size,
+        >>> ...                     image=image,
+        >>> ...                     console_key=console_key,
+        >>> ...                     server_key=server_key,
+        >>> ...                     connect_attempts=10,
+        >>> ...                     nowait=True,
+        >>> ...                     zone=location.id)
         """
         hostname = kwargs.get('hostname', name)
         service_type = size.id

--- a/libcloud/compute/drivers/profitbricks.py
+++ b/libcloud/compute/drivers/profitbricks.py
@@ -248,7 +248,7 @@ class ProfitBricksNodeDriver(NodeDriver):
 
     These are instance types that match up with what other providers support.
 
-    You can configure disk size, core size, and memory size using the ex_
+    You can configure disk size, core size, and memory size using the ``ex_``
     parameters on the create_node method.
     """
 

--- a/libcloud/storage/drivers/google_storage.py
+++ b/libcloud/storage/drivers/google_storage.py
@@ -113,16 +113,24 @@ class GoogleStorageDriver(BaseS3StorageDriver):
     Installed App credentials, and GCE instance service accounts)
 
     Examples:
-    Service Accounts
+
+    Service Accounts::
+
         driver = GoogleStorageDriver(key=client_email, secret=private_key, ...)
-    Installed Application
+
+    Installed Application::
+
         driver = GoogleStorageDriver(key=client_id, secret=client_secret, ...)
-    From GCE instance
+
+    From GCE instance::
+
         driver = GoogleStorageDriver(key=foo , secret=bar, ...)
 
     Can also authenticate via Google Cloud Storage's S3 interoperability API.
-    S3 user keys are 20 alphanumeric characters, starting with GOOG
-    Example:
+    S3 user keys are 20 alphanumeric characters, starting with GOOG.
+
+    Example::
+
         driver = GoogleStorageDriver(key='GOOG0123456789ABCXYZ',
                                      secret=key_secret)
     """

--- a/libcloud/test/compute/test_elasticstack.py
+++ b/libcloud/test/compute/test_elasticstack.py
@@ -34,16 +34,6 @@ class ElasticStackTestCase(object):
 
     def setUp(self):
         # Re-use ElasticHosts fixtures for the base ElasticStack platform tests
-        """ElasticStack.type = Provider.ELASTICHOSTS
-        ElasticStack.api_name = 'elastichosts'
-
-        ElasticStackBaseConnection.host = 'test.com'
-        ElasticStack.connectionCls.conn_classes = (None,
-                                                   ElasticStackMockHttp)
-        ElasticStack._standard_drives = ElasticHosts._standard_drives
-
-        self.driver = ElasticStack('foo', 'bar')
-        """
         self.mockHttp = ElasticStackMockHttp
         self.mockHttp.type = None
 

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ deps = sphinx
 changedir = docs
 commands = python ../contrib/generate_provider_feature_matrix_table.py
            sphinx-apidoc -d 2 ../libcloud/ -o apidocs/
-           sphinx-build -b html -d {envtmpdir}/doctrees . _build/html
+           sphinx-build -W -b html -d {envtmpdir}/doctrees . _build/html
 
 [testenv:scrape-ec2-prices]
 deps = requests


### PR DESCRIPTION
This pull request re-enabled features which treats sphinx warnings as errors which cause build to fail.

We had this feature enabled in the past, but at some point we disabled it (probably when we enabled sphinx auto doc) so we accumulated a bunch of documentation and docstring related debts since warnings didn't cause build to fail and people simply ignored those issues.

Future TODO (up for grabs):
- [ ] Fix all the docstring related issues
- [ ] Fix all the cross reference related issue (`more than one target found for cross-reference` messages)
