### PR TITLE
DimesionData: Generic pagination, anti-affinity rules, create firewall expansion

### DIFF
--- a/libcloud/common/dimensiondata.py
+++ b/libcloud/common/dimensiondata.py
@@ -436,8 +436,35 @@ class DimensionDataConnection(ConnectionUserAndKey):
 
     def paginated_request_with_orgId_api_2(self, action, params=None, data='',
                                            headers=None, method='GET',
-                                           return_generator=False,
-                                           page_count=250):
+                                           page_size=250):
+        """
+        A paginated request to the MCP2.0 API
+        This essentially calls out to request_with_orgId_api_2 for each page
+        and yields the response to make a generator
+        This generator can be looped through to grab all the pages.
+
+        :param action: The resource to access (i.e. 'network/vlan')
+        :type  action: ``str``
+
+        :param params: Parameters to give to the action
+        :type  params: ``dict`` or ``None``
+
+        :param data: The data payload to be added to the request
+        :type  data: ``str``
+
+        :param headers: Additional header to be added to the request
+        :type  headers: ``str`` or ``dict`` or ``None``
+
+        :param method: HTTP Method for the request (i.e. 'GET', 'POST')
+        :type  method: ``str``
+
+        :param page_size: The size of each page to be returned
+                          Note: Max page size in MCP2.0 is currently 250
+        :type  page_size: ``int``
+        """
+        if params is None:
+            params = {}
+        params['pageSize'] = page_size
 
         paged_resp = self.request_with_orgId_api_2(action, params,
                                                    data, headers,
@@ -750,9 +777,21 @@ class DimensionDataNatRule(object):
 
 class DimensionDataAntiAffinityRule(object):
     """
-    Anti-Affinity Rule
+    Anti-Affinity rule for DimensionData
+
+    An Anti-Affinity rule ensures that servers in the rule will
+    not reside on the same VMware ESX host.
     """
     def __init__(self, id, node_list):
+        """
+        Instantiate a new :class:`DimensionDataAntiAffinityRule`
+
+        :param id: The ID of the Anti-Affinity rule
+        :type  id: ``str``
+
+        :param node_list: List of node ids that belong in this rule
+        :type  node_list: ``list`` of ``str``
+        """
         self.id = id
         self.node_list = node_list
 

--- a/libcloud/common/dimensiondata.py
+++ b/libcloud/common/dimensiondata.py
@@ -22,6 +22,7 @@ from libcloud.utils.py3 import b
 from libcloud.common.base import ConnectionUserAndKey, XmlResponse
 from libcloud.common.types import LibcloudError, InvalidCredsError
 from libcloud.compute.base import Node
+from libcloud.utils.py3 import basestring
 from libcloud.utils.xml import findtext
 
 # Roadmap / TODO:

--- a/libcloud/common/dimensiondata.py
+++ b/libcloud/common/dimensiondata.py
@@ -22,7 +22,6 @@ from libcloud.utils.py3 import b
 from libcloud.common.base import ConnectionUserAndKey, XmlResponse
 from libcloud.common.types import LibcloudError, InvalidCredsError
 from libcloud.compute.base import Node
-from libcloud.utils.py3 import basestring
 from libcloud.utils.xml import findtext
 
 # Roadmap / TODO:
@@ -434,6 +433,22 @@ class DimensionDataConnection(ConnectionUserAndKey):
             params=params, data=data,
             method=method, headers=headers)
 
