### PR TITLE
Feature/dd quick fixes

### DIFF
--- a/libcloud/backup/drivers/dimensiondata.py
+++ b/libcloud/backup/drivers/dimensiondata.py
@@ -209,14 +209,11 @@ class DimensionDataBackupDriver(BackupDriver):
             'server/%s/backup/modify' % (server_id),
             method='POST',
             data=ET.tostring(request)).object
-        return BackupTarget(
-            id=server_id,
-            name=name,
-            address=address,
-            type=type,
-            extra=extra,
-            driver=self
-        )
+        if isinstance(target, BackupTarget):
+            target.extra = extra
+        else:
+            target = self.ex_get_target_by_id(server_id)
+        return target
 
     def delete_target(self, target):
         """
@@ -378,6 +375,19 @@ class DimensionDataBackupDriver(BackupDriver):
         """
         raise NotImplementedError(
             'cancel_target_job not implemented for this driver')
+
+    def ex_get_target_by_id(self, id):
+        """
+        Get a target by server id
+
+        :param id: The id of the target you want to get
+        :type  id: ``str``
+
+        :rtype: :class:`BackupTarget`
+        """
+        node = self.connection.request_with_orgId_api_2(
+            'server/server/%s' % id).object
+        return self._to_target(node)
 
     def ex_add_client_to_target(self, target, client_type, storage_policy,
                                 schedule_policy, trigger, email):

--- a/libcloud/backup/drivers/dimensiondata.py
+++ b/libcloud/backup/drivers/dimensiondata.py
@@ -35,6 +35,8 @@ from libcloud.common.dimensiondata import GENERAL_NS, BACKUP_NS
 from libcloud.utils.py3 import basestring
 from libcloud.utils.xml import fixxpath, findtext, findall
 
+DEFAULT_BACKUP_PLAN = 'Advanced'
+
 
 class DimensionDataBackupDriver(BackupDriver):
     """
@@ -113,7 +115,11 @@ class DimensionDataBackupDriver(BackupDriver):
 
         :rtype: Instance of :class:`BackupTarget`
         """
-        service_plan = extra.get('servicePlan', 'Advanced')
+        if extra is not None:
+            service_plan = extra.get('servicePlan', DEFAULT_BACKUP_PLAN)
+        else:
+            service_plan = DEFAULT_BACKUP_PLAN
+
         create_node = ET.Element('NewBackup',
                                  {'xmlns': BACKUP_NS})
         create_node.set('servicePlan', service_plan)
@@ -180,8 +186,7 @@ class DimensionDataBackupDriver(BackupDriver):
         return NotImplementedError(
             'create_target_from_container not supported for this driver')
 
-    def update_target(self, target, name=None, address=None, extra=None,
-                      type=BackupTargetType.VIRTUAL):
+    def update_target(self, target, name=None, address=None, extra=None):
         """
         Update the properties of a backup target, only changing the serviceplan
         is supported.
@@ -200,7 +205,10 @@ class DimensionDataBackupDriver(BackupDriver):
 
         :rtype: Instance of :class:`BackupTarget`
         """
-        service_plan = extra.get('servicePlan', 'Advanced')
+        if extra is not None:
+            service_plan = extra.get('servicePlan', DEFAULT_BACKUP_PLAN)
+        else:
+            service_plan = DEFAULT_BACKUP_PLAN
         request = ET.Element('ModifyBackup',
                              {'xmlns': BACKUP_NS})
         request.set('servicePlan', service_plan)

--- a/libcloud/backup/drivers/dimensiondata.py
+++ b/libcloud/backup/drivers/dimensiondata.py
@@ -113,7 +113,7 @@ class DimensionDataBackupDriver(BackupDriver):
 
         :rtype: Instance of :class:`BackupTarget`
         """
-        service_plan = extra.get('service_plan', 'Advanced')
+        service_plan = extra.get('servicePlan', 'Advanced')
         create_node = ET.Element('NewBackup',
                                  {'xmlns': BACKUP_NS})
         create_node.set('servicePlan', service_plan)

--- a/libcloud/backup/drivers/dimensiondata.py
+++ b/libcloud/backup/drivers/dimensiondata.py
@@ -180,7 +180,8 @@ class DimensionDataBackupDriver(BackupDriver):
         return NotImplementedError(
             'create_target_from_container not supported for this driver')
 
-    def update_target(self, target, name=None, address=None, extra=None):
+    def update_target(self, target, name=None, address=None, extra=None,
+                      type=BackupTargetType.VIRTUAL):
         """
         Update the properties of a backup target, only changing the serviceplan
         is supported.
