### PR TITLE
Addressing https://issues.apache.org/jira/browse/LIBCLOUD-800. Changed

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -22,6 +22,7 @@ import time
 import sys
 
 from libcloud.common.base import LazyObject
+from libcloud.common.google import GoogleOAuth2Credential
 from libcloud.common.google import GoogleResponse
 from libcloud.common.google import GoogleBaseConnection
 from libcloud.common.google import GoogleBaseError
@@ -1070,7 +1071,7 @@ class GCENodeDriver(NodeDriver):
         self.project = project
         self.scopes = scopes
         self.credential_file = credential_file or \
-            GCEConnection.credential_file + '.' + self.project
+            GoogleOAuth2Credential.default_credential_file + '.' + self.project
 
         super(GCENodeDriver, self).__init__(user_id, key, **kwargs)
 


### PR DESCRIPTION
GoogleStorageConnection to not inherit from GoogleBaseConnection. Separated OAuth2 credential management from GoogleBaseConnection. This allows both GoogleBaseConnection and GoogleStorageConnection to use OAuth2. Modified and ran tests to validate changes.

Also ran a few manual tests using GoogleStorageDriver and GCENodeDriver. GoogleStorageDriver works with either OAuth2 credentials or S3 Interoperability credentials. Tested setting the mime type on an uploaded GCS object.
