### PR TITLE
Fix/create firewall rule

### DIFF
--- a/libcloud/compute/drivers/dimensiondata.py
+++ b/libcloud/compute/drivers/dimensiondata.py
@@ -1182,7 +1182,7 @@ class DimensionDataNodeDriver(NodeDriver):
                 dest_port.set('begin', rule.destination.port_begin)
             if rule.destination.port_end is not None:
                 dest_port.set('end', rule.destination.port_end)
-        ET.SubElement(create_node, "enabled").text = 'true'
+        ET.SubElement(create_node, "enabled").text = str(rule.enabled).lower()
         placement = ET.SubElement(create_node, "placement")
         placement.set('position', position)
 

--- a/libcloud/loadbalancer/drivers/dimensiondata.py
+++ b/libcloud/loadbalancer/drivers/dimensiondata.py
@@ -340,9 +340,9 @@ class DimensionDataLBDriver(Driver):
         create_pool_m = ET.Element('addPoolMember', {'xmlns': TYPES_URN})
         ET.SubElement(create_pool_m, "poolId").text = pool.id
         ET.SubElement(create_pool_m, "nodeId").text = node.id
-        ET.SubElement(create_pool_m, "status").text = 'ENABLED'
         if port is not None:
             ET.SubElement(create_pool_m, "port").text = str(port)
+        ET.SubElement(create_pool_m, "status").text = 'ENABLED'
 
         response = self.connection.request_with_orgId_api_2(
             'networkDomainVip/addPoolMember',


### PR DESCRIPTION
script sends 'True' as boolean value in the request xml for the enabled parameter to the CAAS API  but 'True' is not a valid value  of the atomic type 'xs:boolean'.
