### PR TITLE
Revert addition of NodeDriver.ex_creation_time

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,14 +47,10 @@ Compute
   (GITHUB-694)
   [Jeff Dunham]
 
-- Support for creation time (`ex_created_time`) in EC2 and digitalocean drivers
-  (GITHUB-697)
-  [Rick van de Loo]
-
-- Added `Node.create_at` which, on supported drivers, contains the datetime the
+- Added `Node.created_at` which, on supported drivers, contains the datetime the
   node was first started.
   (GITHUB-698)
-  [Allard Hoeve]
+  [Allard Hoeve] [Rick van de Loo]
 
 Storage
 ~~~~~~~

--- a/libcloud/compute/drivers/digitalocean.py
+++ b/libcloud/compute/drivers/digitalocean.py
@@ -454,18 +454,6 @@ class DigitalOcean_v2_NodeDriver(DigitalOcean_v2_BaseDriver,
                                       method='DELETE')
         return res.status == httplib.NO_CONTENT
 
-    def ex_get_creation_time(self, node):
-        """
-        Return the date and time that represent when the Instance was created.
-        :param      node: Node instance
-        :type       node: :class:`Node`
-
-        :return: ISO8601 combined date and time format string for when the
-         Droplet was created.
-        :rtype: ``str``
-        """
-        return node.extra['created_at']
-
     def get_image(self, image_id):
         """
         Get an image based on an image_id

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -4256,18 +4256,6 @@ class BaseEC2NodeDriver(NodeDriver):
         """
         return node.extra['tags']
 
-    def ex_get_creation_time(self, node):
-        """
-        Return the date and time that represent when the Instance was created.
-        :param      node: Node instance
-        :type       node: :class:`Node
-
-        :return: ISO8601 combined date and time format string for when the
-                 Instance was created.
-        :rtype: ``str``
-        """
-        return node.extra['launch_time']
-
     def ex_allocate_address(self, domain='standard'):
         """
         Allocate a new Elastic IP address for EC2 classic or VPC

--- a/libcloud/test/compute/test_digitalocean_v2.py
+++ b/libcloud/test/compute/test_digitalocean_v2.py
@@ -149,11 +149,6 @@ class DigitalOcean_v2_Tests(LibcloudTestCase):
         result = self.driver.destroy_node(node)
         self.assertTrue(result)
 
-    def test_ex_get_creation_time(self):
-        node = self.driver.list_nodes()[0]
-        creation_time = self.driver.ex_get_creation_time(node)
-        self.assertEqual(creation_time, "2014-11-14T16:29:21Z")
-
     def test_ex_rename_node_success(self):
         node = self.driver.list_nodes()[0]
         DigitalOceanMockHttp.type = 'RENAME'

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -975,19 +975,6 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
         self.assertEqual(metadata['Num'], '42')
         self.assertEqual(len(metadata), 3)
 
-    def test_ex_get_creation_time(self):
-        image = NodeImage(id='ami-be3adfd8',
-                          name=self.image_name,
-                          driver=self.driver)
-        size = NodeSize('m1.small', 'Small Instance', None, None, None, None,
-                        driver=self.driver)
-        node = self.driver.create_node(name='foo',
-                                       image=image,
-                                       size=size)
-
-        creation_time = self.driver.ex_get_creation_time(node)
-        self.assertEqual(creation_time, '2007-08-07T11:51:50.000Z')
-
     def test_ex_get_limits(self):
         limits = self.driver.ex_get_limits()
 


### PR DESCRIPTION
... now that we have `Node.created_at`.

This reverts commit e513687ea8e335b4a71d9f6e569f61bfcb65b0e9 and #697.
