### PR TITLE
Fix openstack v3 authentication

### DIFF
--- a/libcloud/common/openstack.py
+++ b/libcloud/common/openstack.py
@@ -94,6 +94,17 @@ class OpenStackBaseConnection(ConnectionUserAndKey):
                                 ex_force_base_url must also be provided.
     :type ex_force_auth_token: ``str``
 
+    :param token_scope: Whether to scope a token to a "project", a
+                        "domain" or "unscoped".
+    :type token_scope: ``str``
+
+    :param ex_domain_name: When authenticating, provide this domain name to
+                           the identity service.  A scoped token will be
+                           returned. Some cloud providers require the domain
+                           name to be provided at authentication time. Others
+                           will use a default domain if none is provided.
+    :type ex_domain_name: ``str``
+
     :param ex_tenant_name: When authenticating, provide this tenant name to the
                            identity service. A scoped token will be returned.
                            Some cloud providers require the tenant name to be
@@ -133,6 +144,8 @@ class OpenStackBaseConnection(ConnectionUserAndKey):
                  ex_force_auth_url=None,
                  ex_force_auth_version=None,
                  ex_force_auth_token=None,
+                 ex_token_scope=None,
+                 ex_domain_name=None,
                  ex_tenant_name=None,
                  ex_force_service_type=None,
                  ex_force_service_name=None,
@@ -148,6 +161,8 @@ class OpenStackBaseConnection(ConnectionUserAndKey):
         self._ex_force_base_url = ex_force_base_url
         self._ex_force_auth_url = ex_force_auth_url
         self._ex_force_auth_token = ex_force_auth_token
+        self._ex_token_scope = ex_token_scope
+        self._ex_domain_name = ex_domain_name
         self._ex_tenant_name = ex_tenant_name
         self._ex_force_service_type = ex_force_service_type
         self._ex_force_service_name = ex_force_service_name
@@ -185,6 +200,8 @@ class OpenStackBaseConnection(ConnectionUserAndKey):
                             user_id=self.user_id,
                             key=self.key,
                             tenant_name=self._ex_tenant_name,
+                            domain_name=self._ex_domain_name,
+                            token_scope=self._ex_token_scope,
                             timeout=self.timeout,
                             parent_conn=self)
 
@@ -399,6 +416,8 @@ class OpenStackDriverMixin(object):
         self._ex_force_auth_url = kwargs.get('ex_force_auth_url', None)
         self._ex_force_auth_version = kwargs.get('ex_force_auth_version', None)
         self._ex_force_auth_token = kwargs.get('ex_force_auth_token', None)
+        self._ex_token_scope = kwargs.get('ex_token_scope', None)
+        self._ex_domain_name = kwargs.get('ex_domain_name', None)
         self._ex_tenant_name = kwargs.get('ex_tenant_name', None)
         self._ex_force_service_type = kwargs.get('ex_force_service_type', None)
         self._ex_force_service_name = kwargs.get('ex_force_service_name', None)
@@ -419,6 +438,10 @@ class OpenStackDriverMixin(object):
             rv['ex_force_auth_url'] = self._ex_force_auth_url
         if self._ex_force_auth_version:
             rv['ex_force_auth_version'] = self._ex_force_auth_version
+        if self._ex_token_scope:
+            rv['ex_token_scope'] = self._ex_token_scope
+        if self._ex_domain_name:
+            rv['ex_domain_name'] = self._ex_domain_name
         if self._ex_tenant_name:
             rv['ex_tenant_name'] = self._ex_tenant_name
         if self._ex_force_service_type:

--- a/libcloud/common/openstack.py
+++ b/libcloud/common/openstack.py
@@ -31,7 +31,8 @@ from libcloud.compute.types import KeyPairDoesNotExistError
 from libcloud.common.openstack_identity import get_class_for_auth_version
 
 # Imports for backward compatibility reasons
-from libcloud.common.openstack_identity import OpenStackServiceCatalog
+from libcloud.common.openstack_identity import (OpenStackServiceCatalog,
+                                                OpenStackIdentityTokenScope)
 
 
 try:
@@ -144,8 +145,8 @@ class OpenStackBaseConnection(ConnectionUserAndKey):
                  ex_force_auth_url=None,
                  ex_force_auth_version=None,
                  ex_force_auth_token=None,
-                 ex_token_scope=None,
-                 ex_domain_name=None,
+                 ex_token_scope=OpenStackIdentityTokenScope.PROJECT,
+                 ex_domain_name='Default',
                  ex_tenant_name=None,
                  ex_force_service_type=None,
                  ex_force_service_name=None,

--- a/libcloud/common/openstack_identity.py
+++ b/libcloud/common/openstack_identity.py
@@ -571,7 +571,8 @@ class OpenStackIdentityConnection(ConnectionUserAndKey):
     timeout = None
 
     def __init__(self, auth_url, user_id, key, tenant_name=None,
-                 domain_name=None, token_scope=None,
+                 domain_name='Default',
+                 token_scope=OpenStackIdentityTokenScope.PROJECT,
                  timeout=None, parent_conn=None):
         super(OpenStackIdentityConnection, self).__init__(user_id=user_id,
                                                           key=key,
@@ -589,10 +590,8 @@ class OpenStackIdentityConnection(ConnectionUserAndKey):
 
         self.auth_url = auth_url
         self.tenant_name = tenant_name
-        self.domain_name = domain_name if domain_name is not None else \
-            'Default'
-        self.token_scope = token_scope if token_scope is not None else \
-            OpenStackIdentityTokenScope.PROJECT
+        self.domain_name = domain_name
+        self.token_scope = token_scope
         self.timeout = timeout
 
         self.urls = {}
@@ -929,7 +928,8 @@ class OpenStackIdentity_3_0_Connection(OpenStackIdentityConnection):
     ]
 
     def __init__(self, auth_url, user_id, key, tenant_name=None,
-                 domain_name=None, token_scope=None,
+                 domain_name='Default',
+                 token_scope=OpenStackIdentityTokenScope.PROJECT,
                  timeout=None, parent_conn=None):
         """
         :param tenant_name: Name of the project this user belongs to. Note:
@@ -964,6 +964,9 @@ class OpenStackIdentity_3_0_Connection(OpenStackIdentityConnection):
                 (not self.tenant_name or not self.domain_name)):
             raise ValueError('Must provide tenant_name and domain_name '
                              'argument')
+        elif (self.token_scope == OpenStackIdentityTokenScope.DOMAIN and
+                not self.domain_name):
+            raise ValueError('Must provide domain_name argument')
 
         self.auth_user_roles = None
 

--- a/libcloud/test/common/test_openstack_identity.py
+++ b/libcloud/test/common/test_openstack_identity.py
@@ -274,6 +274,16 @@ class OpenStackIdentity_3_0_ConnectionTests(unittest.TestCase):
                                 key='test',
                                 token_scope='project')
 
+        # Missing domain_name
+        expected_msg = 'Must provide domain_name argument'
+        self.assertRaisesRegexp(ValueError, expected_msg,
+                                OpenStackIdentity_3_0_Connection,
+                                auth_url='http://none',
+                                user_id='test',
+                                key='test',
+                                token_scope='domain',
+                                domain_name=None)
+
         # Scope to project all ok
         OpenStackIdentity_3_0_Connection(auth_url='http://none',
                                          user_id='test',


### PR DESCRIPTION
## Fix openstack v3 authentication
### Description

This PR allows to define the OpenStack `domain` to another value that the default `Default`.
It also adds the ability to define the `scope` of the token.

With the code for the OpenStack Identity API v3, [two new parameters were added](https://github.com/apache/libcloud/blob/v0.20.1/libcloud/common/openstack_identity.py#L925): `domain_name` and `token_scope` but it was impossible to define them to a value other than their respective default.
### Status
- done, ready for review
### Checklist (tick everything that applies)
- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] ~~[ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)~~