+    def paginated_request_with_orgId_api_2(self, action, params=None, data='',
+                                           headers=None, method='GET',
+                                           return_generator=False,
+                                           page_count=250):
+
+        paged_resp = self.request_with_orgId_api_2(action, params,
+                                                   data, headers,
+                                                   method).object
+        yield paged_resp
+
+        while paged_resp.get('pageCount') >= paged_resp.get('pageSize'):
+            params['pageNumber'] = int(paged_resp.get('pageNumber')) + 1
+            paged_resp = self._list_nodes_single_page(action, params, data,
+                                                      headers, method).object
+            yield paged_resp
+
     def get_resource_path_api_1(self):
         """
         This method returns a resource path which is necessary for referencing
@@ -729,6 +744,19 @@ class DimensionDataNatRule(object):
     def __repr__(self):
         return (('<DimensionDataNatRule: id=%s, status=%s>')
                 % (self.id, self.status))
+
+
+class DimensionDataAntiAffinityRule(object):
+    """
+    Anti-Affinity Rule
+    """
+    def __init__(self, id, node_list):
+        self.id = id
+        self.node_list = node_list
+
+    def __repr__(self):
+        return (('<DimensionDataAntiAffinityRule: id=%s>')
+                % (self.id))
 
 
 class DimensionDataVlan(object):

--- a/libcloud/common/dimensiondata.py
+++ b/libcloud/common/dimensiondata.py
@@ -446,8 +446,9 @@ class DimensionDataConnection(ConnectionUserAndKey):
 
         while paged_resp.get('pageCount') >= paged_resp.get('pageSize'):
             params['pageNumber'] = int(paged_resp.get('pageNumber')) + 1
-            paged_resp = self._list_nodes_single_page(action, params, data,
-                                                      headers, method).object
+            paged_resp = self.request_with_orgId_api_2(action, params,
+                                                       data, headers,
+                                                       method).object
             yield paged_resp
 
     def get_resource_path_api_1(self):

--- a/libcloud/compute/drivers/dimensiondata.py
+++ b/libcloud/compute/drivers/dimensiondata.py
@@ -688,6 +688,17 @@ class DimensionDataNodeDriver(NodeDriver):
         return response_code in ['IN_PROGRESS', 'SUCCESS']
 
     def ex_create_anti_affinity_rule(self, node_list):
+        """
+        Create an anti affinity rule given a list of nodes
+        Anti affinity rules ensure that servers will not reside
+        on the same VMware ESX host
+
+        :param node_list: The list of nodes to create a rule for
+        :type  node_list: ``list`` of :class:`Node` or
+                          ``list`` of ``str``
+
+        :rtype: ``bool``
+        """
         if not isinstance(node_list, (list, tuple)):
             raise TypeError("Node list must be a list or a tuple.")
         anti_affinity_xml_request = ET.Element('NewAntiAffinityRule',
@@ -703,6 +714,15 @@ class DimensionDataNodeDriver(NodeDriver):
         return response_code in ['IN_PROGRESS', 'SUCCESS']
 
     def ex_delete_anti_affinity_rule(self, anti_affinity_rule):
+        """
+        Remove anti affinity rule
+
+        :param anti_affinity_rule: The anti affinity rule to delete
+        :type  anti_affinity_rule: :class:`DimensionDataAntiAffinityRule` or
+                                   ``str``
+
+        :rtype: ``bool``
+        """
         rule_id = self._anti_affinity_rule_to_anti_affinity_rule_id(
             anti_affinity_rule)
         result = self.connection.request_with_orgId_api_1(
@@ -712,10 +732,34 @@ class DimensionDataNodeDriver(NodeDriver):
         return response_code in ['IN_PROGRESS', 'SUCCESS']
 
     def ex_list_anti_affinity_rules(self, network=None, network_domain=None,
-                                    node=None, ex_filter_id=None,
-                                    ex_filter_state=None,
-                                    return_generator=False):
+                                    node=None, filter_id=None,
+                                    filter_state=None):
+        """
+        List anti affinity rules for a network, network domain, or node
 
+        :param network: The network to list anti affinity rules for
+                        One of network, network_domain, or node is required
+        :type  network: :class:`DimensionDataNetwork` or ``str``
+
+        :param network_domain: The network domain to list anti affinity rules
+                               One of network, network_domain,
+                               or node is required
+        :type  network_domain: :class:`DimensionDataNetworkDomain` or ``str``
+
+        :param node: The node to list anti affinity rules for
+                     One of network, netwok_domain, or node is required
+        :type  node: :class:`Node` or ``str``
+
+        :param filter_id: This will allow you to filter the rules
+                          by this node id
+        :type  filter_id: ``str``
+
+        :type  filter_state: This will allow you to filter rules by
+                             node state (i.e. NORMAL)
+        :type  filter_state: ``str``
+
+        :rtype: ``list`` of :class:`DimensionDataAntiAffinityRule`
+        """
         not_none_arguments = [key
                               for key in (network, network_domain, node)
                               if key is not None]
@@ -732,11 +776,11 @@ class DimensionDataNodeDriver(NodeDriver):
                 self._network_to_network_id(network)
         if node is not None:
             params['serverId'] = \
-                self._node_to_node_id(network_domain)
-        if ex_filter_id is not None:
-            params['id'] = ex_filter_id
-        if ex_filter_state is not None:
-            params['state'] = ex_filter_state
+                self._node_to_node_id(node)
+        if filter_id is not None:
+            params['id'] = filter_id
+        if filter_state is not None:
+            params['state'] = filter_state
 
         paged_result = self.connection.paginated_request_with_orgId_api_2(
             'server/antiAffinityRule',

--- a/libcloud/compute/drivers/dimensiondata.py
+++ b/libcloud/compute/drivers/dimensiondata.py
@@ -1149,7 +1149,7 @@ class DimensionDataNodeDriver(NodeDriver):
         """
         Deletes an existing VLAN
 
-        :param      vlan: the VLAN to delete
+        :param      vlan: The VLAN to delete
         :type       vlan: :class:`DimensionDataNetworkDomain`
 
         :rtype: ``bool``

--- a/libcloud/compute/drivers/dimensiondata.py
+++ b/libcloud/compute/drivers/dimensiondata.py
@@ -1332,7 +1332,7 @@ class DimensionDataNodeDriver(NodeDriver):
                 dest_port.set('begin', rule.destination.port_begin)
             if rule.destination.port_end is not None:
                 dest_port.set('end', rule.destination.port_end)
