### PR TITLE
Add support for Google Compute Engine Image Families

### DIFF
--- a/libcloud/test/compute/fixtures/gce/global_images_family_notfound.json
+++ b/libcloud/test/compute/fixtures/gce/global_images_family_notfound.json
@@ -1,0 +1,13 @@
+{
+  "error": {
+    "code": 404,
+    "errors": [
+      {
+        "domain": "global",
+        "message": "The resource 'projects/project-name/global/images/family/coreos' was not found",
+        "reason": "notFound"
+      }
+    ],
+    "message": "The resource 'projects/project-name/global/images/family/coreos' was not found"
+  }
+}

--- a/libcloud/test/compute/fixtures/gce/projects_coreos-cloud_global_images_family_coreos.json
+++ b/libcloud/test/compute/fixtures/gce/projects_coreos-cloud_global_images_family_coreos.json
@@ -1,0 +1,17 @@
+{
+ "kind": "compute#image",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-beta-522-3-0-v20141226",
+ "id": "14171939663085407486",
+ "creationTimestamp": "2014-12-26T15:04:01.237-08:00",
+ "name": "coreos-beta-522-3-0-v20141226",
+ "description": "CoreOS beta 522.3.0",
+ "family": "coreos",
+ "sourceType": "RAW",
+ "rawDisk": {
+  "source": "",
+  "containerType": "TAR"
+ },
+ "status": "READY",
+ "archiveSizeBytes": "220932284",
+ "diskSizeGb": "9"
+}


### PR DESCRIPTION
## Support for Google Compute Engine Image Families
### Description

Google Compute Engine has a new feature that allows one to specify an image using a "family". This will return the latest, non-deprecated image that has been created in the given project with that family attribute. This change adds support for using an image family in create_node and create_volume as well as a new method ex_get_image_from_family that will return an image resource from a family name.
### Status
- done, ready for review
### Checklist (tick everything that applies)
- [X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [X] Documentation
- [X] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [X] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)

Lint is clean for the changes, the changes have nearly 100% test coverage, and docstrings have been updated appropriately.
