### PR TITLE
DimensionData: Adding ability to remove a backup clients + small updates

### DIFF
--- a/libcloud/backup/drivers/dimensiondata.py
+++ b/libcloud/backup/drivers/dimensiondata.py
@@ -186,7 +186,7 @@ class DimensionDataBackupDriver(BackupDriver):
         is supported.
 
         :param target: Backup target to update
-        :type  target: Instance of :class:`BackupTarget`
+        :type  target: Instance of :class:`BackupTarget` or ``str``
 
         :param name: Name of the target
         :type name: ``str``
@@ -203,9 +203,9 @@ class DimensionDataBackupDriver(BackupDriver):
         request = ET.Element('ModifyBackup',
                              {'xmlns': BACKUP_NS})
         request.set('servicePlan', service_plan)
-
+        server_id = self._target_to_target_address(target)
         self.connection.request_with_orgId_api_1(
-            'server/%s/backup/modify' % (target.address),
+            'server/%s/backup/modify' % (server_id),
             method='POST',
             data=ET.tostring(request)).object
         target.extra = extra
@@ -220,9 +220,9 @@ class DimensionDataBackupDriver(BackupDriver):
 
         :rtype: ``bool``
         """
-        address = self._target_to_target_address(target)
+        server_id = self._target_to_target_address(target)
         response = self.connection.request_with_orgId_api_1(
-            'server/%s/backup?disable' % (address),
+            'server/%s/backup?disable' % (server_id),
             method='GET').object
         response_code = findtext(response, 'result', GENERAL_NS)
         return response_code in ['IN_PROGRESS', 'SUCCESS']
@@ -402,7 +402,6 @@ class DimensionDataBackupDriver(BackupDriver):
 
         :rtype: ``bool``
         """
-
         server_id = self._target_to_target_address(target)
 
         backup_elm = ET.Element('NewBackupClient',
@@ -466,11 +465,7 @@ class DimensionDataBackupDriver(BackupDriver):
 
         :rtype: :class:`DimensionDataBackupDetails`
         """
-
-        if isinstance(target, BackupTarget):
-            server_id = target.address
-        else:
-            server_id = target
+        server_id = self._target_to_target_address(target)
         response = self.connection.request_with_orgId_api_1(
             'server/%s/backup' % (server_id),
             method='GET').object
@@ -481,12 +476,13 @@ class DimensionDataBackupDriver(BackupDriver):
         Returns a list of available backup client types
 
         :param  target: The backup target to list available types for
-        :type   target: :class:`BackupTarget`
+        :type   target: :class:`BackupTarget` or ``str``
 
         :rtype: ``list`` of :class:`DimensionDataBackupClientType`
         """
+        server_id = self._target_to_target_address(target)
         response = self.connection.request_with_orgId_api_1(
-            'server/%s/backup/client/type' % (target.address),
+            'server/%s/backup/client/type' % (server_id),
             method='GET').object
         return self._to_client_types(response)
 
@@ -495,12 +491,13 @@ class DimensionDataBackupDriver(BackupDriver):
         Returns a list of available backup storage policies
 
         :param  target: The backup target to list available policies for
-        :type   target: :class:`BackupTarget`
+        :type   target: :class:`BackupTarget` or ``str``
 
         :rtype: ``list`` of :class:`DimensionDataBackupStoragePolicy`
         """
+        server_id = self._target_to_target_address(target)
         response = self.connection.request_with_orgId_api_1(
-            'server/%s/backup/client/storagePolicy' % (target.address),
+            'server/%s/backup/client/storagePolicy' % (server_id),
             method='GET').object
         return self._to_storage_policies(response)
 
@@ -509,12 +506,13 @@ class DimensionDataBackupDriver(BackupDriver):
         Returns a list of available backup schedule policies
 
         :param  target: The backup target to list available policies for
-        :type   target: :class:`BackupTarget`
+        :type   target: :class:`BackupTarget` or ``str``
 
         :rtype: ``list`` of :class:`DimensionDataBackupSchedulePolicy`
         """
+        server_id = self._target_to_target_address(target)
         response = self.connection.request_with_orgId_api_1(
-            'server/%s/backup/client/schedulePolicy' % (target.address),
+            'server/%s/backup/client/schedulePolicy' % (server_id),
             method='GET').object
         return self._to_schedule_policies(response)
 

--- a/libcloud/backup/drivers/dimensiondata.py
+++ b/libcloud/backup/drivers/dimensiondata.py
@@ -32,6 +32,7 @@ from libcloud.common.dimensiondata import DimensionDataBackupStoragePolicy
 from libcloud.common.dimensiondata import API_ENDPOINTS, DEFAULT_REGION
 from libcloud.common.dimensiondata import TYPES_URN
 from libcloud.common.dimensiondata import GENERAL_NS, BACKUP_NS
+from libcloud.utils.py3 import basestring
 from libcloud.utils.xml import fixxpath, findtext, findall
 
 

--- a/libcloud/common/dimensiondata.py
+++ b/libcloud/common/dimensiondata.py
@@ -18,10 +18,9 @@ Dimension Data Common Components
 from base64 import b64encode
 from time import sleep
 from libcloud.utils.py3 import httplib
-from libcloud.utils.py3 import b, basestring
+from libcloud.utils.py3 import b
 from libcloud.common.base import ConnectionUserAndKey, XmlResponse
 from libcloud.common.types import LibcloudError, InvalidCredsError
-from libcloud.compute.base import NodeLocation
 from libcloud.utils.xml import findtext
 
 # Roadmap / TODO:
@@ -897,7 +896,7 @@ class DimensionDataBackupClient(object):
 
     def __repr__(self):
         return (('<DimensionDataBackupClient: id=%s>')
-                % (self.asset_id))
+                % (self.id))
 
 
 class DimensionDataBackupClientAlert(object):
