### PR TITLE
[WIP] [DON'T MERGE] Use ssl.PROTOCOL_SSLv23 constant by default under Python >= 2.7.9 < 3 and >= 3.4

### DIFF
--- a/libcloud/httplib_ssl.py
+++ b/libcloud/httplib_ssl.py
@@ -12,10 +12,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """
 Subclass for httplib.HTTPSConnection with optional certificate name
 verification, depending on libcloud.security settings.
 """
+
 import os
 import sys
 import socket
@@ -24,6 +26,7 @@ import base64
 import warnings
 
 import libcloud.security
+from libcloud.security import get_ssl_version
 from libcloud.utils.py3 import b
 from libcloud.utils.py3 import httplib
 from libcloud.utils.py3 import urlparse
@@ -290,6 +293,9 @@ class LibcloudHTTPSConnection(httplib.HTTPSConnection, LibcloudBaseConnection):
         if self.http_proxy_used:
             self._activate_http_proxy(sock=sock)
 
+        # Dynamically retrieve SSL version which is to be used
+        ssl_version = get_ssl_version()
+
         try:
             self.sock = ssl.wrap_socket(
                 sock,
@@ -297,31 +303,10 @@ class LibcloudHTTPSConnection(httplib.HTTPSConnection, LibcloudBaseConnection):
                 self.cert_file,
                 cert_reqs=ssl.CERT_REQUIRED,
                 ca_certs=self.ca_cert,
-                ssl_version=libcloud.security.SSL_VERSION)
+                ssl_version=ssl_version)
         except socket.error:
             exc = sys.exc_info()[1]
-            exc_msg = str(exc)
-
-            # Re-throw an exception with a more friendly error message
-            if 'connection reset by peer' in exc_msg.lower():
-                ssl_version = libcloud.security.SSL_VERSION
-                ssl_version = SSL_CONSTANT_TO_TLS_VERSION_MAP[ssl_version]
-                msg = (UNSUPPORTED_TLS_VERSION_ERROR_MSG %
-                       (exc_msg, ssl_version))
-
-                # Note: In some cases arguments are (errno, message) and in
-                # other it's just (message,)
-                exc_args = getattr(exc, 'args', [])
-
-                if len(exc_args) == 2:
-                    new_exc_args = [exc.args[0], msg]
-                else:
-                    new_exc_args = [msg]
-
-                new_exc = socket.error(*new_exc_args)
-                new_exc.original_exc = exc
-                raise new_exc
-
+            exc = get_socket_error_exception(ssl_version=ssl_version, exc=exc)
             raise exc
 
         cert = self.sock.getpeercert()
@@ -330,3 +315,33 @@ class LibcloudHTTPSConnection(httplib.HTTPSConnection, LibcloudBaseConnection):
         except CertificateError:
             e = sys.exc_info()[1]
             raise ssl.SSLError('Failed to verify hostname: %s' % (str(e)))
+
+
+def get_socket_error_exception(ssl_version, exc):
+    """
+    Function which intercepts socket.error exceptions and re-throws an
+    exception with a more user-friendly message in case server doesn't support
+    requested SSL version.
+    """
+    exc_msg = str(exc)
+
+    # Re-throw an exception with a more friendly error message
+    if 'connection reset by peer' in exc_msg.lower():
+        ssl_version_name = SSL_CONSTANT_TO_TLS_VERSION_MAP[ssl_version]
+        msg = (UNSUPPORTED_TLS_VERSION_ERROR_MSG %
+               (exc_msg, ssl_version_name))
+
+        # Note: In some cases arguments are (errno, message) and in
+        # other it's just (message,)
+        exc_args = getattr(exc, 'args', [])
+
+        if len(exc_args) == 2:
+            new_exc_args = [exc.args[0], msg]
+        else:
+            new_exc_args = [msg]
+
+        new_exc = socket.error(*new_exc_args)
+        new_exc.original_exc = exc
+        return new_exc
+
+    return exc

--- a/libcloud/utils/py3.py
+++ b/libcloud/utils/py3.py
@@ -30,11 +30,13 @@ except ImportError:
 
 PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
+PY2_post_279 = PY2 and sys.version_info >= (2, 7, 0)
 PY2_pre_25 = PY2 and sys.version_info < (2, 5)
 PY2_pre_26 = PY2 and sys.version_info < (2, 6)
 PY2_pre_27 = PY2 and sys.version_info < (2, 7)
 PY2_pre_279 = PY2 and sys.version_info < (2, 7, 9)
 PY3_pre_32 = PY3 and sys.version_info < (3, 2)
+PY3_post_34 = PY3 and sys.version_info >= (3, 4, 0)
 
 PY2 = False
 PY25 = False


### PR DESCRIPTION
Note: This pull request is W.I.P. and not yet ready to be reviewed and merged.

This pull request updates the code to use `ssl.PROTOCOL_SSLv23` constant for `ssl_version` attribute when establishing SSL / TLS connection when using Python >= 2.7.9 < 3 and Python >= 3.4.

This constant offers the best security and compatibility since it will pick between TLS v1.0, TLS v1.1 and TLS v1.2 depending on the version supported / requested by the server. This is only done under aforementioned Python versions since un-secure SSL v3.0 is disabled by default in those versions.

In other versions where SSL v3.0 is not disabled we still use TLS v1.0 (`ssl.PROTOCOL_TLSv1`) which means nothing has changed - that's the same as the old / existing behavior.

Another thing to keep in mind is that user can also explicitly specify which version they want to use using `libcloud.security.SSL_VERSION` variable and this value has precedence over dynamically obtained values.

Ideally, if users know that the server supports TLS v1.2 they should explicitly specify and use that aka the highest supported versions (that's also mentioned in the documentation).