-        ET.SubElement(create_node, "enabled").text = 'true'
+        ET.SubElement(create_node, "enabled").text = rule.enabled
 
         # Set up positioning of rule
         placement = ET.SubElement(create_node, "placement")

--- a/libcloud/compute/drivers/dimensiondata.py
+++ b/libcloud/compute/drivers/dimensiondata.py
@@ -1147,10 +1147,10 @@ class DimensionDataNodeDriver(NodeDriver):
 
     def ex_delete_vlan(self, vlan):
         """
-        deletes an existing vlan
+        Deletes an existing VLAN
 
-        :param      vlan: the vlan to delete
-        :type       vlan: :class:`dimensiondatanetworkdomain`
+        :param      vlan: the VLAN to delete
+        :type       vlan: :class:`DimensionDataNetworkDomain`
 
         :rtype: ``bool``
         """

--- a/libcloud/test/compute/fixtures/dimensiondata/caas_2_1_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_network_firewallRule.xml
+++ b/libcloud/test/compute/fixtures/dimensiondata/caas_2_1_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_network_firewallRule.xml
@@ -214,12 +214,60 @@
         <ipVersion>IPV6</ipVersion>
         <protocol>TCP</protocol>
         <source>
-            <ip address="2607:f480:111:1336:6503:544c:74a6:3a28"/>            
+            <ip address="2607:f480:111:1336:6503:544c:74a6:3a28"/>
         </source>
         <destination>
             <ip address="ANY"/>
         </destination>
         <enabled>true</enabled>
         <state>NORMAL</state>
+      </firewallRule>
+      <firewallRule id="ce250bd3-0e45-4c13-a6d2-74e0657ef699" datacenterId="NA9" ruleType="CLIENT_RULE">
+        <networkDomainId>423c4386-87b4-43c4-9604-88ae237bfc7f</networkDomainId>
+        <name>RULE_WITH_SOURCE_AND_DEST_IP_ONLY</name>
+        <action>ACCEPT_DECISIVELY</action>
+        <ipVersion>IPV4</ipVersion>
+        <protocol>TCP</protocol>
+        <source>
+          <ip address="10.10.10.15"/>
+        </source>
+        <destination>
+          <ip address="10.10.10.14"/>
+        </destination>
+        <enabled>true</enabled>
+        <state>NORMAL</state>
+      </firewallRule>
+      <firewallRule id="ce250bd3-0e45-4c13-a6d2-74e0657ef699" datacenterId="NA9" ruleType="CLIENT_RULE">
+        <networkDomainId>423c4386-87b4-43c4-9604-88ae237bfc7f</networkDomainId>
+        <name>RULE_WITH_DEST_IP_NO_PORT</name>
+        <action>ACCEPT_DECISIVELY</action>
+        <ipVersion>IPV4</ipVersion>
+        <protocol>TCP</protocol>
+        <source>
+          <ip address="10.10.10.15"/>
+        </source>
+        <destination>
+          <ip address="10.10.10.14"/>
+          <port begin="40000" end="40005"/>
+        </destination>
+        <enabled>true</enabled>
+        <state>NORMAL</state>
+      </firewallRule>
+      <firewallRule id="ce250bd3-0e45-4c13-a6d2-74e0657ef700" datacenterId="NA9" ruleType="CLIENT_RULE">
+        <networkDomainId>423c4386-87b4-43c4-9604-88ae237bfc7f</networkDomainId>
+        <name>RULE_WITH_SOURCE_AND_DEST</name>
+        <action>ACCEPT_DECISIVELY</action>
+        <ipVersion>IPV4</ipVersion>
+        <protocol>TCP</protocol>
+        <source>
+          <ip address="10.10.10.0" prefixSize="24"/>
+          <port begin="40000" end="40005"/>
+      </source>
+      <destination>
+        <ip address="10.10.10.0" prefixSize="24"/>
+        <port begin="40000"/>
+      </destination>
+      <enabled>true</enabled>
+      <state>NORMAL</state>
     </firewallRule>
 </firewallRules>