@@ -208,8 +209,14 @@ class DimensionDataBackupDriver(BackupDriver):
             'server/%s/backup/modify' % (server_id),
             method='POST',
             data=ET.tostring(request)).object
-        target.extra = extra
-        return target
+        return BackupTarget(
+            id=server_id,
+            name=name,
+            address=address,
+            type=type,
+            extra=extra,
+            driver=self
+        )
 
     def delete_target(self, target):
         """
@@ -558,7 +565,7 @@ class DimensionDataBackupDriver(BackupDriver):
         return DimensionDataBackupDetails(
             asset_id=object.get('asset_id'),
             service_plan=object.get('servicePlan'),
-            state=object.get('state'),
+            status=object.get('state'),
             clients=self._to_clients(object)
         )
 

--- a/libcloud/common/dimensiondata.py
+++ b/libcloud/common/dimensiondata.py
@@ -1061,7 +1061,8 @@ class DimensionDataBackupDetails(object):
         :param service_plan: The service plan for backups. i.e (Essentials)
         :type  service_plan: ``str``
 
-        :param status: The overall status this backup target. i.e. (unregistered)
+        :param status: The overall status this backup target.
+                       i.e. (unregistered)
         :type  status: ``str``
 
         :param clients: Backup clients attached to this target

--- a/libcloud/common/dimensiondata.py
+++ b/libcloud/common/dimensiondata.py
@@ -1051,7 +1051,7 @@ class DimensionDataBackupDetails(object):
     a targets backups configuration
     """
 
-    def __init__(self, asset_id, service_plan, state, clients=None):
+    def __init__(self, asset_id, service_plan, status, clients=None):
         """
         Initialize an instance of :class:`DimensionDataBackupDetails`
 
@@ -1061,15 +1061,15 @@ class DimensionDataBackupDetails(object):
         :param service_plan: The service plan for backups. i.e (Essentials)
         :type  service_plan: ``str``
 
-        :param state: The overall state this backup target. i.e. (unregistered)
-        :type  state: ``str``
+        :param status: The overall status this backup target. i.e. (unregistered)
+        :type  status: ``str``
 
         :param clients: Backup clients attached to this target
         :type  clients: ``list`` of :class:`DimensionDataBackupClient`
         """
         self.asset_id = asset_id
         self.service_plan = service_plan
-        self.state = state
+        self.status = status
         self.clients = clients
 
     def __repr__(self):

--- a/libcloud/test/backup/fixtures/dimensiondata/caas_2_1_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_server_e75ead52_692f_4314_8725_c8a4f4d13a87.xml
+++ b/libcloud/test/backup/fixtures/dimensiondata/caas_2_1_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_server_e75ead52_692f_4314_8725_c8a4f4d13a87.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<server xmlns="urn:didata.com:api:cloud:types" id="e75ead52-692f-4314-8725-c8a4f4d13a87" datacenterId="NA9">
+        <name>Production Web Server</name>
+        <description>Server to host our main web application.</description>
+        <operatingSystem id="WIN2008S32" displayName="WIN2008S/32" family="WINDOWS" />
+        <cpu count="2" speed="STANDARD" coresPerSocket="1" />
+        <memoryGb>4</memoryGb>
+        <disk id="c2e1f199-116e-4dbc-9960-68720b832b0a" scsiId="0" sizeGb="50" speed="STANDARD" state="NORMAL" />
+        <networkInfo networkDomainId="553f26b6-2a73-42c3-a78b-6116f11291d0">
+            <primaryNic id="5e869800-df7b-4626-bcbf-8643b8be11fd" privateIpv4="10.0.4.8" ipv6="2607:f480:1111:1282:2960:fb72:7154:6160" vlanId="bc529e20-dc6f-42ba-be20-0ffe44d1993f" vlanName="Production VLAN" state="NORMAL" />
+        </networkInfo>
+        <backup assetId="5579f3a7-4c32-4cf5-8a7e-b45c36a35c10" servicePlan="Advanced" state="NORMAL" />
+        <monitoring monitoringId="11049" servicePlan="ESSENTIALS" state="NORMAL" />
+        <softwareLabel>MSSQL2008R2S</softwareLabel>
+        <sourceImageId>3ebf3c0f-90fe-4a8b-8585-6e65b316592c</sourceImageId>
+        <createTime>2015-12-02T10:31:33.000Z</createTime>
+        <deployed>true</deployed>
+        <started>true</started>
+        <state>PENDING_CHANGE</state>
+        <progress>
+            <action>DEPLOY_SERVER</action>
+            <requestTime>2015-12-02T11:07:40.000Z</requestTime>
+            <userName>devuser1</userName>
+        </progress>
+        <vmwareTools versionStatus="CURRENT" runningStatus="RUNNING" apiVersion="9354" />
+        <virtualHardware version="vmx-08" upToDate="false" />
+    </server>

