### PR TITLE
Paramiko consume multi byte UTF-8 characters fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,10 +7,14 @@ Changes with Apache Libcloud in development
 General
 ~~~~~~~
 
-- Fix a bug with consuming stdout and stderr in the Paramiko SSH client which
-  would manifest itself under very rare scenario when a consumed chunk only
-  contained single byte or part of a multi byte UTF-8 character.
+- Fix a bug with consuming stdout and stderr in the paramiko SSH client which
+  would manifest itself under very rare condition when a consumed chunk only
+  contained a single byte or part of a multi byte UTF-8 character.
   [Lakshmi Kannan, Tomaz Muraus]
+
+- Increase default chunk size from ``1024`` to ``4096`` bytes in the paramiko
+  SSH client. This results in smaller number of receive calls on the average.
+  [Tomaz Muraus]
 
 Changes with Apache Libcloud 1.0-pre1
 -------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+Changes with Apache Libcloud in development
+-------------------------------------------
+
+General
+~~~~~~~
+
+- Fix a bug with consuming stdout and stderr in the Paramiko SSH client which
+  would manifest itself under very rare scenario when a consumed chunk only
+  contained single byte or part of a multi byte UTF-8 character.
+  [Lakshmi Kannan, Tomaz Muraus]
+
 Changes with Apache Libcloud 1.0-pre1
 -------------------------------------
 

--- a/libcloud/compute/ssh.py
+++ b/libcloud/compute/ssh.py
@@ -440,6 +440,7 @@ class ParamikoSSHClient(BaseSSHClient):
                     break
 
                 data = recv_method(self.CHUNK_SIZE)
+                result_bytes += b(data)
 
         # We only decode data at the end because a single chunk could contain
         # a part of multi byte UTF-8 character (whole multi bytes character

--- a/libcloud/compute/ssh.py
+++ b/libcloud/compute/ssh.py
@@ -200,7 +200,7 @@ class ParamikoSSHClient(BaseSSHClient):
     """
 
     # Maximum number of bytes to read at once from a socket
-    CHUNK_SIZE = 1024
+    CHUNK_SIZE = 4096
 
     # How long to sleep while waiting for command to finish
     SLEEP_DELAY = 1.5

--- a/libcloud/compute/ssh.py
+++ b/libcloud/compute/ssh.py
@@ -201,6 +201,7 @@ class ParamikoSSHClient(BaseSSHClient):
 
     # Maximum number of bytes to read at once from a socket
     CHUNK_SIZE = 1024
+
     # How long to sleep while waiting for command to finish
     SLEEP_DELAY = 1.5
 
@@ -402,41 +403,49 @@ class ParamikoSSHClient(BaseSSHClient):
         """
         Try to consume stdout data from chan if it's receive ready.
         """
-
-        stdout = StringIO()
-        if chan.recv_ready():
-            data = chan.recv(self.CHUNK_SIZE)
-
-            while data:
-                stdout.write(b(data).decode('utf-8'))
-                ready = chan.recv_ready()
-
-                if not ready:
-                    break
-
-                data = chan.recv(self.CHUNK_SIZE)
-
+        stdout = self._consume_data_from_channel(
+            chan=chan,
+            recv_method=chan.recv,
+            recv_ready_method=chan.recv_ready)
         return stdout
 
     def _consume_stderr(self, chan):
         """
         Try to consume stderr data from chan if it's receive ready.
         """
+        stderr = self._consume_data_from_channel(
+            chan=chan,
+            recv_method=chan.recv_stderr,
+            recv_ready_method=chan.recv_stderr_ready)
+        return stderr
 
-        stderr = StringIO()
-        if chan.recv_stderr_ready():
-            data = chan.recv_stderr(self.CHUNK_SIZE)
+    def _consume_data_from_channel(self, chan, recv_method, recv_ready_method):
+        """
+        Try to consume data from the provided channel.
+
+        Keep in mind that data is only consumed if the channel is receive
+        ready.
+        """
+        result = StringIO()
+        result_bytes = bytearray()
+
+        if recv_ready_method():
+            data = recv_method(self.CHUNK_SIZE)
+            result_bytes += b(data)
 
             while data:
-                stderr.write(b(data).decode('utf-8'))
-                ready = chan.recv_stderr_ready()
+                ready = recv_ready_method()
 
                 if not ready:
                     break
 
-                data = chan.recv_stderr(self.CHUNK_SIZE)
+                data = recv_method(self.CHUNK_SIZE)
 
-        return stderr
+        # We only decode data at the end because a single chunk could contain
+        # a part of multi byte UTF-8 character (whole multi bytes character
+        # could be split over two chunks)
+        result.write(result_bytes.decode('utf-8'))
+        return result
 
     def _get_pkey_object(self, key):
         """

