### PR TITLE
Backblaze Storage Driver : Include get_container and get_object methods

### DIFF
--- a/libcloud/storage/drivers/backblaze_b2.py
+++ b/libcloud/storage/drivers/backblaze_b2.py
@@ -362,6 +362,8 @@ class BackblazeB2StorageDriver(StorageDriver):
         upload_host = parsed_url.netloc
         request_path = parsed_url.path
 
+        if isinstance(data, str):
+            data = bytearray(data)
         response = self.connection.upload_request(action=request_path,
                                                   headers=headers,
                                                   upload_host=upload_host,

--- a/libcloud/test/storage/test_backblaze_b2.py
+++ b/libcloud/test/storage/test_backblaze_b2.py
@@ -62,6 +62,19 @@ class BackblazeB2StorageDriverTestCase(unittest.TestCase):
         self.assertEqual(objects[0].extra['fileId'], 'abcd')
         self.assertEqual(objects[0].extra['uploadTimestamp'], 1450545966000)
 
+    def test_get_container(self):
+        container = self.driver.get_container('test00001')
+        self.assertEqual(container.name, 'test00001')
+        self.assertEqual(container.extra['id'], '481c37de2e1ab3bf5e150710')
+        self.assertEqual(container.extra['bucketType'], 'allPrivate')
+
+    def test_get_object(self):
+        obj = self.driver.get_object('test00001', '2.txt')
+        self.assertEqual(obj.name, '2.txt')
+        self.assertEqual(obj.size, 2)
+        self.assertEqual(obj.extra['fileId'], 'abcd')
+        self.assertEqual(obj.extra['uploadTimestamp'], 1450545966000)
+
     def test_create_container(self):
         container = self.driver.create_container(container_name='test0005')
         self.assertEqual(container.name, 'test0005')
@@ -93,6 +106,18 @@ class BackblazeB2StorageDriverTestCase(unittest.TestCase):
         container = self.driver.list_containers()[0]
         obj = self.driver.upload_object(file_path=file_path, container=container,
                                         object_name='test0007.txt')
+        self.assertEqual(obj.name, 'test0007.txt')
+        self.assertEqual(obj.size, 24)
+        self.assertEqual(obj.extra['fileId'], 'abcde')
+
+    def test_upload_object_via_stream(self):
+        container = self.driver.list_containers()[0]
+        file_path = os.path.abspath(__file__)
+        file = open(file_path, 'rb')
+        iterator = iter(file)
+        obj = self.driver.upload_object_via_stream(iterator=iterator,
+                                                   container=container,
+                                                   object_name='test0007.txt')
         self.assertEqual(obj.name, 'test0007.txt')
         self.assertEqual(obj.size, 24)
         self.assertEqual(obj.extra['fileId'], 'abcde')

--- a/libcloud/utils/escape.py
+++ b/libcloud/utils/escape.py
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__all__ = [
+    'sanitize_object_name',
+]
+
+
+def sanitize_object_name(object_name):
+    return object_name.replace('\\', '/')


### PR DESCRIPTION
Include get_container and  get_object methods in the BackblazeB2StorageDriver

This is required for compatibility with libraries that reference these methods.

@Kami Since you wrote the initial backblaze implementation (I know it's still under dev), it would be great if you could review this. Thanks!