@@ -919,8 +918,8 @@ class DimensionDataBackupClientAlert(object):
         self.notify_list = notify_list
 
     def __repr__(self):
-        return (('<DimensionDataBackupClientAlert: id=%s>')
-                % (self.asset_id))
+        return (('<DimensionDataBackupClientAlert: trigger=%s>')
+                % (self.trigger))
 
 
 class DimensionDataBackupClientRunningJob(object):

--- a/libcloud/common/dimensiondata.py
+++ b/libcloud/common/dimensiondata.py
@@ -95,29 +95,6 @@ BAD_MESSAGE_XML_ELEMENTS = (
 )
 
 
-def location_to_location_id(location):
-    """
-    Helper function to get a location id from a location whether
-    it be a NodeLocation or a string
-
-    :param location: The location to get an id from
-    :type  location: :class:`NodeLocation` or ``str``
-
-    :return: The location id
-    :rtype: ``str`` or None (if no location passed in)
-    """
-    if location is not None:
-        if isinstance(location, NodeLocation):
-            return location.id
-        elif isinstance(location, basestring):
-            return location
-        else:
-            raise TypeError(
-                "Invalid location type for location_to_location_id()"
-            )
-    return None
-
-
 class NetworkDomainServicePlan(object):
     ESSENTIALS = "ESSENTIALS"
     ADVANCED = "ADVANCED"

--- a/libcloud/compute/drivers/dimensiondata.py
+++ b/libcloud/compute/drivers/dimensiondata.py
@@ -827,9 +827,11 @@ class DimensionDataNodeDriver(NodeDriver):
         :rtype: :class:`DimensionDataNetworkDomain`
         """
         create_node = ET.Element('deployNetworkDomain', {'xmlns': TYPES_URN})
-        ET.SubElement(create_node,
-                      "datacenterId"
-                     ).text = self._location_to_location_id(location)
+        ET.SubElement(
+            create_node,
+            "datacenterId"
+        ).text = self._location_to_location_id(location)
+
         ET.SubElement(create_node, "name").text = name
         if description is not None:
             ET.SubElement(create_node, "description").text = description

--- a/libcloud/compute/drivers/dimensiondata.py
+++ b/libcloud/compute/drivers/dimensiondata.py
@@ -37,7 +37,6 @@ from libcloud.common.dimensiondata import NetworkDomainServicePlan
 from libcloud.common.dimensiondata import API_ENDPOINTS, DEFAULT_REGION
 from libcloud.common.dimensiondata import TYPES_URN
 from libcloud.common.dimensiondata import SERVER_NS, NETWORK_NS, GENERAL_NS
-from libcloud.common.dimensiondata import location_to_location_id
 from libcloud.utils.py3 import urlencode
 from libcloud.utils.xml import fixxpath, findtext, findall
 from libcloud.utils.py3 import basestring
@@ -330,7 +329,7 @@ class DimensionDataNodeDriver(NodeDriver):
         """
         params = {}
         if location is not None:
-            params['datacenterId'] = location_to_location_id(location)
+            params['datacenterId'] = self._location_to_location_id(location)
 
         return self._to_base_images(
             self.connection.request_with_orgId_api_2(
@@ -393,7 +392,7 @@ class DimensionDataNodeDriver(NodeDriver):
         """
         url_ext = ''
         if location is not None:
-            url_ext = '/' + location_to_location_id(location)
+            url_ext = '/' + self._location_to_location_id(location)
 
         return self._to_networks(
             self.connection
@@ -454,7 +453,7 @@ class DimensionDataNodeDriver(NodeDriver):
 
         params = {}
         if location is not None:
-            params['datacenterId'] = location_to_location_id(location)
+            params['datacenterId'] = self._location_to_location_id(location)
 
         if ipv6 is not None:
             params['ipv6'] = ipv6
@@ -715,7 +714,7 @@ class DimensionDataNodeDriver(NodeDriver):
         :return: A new instance of `DimensionDataNetwork`
         :rtype:  Instance of :class:`DimensionDataNetwork`
         """
-        network_location = location_to_location_id(location)
+        network_location = self._location_to_location_id(location)
 
         create_node = ET.Element('NewNetworkWithLocation',
                                  {'xmlns': NETWORK_NS})
@@ -798,7 +797,7 @@ class DimensionDataNodeDriver(NodeDriver):
         """
         params = {}
         if location is not None:
-            params['datacenterId'] = location_to_location_id(location)
+            params['datacenterId'] = self._location_to_location_id(location)
 
         response = self.connection \
             .request_with_orgId_api_2('network/networkDomain',
@@ -829,7 +828,8 @@ class DimensionDataNodeDriver(NodeDriver):
         """
         create_node = ET.Element('deployNetworkDomain', {'xmlns': TYPES_URN})
         ET.SubElement(create_node,
-                      "datacenterId").text = location_to_location_id(location)
+                      "datacenterId"
+                     ).text = self._location_to_location_id(location)
         ET.SubElement(create_node, "name").text = name
         if description is not None:
             ET.SubElement(create_node, "description").text = description
@@ -1050,7 +1050,7 @@ class DimensionDataNodeDriver(NodeDriver):
         """
         params = {}
         if location is not None:
-            params['datacenterId'] = location_to_location_id(location)
+            params['datacenterId'] = self._location_to_location_id(location)
         if network_domain is not None:
             params['networkDomainId'] = network_domain.id
         response = self.connection.request_with_orgId_api_2('network/vlan',
@@ -1582,7 +1582,7 @@ class DimensionDataNodeDriver(NodeDriver):
         """
         params = {}
         if location is not None:
-            params['datacenterId'] = location_to_location_id(location)
+            params['datacenterId'] = self._location_to_location_id(location)
 
         return self._to_base_images(
             self.connection.request_with_orgId_api_2(
@@ -1923,3 +1923,14 @@ class DimensionDataNodeDriver(NodeDriver):
                                     'failureReason',
                                     TYPES_URN))
         return s
+
+    @staticmethod
+    def _location_to_location_id(location):
+        if isinstance(location, NodeLocation):
+            return location.id
+        elif isinstance(location, basestring):
+            return location
+        else:
+            raise TypeError(
+                "Invalid location type for _location_to_location_id()"
+            )

--- a/libcloud/test/backup/fixtures/dimensiondata/oec_0_9_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_e75ead52_692f_4314_8725_c8a4f4d13a87_backup_client_30b1ff76_c76d_4d7c_b39d_3b72be0384c8_remove_backup_client.xml
+++ b/libcloud/test/backup/fixtures/dimensiondata/oec_0_9_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_e75ead52_692f_4314_8725_c8a4f4d13a87_backup_client_30b1ff76_c76d_4d7c_b39d_3b72be0384c8_remove_backup_client.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <ns6:Status xmlns:ns16="http://oec.api.opsource.net/schemas/storage" xmlns="http://oec.api.opsource.net/schemas/admin" xmlns:ns14="http://oec.api.opsource.net/schemas/directory" xmlns:ns15="http://oec.api.opsource.net/schemas/multigeo" xmlns:ns9="http://oec.api.opsource.net/schemas/backup" xmlns:ns5="http://oec.api.opsource.net/schemas/datacenter" xmlns:ns12="http://oec.api.opsource.net/schemas/support" xmlns:ns13="http://oec.api.opsource.net/schemas/manualimport" xmlns:ns6="http://oec.api.opsource.net/schemas/general" xmlns:ns7="http://oec.api.opsource.net/schemas/reset" xmlns:ns10="http://oec.api.opsource.net/schemas/server" xmlns:ns8="http://oec.api.opsource.net/schemas/network" xmlns:ns11="http://oec.api.opsource.net/schemas/whitelabel" xmlns:ns2="http://oec.api.opsource.net/schemas/organization" xmlns:ns4="http://oec.api.opsource.net/schemas/serverbootstrap" xmlns:ns3="http://oec.api.opsource.net/schemas/vip">
-    <ns6:operation>Get Backup Details</ns6:operation>
-    <ns6:result>ERROR</ns6:result>
-    <ns6:resultDetail>Server e75ead52-692f-4314-8725-c8a4f4d13a87 has not been provisioned for backup</ns6:resultDetail>
-    <ns6:resultCode>REASON_543</ns6:resultCode>
+    <ns6:operation>Disable Backup Client</ns6:operation>
+    <ns6:result>SUCCESS</ns6:result>
+    <ns6:resultDetail>Backup Client disabled</ns6:resultDetail>
+    <ns6:resultCode>REASON_0</ns6:resultCode>
 </ns6:Status>

--- a/libcloud/test/backup/fixtures/dimensiondata/oec_0_9_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_e75ead52_692f_4314_8725_c8a4f4d13a87_backup_client_30b1ff76_c76d_4d7c_b39d_3b72be0384c8_remove_backup_client_BUSY.xml
+++ b/libcloud/test/backup/fixtures/dimensiondata/oec_0_9_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_e75ead52_692f_4314_8725_c8a4f4d13a87_backup_client_30b1ff76_c76d_4d7c_b39d_3b72be0384c8_remove_backup_client_BUSY.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <ns6:Status xmlns:ns16="http://oec.api.opsource.net/schemas/storage" xmlns="http://oec.api.opsource.net/schemas/admin" xmlns:ns14="http://oec.api.opsource.net/schemas/directory" xmlns:ns15="http://oec.api.opsource.net/schemas/multigeo" xmlns:ns9="http://oec.api.opsource.net/schemas/backup" xmlns:ns5="http://oec.api.opsource.net/schemas/datacenter" xmlns:ns12="http://oec.api.opsource.net/schemas/support" xmlns:ns13="http://oec.api.opsource.net/schemas/manualimport" xmlns:ns6="http://oec.api.opsource.net/schemas/general" xmlns:ns7="http://oec.api.opsource.net/schemas/reset" xmlns:ns10="http://oec.api.opsource.net/schemas/server" xmlns:ns8="http://oec.api.opsource.net/schemas/network" xmlns:ns11="http://oec.api.opsource.net/schemas/whitelabel" xmlns:ns2="http://oec.api.opsource.net/schemas/organization" xmlns:ns4="http://oec.api.opsource.net/schemas/serverbootstrap" xmlns:ns3="http://oec.api.opsource.net/schemas/vip">
-    <ns6:operation>Get Backup Details</ns6:operation>
+    <ns6:operation>Disable Backup Client</ns6:operation>
     <ns6:result>ERROR</ns6:result>
-    <ns6:resultDetail>Server e75ead52-692f-4314-8725-c8a4f4d13a87 has not been provisioned for backup</ns6:resultDetail>
-    <ns6:resultCode>REASON_543</ns6:resultCode>
+    <ns6:resultDetail>DISABLE_BACKUP_CLIENT 'didata-backup-test6[172-16-1-14]' - failed - Unexpected error occurred with NA9 Backup system at 2016-02-12 00:03:50.952, TransactionId: (9d483a7a-1cc9-441b-920c-e11fb0e94ba6), PCSOperation: DeprovisionBackupClient, Backup Client is currently performing another operation: Backup client is currently busy</ns6:resultDetail>
+    <ns6:resultCode>REASON_547</ns6:resultCode>
 </ns6:Status>

--- a/libcloud/test/compute/test_dimensiondata.py
+++ b/libcloud/test/compute/test_dimensiondata.py
@@ -552,6 +552,23 @@ class DimensionDataTests(unittest.TestCase, TestCaseMixin):
         location = self.driver.ex_get_location_by_id(None)
         self.assertIsNone(location)
 
+    def test_priv_location_to_location_id(self):
+        location = self.driver.ex_get_location_by_id('NA9')
+        self.assertEqual(
+            self.driver._location_to_location_id(location),
+            'NA9'
+        )
+
+    def test_priv_location_to_location_id_STR(self):
+        self.assertEqual(
+            self.driver._location_to_location_id('NA9'),
+            'NA9'
+        )
+
+    def test_priv_location_to_location_id_TYPEERROR(self):
+        with self.assertRaises(TypeError):
+            self.driver._location_to_location_id([1, 2, 3])
+
 
 class InvalidRequestError(Exception):
     def __init__(self, tag):


### PR DESCRIPTION
Added a new method ex_remove_client_from_target
After comment from @tonybaloney noticed that the translation functions should be privatized instead, can't find any use outside of the classes currently, so I privatized them.  Helps the code look cleaner.
Added both positive/negative test coverage around new backup call.
Added test coverage around privatized translation functions
