### PR TITLE
Register priority for MX records

### DIFF
--- a/libcloud/dns/drivers/gandi.py
+++ b/libcloud/dns/drivers/gandi.py
@@ -147,16 +147,20 @@ class GandiDNSDriver(BaseGandiDriver, DNSDriver):
         return res.object
 
     def _to_record(self, record, zone):
+        extras = {'ttl': record['ttl']}
+        value = record['value']
+        if record['type'] == 'MX':
+            extras['priority'] = record['value'].split(' ')[0]
+            value = record['value'].split(' ')[1]
         return Record(
             id='%s:%s' % (record['type'], record['name']),
             name=record['name'],
             type=self._string_to_record_type(record['type']),
-            data=record['value'],
+            data=value,
             zone=zone,
             driver=self,
             ttl=record['ttl'],
-            extra={'ttl': record['ttl']}
-        )
+            extra=extras
 
     def _to_records(self, records, zone):
         retval = []


### PR DESCRIPTION
As is, this fails to split out the priority value from the raw record value, resulting in a key error for missing priority when trying to export in BIND format.  This is the quick hack I did to get the function to return a more useful Record.
