### PR TITLE
PY3: Change libcloud.common.base.Response.body from str to bytes type

### DIFF
--- a/libcloud/common/base.py
+++ b/libcloud/common/base.py
@@ -170,9 +170,6 @@ class Response(object):
             self.body = self._decompress_response(body=response.read(),
                                                   headers=self.headers)
 
-        if PY3:
-            self.body = b(self.body).decode('utf-8')
-
         if not self.success():
             raise exception_from_message(code=self.status,
                                          message=self.parse_error(),

--- a/libcloud/test/test_response_classes.py
+++ b/libcloud/test/test_response_classes.py
@@ -91,7 +91,7 @@ class ResponseClassesTests(unittest.TestCase):
         self.assertEqual(parsed, '')
 
     def test_deflate_encoding(self):
-        original_data = 'foo bar ponies, wooo zlib'
+        original_data = b'foo bar ponies, wooo zlib'
         compressed_data = zlib.compress(b(original_data))
 
         self._mock_response.read.return_value = compressed_data
@@ -114,7 +114,7 @@ class ResponseClassesTests(unittest.TestCase):
         self.assertEqual(body, original_data)
 
     def test_gzip_encoding(self):
-        original_data = 'foo bar ponies, wooo gzip'
+        original_data = b'foo bar ponies, wooo gzip'
 
         if PY3:
             from io import BytesIO


### PR DESCRIPTION
## PY3: Change libcloud.common.base.Response.body from str to bytes type
### Description

Let's at least fix the case where if `lxml` is present, AWS S3 `driver.list_containers()` raises a `MalformedResponseError` in normal operation, and roll forward as we discover other things that actually need fixing, i.e. 

```
import this
...
Although practicality beats purity.
```

See also #762
### Status
- done, ready for review (I'm sure someone will let me know if it needs more testing in light of #762)
### Checklist (tick everything that applies)
- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