--- a/libcloud/test/compute/test_ssh_client.py
+++ b/libcloud/test/compute/test_ssh_client.py
@@ -29,6 +29,7 @@ from libcloud.compute.ssh import ShellOutSSHClient
 from libcloud.compute.ssh import have_paramiko
 
 from libcloud.utils.py3 import StringIO
+from libcloud.utils.py3 import u
 
 from mock import patch, Mock, MagicMock
 
@@ -268,7 +269,7 @@ class ParamikoSSHClientTests(LibcloudTestCase):
         chan.recv.side_effect = ['123', '456']
 
         stdout = client._consume_stdout(chan).getvalue()
-        self.assertEqual(u'123456', stdout)
+        self.assertEqual(u('123456'), stdout)
         self.assertEqual(len(stdout), 6)
 
         conn_params = {'hostname': 'dummy.host.org',
@@ -281,7 +282,7 @@ class ParamikoSSHClientTests(LibcloudTestCase):
         chan.recv.side_effect = ['987', '6543210']
 
         stdout = client._consume_stdout(chan).getvalue()
-        self.assertEqual(u'9876543210', stdout)
+        self.assertEqual(u('9876543210'), stdout)
         self.assertEqual(len(stdout), 10)
 
     def test_consume_stderr(self):
@@ -295,7 +296,7 @@ class ParamikoSSHClientTests(LibcloudTestCase):
         chan.recv_stderr.side_effect = ['123', '456']
 
         stderr = client._consume_stderr(chan).getvalue()
-        self.assertEqual(u'123456', stderr)
+        self.assertEqual(u('123456'), stderr)
         self.assertEqual(len(stderr), 6)
 
         conn_params = {'hostname': 'dummy.host.org',
@@ -308,7 +309,7 @@ class ParamikoSSHClientTests(LibcloudTestCase):
         chan.recv_stderr.side_effect = ['987', '6543210']
 
         stderr = client._consume_stderr(chan).getvalue()
-        self.assertEqual(u'9876543210', stderr)
+        self.assertEqual(u('9876543210'), stderr)
         self.assertEqual(len(stderr), 10)
 
     def test_consume_stdout_chunk_contains_part_of_multi_byte_utf8_character(self):
@@ -322,7 +323,7 @@ class ParamikoSSHClientTests(LibcloudTestCase):
         chan.recv.side_effect = ['\xF0', '\x90', '\x8D', '\x88']
 
         stdout = client._consume_stdout(chan).getvalue()
-        self.assertEqual(u'\U00010348', stdout)
+        self.assertEqual(u('\U00010348'), stdout)
         self.assertEqual(len(stdout), 1)
 
     def test_consume_stderr_chunk_contains_part_of_multi_byte_utf8_character(self):
@@ -336,7 +337,7 @@ class ParamikoSSHClientTests(LibcloudTestCase):
         chan.recv_stderr.side_effect = ['\xF0', '\x90', '\x8D', '\x88']
 
         stderr = client._consume_stderr(chan).getvalue()
-        self.assertEqual(u'\U00010348', stderr)
+        self.assertEqual(u('\U00010348'), stderr)
         self.assertEqual(len(stderr), 1)
 
 

--- a/libcloud/test/compute/test_ssh_client.py
+++ b/libcloud/test/compute/test_ssh_client.py
@@ -323,7 +323,7 @@ class ParamikoSSHClientTests(LibcloudTestCase):
         chan.recv.side_effect = ['\xF0', '\x90', '\x8D', '\x88']
 
         stdout = client._consume_stdout(chan).getvalue()
-        self.assertEqual(u('\U00010348'), stdout)
+        self.assertEqual('\xf0\x90\x8d\x88', stdout.encode('utf-8'))
         self.assertEqual(len(stdout), 1)
 
     def test_consume_stderr_chunk_contains_part_of_multi_byte_utf8_character(self):
@@ -337,7 +337,7 @@ class ParamikoSSHClientTests(LibcloudTestCase):
         chan.recv_stderr.side_effect = ['\xF0', '\x90', '\x8D', '\x88']
 
         stderr = client._consume_stderr(chan).getvalue()
-        self.assertEqual(u('\U00010348'), stderr)
+        self.assertEqual('\xf0\x90\x8d\x88', stderr.encode('utf-8'))
         self.assertEqual(len(stderr), 1)
 
 


### PR DESCRIPTION
This is a fix for a bug in the paramiko SSH client which would occur when reading / consuming stdout / stderr data from a remote channel.

This issue would only manifest itself under a very specific condition - if the very end of a chunk contains part of a multi byte UTF-8 character.

This was initially caught and fixed by @lakshmi-kannan in StackStorm/st2, but the fix was never backported to Libcloud (the reason for that probably was that Libcloud is more work since we support all those Python versions).

I used that fix as a base for this PR, but included necessary changes to make it work across different versions of Python and also did minor refactoring.
