### PR TITLE
Use libcloud unittest

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -318,6 +318,9 @@ For example:
 Make sure that all the code you have added or modified has appropriate test
 coverage. Also make sure all the tests including the existing ones still pass.
 
+Use ``libcloud.test.unittest`` as the unit testing package to ensure that
+your tests work with older versions of Python.
+
 For more information on how to write and run tests, please see
 :doc:`Testing page </testing>`.
 

--- a/libcloud/test/backup/test_dimensiondata.py
+++ b/libcloud/test/backup/test_dimensiondata.py
@@ -14,13 +14,12 @@
 # limitations under the License.
 
 import sys
-import unittest
 from libcloud.utils.py3 import httplib
 
 from libcloud.common.types import InvalidCredsError
 from libcloud.backup.drivers.dimensiondata import DimensionDataBackupDriver as DimensionData
 
-from libcloud.test import MockHttp
+from libcloud.test import MockHttp, unittest
 from libcloud.test.backup import TestCaseMixin
 from libcloud.test.file_fixtures import BackupFileFixtures
 
@@ -35,19 +34,13 @@ class DimensionDataTests(unittest.TestCase, TestCaseMixin):
         self.driver = DimensionData(*DIMENSIONDATA_PARAMS)
 
     def test_invalid_region(self):
-        try:
+        with self.assertRaises(ValueError):
             self.driver = DimensionData(*DIMENSIONDATA_PARAMS, region='blah')
-        except ValueError:
-            pass
 
     def test_invalid_creds(self):
         DimensionDataMockHttp.type = 'UNAUTHORIZED'
-        try:
+        with self.assertRaises(InvalidCredsError):
             self.driver.list_targets()
-            self.assertTrue(
-                False)  # Above command should have thrown an InvalidCredsException
-        except InvalidCredsError:
-            pass
 
     def test_list_targets(self):
         targets = self.driver.list_targets()

--- a/libcloud/test/compute/test_dimensiondata.py
+++ b/libcloud/test/compute/test_dimensiondata.py
@@ -19,7 +19,6 @@ except ImportError:
     from xml.etree import ElementTree as ET
 
 import sys
-import unittest
 from libcloud.utils.py3 import httplib
 
 from libcloud.common.types import InvalidCredsError
@@ -28,10 +27,9 @@ from libcloud.common.dimensiondata import DimensionDataServerCpuSpecification
 from libcloud.compute.drivers.dimensiondata import DimensionDataNodeDriver as DimensionData
 from libcloud.compute.base import Node, NodeAuthPassword, NodeLocation
 
-from libcloud.test import MockHttp
+from libcloud.test import MockHttp, unittest
 from libcloud.test.compute import TestCaseMixin
 from libcloud.test.file_fixtures import ComputeFileFixtures
-
 from libcloud.test.secrets import DIMENSIONDATA_PARAMS
 
 
@@ -43,14 +41,13 @@ class DimensionDataTests(unittest.TestCase, TestCaseMixin):
         self.driver = DimensionData(*DIMENSIONDATA_PARAMS)
 
     def test_invalid_region(self):
-        self.assertRaises(ValueError,
-                          DimensionData,
-                          *DIMENSIONDATA_PARAMS,
-                          region='blah')
+        with self.assertRaises(ValueError):
+            DimensionData(*DIMENSIONDATA_PARAMS, region='blah')
 
     def test_invalid_creds(self):
         DimensionDataMockHttp.type = 'UNAUTHORIZED'
-        self.assertRaises(InvalidCredsError, self.driver.list_nodes)
+        with self.assertRaises(InvalidCredsError):
+            self.driver.list_nodes()
 
     def test_list_locations_response(self):
         DimensionDataMockHttp.type = None
@@ -83,7 +80,8 @@ class DimensionDataTests(unittest.TestCase, TestCaseMixin):
         DimensionDataMockHttp.type = 'INPROGRESS'
         node = Node(id='11', name=None, state=None,
                     public_ips=None, private_ips=None, driver=self.driver)