--- a/libcloud/test/compute/fixtures/dimensiondata/caas_2_1_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_antiAffinityRule_list.xml
+++ b/libcloud/test/compute/fixtures/dimensiondata/caas_2_1_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_antiAffinityRule_list.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<antiAffinityRules xmlns="urn:didata.com:api:cloud:types" pageNumber="1" pageCount="2" totalCount="2" pageSize="250">
+  <antiAffinityRule id="07e3621a-a920-4a9a-943c-d8021f27f418" state="NORMAL" created="2016-03-24T00:03:27.000Z" datacenterId="NA9">
+    <serverSummary id="22f3544a-c874-4930-a31c-e9e513e51114">
+      <name>ansible-test-image-rhel6</name>
+      <description>my new node</description>
+      <networkingDetails>
+        <networkInfo networkDomainId="423c4386-87b4-43c4-9604-88ae237bfc7f" networkDomainName="Deloitte Test">
+          <primaryNic id="aafffb27-f16b-4757-9b63-ef7d8acd9c7f" privateIpv4="172.16.1.8" ipv6="2607:f480:111:1423:1b57:e47a:c212:257d" vlanId="bd6fbee5-17db-49f8-b1f5-3b213cea3061" vlanName="deloitte-test"/>        </networkInfo>
+      </networkingDetails>
+    </serverSummary>
+    <serverSummary id="5718d174-31d4-4d49-b1c6-fcb0d782f233">
+      <name>ansible-custom-image-test-UAT</name>
+      <description>my new node</description>
+      <networkingDetails>
+        <networkInfo networkDomainId="423c4386-87b4-43c4-9604-88ae237bfc7f" networkDomainName="Deloitte Test">
+          <primaryNic id="b359cea3-4452-46fe-b30b-b3ce839cde9b" privateIpv4="172.16.1.9" ipv6="2607:f480:111:1423:7fa7:9a9b:ecb9:882e" vlanId="bd6fbee5-17db-49f8-b1f5-3b213cea3061" vlanName="deloitte-test"/>
+        </networkInfo>
+      </networkingDetails>
+    </serverSummary>
+  </antiAffinityRule>
+  <antiAffinityRule id="5e10b1ab-68f2-4a8b-a49c-d88d623db665" state="NORMAL" created="2016-03-24T00:07:39.000Z" datacenterId="NA9">
+    <serverSummary id="9f8b5428-bac3-4cf9-adda-62f57fb38671">
+      <name>rhel-ansible-full-test</name>
+      <description>RHEL Ansible Test</description>
+      <networkingDetails>
+        <networkInfo networkDomainId="423c4386-87b4-43c4-9604-88ae237bfc7f" networkDomainName="Deloitte Test">
+          <primaryNic id="e081e784-5768-472c-b7f3-353e1646edc8" privateIpv4="172.16.1.15" ipv6="2607:f480:111:1423:70c9:9216:f7bf:dcf6" vlanId="bd6fbee5-17db-49f8-b1f5-3b213cea3061" vlanName="deloitte-test"/>
+        </networkInfo>
+      </networkingDetails>
+    </serverSummary>
+    <serverSummary id="feee5cd2-d83b-4b80-913d-0bf26c838a33">
+      <name>rhel-ansible-full-test</name>
+      <description>RHEL Ansible Test</description>
+      <networkingDetails>
+        <networkInfo networkDomainId="423c4386-87b4-43c4-9604-88ae237bfc7f" networkDomainName="Deloitte Test">
+          <primaryNic id="3278f833-9535-405c-91b8-0a0470f58aae" privateIpv4="172.16.1.17" ipv6="2607:f480:111:1423:3081:71a8:4c52:a8a" vlanId="bd6fbee5-17db-49f8-b1f5-3b213cea3061" vlanName="deloitte-test"/>
+        </networkInfo>
+      </networkingDetails>
+    </serverSummary>
+  </antiAffinityRule>
+</antiAffinityRules>

--- a/libcloud/test/compute/fixtures/dimensiondata/caas_2_1_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_antiAffinityRule_list.xml
+++ b/libcloud/test/compute/fixtures/dimensiondata/caas_2_1_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_antiAffinityRule_list.xml
@@ -5,16 +5,16 @@
       <name>ansible-test-image-rhel6</name>
       <description>my new node</description>
       <networkingDetails>
-        <networkInfo networkDomainId="423c4386-87b4-43c4-9604-88ae237bfc7f" networkDomainName="Deloitte Test">
-          <primaryNic id="aafffb27-f16b-4757-9b63-ef7d8acd9c7f" privateIpv4="172.16.1.8" ipv6="2607:f480:111:1423:1b57:e47a:c212:257d" vlanId="bd6fbee5-17db-49f8-b1f5-3b213cea3061" vlanName="deloitte-test"/>        </networkInfo>
+        <networkInfo networkDomainId="423c4386-87b4-43c4-9604-88ae237bfc7f" networkDomainName="Jeff Test">
+          <primaryNic id="aafffb27-f16b-4757-9b63-ef7d8acd9c7f" privateIpv4="172.16.1.8" ipv6="2607:f480:111:1423:1b57:e47a:c212:257d" vlanId="bd6fbee5-17db-49f8-b1f5-3b213cea3061" vlanName="jeff-test"/>        </networkInfo>
       </networkingDetails>
     </serverSummary>
     <serverSummary id="5718d174-31d4-4d49-b1c6-fcb0d782f233">
       <name>ansible-custom-image-test-UAT</name>
       <description>my new node</description>
       <networkingDetails>
-        <networkInfo networkDomainId="423c4386-87b4-43c4-9604-88ae237bfc7f" networkDomainName="Deloitte Test">
-          <primaryNic id="b359cea3-4452-46fe-b30b-b3ce839cde9b" privateIpv4="172.16.1.9" ipv6="2607:f480:111:1423:7fa7:9a9b:ecb9:882e" vlanId="bd6fbee5-17db-49f8-b1f5-3b213cea3061" vlanName="deloitte-test"/>
+        <networkInfo networkDomainId="423c4386-87b4-43c4-9604-88ae237bfc7f" networkDomainName="Jeff Test">
+          <primaryNic id="b359cea3-4452-46fe-b30b-b3ce839cde9b" privateIpv4="172.16.1.9" ipv6="2607:f480:111:1423:7fa7:9a9b:ecb9:882e" vlanId="bd6fbee5-17db-49f8-b1f5-3b213cea3061" vlanName="jeff-test"/>
         </networkInfo>
       </networkingDetails>
     </serverSummary>
@@ -24,8 +24,8 @@
       <name>rhel-ansible-full-test</name>
       <description>RHEL Ansible Test</description>
       <networkingDetails>
-        <networkInfo networkDomainId="423c4386-87b4-43c4-9604-88ae237bfc7f" networkDomainName="Deloitte Test">
-          <primaryNic id="e081e784-5768-472c-b7f3-353e1646edc8" privateIpv4="172.16.1.15" ipv6="2607:f480:111:1423:70c9:9216:f7bf:dcf6" vlanId="bd6fbee5-17db-49f8-b1f5-3b213cea3061" vlanName="deloitte-test"/>
+        <networkInfo networkDomainId="423c4386-87b4-43c4-9604-88ae237bfc7f" networkDomainName="Jeff Test">
+          <primaryNic id="e081e784-5768-472c-b7f3-353e1646edc8" privateIpv4="172.16.1.15" ipv6="2607:f480:111:1423:70c9:9216:f7bf:dcf6" vlanId="bd6fbee5-17db-49f8-b1f5-3b213cea3061" vlanName="jeff-test"/>
         </networkInfo>
       </networkingDetails>
     </serverSummary>
@@ -33,8 +33,8 @@
       <name>rhel-ansible-full-test</name>
       <description>RHEL Ansible Test</description>
       <networkingDetails>
-        <networkInfo networkDomainId="423c4386-87b4-43c4-9604-88ae237bfc7f" networkDomainName="Deloitte Test">
-          <primaryNic id="3278f833-9535-405c-91b8-0a0470f58aae" privateIpv4="172.16.1.17" ipv6="2607:f480:111:1423:3081:71a8:4c52:a8a" vlanId="bd6fbee5-17db-49f8-b1f5-3b213cea3061" vlanName="deloitte-test"/>
+        <networkInfo networkDomainId="423c4386-87b4-43c4-9604-88ae237bfc7f" networkDomainName="Jeff Test">
+          <primaryNic id="3278f833-9535-405c-91b8-0a0470f58aae" privateIpv4="172.16.1.17" ipv6="2607:f480:111:1423:3081:71a8:4c52:a8a" vlanId="bd6fbee5-17db-49f8-b1f5-3b213cea3061" vlanName="jeff-test"/>
         </networkInfo>
       </networkingDetails>
     </serverSummary>

--- a/libcloud/test/compute/fixtures/dimensiondata/caas_2_1_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_antiAffinityRule_list_PAGINATED.xml
+++ b/libcloud/test/compute/fixtures/dimensiondata/caas_2_1_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_antiAffinityRule_list_PAGINATED.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<antiAffinityRules xmlns="urn:didata.com:api:cloud:types" pageNumber="1" pageCount="2" totalCount="2" pageSize="2">
+  <antiAffinityRule id="07e3621a-a920-4a9a-943c-d8021f27f418" state="NORMAL" created="2016-03-24T00:03:27.000Z" datacenterId="NA9">
+    <serverSummary id="22f3544a-c874-4930-a31c-e9e513e51114">
+      <name>ansible-test-image-rhel6</name>
+      <description>my new node</description>
+      <networkingDetails>
+        <networkInfo networkDomainId="423c4386-87b4-43c4-9604-88ae237bfc7f" networkDomainName="Deloitte Test">
+          <primaryNic id="aafffb27-f16b-4757-9b63-ef7d8acd9c7f" privateIpv4="172.16.1.8" ipv6="2607:f480:111:1423:1b57:e47a:c212:257d" vlanId="bd6fbee5-17db-49f8-b1f5-3b213cea3061" vlanName="deloitte-test"/>        </networkInfo>
+      </networkingDetails>
+    </serverSummary>
+    <serverSummary id="5718d174-31d4-4d49-b1c6-fcb0d782f233">
+      <name>ansible-custom-image-test-UAT</name>
+      <description>my new node</description>
+      <networkingDetails>
+        <networkInfo networkDomainId="423c4386-87b4-43c4-9604-88ae237bfc7f" networkDomainName="Deloitte Test">
+          <primaryNic id="b359cea3-4452-46fe-b30b-b3ce839cde9b" privateIpv4="172.16.1.9" ipv6="2607:f480:111:1423:7fa7:9a9b:ecb9:882e" vlanId="bd6fbee5-17db-49f8-b1f5-3b213cea3061" vlanName="deloitte-test"/>
+        </networkInfo>
+      </networkingDetails>
+    </serverSummary>
+  </antiAffinityRule>
+  <antiAffinityRule id="5e10b1ab-68f2-4a8b-a49c-d88d623db665" state="NORMAL" created="2016-03-24T00:07:39.000Z" datacenterId="NA9">
+    <serverSummary id="9f8b5428-bac3-4cf9-adda-62f57fb38671">
+      <name>rhel-ansible-full-test</name>
+      <description>RHEL Ansible Test</description>
+      <networkingDetails>
+        <networkInfo networkDomainId="423c4386-87b4-43c4-9604-88ae237bfc7f" networkDomainName="Deloitte Test">
+          <primaryNic id="e081e784-5768-472c-b7f3-353e1646edc8" privateIpv4="172.16.1.15" ipv6="2607:f480:111:1423:70c9:9216:f7bf:dcf6" vlanId="bd6fbee5-17db-49f8-b1f5-3b213cea3061" vlanName="deloitte-test"/>
+        </networkInfo>
+      </networkingDetails>
+    </serverSummary>
+    <serverSummary id="feee5cd2-d83b-4b80-913d-0bf26c838a33">
+      <name>rhel-ansible-full-test</name>
+      <description>RHEL Ansible Test</description>
+      <networkingDetails>
+        <networkInfo networkDomainId="423c4386-87b4-43c4-9604-88ae237bfc7f" networkDomainName="Deloitte Test">
+          <primaryNic id="3278f833-9535-405c-91b8-0a0470f58aae" privateIpv4="172.16.1.17" ipv6="2607:f480:111:1423:3081:71a8:4c52:a8a" vlanId="bd6fbee5-17db-49f8-b1f5-3b213cea3061" vlanName="deloitte-test"/>
+        </networkInfo>
+      </networkingDetails>
+    </serverSummary>
+  </antiAffinityRule>
+</antiAffinityRules>