--- a/libcloud/test/backup/fixtures/dimensiondata/caas_2_1_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_server_e75ead52_692f_4314_8725_c8a4f4d13a87_DEFAULT.xml
+++ b/libcloud/test/backup/fixtures/dimensiondata/caas_2_1_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_server_e75ead52_692f_4314_8725_c8a4f4d13a87_DEFAULT.xml
@@ -9,7 +9,7 @@
         <networkInfo networkDomainId="553f26b6-2a73-42c3-a78b-6116f11291d0">
             <primaryNic id="5e869800-df7b-4626-bcbf-8643b8be11fd" privateIpv4="10.0.4.8" ipv6="2607:f480:1111:1282:2960:fb72:7154:6160" vlanId="bc529e20-dc6f-42ba-be20-0ffe44d1993f" vlanName="Production VLAN" state="NORMAL" />
         </networkInfo>
-        <backup assetId="5579f3a7-4c32-4cf5-8a7e-b45c36a35c10" servicePlan="Essentials" state="NORMAL" />
+        <backup assetId="5579f3a7-4c32-4cf5-8a7e-b45c36a35c10" servicePlan="Advanced" state="NORMAL" />
         <monitoring monitoringId="11049" servicePlan="ESSENTIALS" state="NORMAL" />
         <softwareLabel>MSSQL2008R2S</softwareLabel>
         <sourceImageId>3ebf3c0f-90fe-4a8b-8585-6e65b316592c</sourceImageId>

--- a/libcloud/test/backup/test_dimensiondata.py
+++ b/libcloud/test/backup/test_dimensiondata.py
@@ -75,6 +75,12 @@ class DimensionDataTests(unittest.TestCase, TestCaseMixin):
         new_target = self.driver.update_target(target, extra=extra)
         self.assertEqual(new_target.extra['servicePlan'], 'Enterprise')
 
+    def test_update_target_STR(self):
+        target = 'e75ead52-692f-4314-8725-c8a4f4d13a87'
+        extra = {'servicePlan': 'Advanced'}
+        new_target = self.driver.update_target(target, extra=extra)
+        self.assertEqual(new_target.extra['servicePlan'], 'Advanced')
+
     def test_delete_target(self):
         target = self.driver.list_targets()[0]
         self.assertTrue(self.driver.delete_target(target))
@@ -254,6 +260,11 @@ class DimensionDataMockHttp(MockHttp):
 
     def _oec_0_9_myaccount_NOJOB(self, method, url, body, headers):
         body = self.fixtures.load('oec_0_9_myaccount.xml')
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+
+    def _caas_2_1_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_server_e75ead52_692f_4314_8725_c8a4f4d13a87(self, method, url, body, headers):
+        body = self.fixtures.load(
+            'caas_2_1_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_server_e75ead52_692f_4314_8725_c8a4f4d13a87.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
     def _caas_2_1_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_server(self, method, url, body, headers):


### PR DESCRIPTION
Making the status field of the DimensionDataBackupDetails object state like others, that way we can wait for state like we would for other things.
Adding an new ex_get_target_by_id for getting a single target.
Fixing up update_target as it only worked really if you passed a target in.  I didn't really test out this functionality before so it was a miss on me.
