### PR TITLE
Throw a more friendly error message if establishing SSL / TLS connection fails

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,11 @@ General
   (GITHUB-556, LIBCLOUD-728)
   [Scott Kruger]
 
+- Throw a more user-friendly exception if a client fails to establish SSL / TLS
+  connection with a server because of an unsupported SSL / TLS version.
+  (GITHUB-682)
+  [Tomaz Muraus]
+
 Compute
 ~~~~~~~
 

--- a/libcloud/httplib_ssl.py
+++ b/libcloud/httplib_ssl.py
@@ -298,8 +298,7 @@ class LibcloudHTTPSConnection(httplib.HTTPSConnection, LibcloudBaseConnection):
                 cert_reqs=ssl.CERT_REQUIRED,
                 ca_certs=self.ca_cert,
                 ssl_version=libcloud.security.SSL_VERSION)
-        except Exception:
-            exc_cls = sys.exc_info()[0]
+        except socket.error:
             e = sys.exc_info()[1]
             exc_msg = str(e)
 
@@ -310,7 +309,7 @@ class LibcloudHTTPSConnection(httplib.HTTPSConnection, LibcloudBaseConnection):
                 msg = (UNSUPPORTED_TLS_VERSION_ERROR_MSG %
                        (exc_msg, ssl_version))
 
-                new_e = exc_cls(msg)
+                new_e = socket.error(msg)
                 new_e.original_exc = e
                 raise new_e
 

--- a/libcloud/httplib_ssl.py
+++ b/libcloud/httplib_ssl.py
@@ -291,22 +291,25 @@ class LibcloudHTTPSConnection(httplib.HTTPSConnection, LibcloudBaseConnection):
             self._activate_http_proxy(sock=sock)
 
         try:
-            self.sock = ssl.wrap_socket(sock,
-                                        self.key_file,
-                                        self.cert_file,
-                                        cert_reqs=ssl.CERT_REQUIRED,
-                                        ca_certs=self.ca_cert,
-                                        ssl_version=libcloud.security.SSL_VERSION)
+            self.sock = ssl.wrap_socket(
+                sock,
+                self.key_file,
+                self.cert_file,
+                cert_reqs=ssl.CERT_REQUIRED,
+                ca_certs=self.ca_cert,
+                ssl_version=libcloud.security.SSL_VERSION)
         except Exception:
             exc_cls = sys.exc_info()[0]
             e = sys.exc_info()[1]
-
             exc_msg = str(e)
+
             # Re-throw an exception with a more friendly error message
             if 'connection reset by peer' in exc_msg.lower():
                 ssl_version = libcloud.security.SSL_VERSION
                 ssl_version = SSL_CONSTANT_TO_TLS_VERSION_MAP[ssl_version]
-                msg = UNSUPPORTED_TLS_VERSION_ERROR_MSG % (exc_msg, ssl_version)
+                msg = (UNSUPPORTED_TLS_VERSION_ERROR_MSG %
+                       (exc_msg, ssl_version))
+
                 new_e = exc_cls(msg)
                 new_e.original_exc = e
                 raise new_e

--- a/libcloud/test/test_httplib_ssl.py
+++ b/libcloud/test/test_httplib_ssl.py
@@ -128,8 +128,17 @@ class TestHttpLibSSLTests(unittest.TestCase):
         mock_wrap_socket.side_effect = socket.error('Connection reset by peer')
 
         expected_msg = 'Failed to establish SSL / TLS connection'
-        self.assertRaisesRegexp(Exception, expected_msg,
+        self.assertRaisesRegexp(socket.error, expected_msg,
                                 self.httplib_object.connect)
+
+        # Same error but including errno
+        with self.assertRaises(socket.error) as cm:
+            mock_wrap_socket.side_effect = socket.error(104, 'Connection reset by peer')
+            self.httplib_object.connect()
+
+        e = cm.exception
+        self.assertEqual(e.errno, 104)
+        self.assertTrue(expected_msg in str(e))
 
 
 if __name__ == '__main__':

--- a/libcloud/test/test_httplib_ssl.py
+++ b/libcloud/test/test_httplib_ssl.py
@@ -108,6 +108,7 @@ class TestHttpLibSSLTests(unittest.TestCase):
                                 self.httplib_object._setup_ca_cert)
 
     @mock.patch('socket.create_connection', mock.MagicMock())
+    @mock.patch('socket.socket', mock.MagicMock())
     @mock.patch('ssl.wrap_socket')
     def test_connect_throws_friendly_error_message_on_ssl_wrap_connection_reset_by_peer(self, mock_wrap_socket):
         # Test that we re-throw a more friendly error message in case

--- a/libcloud/test/test_httplib_ssl.py
+++ b/libcloud/test/test_httplib_ssl.py
@@ -116,6 +116,7 @@ class TestHttpLibSSLTests(unittest.TestCase):
         # SSL connection
         libcloud.security.VERIFY_SSL_CERT = True
         self.httplib_object.verify = True
+        self.httplib_object.http_proxy_used = False
 
         # No connection reset by peer, original exception should be thrown
         mock_wrap_socket.side_effect = Exception('foo bar fail')


### PR DESCRIPTION
With this change we now throw a more user-friendly error message in case establishing SSL / TLS connection fails.

New error message:

``` python
  File "/home/kami/w/lc/libcloud/libcloud/httplib_ssl.py", line 312, in connect
    raise new_e
socket.error: Failed to establish SSL / TLS connection ([Errno 104] Connection reset by peer). It is possible that the server doesn't support requested SSL / TLS version (TLS v1.0).
For information on how to work around this issue, please see https://libcloud.readthedocs.org/en/latest/other/ssl-certificate-validation.html#changing-used-ssl-tls-version
```

Related to https://issues.apache.org/jira/browse/LIBCLOUD-791
