### PR TITLE
Fixes the function ex_create_floating_ip for Openstack

### DIFF
--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -2313,15 +2313,20 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
         ip_obj, = [x for x in floating_ips if x.ip_address == ip]
         return ip_obj
 
-    def ex_create_floating_ip(self, ip_pool):
+    def ex_create_floating_ip(self, ip_pool=None):
         """
-        Create new floating IP
+        Create new floating IP. The ip_pool attribute is optional only if your
+        infrastructure has only one IP pool available.
 
         :param      ip_pool: name of the floating IP pool
         :type       ip_pool: ``str``
 
         :rtype: :class:`OpenStack_1_1_FloatingIpAddress`
         """
+        if (ip_pool is None) and (len(self.ex_list_floating_ip_pools()) == 1):
+            ip_pool = self.ex_list_floating_ip_pools()[0].name
+        elif (ip_pool is None) and (len(self.ex_list_floating_ip_pools()) > 1):
+            return None
         resp = self.connection.request('/os-floating-ips',
                                        method='POST',
                                        data={'pool': ip_pool})

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -2313,15 +2313,19 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
         ip_obj, = [x for x in floating_ips if x.ip_address == ip]
         return ip_obj
 
-    def ex_create_floating_ip(self):
+    def ex_create_floating_ip(self, ip_pool):
         """
         Create new floating IP
+
+        :param      ip_pool: name of the floating IP pool
+        :type       ip_pool: ``str``
 
         :rtype: :class:`OpenStack_1_1_FloatingIpAddress`
         """
         resp = self.connection.request('/os-floating-ips',
                                        method='POST',
-                                       data={})
+                                       data={'pool': ip_pool})
+
         data = resp.object['floating_ip']
         id = data['id']
         ip_address = data['ip']

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -2323,13 +2323,10 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
 
         :rtype: :class:`OpenStack_1_1_FloatingIpAddress`
         """
-        if (ip_pool is None) and (len(self.ex_list_floating_ip_pools()) == 1):
-            ip_pool = self.ex_list_floating_ip_pools()[0].name
-        elif (ip_pool is None) and (len(self.ex_list_floating_ip_pools()) > 1):
-            return None
+        data = {'pool': ip_pool} if ip_pool is not None else {}
         resp = self.connection.request('/os-floating-ips',
                                        method='POST',
-                                       data={'pool': ip_pool})
+                                       data=data)
 
         data = resp.object['floating_ip']
         id = data['id']


### PR DESCRIPTION
I'm not sure if this function is supported or not (floating_ip_pool.create_floating_ip is working), but I fixed it since it is the only documented function for creating floating IPs on http://libcloud.readthedocs.org/en/latest/compute/drivers/openstack.html ... and I fixed it before I found the "floating_ip_pool.create_floating_ip" function.
