### PR TITLE
dns: correct spelling in update_zone() doc string

### DIFF
--- a/libcloud/dns/base.py
+++ b/libcloud/dns/base.py
@@ -285,7 +285,7 @@ class DNSDriver(BaseDriver):
 
     def update_zone(self, zone, domain, type='master', ttl=None, extra=None):
         """
-        Update en existing zone.
+        Update an existing zone.
 
         :param zone: Zone to update.
         :type  zone: :class:`Zone`

--- a/libcloud/dns/drivers/durabledns.py
+++ b/libcloud/dns/drivers/durabledns.py
@@ -397,7 +397,7 @@ class DurableDNSDriver(DNSDriver):
 
     def update_zone(self, zone, domain, type='master', ttl=None, extra=None):
         """
-        Update en existing zone.
+        Update an existing zone.
 
         :param zone: Zone to update.
         :type  zone: :class:`Zone`

--- a/libcloud/dns/drivers/pointdns.py
+++ b/libcloud/dns/drivers/pointdns.py
@@ -310,7 +310,7 @@ class PointDNSDriver(DNSDriver):
 
     def update_zone(self, zone, domain, type='master', ttl=None, extra=None):
         """
-        Update en existing zone.
+        Update an existing zone.
 
         :param zone: Zone to update.
         :type  zone: :class:`Zone`

--- a/libcloud/dns/drivers/worldwidedns.py
+++ b/libcloud/dns/drivers/worldwidedns.py
@@ -167,7 +167,7 @@ class WorldWideDNSDriver(DNSDriver):
     def update_zone(self, zone, domain, type='master', ttl=None, extra=None,
                     ex_raw=False):
         """
-        Update en existing zone.
+        Update an existing zone.
 
         :param zone: Zone to update.
         :type  zone: :class:`Zone`


### PR DESCRIPTION
Trivial change, "en" -> "an"
