### PR TITLE
[Ideas welcome] Should lxml be properly supported or removed?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ addons:
 matrix:
   fast_finish: true
   include:
+    - env: ENV=3.5-lxml
+      python: 3.5
+      before_script: TOX_ENV=py3.5-lxml
     - env: ENV=lint
       python: 2.7
       before_script: TOX_ENV=lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,30 @@ addons:
 matrix:
   fast_finish: true
   include:
+    - env: ENV=2.6-lxml
+      python: 2.6
+      before_script: TOX_ENV=py2.6-lxml
+    - env: ENV=2.7-lxml
+      python: 2.7
+      before_script: TOX_ENV=py2.7-lxml
+    - env: ENV=3.2-lxml
+      python: 3.2
+      before_script: TOX_ENV=py3.2-lxml
+    - env: ENV=3.3-lxml
+      python: 3.3
+      before_script: TOX_ENV=py3.3-lxml
+    - env: ENV=3.4-lxml
+      python: 3.4
+      before_script: TOX_ENV=py3.4-lxml
     - env: ENV=3.5-lxml
       python: 3.5
       before_script: TOX_ENV=py3.5-lxml
+    - env: ENV=pypy-lxml
+      python: pypy
+      before_script: TOX_ENV=pypypy-lxml
+    - env: ENV=pypy3-lxml
+      python: pypy3
+      before_script: TOX_ENV=pypypy3-lxml
     - env: ENV=lint
       python: 2.7
       before_script: TOX_ENV=lint

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{2.5,2.6,2.7,pypy,pypy3,3.2,3.3,3.4,3.5},py3.5-lxml,lint
+envlist = py{2.5,2.6,2.7,pypy,pypy3,3.2,3.3,3.4,3.5},py{2.5,2.6,2.7,pypy,pypy3,3.2,3.3,3.4,3.5}-lxml,lint
 
 [testenv]
 deps =
@@ -21,7 +21,7 @@ basepython =
     py3.5: python3.5
 whitelist_externals = cp
 
-[testenv:py3.5-lxml]
+[testenv:py{2.5,2.6,2.7,pypy,pypy3,3.2,3.3,3.4,3.5}-lxml]
 deps = -r{toxinidir}/requirements-tests.txt
        lxml
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{2.5,2.6,2.7,pypy,pypy3,3.2,3.3,3.4,3.5},lint
+envlist = py{2.5,2.6,2.7,pypy,pypy3,3.2,3.3,3.4,3.5},py3.5-lxml,lint
 
 [testenv]
 deps =
@@ -20,6 +20,10 @@ basepython =
     py3.4: python3.4
     py3.5: python3.5
 whitelist_externals = cp
+
+[testenv:py3.5-lxml]
+deps = -r{toxinidir}/requirements-tests.txt
+       lxml
 
 [testenv:docs]
 deps = sphinx

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,34 @@ basepython =
     py3.5: python3.5
 whitelist_externals = cp
 
-[testenv:py{2.5,2.6,2.7,pypy,pypy3,3.2,3.3,3.4,3.5}-lxml]
+# Explicitly spell out all environments to test with builtin xml and lxml,
+# as it seems I can't use the following:
+# [testenv:py{2.5,2.6,2.7,pypy,pypy3,3.2,3.3,3.4,3.5}-lxml]
+[testenv:py2.5-lxml]
+deps = -r{toxinidir}/requirements-tests.txt
+       lxml
+[testenv:py2.6-lxml]
+deps = -r{toxinidir}/requirements-tests.txt
+       lxml
+[testenv:py2.7-lxml]
+deps = -r{toxinidir}/requirements-tests.txt
+       lxml
+[testenv:pypypy-lxml]
+deps = -r{toxinidir}/requirements-tests.txt
+       lxml
+[testenv:pypypy3-lxml]
+deps = -r{toxinidir}/requirements-tests.txt
+       lxml
+[testenv:py3.2-lxml]
+deps = -r{toxinidir}/requirements-tests.txt
+       lxml
+[testenv:py3.3-lxml]
+deps = -r{toxinidir}/requirements-tests.txt
+       lxml
+[testenv:py3.4-lxml]
+deps = -r{toxinidir}/requirements-tests.txt
+       lxml
+[testenv:py3.5-lxml]
 deps = -r{toxinidir}/requirements-tests.txt
        lxml
 


### PR DESCRIPTION
## lxml if present causes many errors
### Description

This PR asks the question - is [lxml](http://lxml.de/) supported as part of libcloud? Should it be?

So far it has found little evidence lxml is in practice supported, and real-world errors if lxml is present.
Known to affect some real-world AWS S3 cases, and probably lots of other drivers based on the tests which detect 52 errors (Py2.7) and 595 errors (Py3.5). 

Unfortunately [lxml](http://lxml.de/) often sneaks its way into real-world virtual environments via dependencies such as [premailer](https://github.com/peterbe/premailer) so removing it entirely from a solution as a workaround would often be difficult to do in practice.

It would be appreciated if libcloud's authors made a decision about whether to drop lxml in places like this one [here](https://github.com/apache/libcloud/blob/v1.0.0-rc2/libcloud/backup/drivers/dimensiondata.py#L16-L19), or whether the time should be taken to properly support both Python's builtin `xml` module, and `lxml`.

See also https://github.com/apache/libcloud/commit/0619c9257556b52794f3a2f70760abc01798faf5
### Status
- work in progress, ideas and suggestions on how to fix this would be welcome
### History

Original script that triggered the discovery:

```
from libcloud.storage.types import ObjectDoesNotExistError, Provider
from libcloud.storage.providers import get_driver
driver_cls = get_driver(Provider.S3_US_WEST)
# Get keys from following
# http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html
driver = driver_cls('your_access_key','your_secret_key')
driver.list_containers()
```

Results in **MalformedResponseError**

```
# Note: Added some whitespace for readability and redacted some possibly sensitive info
MalformedResponseError: <MalformedResponseException in <libcloud.storage.drivers.s3.S3USWestStorageDriver object at 0x10856e128> 'Failed to parse XML'>:
'<?xml version="1.0" encoding="UTF-8"?>
<ListAllMyBucketsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
<Owner>
    <ID>redacted</ID>
    <DisplayName>redacted</DisplayName>
</Owner>
<Buckets>
    <Bucket><Name>redacted</Name><CreationDate>2011-06-23T16:49:03.000Z</CreationDate></Bucket>
    <Bucket><Name>redacted</Name><CreationDate>2016-04-14T06:49:08.000Z</CreationDate></Bucket>
    <Bucket><Name>redacted</Name><CreationDate>2011-06-24T06:57:52.000Z</CreationDate></Bucket>
</Buckets>
</ListAllMyBucketsResult>'
```
### Checklist (tick everything that applies)

WIP
- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
