### PR TITLE
Added explination for 'if XXX and YYY != XXX:' 

### DIFF
--- a/libcloud/common/openstack_identity.py
+++ b/libcloud/common/openstack_identity.py
@@ -233,6 +233,12 @@ class OpenStackServiceCatalog(object):
         endpoints = []
 
         for entry in self._entries:
+            """
+                if XXX and YYYY != XXX 
+                provides support for partials lookups
+                i.e. This lets you pass in only one of them, neither, or both,
+                and it does the right thing in all cases.
+            """
             if service_type and entry.service_type != service_type:
                 continue
 


### PR DESCRIPTION
Following attempt to clean up what looked to me like a redundant check I found out it wasn't in fact redundant but was providing support for partial lookups

Per Greg Hill's explanation:
The problem is name and service_type are optional parameters that default to None, if you look at the method signature. This lets you pass in only one of them, neither, or both, and it does the right thing in all cases.

I've added a comment to make this clear to future contributes.

For others reading this where it still isn't clear
if XXX and YYY != XXX:
does not translate to: (as was my initial thought) 
if YYY != XXX:

it actually translates to (we are checking if the Value is SET on the left side of the AND.
if XXX:
    if YYY != XXX:
