### PR TITLE
Added ex_clean_failed_deployment method for Dimension Data Driver

### DIFF
--- a/libcloud/compute/drivers/dimensiondata.py
+++ b/libcloud/compute/drivers/dimensiondata.py
@@ -1831,10 +1831,14 @@ class DimensionDataNodeDriver(NodeDriver):
         Removes a node that has failed to deploy
 
         :param  node: The failed node to clean
-        :type   node: :class:`Node`
+        :type   node: :class:`Node` or ``str``
         """
+        if isinstance(node, str):
+            node_id = node
+        else:
+            node_id = node.id
         request_elm = ET.Element('cleanServer',
-                                 {'xmlns': TYPES_URN, 'id': node.id})
+                                 {'xmlns': TYPES_URN, 'id': node_id})
         body = self.connection.request_with_orgId_api_2(
             'server/cleanServer',
             method='POST',

--- a/libcloud/compute/drivers/dimensiondata.py
+++ b/libcloud/compute/drivers/dimensiondata.py
@@ -1833,10 +1833,7 @@ class DimensionDataNodeDriver(NodeDriver):
         :param  node: The failed node to clean
         :type   node: :class:`Node` or ``str``
         """
-        if isinstance(node, str):
-            node_id = node
-        else:
-            node_id = node.id
+        node_id = self._node_to_node_id(node)
         request_elm = ET.Element('cleanServer',
                                  {'xmlns': TYPES_URN, 'id': node_id})
         body = self.connection.request_with_orgId_api_2(

--- a/libcloud/compute/drivers/dimensiondata.py
+++ b/libcloud/compute/drivers/dimensiondata.py
@@ -1826,6 +1826,22 @@ class DimensionDataNodeDriver(NodeDriver):
         response_code = findtext(result, 'result', GENERAL_NS)
         return response_code in ['IN_PROGRESS', 'SUCCESS']
 
+    def ex_clean_failed_deployment(self, node):
+        """
+        Removes a node that has failed to deploy
+
+        :param  node: The failed node to clean
+        :type   node: :class:`Node`
+        """
+        request_elm = ET.Element('cleanServer',
+                                 {'xmlns': TYPES_URN, 'id': node.id})
+        body = self.connection.request_with_orgId_api_2(
+            'server/cleanServer',
+            method='POST',
+            data=ET.tostring(request_elm)).object
+        response_code = findtext(body, 'responseCode', TYPES_URN)
+        return response_code in ['IN_PROGRESS', 'OK']
+
     def ex_list_customer_images(self, location=None):
         """
         Return a list of customer imported images

--- a/libcloud/test/compute/fixtures/dimensiondata/caas_2_1_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_cleanServer.xml
+++ b/libcloud/test/compute/fixtures/dimensiondata/caas_2_1_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_cleanServer.xml
@@ -5,5 +5,5 @@ xmlns="urn:didata.com:api:cloud:types" requestId="au/2016-04-
 <operation>CLEAN_SERVER</operation>
 <responseCode>IN_PROGRESS</responseCode>
 <message>The request to clean a failed Server deployment for Server
-ee9dd854-f013-4006-89f9-d9f3f97dff57 has been accepted and is being processed.</message>
+e75ead52-692f-4314-8725-c8a4f4d13a87 has been accepted and is being processed.</message>
 </response>

--- a/libcloud/test/compute/fixtures/dimensiondata/caas_2_1_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_cleanServer.xml
+++ b/libcloud/test/compute/fixtures/dimensiondata/caas_2_1_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_cleanServer.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<response
+xmlns="urn:didata.com:api:cloud:types" requestId="au/2016-04-
+14T10:08:07.701+10:00/1cc24d5e-4612-499b-a5d4-8fd5dbb511f0">
+<operation>CLEAN_SERVER</operation>
+<responseCode>IN_PROGRESS</responseCode>
+<message>The request to clean a failed Server deployment for Server
+ee9dd854-f013-4006-89f9-d9f3f97dff57 has been accepted and is being processed.</message>
+</response>

--- a/libcloud/test/compute/test_dimensiondata.py
+++ b/libcloud/test/compute/test_dimensiondata.py
@@ -186,6 +186,12 @@ class DimensionDataTests(unittest.TestCase, TestCaseMixin):
         self.assertEqual(images[0].extra['cpu'].cpu_count, 2)
         self.assertEqual(images[0].extra['OS_displayName'], 'REDHAT6/64')
 
+    def test_clean_failed_deployment_response(self):
+        node = Node(id='11', name=None, state=None,
+                    public_ips=None, private_ips=None, driver=self.driver)
+        ret = self.driver.ex_clean_failed_deployment(node)
+        self.assertTrue(ret is True)
+
     def test_ex_list_customer_images(self):
         images = self.driver.ex_list_customer_images()
         self.assertEqual(len(images), 3)
@@ -1715,6 +1721,11 @@ class DimensionDataMockHttp(MockHttp):
             raise InvalidRequestError(request.tag)
         body = self.fixtures.load(
             'caas_2_1_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_reconfigureServer.xml')
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+
+    def _caas_2_1_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_cleanServer(self, method, url, body, headers):
+        body = self.fixtures.load(
+            'caas_2_1_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_cleanServer.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
 if __name__ == '__main__':

--- a/libcloud/test/compute/test_dimensiondata.py
+++ b/libcloud/test/compute/test_dimensiondata.py
@@ -186,9 +186,14 @@ class DimensionDataTests(unittest.TestCase, TestCaseMixin):
         self.assertEqual(images[0].extra['cpu'].cpu_count, 2)
         self.assertEqual(images[0].extra['OS_displayName'], 'REDHAT6/64')
 
-    def test_clean_failed_deployment_response(self):
+    def test_clean_failed_deployment_response_with_node(self):
         node = Node(id='11', name=None, state=None,
                     public_ips=None, private_ips=None, driver=self.driver)
+        ret = self.driver.ex_clean_failed_deployment(node)
+        self.assertTrue(ret is True)
+
+    def test_clean_failed_deployment_response_with_node_id(self):
+        node = 'e75ead52-692f-4314-8725-c8a4f4d13a87'
         ret = self.driver.ex_clean_failed_deployment(node)
         self.assertTrue(ret is True)
 


### PR DESCRIPTION
## Add ex_clean_failed_deployment to Dimension Data Driver
### Description

This method gives the ability to remove failed node deployments.  The Dimension Data API has this ability, just adding this into the libcloud driver.
### Status
- done, ready for review
### Checklist (tick everything that applies)
- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
