### PR TITLE
Fix most Python 2 lxml tests

### DIFF
--- a/libcloud/compute/drivers/abiquo.py
+++ b/libcloud/compute/drivers/abiquo.py
@@ -20,7 +20,10 @@ This version is compatible with the following versions of Abiquo:
 
     * Abiquo 3.1 (http://wiki.abiquo.com/display/ABI31/The+Abiquo+API)
 """
-import xml.etree.ElementTree as ET
+try:
+    from lxml import etree as ET
+except ImportError:
+    from xml.etree import ElementTree as ET
 
 from libcloud.compute.base import NodeDriver, NodeSize
 from libcloud.compute.types import Provider, LibcloudError

--- a/libcloud/storage/drivers/azure_blobs.py
+++ b/libcloud/storage/drivers/azure_blobs.py
@@ -19,7 +19,10 @@ import base64
 import os
 import binascii
 
-from xml.etree.ElementTree import Element, SubElement
+try:
+    from lxml import etree as ET
+except ImportError:
+    from xml.etree import ElementTree as ET
 
 from libcloud.utils.py3 import PY3
 from libcloud.utils.py3 import httplib
@@ -693,10 +696,10 @@ class AzureBlobsStorageDriver(StorageDriver):
         :type upload_id: ``list``
         """
 
-        root = Element('BlockList')
+        root = ET.Element('BlockList')
 
         for block_id in chunks:
-            part = SubElement(root, 'Uncommitted')
+            part = ET.SubElement(root, 'Uncommitted')
             part.text = str(block_id)
 
         data = tostring(root)


### PR DESCRIPTION
## Fix libcloud + lxml tests under Python 2.x (ex. vcloud)
### Description

Travis will hopefully confirm this improves the Python 2.x lxml tests from:
`FAILED (failures=1, errors=52, skipped=14)`
To:
`FAILED (failures=1, errors=9, skipped=14)`

I spent an hour trying to understand VCloud's XML builder but it's just a bit complicated for me at this time, which is all that's left to fix under Python 2.7 for me at least. If I can make time to figure it out I'll create another PR.
#### Context

Hopefully #769 gets a better chance of going through or getting some feedback so Mathspace isn't forced to switch to boto3, this being our third cloud provider in the last year (long story) which theoretically at least makes sticking with libcloud very attractive as long as we can get it working under Python 3, preferably without forking it.
### Status
- done, ready for review
### Checklist (tick everything that applies)
- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