--- a/libcloud/test/compute/fixtures/dimensiondata/caas_2_1_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_antiAffinityRule_list_PAGINATED.xml
+++ b/libcloud/test/compute/fixtures/dimensiondata/caas_2_1_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_antiAffinityRule_list_PAGINATED.xml
@@ -5,16 +5,16 @@
       <name>ansible-test-image-rhel6</name>
       <description>my new node</description>
       <networkingDetails>
-        <networkInfo networkDomainId="423c4386-87b4-43c4-9604-88ae237bfc7f" networkDomainName="Deloitte Test">
-          <primaryNic id="aafffb27-f16b-4757-9b63-ef7d8acd9c7f" privateIpv4="172.16.1.8" ipv6="2607:f480:111:1423:1b57:e47a:c212:257d" vlanId="bd6fbee5-17db-49f8-b1f5-3b213cea3061" vlanName="deloitte-test"/>        </networkInfo>
+        <networkInfo networkDomainId="423c4386-87b4-43c4-9604-88ae237bfc7f" networkDomainName="Jeff Test">
+          <primaryNic id="aafffb27-f16b-4757-9b63-ef7d8acd9c7f" privateIpv4="172.16.1.8" ipv6="2607:f480:111:1423:1b57:e47a:c212:257d" vlanId="bd6fbee5-17db-49f8-b1f5-3b213cea3061" vlanName="jeff-test"/>        </networkInfo>
       </networkingDetails>
     </serverSummary>
     <serverSummary id="5718d174-31d4-4d49-b1c6-fcb0d782f233">
       <name>ansible-custom-image-test-UAT</name>
       <description>my new node</description>
       <networkingDetails>
-        <networkInfo networkDomainId="423c4386-87b4-43c4-9604-88ae237bfc7f" networkDomainName="Deloitte Test">
-          <primaryNic id="b359cea3-4452-46fe-b30b-b3ce839cde9b" privateIpv4="172.16.1.9" ipv6="2607:f480:111:1423:7fa7:9a9b:ecb9:882e" vlanId="bd6fbee5-17db-49f8-b1f5-3b213cea3061" vlanName="deloitte-test"/>
+        <networkInfo networkDomainId="423c4386-87b4-43c4-9604-88ae237bfc7f" networkDomainName="Jeff Test">
+          <primaryNic id="b359cea3-4452-46fe-b30b-b3ce839cde9b" privateIpv4="172.16.1.9" ipv6="2607:f480:111:1423:7fa7:9a9b:ecb9:882e" vlanId="bd6fbee5-17db-49f8-b1f5-3b213cea3061" vlanName="jeff-test"/>
         </networkInfo>
       </networkingDetails>
     </serverSummary>
@@ -24,8 +24,8 @@
       <name>rhel-ansible-full-test</name>
       <description>RHEL Ansible Test</description>
       <networkingDetails>
