### PR TITLE
Fix gce_demo for loadbalancing and Python 3

### DIFF
--- a/demos/gce_demo.py
+++ b/demos/gce_demo.py
@@ -553,7 +553,7 @@ def main_load_balancer():
     name = '%s-firewall' % DEMO_BASE_NAME
     allowed = [{'IPProtocol': 'tcp',
                 'ports': ['80']}]
-    firewall = gce.ex_create_firewall(name, allowed, source_tags=[tag])
+    firewall = gce.ex_create_firewall(name, allowed, target_tags=[tag])
     display('    Firewall %s created' % firewall.name)
 
     # == Create a Health Check ==
@@ -634,7 +634,7 @@ def main_load_balancer():
         sys.stdout.flush()
         time.sleep(.25)
 
-    print ""
+    print('')
     if CLEANUP:
         balancers = gcelb.list_balancers()
         healthchecks = gcelb.ex_list_healthchecks()


### PR DESCRIPTION
## Fix gce_demo.py for load balancing and Python 3
### Description

Firewall for load balancing needs target tags set instead of source tags.
The 'print' statement was causing this code to not run in Python 3.x.
### Status
- done, ready for review
### Checklist (tick everything that applies)
- [X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [NA] Documentation
- [NA] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [X] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
