### PR TITLE
EC2 support for AWS Seoul region

### DIFF
--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -1042,7 +1042,7 @@ REGION_DETAILS = {
         'endpoint': 'ec2.ap-northeast-2.amazonaws.com',
         'api_name': 'ec2_ap_northeast',
         'country': 'South Korea',
-        'signature_version': '2',
+        'signature_version': '4',
         'instance_types': [
             'c4.large',
             'c4.xlarge',

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -1054,7 +1054,6 @@ REGION_DETAILS = {
             'm4.2xlarge',
             'm4.4xlarge',
             'm4.10xlarge',
-            'hs1.8xlarge',
             'i2.xlarge',
             'i2.2xlarge',
             'i2.4xlarge',

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -6359,12 +6359,23 @@ class EC2APSENodeDriver(EC2NodeDriver):
     _region = 'ap-southeast-1'
 
 
-class EC2APNENodeDriver(EC2NodeDriver):
+class EC2APNE1NodeDriver(EC2NodeDriver):
     """
-    Driver class for EC2 in the Northeast Asia Pacific Region.
+    Driver class for EC2 in the Northeast Asia Pacific 1(Tokyo) Region.
     """
     name = 'Amazon EC2 (ap-northeast-1)'
     _region = 'ap-northeast-1'
+
+
+EC2APNENodeDriver = EC2APNE1NodeDriver  # fallback
+
+
+class EC2APNE2NodeDriver(EC2NodeDriver):
+    """
+    Driver class for EC2 in the Northeast Asia Pacific 2(Seoul) Region.
+    """
+    name = 'Amazon EC2 (ap-northeast-2)'
+    _region = 'ap-northeast-2'
 
 
 class EC2SAEastNodeDriver(EC2NodeDriver):

--- a/libcloud/compute/providers.py
+++ b/libcloud/compute/providers.py
@@ -43,6 +43,10 @@ DRIVERS = {
     ('libcloud.compute.drivers.ec2', 'EC2APSENodeDriver'),
     Provider.EC2_AP_NORTHEAST:
     ('libcloud.compute.drivers.ec2', 'EC2APNENodeDriver'),
+    Provider.EC2_AP_NORTHEAST1:
+    ('libcloud.compute.drivers.ec2', 'EC2APNE1NodeDriver'),
+    Provider.EC2_AP_NORTHEAST2:
+    ('libcloud.compute.drivers.ec2', 'EC2APNE2NodeDriver'),
     Provider.EC2_SA_EAST:
     ('libcloud.compute.drivers.ec2', 'EC2SAEastNodeDriver'),
     Provider.EC2_AP_SOUTHEAST2:

--- a/libcloud/compute/types.py
+++ b/libcloud/compute/types.py
@@ -167,6 +167,8 @@ class Provider(Type):
     EC2_US_WEST = 'ec2_us_west'
     EC2_AP_SOUTHEAST = 'ec2_ap_southeast'
     EC2_AP_NORTHEAST = 'ec2_ap_northeast'
+    EC2_AP_NORTHEAST1 = 'ec2_ap_northeast_1'
+    EC2_AP_NORTHEAST2 = 'ec2_ap_northeast_2'
     EC2_US_WEST_OREGON = 'ec2_us_west_oregon'
     EC2_SA_EAST = 'ec2_sa_east'
     EC2_AP_SOUTHEAST2 = 'ec2_ap_southeast_2'


### PR DESCRIPTION
- Fixed signature version of AWS Seoul region to 4 due to that does not support
- Added provider and driver for region.
