### PR TITLE
Throw a more user-friendly exception on "No address associated with hostname" error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,9 @@ General
   (GITHUB-700)
   [Anthony Shaw]
 
+- Throw a more user-friendly exception on "No address associated with hostname".
+  [Tomaz Muraus]
+
 Compute
 ~~~~~~~
 

--- a/libcloud/common/base.py
+++ b/libcloud/common/base.py
@@ -829,9 +829,11 @@ class Connection(object):
                 # with hostname" error. This error could simpli indicate that
                 # "host" Connection class attribute is set to an incorrect
                 # value
-                msg = ('%s. Perhaphs "host" Connection class attribute (%s) '
-                       'is set to an invalid, non-hostname value?' %
-                       (message, self.host))
+                class_name = self.__class__.__name__
+                msg = ('%s. Perhaphs "host" Connection class attribute '
+                       '(%s.connection) is set to an invalid, non-hostname '
+                       'value (%s)?' %
+                       (message, class_name, self.host))
                 raise socket.gaierror(msg)
             self.reset_context()
             raise e


### PR DESCRIPTION
Usually this issue represents a bug in the driver (`host` connection class attribute being set to an incorrect value), but the original exception is kinda cryptic so it's hard for the users to figure out what is going on.

Before:

``` python
Traceback (most recent call last):
  File "example.py", line 5, in <module>
    print driver.list_zones()
  File "/home/kami/w/lc/libcloud/libcloud/dns/drivers/godaddy.py", line 146, in list_zones
    '/v1/domains/').object
  File "/home/kami/w/lc/libcloud/libcloud/common/base.py", line 827, in request
    headers=headers)
  File "/usr/lib64/python2.7/httplib.py", line 1053, in request
    self._send_request(method, url, body, headers)
  File "/usr/lib64/python2.7/httplib.py", line 1093, in _send_request
    self.endheaders(body)
  File "/usr/lib64/python2.7/httplib.py", line 1049, in endheaders
    self._send_output(message_body)
  File "/usr/lib64/python2.7/httplib.py", line 893, in _send_output
    self.send(msg)
  File "/usr/lib64/python2.7/httplib.py", line 855, in send
    self.connect()
  File "/home/kami/w/lc/libcloud/libcloud/httplib_ssl.py", line 284, in connect
    self.timeout)
  File "/usr/lib64/python2.7/socket.py", line 557, in create_connection
    for res in getaddrinfo(host, port, 0, SOCK_STREAM):
socket.gaierror: [Errno -5] No address associated with hostname
```

After:

``` python
Traceback (most recent call last):
  File "example.py", line 5, in <module>
    print driver.list_zones()
  File "/home/kami/w/lc/libcloud/libcloud/dns/drivers/godaddy.py", line 146, in list_zones
    '/v1/domains/').object
  File "/home/kami/w/lc/libcloud/libcloud/common/base.py", line 842, in request
    raise socket.gaierror(msg)
socket.gaierror: [Errno -5] No address associated with hostname. Perhaphs "host" Connection class attribute (GoDaddyDNSConnection.connection) is set to an invalid, non-hostname value (http://www.google.com)?

```
