### PR TITLE
Run tests with lxml on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ addons:
 matrix:
   fast_finish: true
   include:
+    - env: ENV=3.5-lxml
+      python: 3.5
+      before_script: TOX_ENV=py3.5-lxml
     - env: ENV=lint
       python: 2.7
       before_script: TOX_ENV=lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,11 +60,11 @@ matrix:
             - gcc
   # For now allow failures of all the builds which use lxml
   allow_failures:
-    - env: ENV=py2.6-lxml
-    - env: ENV=py2.7-lxml
-    - env: ENV=pypypy-lxml
-    - env: ENV=pypypy3-lxml
-    - env: ENV=3.2-lxml
+    - env: ENV=2.6-lxml
+    - env: ENV=2.7-lxml
+    - env: ENV=pypy-lxml
+    - env: ENV=pypy3-lxml
+    - env: ENV=py3.2-lxml
     - env: ENV=3.3-lxml
     - env: ENV=3.4-lxml
     - env: ENV=3.5-lxml

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,14 +60,14 @@ matrix:
             - gcc
   # For now allow failures of all the builds which use lxml
   allow_failures:
-    - env: TASK=py2.6-lxml
-    - env: TASK=py2.7-lxml
-    - env: TASK=pypypy-lxml
-    - env: TASK=pypypy3-lxml
-    - env: TASK=3.2-lxml
-    - env: TASK=3.3-lxml
-    - env: TASK=3.4-lxml
-    - env: TASK=3.5-lxml
+    - env: TOX_ENV=py2.6-lxml
+    - env: TOX_ENV=py2.7-lxml
+    - env: TOX_ENV=pypypy-lxml
+    - env: TOX_ENV=pypypy3-lxml
+    - env: TOX_ENV=3.2-lxml
+    - env: TOX_ENV=3.3-lxml
+    - env: TOX_ENV=3.4-lxml
+    - env: TOX_ENV=3.5-lxml
       # Trigger ReadTheDocs build
       after_success: ./contrib/trigger_rtd_build.py 8284
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,30 @@ addons:
 matrix:
   fast_finish: true
   include:
+    - env: ENV=2.6-lxml
+      python: 2.6
+      before_script: TOX_ENV=py2.6-lxml
+    - env: ENV=2.7-lxml
+      python: 2.7
+      before_script: TOX_ENV=py2.7-lxml
+    - env: ENV=3.2-lxml
+      python: 3.2
+      before_script: TOX_ENV=py3.2-lxml
+    - env: ENV=3.3-lxml
+      python: 3.3
+      before_script: TOX_ENV=py3.3-lxml
+    - env: ENV=3.4-lxml
+      python: 3.4
+      before_script: TOX_ENV=py3.4-lxml
     - env: ENV=3.5-lxml
       python: 3.5
       before_script: TOX_ENV=py3.5-lxml
+    - env: ENV=pypy-lxml
+      python: pypy
+      before_script: TOX_ENV=pypypy-lxml
+    - env: ENV=pypy3-lxml
+      python: pypy3
+      before_script: TOX_ENV=pypypy3-lxml
     - env: ENV=lint
       python: 2.7
       before_script: TOX_ENV=lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,14 +60,14 @@ matrix:
             - gcc
   # For now allow failures of all the builds which use lxml
   allow_failures:
-    - env: TOX_ENV=py2.6-lxml
-    - env: TOX_ENV=py2.7-lxml
-    - env: TOX_ENV=pypypy-lxml
-    - env: TOX_ENV=pypypy3-lxml
-    - env: TOX_ENV=3.2-lxml
-    - env: TOX_ENV=3.3-lxml
-    - env: TOX_ENV=3.4-lxml
-    - env: TOX_ENV=3.5-lxml
+    - env: ENV=py2.6-lxml
+    - env: ENV=py2.7-lxml
+    - env: ENV=pypypy-lxml
+    - env: ENV=pypypy3-lxml
+    - env: ENV=3.2-lxml
+    - env: ENV=3.3-lxml
+    - env: ENV=3.4-lxml
+    - env: ENV=3.5-lxml
       # Trigger ReadTheDocs build
       after_success: ./contrib/trigger_rtd_build.py 8284
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,16 @@ matrix:
           packages:
             - graphviz
             - gcc
+  # For now allow failures of all the builds which use lxml
+  allow_failures:
+    - env: TASK=py2.6-lxml
+    - env: TASK=py2.7-lxml
+    - env: TASK=pypypy-lxml
+    - env: TASK=pypypy3-lxml
+    - env: TASK=3.2-lxml
+    - env: TASK=3.3-lxml
+    - env: TASK=3.4-lxml
+    - env: TASK=3.5-lxml
       # Trigger ReadTheDocs build
       after_success: ./contrib/trigger_rtd_build.py 8284
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,7 @@ matrix:
     - env: ENV=pypy-lxml
     - env: ENV=pypy3-lxml
     - env: ENV=py3.2-lxml
