### PR TITLE
Fixed httplib_ssl socket exception handling.

### DIFF
--- a/libcloud/httplib_ssl.py
+++ b/libcloud/httplib_ssl.py
@@ -340,3 +340,5 @@ def get_socket_error_exception(ssl_version, exc):
         new_exc = socket.error(*new_exc_args)
         new_exc.original_exc = exc
         return new_exc
+    else:
+        return exc


### PR DESCRIPTION
Addressing https://issues.apache.org/jira/browse/LIBCLOUD-803
