### PR TITLE
PY3: Reduce AWS S3 test errors if lxml is present

### DIFF
--- a/libcloud/common/base.py
+++ b/libcloud/common/base.py
@@ -270,7 +270,11 @@ class XmlResponse(Response):
             return self.body
 
         try:
-            body = ET.XML(self.body)
+            try:
+                body = ET.XML(self.body)
+            except ValueError:
+                # lxml wants a bytes and tests are basically hard-coded to str
+                body = ET.XML(self.body.encode('utf-8'))
         except:
             raise MalformedResponseError('Failed to parse XML',
                                          body=self.body,

--- a/libcloud/test/storage/test_s3.py
+++ b/libcloud/test/storage/test_s3.py
@@ -338,7 +338,11 @@ class S3MockRawResponse(MockRawResponse):
             return self.body
 
         try:
-            body = ET.XML(self.body)
+            try:
+                body = ET.XML(self.body)
+            except ValueError:
+                # lxml wants a bytes and tests are basically hard-coded to str
+                body = ET.XML(self.body.encode('utf-8'))
         except:
             raise MalformedResponseError("Failed to parse XML",
                                          body=self.body,


### PR DESCRIPTION
## PY3: Reduce AWS S3 test errors if lxml is present
### Description

This fixes the AWS S3 `driver.list_containers()` error described in #762 and #767, among others, e.g. 

```
# Now passes completely if lxml is present
$ PYTHONPATH=. python libcloud/test/storage/test_s3.py
----------------------------------------------------------------------
Ran 192 tests in 0.480s

OK
```

At least lxml should raise `ValueError` pretty quickly if `Response.body` is a `str` type, and it was almost certainly assumed to be `'utf-8'`, this being the web, so we'll pay the price of the decode & encode on the production happy path to get a probable overall speedup from lxml. http://lxml.de/performance.html

Seems cleaner than alternate approaches like trying to inject an additional `Response.content` attribute to work with the Python 3 bytes type or changing the `response.body` to a `bytes` type (causes thousands of JSON tests to break). e.g. See https://github.com/apache/libcloud/pull/767

I don't have an aliyun.py, etc driver to test against so don't feel comfortable changing that though happy for others to do so.

In my local Python 3.5+lxml virtualenv, running "python setup.py test", which hopefully Travis will confirm:

```
BEFORE
----------------------------------------------------------------------
Ran 5439 tests in 24.415s

FAILED (failures=4, errors=595, skipped=14)

AFTER
----------------------------------------------------------------------
Ran 5439 tests in 27.036s

FAILED (failures=4, errors=176, skipped=14)
```
### Status
- done, ready for review
### Checklist (tick everything that applies)
- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