+    - env: ENV=3.2-lxml
     - env: ENV=3.3-lxml
     - env: ENV=3.4-lxml
     - env: ENV=3.5-lxml

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{2.5,2.6,2.7,pypy,pypy3,3.2,3.3,3.4,3.5},py3.5-lxml,lint
+envlist = py{2.5,2.6,2.7,pypy,pypy3,3.2,3.3,3.4,3.5},py{2.5,2.6,2.7,pypy,pypy3,3.2,3.3,3.4,3.5}-lxml,lint
 
 [testenv]
 deps =
@@ -21,7 +21,7 @@ basepython =
     py3.5: python3.5
 whitelist_externals = cp
 
-[testenv:py3.5-lxml]
+[testenv:py{2.5,2.6,2.7,pypy,pypy3,3.2,3.3,3.4,3.5}-lxml]
 deps = -r{toxinidir}/requirements-tests.txt
        lxml
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{2.5,2.6,2.7,pypy,pypy3,3.2,3.3,3.4,3.5},py{2.5,2.6,2.7,pypy,pypy3,3.2,3.3,3.4,3.5}-lxml,lint
+envlist = py{2.5,2.6,2.7,pypy,pypy3,3.2,3.3,3.4,3.5},lint
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{2.5,2.6,2.7,pypy,pypy3,3.2,3.3,3.4,3.5},lint
+envlist = py{2.5,2.6,2.7,pypy,pypy3,3.2,3.3,3.4,3.5},py3.5-lxml,lint
 
 [testenv]
 deps =
@@ -20,6 +20,10 @@ basepython =
     py3.4: python3.4
     py3.5: python3.5
 whitelist_externals = cp
+
+[testenv:py3.5-lxml]
+deps = -r{toxinidir}/requirements-tests.txt
+       lxml
 
 [testenv:docs]
 deps = sphinx

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,34 @@ basepython =
     py3.5: python3.5
 whitelist_externals = cp
 
-[testenv:py{2.5,2.6,2.7,pypy,pypy3,3.2,3.3,3.4,3.5}-lxml]
+# Explicitly spell out all environments to test with builtin xml and lxml,
+# as it seems I can't use the following:
+# [testenv:py{2.5,2.6,2.7,pypy,pypy3,3.2,3.3,3.4,3.5}-lxml]
+[testenv:py2.5-lxml]
+deps = -r{toxinidir}/requirements-tests.txt
+       lxml
+[testenv:py2.6-lxml]
+deps = -r{toxinidir}/requirements-tests.txt
+       lxml
+[testenv:py2.7-lxml]
+deps = -r{toxinidir}/requirements-tests.txt
+       lxml
+[testenv:pypypy-lxml]
+deps = -r{toxinidir}/requirements-tests.txt
+       lxml
+[testenv:pypypy3-lxml]
+deps = -r{toxinidir}/requirements-tests.txt
+       lxml
+[testenv:py3.2-lxml]
+deps = -r{toxinidir}/requirements-tests.txt
+       lxml
+[testenv:py3.3-lxml]
+deps = -r{toxinidir}/requirements-tests.txt
+       lxml
+[testenv:py3.4-lxml]
+deps = -r{toxinidir}/requirements-tests.txt
+       lxml
+[testenv:py3.5-lxml]
 deps = -r{toxinidir}/requirements-tests.txt
        lxml
 

--- a/tox.ini
+++ b/tox.ini
@@ -26,9 +26,13 @@ whitelist_externals = cp
 # [testenv:py{2.5,2.6,2.7,pypy,pypy3,3.2,3.3,3.4,3.5}-lxml]
 [testenv:py2.5-lxml]
 deps = -r{toxinidir}/requirements-tests.txt
+       unittest2
+       paramiko
        lxml
 [testenv:py2.6-lxml]
 deps = -r{toxinidir}/requirements-tests.txt
+       unittest2
+       paramiko
        lxml
 [testenv:py2.7-lxml]
 deps = -r{toxinidir}/requirements-tests.txt


### PR DESCRIPTION
This pull request builds on top of #762 (thanks!).

That PR indicated that using lxml is broken in some scenarios so first step should be to get  tests to run with lxml on Travis.

Right now those tests are failing in some cases, but I marked them as allowed to fail on Travis so they won't cause the whole build to fail.