-        <networkInfo networkDomainId="423c4386-87b4-43c4-9604-88ae237bfc7f" networkDomainName="Deloitte Test">
-          <primaryNic id="e081e784-5768-472c-b7f3-353e1646edc8" privateIpv4="172.16.1.15" ipv6="2607:f480:111:1423:70c9:9216:f7bf:dcf6" vlanId="bd6fbee5-17db-49f8-b1f5-3b213cea3061" vlanName="deloitte-test"/>
+        <networkInfo networkDomainId="423c4386-87b4-43c4-9604-88ae237bfc7f" networkDomainName="Jeff Test">
+          <primaryNic id="e081e784-5768-472c-b7f3-353e1646edc8" privateIpv4="172.16.1.15" ipv6="2607:f480:111:1423:70c9:9216:f7bf:dcf6" vlanId="bd6fbee5-17db-49f8-b1f5-3b213cea3061" vlanName="jeff-test"/>
         </networkInfo>
       </networkingDetails>
     </serverSummary>
@@ -33,8 +33,8 @@
       <name>rhel-ansible-full-test</name>
       <description>RHEL Ansible Test</description>
       <networkingDetails>
-        <networkInfo networkDomainId="423c4386-87b4-43c4-9604-88ae237bfc7f" networkDomainName="Deloitte Test">
-          <primaryNic id="3278f833-9535-405c-91b8-0a0470f58aae" privateIpv4="172.16.1.17" ipv6="2607:f480:111:1423:3081:71a8:4c52:a8a" vlanId="bd6fbee5-17db-49f8-b1f5-3b213cea3061" vlanName="deloitte-test"/>
+        <networkInfo networkDomainId="423c4386-87b4-43c4-9604-88ae237bfc7f" networkDomainName="Jeff Test">
+          <primaryNic id="3278f833-9535-405c-91b8-0a0470f58aae" privateIpv4="172.16.1.17" ipv6="2607:f480:111:1423:3081:71a8:4c52:a8a" vlanId="bd6fbee5-17db-49f8-b1f5-3b213cea3061" vlanName="jeff-test"/>
         </networkInfo>
       </networkingDetails>
     </serverSummary>

--- a/libcloud/test/compute/fixtures/dimensiondata/oec_0_9_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_antiAffinityRule_create.xml
+++ b/libcloud/test/compute/fixtures/dimensiondata/oec_0_9_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_antiAffinityRule_create.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ns5:Status xmlns:ns16="http://oec.api.opsource.net/schemas/storage" xmlns="http://oec.api.opsource.net/schemas/server" xmlns:ns14="http://oec.api.opsource.net/schemas/serverbootstrap" xmlns:ns15="http://oec.api.opsource.net/schemas/multigeo" xmlns:ns9="http://oec.api.opsource.net/schemas/admin" xmlns:ns5="http://oec.api.opsource.net/schemas/general" xmlns:ns12="http://oec.api.opsource.net/schemas/whitelabel" xmlns:ns13="http://oec.api.opsource.net/schemas/reset" xmlns:ns6="http://oec.api.opsource.net/schemas/vip" xmlns:ns7="http://oec.api.opsource.net/schemas/datacenter" xmlns:ns10="http://oec.api.opsource.net/schemas/backup" xmlns:ns8="http://oec.api.opsource.net/schemas/manualimport" xmlns:ns11="http://oec.api.opsource.net/schemas/support" xmlns:ns2="http://oec.api.opsource.net/schemas/network" xmlns:ns4="http://oec.api.opsource.net/schemas/directory" xmlns:ns3="http://oec.api.opsource.net/schemas/organization">
+    <ns5:operation>Create Anti Affinity Rule</ns5:operation>
+    <ns5:result>SUCCESS</ns5:result>
+    <ns5:resultDetail>Request to create Server Anti-Affinity Rule between 'rhel-ansible-full-test' and 'rhel-ansible-full-test' on 'Deloitte Test' has been accepted and is being processed.</ns5:resultDetail>
+    <ns5:resultCode>REASON_0</ns5:resultCode>
+    <ns5:additionalInformation name="antiaffinityrule.id">
+        <ns5:value>5e10b1ab-68f2-4a8b-a49c-d88d623db665</ns5:value>
+    </ns5:additionalInformation>
+</ns5:Status>
+

--- a/libcloud/test/compute/fixtures/dimensiondata/oec_0_9_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_antiAffinityRule_create_FAIL.xml
+++ b/libcloud/test/compute/fixtures/dimensiondata/oec_0_9_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_antiAffinityRule_create_FAIL.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ns5:Status xmlns:ns16="http://oec.api.opsource.net/schemas/storage" xmlns="http://oec.api.opsource.net/schemas/server" xmlns:ns14="http://oec.api.opsource.net/schemas/serverbootstrap" xmlns:ns15="http://oec.api.opsource.net/schemas/multigeo" xmlns:ns9="http://oec.api.opsource.net/schemas/admin" xmlns:ns5="http://oec.api.opsource.net/schemas/general" xmlns:ns12="http://oec.api.opsource.net/schemas/whitelabel" xmlns:ns13="http://oec.api.opsource.net/schemas/reset" xmlns:ns6="http://oec.api.opsource.net/schemas/vip" xmlns:ns7="http://oec.api.opsource.net/schemas/datacenter" xmlns:ns10="http://oec.api.opsource.net/schemas/backup" xmlns:ns8="http://oec.api.opsource.net/schemas/manualimport" xmlns:ns11="http://oec.api.opsource.net/schemas/support" xmlns:ns2="http://oec.api.opsource.net/schemas/network" xmlns:ns4="http://oec.api.opsource.net/schemas/directory" xmlns:ns3="http://oec.api.opsource.net/schemas/organization">
+  <ns5:operation>Create Anti Affinity Rule</ns5:operation>
+  <ns5:result>ERROR</ns5:result>
+  <ns5:resultDetail>Server 'ansible-test-image-rhel6' (id 22f3544a-c874-4930-a31c-e9e513e51114) is already used in another Anti-Affinity Rule (id 07e3621a-a920-4a9a-943c-d8021f27f418).</ns5:resultDetail>
+  <ns5:resultCode>REASON_692</ns5:resultCode>
+</ns5:Status>