-        self.assertRaises(DimensionDataAPIException, node.reboot)
+        with self.assertRaises(DimensionDataAPIException):
+            node.reboot()
 
     def test_destroy_node_response(self):
         node = Node(id='11', name=None, state=None,
@@ -95,7 +93,8 @@ class DimensionDataTests(unittest.TestCase, TestCaseMixin):
         DimensionDataMockHttp.type = 'INPROGRESS'
         node = Node(id='11', name=None, state=None,
                     public_ips=None, private_ips=None, driver=self.driver)
-        self.assertRaises(DimensionDataAPIException, node.destroy)
+        with self.assertRaises(DimensionDataAPIException):
+            node.destroy()
 
     def test_list_images(self):
         images = self.driver.list_images()
@@ -148,15 +147,13 @@ class DimensionDataTests(unittest.TestCase, TestCaseMixin):
     def test_create_node_no_network(self):
         rootPw = NodeAuthPassword('pass123')
         image = self.driver.list_images()[0]
-        self.assertRaises(
-            ValueError,
-            self.driver.create_node,
-            name='test2',
-            image=image,
-            auth=rootPw,
-            ex_description='test2 node',
-            ex_network=None,
-            ex_isStarted=False)
+        with self.assertRaises(ValueError):
+            self.driver.create_node(name='test2',
+                                    image=image,
+                                    auth=rootPw,
+                                    ex_description='test2 node',
+                                    ex_network=None,
+                                    ex_isStarted=False)
 
     def test_ex_shutdown_graceful(self):
         node = Node(id='11', name=None, state=None,
@@ -168,9 +165,8 @@ class DimensionDataTests(unittest.TestCase, TestCaseMixin):
         DimensionDataMockHttp.type = 'INPROGRESS'
         node = Node(id='11', name=None, state=None,
                     public_ips=None, private_ips=None, driver=self.driver)
-        self.assertRaises(DimensionDataAPIException,
-                          self.driver.ex_shutdown_graceful,
-                          node)
+        with self.assertRaises(DimensionDataAPIException):
+            self.driver.ex_shutdown_graceful(node)
 
     def test_ex_start_node(self):
         node = Node(id='11', name=None, state=None,
@@ -182,9 +178,8 @@ class DimensionDataTests(unittest.TestCase, TestCaseMixin):
         DimensionDataMockHttp.type = 'INPROGRESS'
         node = Node(id='11', name=None, state=None,
                     public_ips=None, private_ips=None, driver=self.driver)
-        self.assertRaises(DimensionDataAPIException,
-                          self.driver.ex_start_node,
-                          node)
+        with self.assertRaises(DimensionDataAPIException):
+            self.driver.ex_start_node(node)
 
     def test_ex_power_off(self):
         node = Node(id='11', name=None, state=None,
@@ -202,9 +197,8 @@ class DimensionDataTests(unittest.TestCase, TestCaseMixin):
         DimensionDataMockHttp.type = 'INPROGRESS'
         node = Node(id='11', name=None, state=None,
                     public_ips=None, private_ips=None, driver=self.driver)
-        self.assertRaises(DimensionDataAPIException,
-                          self.driver.ex_power_off,
-                          node)
+        with self.assertRaises(DimensionDataAPIException):
+            self.driver.ex_power_off(node)
 
     def test_ex_reset(self):
         node = Node(id='11', name=None, state=None,

--- a/libcloud/test/loadbalancer/test_dimensiondata.py
+++ b/libcloud/test/loadbalancer/test_dimensiondata.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import sys
-import unittest
 from libcloud.utils.py3 import httplib
 
 from libcloud.common.types import InvalidCredsError
@@ -24,7 +23,7 @@ from libcloud.loadbalancer.drivers.dimensiondata \
     import DimensionDataLBDriver as DimensionData
 from libcloud.loadbalancer.types import State
 
-from libcloud.test import MockHttp
+from libcloud.test import MockHttp, unittest
 from libcloud.test.file_fixtures import LoadBalancerFileFixtures
 
 from libcloud.test.secrets import DIMENSIONDATA_PARAMS
@@ -38,19 +37,13 @@ class DimensionDataTests(unittest.TestCase):
         self.driver = DimensionData(*DIMENSIONDATA_PARAMS)
 
     def test_invalid_region(self):
-        try:
+        with self.assertRaises(ValueError):
             self.driver = DimensionData(*DIMENSIONDATA_PARAMS, region='blah')
-        except ValueError:
-            pass
 
     def test_invalid_creds(self):
         DimensionDataMockHttp.type = 'UNAUTHORIZED'
-        try:
+        with self.assertRaises(InvalidCredsError):
             self.driver.list_balancers()
-            self.assertTrue(False)
-            # Above command should have thrown an InvalidCredsException
-        except InvalidCredsError:
-            pass
 
     def test_create_balancer(self):
         self.driver.ex_set_current_network_domain('1234')


### PR DESCRIPTION
This changeset includes two patches:
1. Modify Dimension Data tests again to use `libcloud.test.unittest` which contains logic for deciding the appropriate package version that works across Python versions. This allows us to use assertRaises as a context manager which makes the test cleaner.
2. Add an entry in `docs/development.rst` to recommend using `libcloud.test.unittest`. This is based on a suggestion from @Kami in PR #674.
