### PR TITLE
Adding a new exception code/message, testing backup exceptions

### DIFF
--- a/1
+++ b/1
@@ -16,7 +16,6 @@
 import sys
 from libcloud.utils.py3 import httplib
 
-from libcloud.common.dimensiondata import DimensionDataAPIException
 from libcloud.common.types import InvalidCredsError
 from libcloud.backup.drivers.dimensiondata import DimensionDataBackupDriver as DimensionData
 
@@ -61,13 +60,11 @@ class DimensionDataTests(unittest.TestCase, TestCaseMixin):
 
     def test_create_target_EXISTS(self):
         DimensionDataMockHttp.type = 'EXISTS'
-        with self.assertRaises(DimensionDataAPIException) as context:
-            self.driver.create_target(
+        with self.assertRaises(DimensionDataAPIException):
+            target = self.driver.create_target(
                 'name',
                 'e75ead52-692f-4314-8725-c8a4f4d13a87',
                 extra={'servicePlan': 'Enterprise'})
-        self.assertEqual(context.exception.code, 'ERROR')
-        self.assertEqual(context.exception.msg, 'Cloud backup for this server is already enabled or being enabled (state: NORMAL).')
 
     def test_update_target(self):
         target = self.driver.list_targets()[0]
@@ -124,10 +121,6 @@ class DimensionDataMockHttp(MockHttp):
         body = self.fixtures.load('oec_0_9_myaccount.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
-    def _oec_0_9_myaccount_EXISTS(self, method, url, body, headers):
-        body = self.fixtures.load('oec_0_9_myaccount.xml')
-        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
-
     def _caas_2_1_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_server(self, method, url, body, headers):
         body = self.fixtures.load(
             'caas_2_1_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_server.xml')
@@ -155,12 +148,6 @@ class DimensionDataMockHttp(MockHttp):
         body = self.fixtures.load(
             'oec_0_9_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_e75ead52_692f_4314_8725_c8a4f4d13a87_backup.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
-
-    def _oec_0_9_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_e75ead52_692f_4314_8725_c8a4f4d13a87_backup_EXISTS(
-            self, method, url, body, headers):
-        body = self.fixtures.load(
-            'oec_0_9_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_e75ead52_692f_4314_8725_c8a4f4d13a87_backup_EXISTS.xml')
-        return (httplib.BAD_REQUEST, body, {}, httplib.responses[httplib.OK])
 
     def _oec_0_9_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_e75ead52_692f_4314_8725_c8a4f4d13a87_backup_modify(
             self, method, url, body, headers):

--- a/libcloud/common/dimensiondata.py
+++ b/libcloud/common/dimensiondata.py
@@ -81,6 +81,18 @@ API_ENDPOINTS = {
 # Default API end-point for the base connection class.
 DEFAULT_REGION = 'dd-na'
 
+BAD_CODE_XML_ELEMENTS = (
+    ('responseCode', SERVER_NS),
+    ('reponseCode', TYPES_URN),
+    ('result', GENERAL_NS)
+)
+
+BAD_MESSAGE_XML_ELEMENTS = (
+    ('message', SERVER_NS),
+    ('message', TYPES_URN),
+    ('resultDetail', GENERAL_NS)
+)
+
 
 class NetworkDomainServicePlan(object):
     ESSENTIALS = "ESSENTIALS"
@@ -97,12 +109,14 @@ class DimensionDataResponse(XmlResponse):
         body = self.parse_body()
 
         if self.status == httplib.BAD_REQUEST:
-            code = findtext(body, 'responseCode', SERVER_NS)
-            if code is None:
-                code = findtext(body, 'responseCode', TYPES_URN)
-            message = findtext(body, 'message', SERVER_NS)
-            if message is None:
-                message = findtext(body, 'message', TYPES_URN)
+            for response_code in BAD_CODE_XML_ELEMENTS:
+                code = findtext(body, response_code[0], response_code[1])
+                if code is not None:
+                    break
+            for message in BAD_MESSAGE_XML_ELEMENTS:
+                message = findtext(body, message[0], message[1])
+                if message is not None:
+                    break
             raise DimensionDataAPIException(code=code,
                                             msg=message,
                                             driver=self.connection.driver)

--- a/libcloud/test/backup/fixtures/dimensiondata/oec_0_9_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_e75ead52_692f_4314_8725_c8a4f4d13a87_backup_EXISTS.xml
+++ b/libcloud/test/backup/fixtures/dimensiondata/oec_0_9_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_e75ead52_692f_4314_8725_c8a4f4d13a87_backup_EXISTS.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ns0:Status xmlns:ns0="http://oec.api.opsource.net/schemas/general">
+    <ns0:operation>Enable Backup for Server</ns0:operation>
+    <ns0:result>ERROR</ns0:result>
+    <ns0:resultDetail>Cloud backup for this server is already enabled or being enabled (state: NORMAL).</ns0:resultDetail>
+    <ns0:resultCode>REASON_550</ns0:resultCode>
+</ns0:Status>


### PR DESCRIPTION
The backup client bad responses have different XML responses than the others.
<ns0:Status xmlns:ns0="http://oec.api.opsource.net/schemas/general">
    ns0:operationEnable Backup for Server/ns0:operation
    ns0:resultERROR/ns0:result
    ns0:resultDetailCloud backup for this server is already enabled or being enabled (state: NORMAL)./ns0:resultDetail
    ns0:resultCodeREASON_550/ns0:resultCode
/ns0:Status

I added in handling for this and making it easier to create new bad xml elements in case there are more later on.
Added tests to test the bad handling in the backup client
