### PR TITLE
Fix OpenStack IP type resolution

### DIFF
--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -2074,15 +2074,15 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
                 # public and 'fixed' for private
                 explicit_ip_type = value.get('OS-EXT-IPS:type', None)
 
-                if explicit_ip_type == 'floating':
+                if public_subnet:
+                    # Check for public subnet
+                    is_public_ip = True
+                elif explicit_ip_type == 'floating':
                     is_public_ip = True
                 elif explicit_ip_type == 'fixed':
                     is_public_ip = False
                 elif label in public_networks_labels:
                     # Try label next
-                    is_public_ip = True
-                elif public_subnet:
-                    # Check for public subnet
                     is_public_ip = True
 
                 if is_public_ip:
@@ -2108,6 +2108,7 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
             created_at=created,
             driver=self,
             extra=dict(
+                addresses=api_node['addresses'],
                 hostId=api_node['hostId'],
                 access_ip=api_node.get('accessIPv4'),
                 access_ipv6=api_node.get('accessIPv6', None),

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -2068,8 +2068,8 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
                 except:
                     # IPv6
 
-                    # Openstack Icehouse sets 'OS-EXT-IPS:type' to 'floating' for
-                    # public and 'fixed' for private
+                    # Openstack Icehouse sets 'OS-EXT-IPS:type' to 'floating'
+                    # for public and 'fixed' for private
                     explicit_ip_type = value.get('OS-EXT-IPS:type', None)
 
                     if label in public_networks_labels:

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -2061,29 +2061,23 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
         for label, values in api_node['addresses'].items():
             for value in values:
                 ip = value['addr']
-
                 is_public_ip = False
 
                 try:
-                    public_subnet = is_public_subnet(ip)
+                    is_public_ip = is_public_subnet(ip)
                 except:
                     # IPv6
-                    public_subnet = False
 
-                # Openstack Icehouse sets 'OS-EXT-IPS:type' to 'floating' for
-                # public and 'fixed' for private
-                explicit_ip_type = value.get('OS-EXT-IPS:type', None)
+                    # Openstack Icehouse sets 'OS-EXT-IPS:type' to 'floating' for
+                    # public and 'fixed' for private
+                    explicit_ip_type = value.get('OS-EXT-IPS:type', None)
 
-                if public_subnet:
-                    # Check for public subnet
-                    is_public_ip = True
-                elif explicit_ip_type == 'floating':
-                    is_public_ip = True
-                elif explicit_ip_type == 'fixed':
-                    is_public_ip = False
-                elif label in public_networks_labels:
-                    # Try label next
-                    is_public_ip = True
+                    if label in public_networks_labels:
+                        is_public_ip = True
+                    elif explicit_ip_type == 'floating':
+                        is_public_ip = True
+                    elif explicit_ip_type == 'fixed':
+                        is_public_ip = False
 
                 if is_public_ip:
                     public_ips.append(ip)

--- a/libcloud/test/compute/fixtures/openstack_v1.1/_servers_detail.json
+++ b/libcloud/test/compute/fixtures/openstack_v1.1/_servers_detail.json
@@ -58,6 +58,28 @@
                         "addr": "10.3.3.3",
                         "version": 4
                     }
+                ],
+                "pubnet": [
+                    {
+                        "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:79:90:aa",
+                        "OS-EXT-IPS:type": "fixed",
+                        "addr": "1.1.1.1",
+                        "version": 4
+                    },
+                    {
+                        "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:79:90:aa",
+                        "OS-EXT-IPS:type": "floating",
+                        "addr": "2.2.2.2",
+                        "version": 4
+                    }
+                ],
+                "privnet": [
+                    {
+                        "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:79:90:aa",
+                        "OS-EXT-IPS:type": "floating",
+                        "addr": "172.16.1.1",
+                        "version": 4
+                    }
                 ]
             },
             "tenant_id": "rs-reach-project",

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -758,8 +758,11 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
         self.assertTrue('12.16.18.28' in node.public_ips)
         self.assertTrue('50.57.94.35' in node.public_ips)
 
-        # floating ip
-        self.assertTrue('192.168.3.3' in node.public_ips)
+        # fixed public ip
+        self.assertTrue('1.1.1.1' in node.public_ips)
+
+        # floating public ip
+        self.assertTrue('2.2.2.2' in node.public_ips)
 
         # test public IPv6
         self.assertTrue(
@@ -768,8 +771,12 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
         # test private IPv4
         self.assertTrue('10.182.64.34' in node.private_ips)
 
-        # floating ip
+        # fixed private ip
         self.assertTrue('10.3.3.3' in node.private_ips)
+
+        # floating private ip
+        self.assertTrue('192.168.3.3' in node.private_ips)
+        self.assertTrue('172.16.1.1' in node.private_ips)
 
         # test private IPv6
         self.assertTrue(


### PR DESCRIPTION
Checking the type of the IP with `explicit_ip_type` is not reliable.
A fixed IP is not always a private IP and a floating IP is not always a public one.

So I moved up the check of the public subnets.

I also added the `addresses` element of the reply in the `extra` dict.
This allows users to implement their own algorithm to find the right IP (e.g. by network name).
