### PR TITLE
Add default cert-CA path for SuSE based distributions

### DIFF
--- a/libcloud/security.py
+++ b/libcloud/security.py
@@ -56,6 +56,9 @@ CA_CERTS_PATH = [
 
     # homebrew: curl-ca-bundle (backward compatibility)
     '/usr/local/opt/curl-ca-bundle/share/ca-bundle.crt',
+
+    # opensuse/sles: openssl
+    '/etc/ssl/certs/YaST-CA.pem',
 ]
 
 # Allow user to explicitly specify which CA bundle to use, using an environment


### PR DESCRIPTION
## Add default cert-CA path for SuSE based distributions
### Description

Refer to https://github.com/saltstack/salt/issues/32743 on details for the issue
### Checklist (tick everything that applies)
- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
