### PR TITLE
DimensionData: Adding new exception code/message, add backup tests

### DIFF
--- a/libcloud/common/dimensiondata.py
+++ b/libcloud/common/dimensiondata.py
@@ -81,6 +81,18 @@ API_ENDPOINTS = {
 # Default API end-point for the base connection class.
 DEFAULT_REGION = 'dd-na'
 
+BAD_CODE_XML_ELEMENTS = (
+    ('responseCode', SERVER_NS),
+    ('reponseCode', TYPES_URN),
+    ('result', GENERAL_NS)
+)
+
+BAD_MESSAGE_XML_ELEMENTS = (
+    ('message', SERVER_NS),
+    ('message', TYPES_URN),
+    ('resultDetail', GENERAL_NS)
+)
+
 
 class NetworkDomainServicePlan(object):
     ESSENTIALS = "ESSENTIALS"
@@ -97,12 +109,14 @@ class DimensionDataResponse(XmlResponse):
         body = self.parse_body()
 
         if self.status == httplib.BAD_REQUEST:
-            code = findtext(body, 'responseCode', SERVER_NS)
-            if code is None:
-                code = findtext(body, 'responseCode', TYPES_URN)
-            message = findtext(body, 'message', SERVER_NS)
-            if message is None:
-                message = findtext(body, 'message', TYPES_URN)
+            for response_code in BAD_CODE_XML_ELEMENTS:
+                code = findtext(body, response_code[0], response_code[1])
+                if code is not None:
+                    break
+            for message in BAD_MESSAGE_XML_ELEMENTS:
+                message = findtext(body, message[0], message[1])
+                if message is not None:
+                    break
             raise DimensionDataAPIException(code=code,
                                             msg=message,
                                             driver=self.connection.driver)

--- a/libcloud/common/dimensiondata.py
+++ b/libcloud/common/dimensiondata.py
@@ -83,7 +83,7 @@ DEFAULT_REGION = 'dd-na'
 
 BAD_CODE_XML_ELEMENTS = (
     ('responseCode', SERVER_NS),
-    ('reponseCode', TYPES_URN),
+    ('responseCode', TYPES_URN),
     ('result', GENERAL_NS)
 )
 

--- a/libcloud/test/backup/fixtures/dimensiondata/oec_0_9_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_e75ead52_692f_4314_8725_c8a4f4d13a87_backup_EXISTS.xml
+++ b/libcloud/test/backup/fixtures/dimensiondata/oec_0_9_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_e75ead52_692f_4314_8725_c8a4f4d13a87_backup_EXISTS.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ns0:Status xmlns:ns0="http://oec.api.opsource.net/schemas/general">
+    <ns0:operation>Enable Backup for Server</ns0:operation>
+    <ns0:result>ERROR</ns0:result>
+    <ns0:resultDetail>Cloud backup for this server is already enabled or being enabled (state: NORMAL).</ns0:resultDetail>
+    <ns0:resultCode>REASON_550</ns0:resultCode>
+</ns0:Status>


### PR DESCRIPTION
Different type of BadResponse XML request happens when accessing some of the backups API
Added in ability to grab message/code from it as well as make it easier to add new elements if they come to fruition.
Added negative tests that failed before the code change and succeed after.
