### PR TITLE
Sort providers

### DIFF
--- a/libcloud/backup/types.py
+++ b/libcloud/backup/types.py
@@ -22,9 +22,9 @@ __all__ = [
 
 class Provider(object):
     DUMMY = 'dummy'
+    DIMENSIONDATA = 'dimensiondata'
     EBS = 'ebs'
     GCE = 'gce'
-    DIMENSIONDATA = 'dimensiondata'
 
 
 class BackupTargetType(object):

--- a/libcloud/backup/types.py
+++ b/libcloud/backup/types.py
@@ -21,6 +21,12 @@ __all__ = [
 
 
 class Provider(object):
+    """
+    Defines for each of the supported providers
+
+    Non-Dummy drivers are sorted in alphabetical order. Please preserve this
+    ordering when adding new drivers.
+    """
     DUMMY = 'dummy'
     DIMENSIONDATA = 'dimensiondata'
     EBS = 'ebs'

--- a/libcloud/compute/types.py
+++ b/libcloud/compute/types.py
@@ -60,111 +60,111 @@ class Provider(Type):
     Defines for each of the supported providers
 
     :cvar DUMMY: Example provider
+    :cvar ABIQUO: Abiquo driver
+    :cvar ALIYUN_ECS: Aliyun ECS driver.
+    :cvar AURORACOMPUTE: Aurora Compute driver.
+    :cvar AZURE: Azure driver.
+    :cvar BLUEBOX: Bluebox
+    :cvar CLOUDSIGMA: CloudSigma
+    :cvar CLOUDSIGMA_US: CloudSigma US Las Vegas
+    :cvar CLOUDSTACK: CloudStack
+    :cvar DIMENSIONDATA: Dimension Data Cloud
+    :cvar EC2_EU_WEST: Amazon AWS EU Ireland
     :cvar EC2_US_EAST: Amazon AWS US N. Virgina
     :cvar EC2_US_WEST: Amazon AWS US N. California
-    :cvar EC2_EU_WEST: Amazon AWS EU Ireland
-    :cvar RACKSPACE: Rackspace next-gen OpenStack based Cloud Servers
-    :cvar RACKSPACE_FIRST_GEN: Rackspace First Gen Cloud Servers
+    :cvar EC2_US_WEST_OREGON: Amazon AWS US West 2 (Oregon)
+    :cvar ECP: Enomaly
+    :cvar ELASTICHOSTS: ElasticHosts.com
+    :cvar EXOSCALE: Exoscale driver.
     :cvar GCE: Google Compute Engine
     :cvar GOGRID: GoGrid
-    :cvar VPSNET: VPS.net
-    :cvar LINODE: Linode.com
-    :cvar VCLOUD: vmware vCloud
-    :cvar RIMUHOSTING: RimuHosting.com
-    :cvar ECP: Enomaly
-    :cvar IBM: IBM Developer Cloud
-    :cvar OPENNEBULA: OpenNebula.org
-    :cvar ELASTICHOSTS: ElasticHosts.com
-    :cvar CLOUDSIGMA: CloudSigma
-    :cvar NIMBUS: Nimbus
-    :cvar BLUEBOX: Bluebox
-    :cvar OPSOURCE: Opsource Cloud
-    :cvar DIMENSIONDATA: Dimension Data Cloud
-    :cvar NINEFOLD: Ninefold
-    :cvar TERREMARK: Terremark
-    :cvar EC2_US_WEST_OREGON: Amazon AWS US West 2 (Oregon)
-    :cvar CLOUDSTACK: CloudStack
-    :cvar CLOUDSIGMA_US: CloudSigma US Las Vegas
-    :cvar LIBVIRT: Libvirt driver
-    :cvar JOYENT: Joyent driver
-    :cvar VCL: VCL driver
-    :cvar KTUCLOUD: kt ucloud driver
     :cvar GRIDSPOT: Gridspot driver
-    :cvar ABIQUO: Abiquo driver
-    :cvar NEPHOSCALE: NephoScale driver
-    :cvar EXOSCALE: Exoscale driver.
+    :cvar IBM: IBM Developer Cloud
     :cvar IKOULA: Ikoula driver.
-    :cvar OUTSCALE_SAS: Outscale SAS driver.
+    :cvar JOYENT: Joyent driver
+    :cvar KTUCLOUD: kt ucloud driver
+    :cvar LIBVIRT: Libvirt driver
+    :cvar LINODE: Linode.com
+    :cvar NEPHOSCALE: NephoScale driver
+    :cvar NIMBUS: Nimbus
+    :cvar NINEFOLD: Ninefold
+    :cvar OPENNEBULA: OpenNebula.org
+    :cvar OPSOURCE: Opsource Cloud
     :cvar OUTSCALE_INC: Outscale INC driver.
+    :cvar OUTSCALE_SAS: Outscale SAS driver.
     :cvar PROFIT_BRICKS: ProfitBricks driver.
+    :cvar RACKSPACE: Rackspace next-gen OpenStack based Cloud Servers
+    :cvar RACKSPACE_FIRST_GEN: Rackspace First Gen Cloud Servers
+    :cvar RIMUHOSTING: RimuHosting.com
+    :cvar TERREMARK: Terremark
+    :cvar VCL: VCL driver
+    :cvar VCLOUD: vmware vCloud
+    :cvar VPSNET: VPS.net
     :cvar VULTR: vultr driver.
-    :cvar AZURE: Azure driver.
-    :cvar AURORACOMPUTE: Aurora Compute driver.
-    :cvar ALIYUN_ECS: Aliyun ECS driver.
     """
-    AZURE = 'azure'
     DUMMY = 'dummy'
+    ABIQUO = 'abiquo'
+    ALIYUN_ECS = 'aliyun_ecs'
+    AURORACOMPUTE = 'aurora_compute'
+    AZURE = 'azure'
+    BLUEBOX = 'bluebox'
+    BRIGHTBOX = 'brightbox'
+    BSNL = 'bsnl'
+    CISCOCCS = 'ciscoccs'
+    CLOUDFRAMES = 'cloudframes'
+    CLOUDSIGMA = 'cloudsigma'
+    CLOUDSTACK = 'cloudstack'
+    CLOUDWATT = 'cloudwatt'
+    DIGITAL_OCEAN = 'digitalocean'
+    DIMENSIONDATA = 'dimensiondata'
     EC2 = 'ec2'
-    RACKSPACE = 'rackspace'
+    ECP = 'ecp'
+    ELASTICHOSTS = 'elastichosts'
+    EUCALYPTUS = 'eucalyptus'
+    EXOSCALE = 'exoscale'
+    GANDI = 'gandi'
     GCE = 'gce'
     GOGRID = 'gogrid'
-    VPSNET = 'vpsnet'
-    LINODE = 'linode'
-    VCLOUD = 'vcloud'
-    RIMUHOSTING = 'rimuhosting'
-    VOXEL = 'voxel'
-    SOFTLAYER = 'softlayer'
-    EUCALYPTUS = 'eucalyptus'
-    ECP = 'ecp'
-    IBM = 'ibm'
-    OPENNEBULA = 'opennebula'
-    ELASTICHOSTS = 'elastichosts'
-    BRIGHTBOX = 'brightbox'
-    CLOUDSIGMA = 'cloudsigma'
-    NIMBUS = 'nimbus'
-    BLUEBOX = 'bluebox'
-    GANDI = 'gandi'
-    OPSOURCE = 'opsource'
-    DIMENSIONDATA = 'dimensiondata'
-    OPENSTACK = 'openstack'
-    SKALICLOUD = 'skalicloud'
-    SERVERLOVE = 'serverlove'
-    NINEFOLD = 'ninefold'
-    TERREMARK = 'terremark'
-    CLOUDSTACK = 'cloudstack'
-    LIBVIRT = 'libvirt'
-    JOYENT = 'joyent'
-    VCL = 'vcl'
-    KTUCLOUD = 'ktucloud'
     GRIDSPOT = 'gridspot'
-    RACKSPACE_FIRST_GEN = 'rackspace_first_gen'
     HOSTVIRTUAL = 'hostvirtual'
-    ABIQUO = 'abiquo'
-    DIGITAL_OCEAN = 'digitalocean'
-    NEPHOSCALE = 'nephoscale'
-    CLOUDFRAMES = 'cloudframes'
-    EXOSCALE = 'exoscale'
+    IBM = 'ibm'
     IKOULA = 'ikoula'
-    OUTSCALE_SAS = 'outscale_sas'
-    OUTSCALE_INC = 'outscale_inc'
-    VSPHERE = 'vsphere'
-    PROFIT_BRICKS = 'profitbricks'
-    VULTR = 'vultr'
-    AURORACOMPUTE = 'aurora_compute'
-    CLOUDWATT = 'cloudwatt'
-    PACKET = 'packet'
-    RUNABOVE = 'runabove'
-    INTERNETSOLUTIONS = 'internetsolutions'
     INDOSAT = 'indosat'
-    BSNL = 'bsnl'
-    NTTA = 'ntta'
+    INTERNETSOLUTIONS = 'internetsolutions'
+    JOYENT = 'joyent'
+    KTUCLOUD = 'ktucloud'
+    LIBVIRT = 'libvirt'
+    LINODE = 'linode'
     MEDONE = 'medone'
-    CISCOCCS = 'ciscoccs'
-    ALIYUN_ECS = 'aliyun_ecs'
+    NEPHOSCALE = 'nephoscale'
+    NIMBUS = 'nimbus'
+    NINEFOLD = 'ninefold'
+    NTTA = 'ntta'
+    OPENNEBULA = 'opennebula'
+    OPENSTACK = 'openstack'
+    OPSOURCE = 'opsource'
+    OUTSCALE_INC = 'outscale_inc'
+    OUTSCALE_SAS = 'outscale_sas'
+    PACKET = 'packet'
+    PROFIT_BRICKS = 'profitbricks'
+    RACKSPACE = 'rackspace'
+    RACKSPACE_FIRST_GEN = 'rackspace_first_gen'
+    RIMUHOSTING = 'rimuhosting'
+    RUNABOVE = 'runabove'
+    SERVERLOVE = 'serverlove'
+    SKALICLOUD = 'skalicloud'
+    SOFTLAYER = 'softlayer'
+    TERREMARK = 'terremark'
+    VCL = 'vcl'
+    VCLOUD = 'vcloud'
+    VOXEL = 'voxel'
+    VPSNET = 'vpsnet'
+    VSPHERE = 'vsphere'
+    VULTR = 'vultr'
 
     # OpenStack based providers
-    HPCLOUD = 'hpcloud'
     CLOUDWATT = 'cloudwatt'
+    HPCLOUD = 'hpcloud'
     KILI = 'kili'
     ONAPP = 'onapp'
 

--- a/libcloud/compute/types.py
+++ b/libcloud/compute/types.py
@@ -59,6 +59,9 @@ class Provider(Type):
     """
     Defines for each of the supported providers
 
+    Non-Dummy drivers are sorted in alphabetical order. Please preserve this
+    ordering when adding new drivers.
+
     :cvar DUMMY: Example provider
     :cvar ABIQUO: Abiquo driver
     :cvar ALIYUN_ECS: Aliyun ECS driver.

--- a/libcloud/container/types.py
+++ b/libcloud/container/types.py
@@ -42,8 +42,8 @@ class Type(object):
 class Provider(object):
     DUMMY = 'dummy'
     DOCKER = 'docker'
-    JOYENT = 'joyent'
     ECS = 'ecs'
+    JOYENT = 'joyent'
     KUBERNETES = 'kubernetes'
 
 

--- a/libcloud/container/types.py
+++ b/libcloud/container/types.py
@@ -40,6 +40,12 @@ class Type(object):
 
 
 class Provider(object):
+    """
+    Defines for each of the supported providers
+
+    Non-Dummy drivers are sorted in alphabetical order. Please preserve this
+    ordering when adding new drivers.
+    """
     DUMMY = 'dummy'
     DOCKER = 'docker'
     ECS = 'ecs'

--- a/libcloud/dns/types.py
+++ b/libcloud/dns/types.py
@@ -30,6 +30,12 @@ __all__ = [
 
 
 class Provider(object):
+    """
+    Defines for each of the supported providers
+
+    Non-Dummy drivers are sorted in alphabetical order. Please preserve this
+    ordering when adding new drivers.
+    """
     DUMMY = 'dummy'
     AURORADNS = 'auroradns'
     BUDDYNS = 'buddyns'

--- a/libcloud/loadbalancer/types.py
+++ b/libcloud/loadbalancer/types.py
@@ -37,16 +37,16 @@ class Provider(object):
     """
     :cvar ALIYUN_SLB: Aliyun SLB loadbalancer driver
     """
-    RACKSPACE = 'rackspace'
+    ALIYUN_SLB = 'aliyun_slb'
+    BRIGHTBOX = 'brightbox'
+    CLOUDSTACK = 'cloudstack'
+    DIMENSIONDATA = 'dimensiondata'
+    ELB = 'elb'
+    GCE = 'gce'
     GOGRID = 'gogrid'
     NINEFOLD = 'ninefold'
-    BRIGHTBOX = 'brightbox'
-    ELB = 'elb'
-    CLOUDSTACK = 'cloudstack'
-    GCE = 'gce'
+    RACKSPACE = 'rackspace'
     SOFTLAYER = 'softlayer'
-    DIMENSIONDATA = 'dimensiondata'
-    ALIYUN_SLB = 'aliyun_slb'
 
     # Deprecated
     RACKSPACE_US = 'rackspace_us'

--- a/libcloud/loadbalancer/types.py
+++ b/libcloud/loadbalancer/types.py
@@ -35,6 +35,11 @@ class LibcloudLBImmutableError(LibcloudLBError):
 
 class Provider(object):
     """
+    Defines for each of the supported providers
+
+    Non-Dummy drivers are sorted in alphabetical order. Please preserve this
+    ordering when adding new drivers.
+
     :cvar ALIYUN_SLB: Aliyun SLB loadbalancer driver
     """
     ALIYUN_SLB = 'aliyun_slb'

--- a/libcloud/storage/types.py
+++ b/libcloud/storage/types.py
@@ -34,6 +34,9 @@ class Provider(object):
     """
     Defines for each of the supported providers
 
+    Non-Dummy drivers are sorted in alphabetical order. Please preserve this
+    ordering when adding new drivers.
+
     :cvar DUMMY: Example provider
     :cvar ALIYUN_OSS: Aliyun OSS storage driver
     :cvar AURORAOBJECTS: AuroraObjects storage driver

--- a/libcloud/storage/types.py
+++ b/libcloud/storage/types.py
@@ -35,43 +35,43 @@ class Provider(object):
     Defines for each of the supported providers
 
     :cvar DUMMY: Example provider
-    :cvar CLOUDFILES: CloudFiles
-    :cvar S3: Amazon S3 US
-    :cvar S3_US_WEST: Amazon S3 US West (Northern California)
-    :cvar S3_EU_WEST: Amazon S3 EU West (Ireland)
-    :cvar S3_AP_SOUTHEAST_HOST: Amazon S3 Asia South East (Singapore)
-    :cvar S3_AP_NORTHEAST_HOST: Amazon S3 Asia South East (Tokyo)
-    :cvar S3_RGW_OUTSCALE: OUTSCALE RGW S3
-    :cvar NINEFOLD: Ninefold
-    :cvar GOOGLE_STORAGE Google Storage
-    :cvar S3_US_WEST_OREGON: Amazon S3 US West 2 (Oregon)
-    :cvar NIMBUS: Nimbus.io driver
-    :cvar LOCAL: Local storage driver
-    :cvar AURORAOBJECTS: AuroraObjects storage driver
     :cvar ALIYUN_OSS: Aliyun OSS storage driver
+    :cvar AURORAOBJECTS: AuroraObjects storage driver
+    :cvar CLOUDFILES: CloudFiles
+    :cvar GOOGLE_STORAGE Google Storage
+    :cvar LOCAL: Local storage driver
+    :cvar NIMBUS: Nimbus.io driver
+    :cvar NINEFOLD: Ninefold
+    :cvar S3: Amazon S3 US
+    :cvar S3_AP_NORTHEAST_HOST: Amazon S3 Asia South East (Tokyo)
+    :cvar S3_AP_SOUTHEAST_HOST: Amazon S3 Asia South East (Singapore)
+    :cvar S3_EU_WEST: Amazon S3 EU West (Ireland)
+    :cvar S3_RGW_OUTSCALE: OUTSCALE RGW S3
+    :cvar S3_US_WEST: Amazon S3 US West (Northern California)
+    :cvar S3_US_WEST_OREGON: Amazon S3 US West 2 (Oregon)
     """
     DUMMY = 'dummy'
+    ALIYUN_OSS = 'aliyun_oss'
+    AURORAOBJECTS = 'auroraobjects'
+    AZURE_BLOBS = 'azure_blobs'
+    BACKBLAZE_B2 = 'backblaze_b2'
+    CLOUDFILES = 'cloudfiles'
+    GOOGLE_STORAGE = 'google_storage'
+    KTUCLOUD = 'ktucloud'
+    LOCAL = 'local'
+    NIMBUS = 'nimbus'
+    NINEFOLD = 'ninefold'
+    OPENSTACK_SWIFT = 'openstack_swift'
     S3 = 's3'
-    S3_US_WEST = 's3_us_west'
-    S3_EU_WEST = 's3_eu_west'
-    S3_AP_SOUTHEAST = 's3_ap_southeast'
     S3_AP_NORTHEAST = 's3_ap_northeast'
     S3_AP_NORTHEAST1 = 's3_ap_northeast_1'
     S3_AP_NORTHEAST2 = 's3_ap_northeast_2'
-    S3_SA_EAST = 's3_sa_east'
+    S3_AP_SOUTHEAST = 's3_ap_southeast'
+    S3_EU_WEST = 's3_eu_west'
     S3_RGW_OUTSCALE = 's3_rgw_outscale'
-    NINEFOLD = 'ninefold'
-    GOOGLE_STORAGE = 'google_storage'
+    S3_SA_EAST = 's3_sa_east'
+    S3_US_WEST = 's3_us_west'
     S3_US_WEST_OREGON = 's3_us_west_oregon'
-    NIMBUS = 'nimbus'
-    LOCAL = 'local'
-    OPENSTACK_SWIFT = 'openstack_swift'
-    CLOUDFILES = 'cloudfiles'
-    AZURE_BLOBS = 'azure_blobs'
-    KTUCLOUD = 'ktucloud'
-    AURORAOBJECTS = 'auroraobjects'
-    BACKBLAZE_B2 = 'backblaze_b2'
-    ALIYUN_OSS = 'aliyun_oss'
 
     # Deperecated
     CLOUDFILES_US = 'cloudfiles_us'


### PR DESCRIPTION
By sorting the providers alphabetically, we make it less likely that each new in-progress driver will conflict with each other when merging in Git.

DNS was already sorted in #745 , so this PR sorts the `Providers` for the rest.