--- a/libcloud/test/compute/fixtures/dimensiondata/oec_0_9_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_antiAffinityRule_delete.xml
+++ b/libcloud/test/compute/fixtures/dimensiondata/oec_0_9_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_antiAffinityRule_delete.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ns5:Status xmlns:ns16="http://oec.api.opsource.net/schemas/storage" xmlns="http://oec.api.opsource.net/schemas/server" xmlns:ns14="http://oec.api.opsource.net/schemas/serverbootstrap" xmlns:ns15="http://oec.api.opsource.net/schemas/multigeo" xmlns:ns9="http://oec.api.opsource.net/schemas/admin" xmlns:ns5="http://oec.api.opsource.net/schemas/general" xmlns:ns12="http://oec.api.opsource.net/schemas/whitelabel" xmlns:ns13="http://oec.api.opsource.net/schemas/reset" xmlns:ns6="http://oec.api.opsource.net/schemas/vip" xmlns:ns7="http://oec.api.opsource.net/schemas/datacenter" xmlns:ns10="http://oec.api.opsource.net/schemas/backup" xmlns:ns8="http://oec.api.opsource.net/schemas/manualimport" xmlns:ns11="http://oec.api.opsource.net/schemas/support" xmlns:ns2="http://oec.api.opsource.net/schemas/network" xmlns:ns4="http://oec.api.opsource.net/schemas/directory" xmlns:ns3="http://oec.api.opsource.net/schemas/organization">
+    <ns5:operation>Delete Anti Affinity Rule</ns5:operation>
+    <ns5:result>SUCCESS</ns5:result>
+    <ns5:resultDetail>Request to delete Server Anti-Affinity Rule between 'ansible-test-image-rhel6' and 'ansible-custom-image-test-UAT' on 'Deloitte Test' has been accepted and is being processed.</ns5:resultDetail>
+    <ns5:resultCode>REASON_0</ns5:resultCode>
+</ns5:Status>

--- a/libcloud/test/compute/fixtures/dimensiondata/oec_0_9_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_antiAffinityRule_delete_FAIL.xml
+++ b/libcloud/test/compute/fixtures/dimensiondata/oec_0_9_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_antiAffinityRule_delete_FAIL.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ns5:Status xmlns:ns16="http://oec.api.opsource.net/schemas/storage" xmlns="http://oec.api.opsource.net/schemas/server" xmlns:ns14="http://oec.api.opsource.net/schemas/serverbootstrap" xmlns:ns15="http://oec.api.opsource.net/schemas/multigeo" xmlns:ns9="http://oec.api.opsource.net/schemas/admin" xmlns:ns5="http://oec.api.opsource.net/schemas/general" xmlns:ns12="http://oec.api.opsource.net/schemas/whitelabel" xmlns:ns13="http://oec.api.opsource.net/schemas/reset" xmlns:ns6="http://oec.api.opsource.net/schemas/vip" xmlns:ns7="http://oec.api.opsource.net/schemas/datacenter" xmlns:ns10="http://oec.api.opsource.net/schemas/backup" xmlns:ns8="http://oec.api.opsource.net/schemas/manualimport" xmlns:ns11="http://oec.api.opsource.net/schemas/support" xmlns:ns2="http://oec.api.opsource.net/schemas/network" xmlns:ns4="http://oec.api.opsource.net/schemas/directory" xmlns:ns3="http://oec.api.opsource.net/schemas/organization">
+    <ns5:operation>Delete Anti Affinity Rule</ns5:operation>
+    <ns5:result>ERROR</ns5:result>
+    <ns5:resultDetail>Could not find Anti Affinity Rule with Id 07e3621a-a920-4a9a-943c-d8021f27f418</ns5:resultDetail>
+    <ns5:resultCode>REASON_693</ns5:resultCode>
+</ns5:Status>


### PR DESCRIPTION
Added:
ex_list_anti_affinity_rules
ex_create_anti_affinity_rule
ex_delete_anti_affinity_rule
generic pagination function
modified ex_create_firewall_rule to be able to place rules in a specific position relative to another rule

Tests for all new added features
Added some more coverage tests to ex_create_firewall rule
97% coverage in our compute driver now.
