### PR TITLE
ex_creation_time method for ec2 and digitalocean

### DIFF
--- a/libcloud/compute/drivers/digitalocean.py
+++ b/libcloud/compute/drivers/digitalocean.py
@@ -453,6 +453,18 @@ class DigitalOcean_v2_NodeDriver(DigitalOcean_v2_BaseDriver,
                                       method='DELETE')
         return res.status == httplib.NO_CONTENT
 
+    def ex_get_creation_time(self, node):
+        """
+        Return the date and time that represent when the Instance was created.
+        :param      node: Node instance
+        :type       node: :class:`Node`
+
+        :return: ISO8601 combined date and time format string for when the
+         Droplet was created.
+        :rtype: ``str``
+        """
+        return node.extra['created_at']
+
     def get_image(self, image_id):
         """
         Get an image based on an image_id

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -4256,6 +4256,18 @@ class BaseEC2NodeDriver(NodeDriver):
         """
         return node.extra['tags']
 
+    def ex_get_creation_time(self, node):
+        """
+        Return the date and time that represent when the Instance was created.
+        :param      node: Node instance
+        :type       node: :class:`Node
+
+        :return: ISO8601 combined date and time format string for when the
+                 Instance was created.
+        :rtype: ``str``
+        """
+        return node.extra['launch_time']
+
     def ex_allocate_address(self, domain='standard'):
         """
         Allocate a new Elastic IP address for EC2 classic or VPC

--- a/libcloud/test/compute/test_digitalocean_v2.py
+++ b/libcloud/test/compute/test_digitalocean_v2.py
@@ -142,6 +142,11 @@ class DigitalOcean_v2_Tests(LibcloudTestCase):
         result = self.driver.destroy_node(node)
         self.assertTrue(result)
 
+    def test_ex_get_creation_time(self):
+        node = self.driver.list_nodes()[0]
+        creation_time = self.driver.ex_get_creation_time(node)
+        self.assertEqual(creation_time, "2014-11-14T16:29:21Z")
+
     def test_ex_rename_node_success(self):
         node = self.driver.list_nodes()[0]
         DigitalOceanMockHttp.type = 'RENAME'

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -971,6 +971,19 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
         self.assertEqual(metadata['Num'], '42')
         self.assertEqual(len(metadata), 3)
 
+    def test_ex_get_creation_time(self):
+        image = NodeImage(id='ami-be3adfd8',
+                          name=self.image_name,
+                          driver=self.driver)
+        size = NodeSize('m1.small', 'Small Instance', None, None, None, None,
+                        driver=self.driver)
+        node = self.driver.create_node(name='foo',
+                                       image=image,
+                                       size=size)
+
+        creation_time = self.driver.ex_get_creation_time(node)
+        self.assertEqual(creation_time, '2007-08-07T11:51:50.000Z')
+
     def test_ex_get_limits(self):
         limits = self.driver.ex_get_limits()
 


### PR DESCRIPTION
ec2 nodes keep the created time string in 'launch_time' and digital ocean nodes keep it in 'created_at'. ex_get_creation_time is a method that takes a node as the argument returns the created time string 
