### PR TITLE
Added method to access the console of a running VM in vCloud 5.5

### DIFF
--- a/libcloud/compute/drivers/vcloud.py
+++ b/libcloud/compute/drivers/vcloud.py
@@ -2190,18 +2190,23 @@ class VCloud_5_5_NodeDriver(VCloud_5_1_NodeDriver):
     def ex_acquire_mks_ticket(self, vapp_or_vm_id, vm_num=0):
         """
         Retrieve a mks ticket that you can use to gain access to the console
-        of a running VM.
-        :param vapp_or_vm_id: vApp or VM ID you want to connect to.
-        :param vm_num: If a vApp ID is provided, vm_num is position in the vApp
-                    VM list of the VM you want to get a screen ticket.
-                    Default is 0.
-        :return: If successful, a dict with the following keys:
-                - host: host (or proxy) through which the console connection
-                        is made
-                - vmx: a reference to the VMX file of the VM for which this
-                       ticket was issued
-                - ticket: screen ticket to use to authenticate the client
-                - port: host port to be used for console access
+        of a running VM. If successful, returns a dict with the following keys:
+        - host: host (or proxy) through which the console connection
+                is made
+        - vmx: a reference to the VMX file of the VM for which this
+               ticket was issued
+        - ticket: screen ticket to use to authenticate the client
+        - port: host port to be used for console access
+
+        :param  vapp_or_vm_id: vApp or VM ID you want to connect to.
+        :type   vapp_or_vm_id: ``str``
+
+        :param  vm_num: If a vApp ID is provided, vm_num is position in the vApp
+                VM list of the VM you want to get a screen ticket.
+                Default is 0.
+        :type   vm_num: ``int``
+
+        :rtype: ``dict``
         """
         vm = self._get_vm_elements(vapp_or_vm_id)[vm_num]
         try:

--- a/libcloud/compute/drivers/vcloud.py
+++ b/libcloud/compute/drivers/vcloud.py
@@ -2190,7 +2190,8 @@ class VCloud_5_5_NodeDriver(VCloud_5_1_NodeDriver):
     def ex_acquire_mks_ticket(self, vapp_or_vm_id, vm_num=0):
         """
         Retrieve a mks ticket that you can use to gain access to the console
-        of a running VM. If successful, returns a dict with the following keys:
+        of a running VM. If successful, returns a dict with the following
+        keys:
         - host: host (or proxy) through which the console connection
                 is made
         - vmx: a reference to the VMX file of the VM for which this
@@ -2201,8 +2202,8 @@ class VCloud_5_5_NodeDriver(VCloud_5_1_NodeDriver):
         :param  vapp_or_vm_id: vApp or VM ID you want to connect to.
         :type   vapp_or_vm_id: ``str``
 
-        :param  vm_num: If a vApp ID is provided, vm_num is position in the vApp
-                VM list of the VM you want to get a screen ticket.
+        :param  vm_num: If a vApp ID is provided, vm_num is position in the
+                vApp VM list of the VM you want to get a screen ticket.
                 Default is 0.
         :type   vm_num: ``int``
 

--- a/libcloud/compute/drivers/vcloud.py
+++ b/libcloud/compute/drivers/vcloud.py
@@ -2186,3 +2186,34 @@ class VCloud_5_5_NodeDriver(VCloud_5_1_NodeDriver):
         self._wait_for_task_completion(res.object.get('href'))
         res = self.connection.request(get_url_path(node.id))
         return self._to_node(res.object)
+
+    def ex_acquire_mks_ticket(self, vapp_or_vm_id, vm_num=0):
+        """
+        Retrieve a mks ticket that you can use to gain access to the console
+        of a running VM.
+        :param vapp_or_vm_id: vApp or VM ID you want to connect to.
+        :param vm_num: If a vApp ID is provided, vm_num is position in the vApp
+                    VM list of the VM you want to get a screen ticket.
+                    Default is 0.
+        :return: If successful, a dict with the following keys:
+                - host: host (or proxy) through which the console connection
+                        is made
+                - vmx: a reference to the VMX file of the VM for which this
+                       ticket was issued
+                - ticket: screen ticket to use to authenticate the client
+                - port: host port to be used for console access
+        """
+        vm = self._get_vm_elements(vapp_or_vm_id)[vm_num]
+        try:
+            res = self.connection.request('%s/screen/action/acquireMksTicket' %
+                                          (get_url_path(vm.get('href'))),
+                                          method='POST')
+            output = {
+                "host": res.object.find(fixxpath(res.object, 'Host')).text,
+                "vmx": res.object.find(fixxpath(res.object, 'Vmx')).text,
+                "ticket": res.object.find(fixxpath(res.object, 'Ticket')).text,
+                "port": res.object.find(fixxpath(res.object, 'Port')).text,
+            }
+            return output
+        except:
+            return None

--- a/libcloud/test/compute/test_vcloud.py
+++ b/libcloud/test/compute/test_vcloud.py
@@ -423,6 +423,10 @@ class VCloud_5_5_Tests(unittest.TestCase, TestCaseMixin):
             'testNode', NodeState.RUNNING, [], [], self.driver)
         self.driver.ex_revert_to_snapshot(node)
 
+    def test_ex_acquire_mks_ticket(self):
+        node = self.driver.ex_find_node('testNode')
+        self.driver.ex_acquire_mks_ticket(node.id)
+
 
 class TerremarkMockHttp(MockHttp):
 


### PR DESCRIPTION
This patch adds support for /api/screen/action/acquireMksTicket API call, required to use the new VMware vCloud Director HTML5 Console (https://www.vmware.com/support/developer/html-console/).

Basic test included.
