### PR TITLE
S3 support for AWS Seoul region

### DIFF
--- a/libcloud/common/aws.py
+++ b/libcloud/common/aws.py
@@ -252,6 +252,7 @@ class AWSRequestSignerAlgorithmV4(AWSRequestSigner):
                             data=None):
         now = datetime.utcnow()
         headers['X-AMZ-Date'] = now.strftime('%Y%m%dT%H%M%SZ')
+        headers['X-AMZ-Content-SHA256'] = self._get_payload_hash(method, data)
         headers['Authorization'] = \
             self._get_authorization_v4_header(params=params, headers=headers,
                                               dt=now, method=method, path=path,
@@ -361,7 +362,7 @@ class SignedAWSConnection(AWSTokenConnection):
 
         if self.signature_version == '2':
             signer_cls = AWSRequestSignerAlgorithmV2
-        elif signature_version == '4':
+        elif self.signature_version == '4':
             signer_cls = AWSRequestSignerAlgorithmV4
         else:
             raise ValueError('Unsupported signature_version: %s' %

--- a/libcloud/common/aws.py
+++ b/libcloud/common/aws.py
@@ -315,7 +315,7 @@ class AWSRequestSignerAlgorithmV4(AWSRequestSigner):
         return ';'.join([k.lower() for k in sorted(headers.keys())])
 
     def _get_canonical_headers(self, headers):
-        return '\n'.join([':'.join([k.lower(), v.strip()])
+        return '\n'.join([':'.join([k.lower(), str(v).strip()])
                           for k, v in sorted(headers.items())]) + '\n'
 
     def _get_payload_hash(self, method, data=None):

--- a/libcloud/common/base.py
+++ b/libcloud/common/base.py
@@ -798,7 +798,9 @@ class Connection(object):
             # @TODO: Should we just pass File object as body to request method
             # instead of dealing with splitting and sending the file ourselves?
             if raw:
-                self.connection.putrequest(method, url)
+                self.connection.putrequest(method, url,
+                                           skip_host=1,
+                                           skip_accept_encoding=1)
 
                 for key, value in list(headers.items()):
                     self.connection.putheader(key, str(value))

--- a/libcloud/storage/drivers/s3.py
+++ b/libcloud/storage/drivers/s3.py
@@ -35,8 +35,8 @@ from libcloud.utils.xml import fixxpath, findtext
 from libcloud.utils.files import read_in_chunks
 from libcloud.common.types import InvalidCredsError, LibcloudError
 from libcloud.common.base import ConnectionUserAndKey, RawResponse
-from libcloud.common.aws import AWSBaseResponse, AWSDriver, AWSTokenConnection, \
-    SignedAWSConnection
+from libcloud.common.aws import AWSBaseResponse, AWSDriver, \
+    AWSTokenConnection, SignedAWSConnection
 
 from libcloud.storage.base import Object, Container, StorageDriver
 from libcloud.storage.types import ContainerError

--- a/libcloud/storage/drivers/s3.py
+++ b/libcloud/storage/drivers/s3.py
@@ -35,7 +35,8 @@ from libcloud.utils.xml import fixxpath, findtext
 from libcloud.utils.files import read_in_chunks
 from libcloud.common.types import InvalidCredsError, LibcloudError
 from libcloud.common.base import ConnectionUserAndKey, RawResponse
-from libcloud.common.aws import AWSBaseResponse, AWSDriver, AWSTokenConnection
+from libcloud.common.aws import AWSBaseResponse, AWSDriver, AWSTokenConnection, \
+    SignedAWSConnection
 
 from libcloud.storage.base import Object, Container, StorageDriver
 from libcloud.storage.types import ContainerError
@@ -54,7 +55,9 @@ S3_US_WEST_HOST = 's3-us-west-1.amazonaws.com'
 S3_US_WEST_OREGON_HOST = 's3-us-west-2.amazonaws.com'
 S3_EU_WEST_HOST = 's3-eu-west-1.amazonaws.com'
 S3_AP_SOUTHEAST_HOST = 's3-ap-southeast-1.amazonaws.com'
-S3_AP_NORTHEAST_HOST = 's3-ap-northeast-1.amazonaws.com'
+S3_AP_NORTHEAST1_HOST = 's3-ap-northeast-1.amazonaws.com'
+S3_AP_NORTHEAST2_HOST = 's3-ap-northeast-2.amazonaws.com'
+S3_AP_NORTHEAST_HOST = S3_AP_NORTHEAST1_HOST
 S3_SA_EAST_HOST = 's3-sa-east-1.amazonaws.com'
 
 API_VERSION = '2006-03-01'
@@ -958,14 +961,39 @@ class S3APSEStorageDriver(S3StorageDriver):
     ex_location_name = 'ap-southeast-1'
 
 
-class S3APNEConnection(S3Connection):
-    host = S3_AP_NORTHEAST_HOST
+class S3APNE1Connection(S3Connection):
+    host = S3_AP_NORTHEAST1_HOST
+
+S3APNEConnection = S3APNE1Connection
 
 
-class S3APNEStorageDriver(S3StorageDriver):
+class S3APNE1StorageDriver(S3StorageDriver):
     name = 'Amazon S3 (ap-northeast-1)'
     connectionCls = S3APNEConnection
     ex_location_name = 'ap-northeast-1'
+
+S3APNEStorageDriver = S3APNE1StorageDriver
+
+
+class S3APNE2Connection(SignedAWSConnection, BaseS3Connection):
+    host = S3_AP_NORTHEAST2_HOST
+    service_name = 's3'
+    version = API_VERSION
+
+    def __init__(self, user_id, key, secure=True, host=None, port=None,
+                 url=None, timeout=None, proxy_url=None, token=None,
+                 retry_delay=None, backoff=None):
+        super(S3APNE2Connection, self).__init__(user_id, key, secure, host,
+                                                port, url, timeout, proxy_url,
+                                                token, retry_delay, backoff,
+                                                4)  # force version 4
+
+
+class S3APNE2StorageDriver(S3StorageDriver):
+    name = 'Amazon S3 (ap-northeast-2)'
+    connectionCls = S3APNE2Connection
+    ex_location_name = 'ap-northeast-2'
+    region_name = 'ap-northeast-2'
 
 
 class S3SAEastConnection(S3Connection):

--- a/libcloud/storage/providers.py
+++ b/libcloud/storage/providers.py
@@ -35,7 +35,11 @@ DRIVERS = {
     Provider.S3_AP_SOUTHEAST:
     ('libcloud.storage.drivers.s3', 'S3APSEStorageDriver'),
     Provider.S3_AP_NORTHEAST:
-    ('libcloud.storage.drivers.s3', 'S3APNEStorageDriver'),
+    ('libcloud.storage.drivers.s3', 'S3APNE1StorageDriver'),
+    Provider.S3_AP_NORTHEAST1:
+    ('libcloud.storage.drivers.s3', 'S3APNE1StorageDriver'),
+    Provider.S3_AP_NORTHEAST2:
+    ('libcloud.storage.drivers.s3', 'S3APNE2StorageDriver'),
     Provider.S3_SA_EAST:
     ('libcloud.storage.drivers.s3', 'S3SAEastStorageDriver'),
     Provider.NINEFOLD:

--- a/libcloud/storage/types.py
+++ b/libcloud/storage/types.py
@@ -50,6 +50,8 @@ class Provider(object):
     S3_EU_WEST = 's3_eu_west'
     S3_AP_SOUTHEAST = 's3_ap_southeast'
     S3_AP_NORTHEAST = 's3_ap_northeast'
+    S3_AP_NORTHEAST1 = 's3_ap_northeast_1'
+    S3_AP_NORTHEAST2 = 's3_ap_northeast_2'
     S3_SA_EAST = 's3_sa_east'
     NINEFOLD = 'ninefold'
     GOOGLE_STORAGE = 'google_storage'

--- a/libcloud/test/__init__.py
+++ b/libcloud/test/__init__.py
@@ -263,7 +263,7 @@ class MockHttpTestCase(MockHttp, unittest.TestCase):
 
 
 class StorageMockHttp(MockHttp):
-    def putrequest(self, method, action):
+    def putrequest(self, method, action, skip_host=0, skip_accept_encoding=0):
         pass
 
     def putheader(self, key, value):

--- a/libcloud/test/common/test_aws.py
+++ b/libcloud/test/common/test_aws.py
@@ -4,10 +4,9 @@ from datetime import datetime
 
 import mock
 
+from libcloud.common.aws import AWSRequestSignerAlgorithmV4
 from libcloud.common.aws import SignedAWSConnection
 from libcloud.common.aws import UNSIGNED_PAYLOAD
-from libcloud.common.aws import AWSRequestSignerAlgorithmV2
-from libcloud.common.aws import AWSRequestSignerAlgorithmV4
 from libcloud.test import LibcloudTestCase
 
 

--- a/libcloud/test/common/test_aws.py
+++ b/libcloud/test/common/test_aws.py
@@ -191,6 +191,15 @@ class AWSRequestSignerAlgorithmV4TestCase(LibcloudTestCase):
         }),
             'Action=DescribeInstances&Filter.1.Name=state&Version=2013-10-15')
 
+    def test_get_canonical_headers_allow_numeric_header_value(self):
+        headers = {
+            'Accept-Encoding': 'gzip,deflate',
+            'Content-Length': 314
+        }
+        self.assertEqual(self.signer._get_canonical_headers(headers),
+                         'accept-encoding:gzip,deflate\n'
+                         'content-length:314\n')
+
     def test_get_request_params_allows_integers_as_value(self):
         self.assertEqual(self.signer._get_request_params({'Action': 'DescribeInstances', 'Port': 22}),
                          'Action=DescribeInstances&Port=22')

--- a/libcloud/test/common/test_aws.py
+++ b/libcloud/test/common/test_aws.py
@@ -227,7 +227,7 @@ class AWSRequestSignerAlgorithmV4TestCase(LibcloudTestCase):
 
     def test_get_payload_hash_with_data_for_PUT_requests(self):
         SignedAWSConnection.method = 'PUT'
-        self.assertEqual(self.signer._get_payload_hash(method='POST', data='DUMMY'),
+        self.assertEqual(self.signer._get_payload_hash(method='PUT', data='DUMMY'),
                          'ceec12762e66397b56dad64fd270bb3d694c78fb9cd665354383c0626dbab013')
 
     def test_get_payload_hash_with_empty_data_for_POST_requests(self):


### PR DESCRIPTION
Support S3 Seoul region. In addition, this PR includes modification about Amazon signature V4 due to Seoul region does not support signature V2.

Modification that S3 requires:
- Removed HTTP method restriction from AWSRequestSignerAlgorithmV4
- Added hash of the request payload as X-AMZ-Content-SHA256 header
- Prevent Host / Accept-Encoding header duplication
