### PR TITLE
[google compute] Add support for subnetworks

### DIFF
--- a/demos/gce_demo.py
+++ b/demos/gce_demo.py
@@ -270,7 +270,6 @@ def clean_up(gce, base_name, node_list=None, resource_list=None):
                 raise
 
 
-# ==== COMPUTE CODE STARTS HERE ====
 def main_compute():
     start_time = datetime.datetime.now()
     display('Compute demo/test start time: %s' % str(start_time))
@@ -300,6 +299,9 @@ def main_compute():
     firewalls = gce.ex_list_firewalls()
     display('Firewalls:', firewalls)
 
+    subnetworks = gce.ex_list_subnetworks()
+    display('Subnetworks:', subnetworks)
+
     networks = gce.ex_list_networks()
     display('Networks:', networks)
 
@@ -317,8 +319,78 @@ def main_compute():
 
     # == Clean up any old demo resources ==
     display('Cleaning up any "%s" resources' % DEMO_BASE_NAME)
+    # Delete subnetworks first, networks last
+    clean_up(gce, DEMO_BASE_NAME, None, subnetworks)
     clean_up(gce, DEMO_BASE_NAME, all_nodes,
-             all_addresses + all_volumes + firewalls + networks + snapshots)
+             all_addresses + all_volumes + firewalls + snapshots + networks)
+
+    # == Create a Legacy Network ==
+    display('Creating Legacy Network:')
+    name = '%s-legacy-network' % DEMO_BASE_NAME
+    cidr = '10.10.0.0/16'
+    network_legacy = gce.ex_create_network(name, cidr)
+    display('  Network %s created' % name)
+
+    # == Delete the Legacy Network ==
+    display('Delete Legacy Network:')
+    network_legacy.destroy()
+    display('  Network %s delete' % name)
+
+    # == Create an auto network ==
+    display('Creating Auto Network:')
+    name = '%s-auto-network' % DEMO_BASE_NAME
+    network_auto = gce.ex_create_network(name, cidr=None, mode='auto')
+    display('  AutoNetwork %s created' % network_auto.name)
+
+    # == Display subnetworks from the auto network ==
+    subnets = []
+    for sn in network_auto.subnetworks:
+        subnets.append(gce.ex_get_subnetwork(sn))
+    display('Display subnetworks:', subnets)
+
+    # == Delete the auto network ==
+    display('Delete Auto Network:')
+    network_auto.destroy()
+    display('  AutoNetwork %s deleted' % name)
+
+    # == Create an custom network ==
+    display('Creating Custom Network:')
+    name = '%s-custom-network' % DEMO_BASE_NAME
+    network_custom = gce.ex_create_network(name, cidr=None, mode='custom')
+    display('  Custom Network %s created' % network_custom.name)
+
+    # == Create a subnetwork ==
+    display('Creating Subnetwork:')
+    sname = '%s-subnetwork' % DEMO_BASE_NAME
+    region = 'us-central1'
+    cidr = '192.168.17.0/24'
+    subnet = gce.ex_create_subnetwork(sname, cidr, network_custom, region)
+    display('  Subnetwork %s created' % subnet.name)
+    # Refresh object, now that it has a subnet
+    network_custom = gce.ex_get_network(name)
+
+    # == Display subnetworks from the auto network ==
+    subnets = []
+    for sn in network_custom.subnetworks:
+        subnets.append(gce.ex_get_subnetwork(sn))
+    display('Display custom subnetworks:', subnets)
+
+    # == Delete an subnetwork ==
+    display('Delete Custom Subnetwork:')
+    subnet.destroy()
+    display('  Custom Subnetwork %s deleted' % sname)
+    is_deleted = False
+    while not is_deleted:
+        time.sleep(3)
+        try:
+            subnet = gce.ex_get_subnetwork(sname, region)
+        except ResourceNotFoundError:
+            is_deleted = True
+
+    # == Delete the auto network ==
+    display('Delete Custom Network:')
+    network_custom.destroy()
+    display('  Custom Network %s deleted' % name)
 
     # == Create Node with disk auto-created ==
     if MAX_NODES > 1:
@@ -480,6 +552,9 @@ def main_compute():
     firewalls = gce.ex_list_firewalls()
     display('Firewalls:', firewalls)
 
+    subnetworks = gce.ex_list_subnetworks()
+    display('Subnetworks:', subnetworks)
+
     networks = gce.ex_list_networks()
     display('Networks:', networks)
 
@@ -488,8 +563,9 @@ def main_compute():
 
     if CLEANUP:
         display('Cleaning up %s resources created' % DEMO_BASE_NAME)
+        clean_up(gce, DEMO_BASE_NAME, None, subnetworks)
         clean_up(gce, DEMO_BASE_NAME, nodes,
-                 addresses + firewalls + networks + snapshots)
+                 addresses + firewalls + snapshots + networks)
         volumes = gce.list_volumes()
         clean_up(gce, DEMO_BASE_NAME, None, volumes)
     end_time = datetime.datetime.now()

--- a/libcloud/test/compute/fixtures/gce/aggregated_subnetworks.json
+++ b/libcloud/test/compute/fixtures/gce/aggregated_subnetworks.json
@@ -1,0 +1,66 @@
+{
+ "kind": "compute#subnetworkAggregatedList",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/aggregated/subnetworks",
+ "items": {
+  "regions/us-central1": {
+   "subnetworks": [
+    {
+     "kind": "compute#subnetwork",
+     "id": "4297043163355844284",
+     "creationTimestamp": "2016-03-25T05:34:27.209-07:00",
+     "gatewayAddress": "10.128.0.1",
+     "name": "cf-972cf02e6ad49112",
+     "network": "https://www.googleapis.com/compute/v1/projects/project_name/global/networks/cf",
+     "ipCidrRange": "10.128.0.0/20",
+     "region": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1",
+     "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1/subnetworks/cf-972cf02e6ad49112"
+    }
+   ]
+  },
+  "regions/europe-west1": {
+   "subnetworks": [
+    {
+     "kind": "compute#subnetwork",
+     "id": "447043451408125628",
+     "creationTimestamp": "2016-03-25T05:34:27.272-07:00",
+     "gatewayAddress": "10.132.0.1",
+     "name": "cf-df1837b06a6f927b",
+     "network": "https://www.googleapis.com/compute/v1/projects/project_name/global/networks/cf",
+     "ipCidrRange": "10.132.0.0/20",
+     "region": "https://www.googleapis.com/compute/v1/projects/project_name/regions/europe-west1",
+     "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/regions/europe-west1/subnetworks/cf-df1837b06a6f927b"
+    }
+   ]
+  },
+  "regions/asia-east1": {
+   "subnetworks": [
+    {
+     "kind": "compute#subnetwork",
+     "id": "1240429769038270140",
+     "creationTimestamp": "2016-03-25T05:34:27.413-07:00",
+     "gatewayAddress": "10.140.0.1",
+     "name": "cf-4c2da366a0381eb9",
+     "network": "https://www.googleapis.com/compute/v1/projects/project_name/global/networks/cf",
+     "ipCidrRange": "10.140.0.0/20",
+     "region": "https://www.googleapis.com/compute/v1/projects/project_name/regions/asia-east1",
+     "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/regions/asia-east1/subnetworks/cf-4c2da366a0381eb9"
+    }
+   ]
+  },
+  "regions/us-east1": {
+   "subnetworks": [
+    {
+     "kind": "compute#subnetwork",
+     "id": "648244394139881148",
+     "creationTimestamp": "2016-03-25T05:34:27.475-07:00",
+     "gatewayAddress": "10.142.0.1",
+     "name": "cf-daf1e2124a902a47",
+     "network": "https://www.googleapis.com/compute/v1/projects/project_name/global/networks/cf",
+     "ipCidrRange": "10.142.0.0/20",
+     "region": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-east1",
+     "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-east1/subnetworks/cf-daf1e2124a902a47"
+    }
+   ]
+  }
+ }
+}

--- a/libcloud/test/compute/fixtures/gce/global_networks.json
+++ b/libcloud/test/compute/fixtures/gce/global_networks.json
@@ -1,34 +1,43 @@
 {
-  "id": "projects/project_name/global/networks",
-  "items": [
-    {
-      "IPv4Range": "10.240.0.0/16",
-      "creationTimestamp": "2013-06-19T12:37:13.233-07:00",
-      "gatewayIPv4": "10.240.0.1",
-      "id": "08257021638942464470",
-      "kind": "compute#network",
-      "name": "default",
-      "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/networks/default"
-    },
-    {
-      "IPv4Range": "10.10.0.0/16",
-      "creationTimestamp": "2013-06-26T09:51:34.018-07:00",
-      "gatewayIPv4": "10.10.0.1",
-      "id": "13254259054875092094",
-      "kind": "compute#network",
-      "name": "libcloud-demo-europe-network",
-      "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/networks/libcloud-demo-europe-network"
-    },
-    {
-      "IPv4Range": "10.10.0.0/16",
-      "creationTimestamp": "2013-06-26T09:48:15.703-07:00",
-      "gatewayIPv4": "10.10.0.1",
-      "id": "17172579178188075621",
-      "kind": "compute#network",
-      "name": "libcloud-demo-network",
-      "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/networks/libcloud-demo-network"
-    }
-  ],
-  "kind": "compute#networkList",
-  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/networks"
+ "kind": "compute#networkList",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/networks",
+ "id": "projects/project_name/global/networks",
+ "items": [
+  {
+   "kind": "compute#network",
+   "id": "5125152985904090792",
+   "creationTimestamp": "2016-03-25T05:34:15.077-07:00",
+   "name": "cf",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/networks/cf",
+   "autoCreateSubnetworks": true,
+   "subnetworks": [
+    "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1/subnetworks/cf-972cf02e6ad49112",
+    "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-east1/subnetworks/cf-daf1e2124a902a47",
+    "https://www.googleapis.com/compute/v1/projects/project_name/regions/asia-east1/subnetworks/cf-4c2da366a0381eb9",
+    "https://www.googleapis.com/compute/v1/projects/project_name/regions/europe-west1/subnetworks/cf-df1837b06a6f927b"
+   ]
+  },
+  {
+   "kind": "compute#network",
+   "id": "7887441312352916157",
+   "creationTimestamp": "2016-04-30T10:33:06.252-07:00",
+   "name": "custom",
+   "description": "Custom network",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/networks/custom",
+   "autoCreateSubnetworks": false,
+   "subnetworks": [
+    "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1/subnetworks/subnet1"
+   ]
+  },
+  {
+   "kind": "compute#network",
+   "id": "2672023774255449680",
+   "creationTimestamp": "2014-01-21T10:30:55.392-08:00",
+   "name": "default",
+   "description": "Default network for the project",
+   "IPv4Range": "10.240.0.0/16",
+   "gatewayIPv4": "10.240.0.1",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/networks/default"
+  }
+ ]
 }

--- a/libcloud/test/compute/fixtures/gce/global_networks_cf.json
+++ b/libcloud/test/compute/fixtures/gce/global_networks_cf.json
@@ -1,0 +1,14 @@
+{
+ "kind": "compute#network",
+ "id": "5125152985904090792",
+ "creationTimestamp": "2016-03-25T05:34:15.077-07:00",
+ "name": "cf",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/networks/cf",
+ "autoCreateSubnetworks": true,
+ "subnetworks": [
+  "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1/subnetworks/cf-972cf02e6ad49112",
+  "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-east1/subnetworks/cf-daf1e2124a902a47",
+  "https://www.googleapis.com/compute/v1/projects/project_name/regions/asia-east1/subnetworks/cf-4c2da366a0381eb9",
+  "https://www.googleapis.com/compute/v1/projects/project_name/regions/europe-west1/subnetworks/cf-df1837b06a6f927b"
+ ]
+}

--- a/libcloud/test/compute/fixtures/gce/operations_operation_regions_us-central1_subnetworks_post.json
+++ b/libcloud/test/compute/fixtures/gce/operations_operation_regions_us-central1_subnetworks_post.json
@@ -1,0 +1,15 @@
+{
+  "id": "16064059851942653139",
+  "insertTime": "2013-06-26T12:21:40.299-07:00",
+  "kind": "compute#operation",
+  "name": "operation-regions_us-central1_subnetworks_post",
+  "operationType": "insert",
+  "progress": 100,
+  "region": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1/operations/operation-regions_us-central1_subnetworks_post",
+  "startTime": "2013-06-26T12:21:40.358-07:00",
+  "status": "DONE",
+  "targetId": "01531551729918243104",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1/subnetworks/cf-972cf02e6ad49112",
+  "user": "897001307951@developer.gserviceaccount.com"
+}

--- a/libcloud/test/compute/fixtures/gce/regions_asia-east1.json
+++ b/libcloud/test/compute/fixtures/gce/regions_asia-east1.json
@@ -1,0 +1,65 @@
+{
+ "kind": "compute#region",
+ "id": "1220",
+ "creationTimestamp": "2014-05-30T18:35:16.514-07:00",
+ "name": "asia-east1",
+ "description": "asia-east1",
+ "status": "UP",
+ "zones": [
+  "https://www.googleapis.com/compute/v1/projects/project_name/zones/asia-east1-a",
+  "https://www.googleapis.com/compute/v1/projects/project_name/zones/asia-east1-b"
+ ],
+ "quotas": [
+  {
+   "metric": "CPUS",
+   "limit": 24.0,
+   "usage": 0.0
+  },
+  {
+   "metric": "DISKS_TOTAL_GB",
+   "limit": 10240.0,
+   "usage": 0.0
+  },
+  {
+   "metric": "STATIC_ADDRESSES",
+   "limit": 7.0,
+   "usage": 0.0
+  },
+  {
+   "metric": "IN_USE_ADDRESSES",
+   "limit": 23.0,
+   "usage": 0.0
+  },
+  {
+   "metric": "SSD_TOTAL_GB",
+   "limit": 2048.0,
+   "usage": 0.0
+  },
+  {
+   "metric": "LOCAL_SSD_TOTAL_GB",
+   "limit": 10240.0,
+   "usage": 0.0
+  },
+  {
+   "metric": "INSTANCE_GROUPS",
+   "limit": 100.0,
+   "usage": 0.0
+  },
+  {
+   "metric": "INSTANCE_GROUP_MANAGERS",
+   "limit": 50.0,
+   "usage": 0.0
+  },
+  {
+   "metric": "INSTANCES",
+   "limit": 240.0,
+   "usage": 0.0
+  },
+  {
+   "metric": "AUTOSCALERS",
+   "limit": 50.0,
+   "usage": 0.0
+  }
+ ],
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/regions/asia-east1"
+}

--- a/libcloud/test/compute/fixtures/gce/regions_europe-west1.json
+++ b/libcloud/test/compute/fixtures/gce/regions_europe-west1.json
@@ -1,0 +1,64 @@
+{
+ "kind": "compute#region",
+ "id": "1100",
+ "creationTimestamp": "2014-05-30T18:35:16.413-07:00",
+ "name": "europe-west1",
+ "description": "europe-west1",
+ "status": "UP",
+ "zones": [
+  "https://www.googleapis.com/compute/v1/projects/project_name/zones/europe-west1-b"
+ ],
+ "quotas": [
+  {
+   "metric": "CPUS",
+   "limit": 24.0,
+   "usage": 0.0
+  },
+  {
+   "metric": "DISKS_TOTAL_GB",
+   "limit": 10240.0,
+   "usage": 0.0
+  },
+  {
+   "metric": "STATIC_ADDRESSES",
+   "limit": 7.0,
+   "usage": 0.0
+  },
+  {
+   "metric": "IN_USE_ADDRESSES",
+   "limit": 23.0,
+   "usage": 0.0
+  },
+  {
+   "metric": "SSD_TOTAL_GB",
+   "limit": 2048.0,
+   "usage": 0.0
+  },
+  {
+   "metric": "LOCAL_SSD_TOTAL_GB",
+   "limit": 10240.0,
+   "usage": 0.0
+  },
+  {
+   "metric": "INSTANCE_GROUPS",
+   "limit": 100.0,
+   "usage": 0.0
+  },
+  {
+   "metric": "INSTANCE_GROUP_MANAGERS",
+   "limit": 50.0,
+   "usage": 0.0
+  },
+  {
+   "metric": "INSTANCES",
+   "limit": 240.0,
+   "usage": 0.0
+  },
+  {
+   "metric": "AUTOSCALERS",
+   "limit": 50.0,
+   "usage": 0.0
+  }
+ ],
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/regions/europe-west1"
+}

--- a/libcloud/test/compute/fixtures/gce/regions_us-central1.json
+++ b/libcloud/test/compute/fixtures/gce/regions_us-central1.json
@@ -1,0 +1,65 @@
+{
+ "kind": "compute#region",
+ "id": "1000",
+ "creationTimestamp": "2014-05-30T18:35:16.413-07:00",
+ "name": "us-central1",
+ "description": "us-central1",
+ "status": "UP",
+ "zones": [
+  "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a",
+  "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-b"
+ ],
+ "quotas": [
+  {
+   "metric": "CPUS",
+   "limit": 1050.0,
+   "usage": 30.0
+  },
+  {
+   "metric": "DISKS_TOTAL_GB",
+   "limit": 20000.0,
+   "usage": 344.0
+  },
+  {
+   "metric": "STATIC_ADDRESSES",
+   "limit": 10.0,
+   "usage": 2.0
+  },
+  {
+   "metric": "IN_USE_ADDRESSES",
+   "limit": 1050.0,
+   "usage": 11.0
+  },
+  {
+   "metric": "SSD_TOTAL_GB",
+   "limit": 2048.0,
+   "usage": 500.0
+  },
+  {
+   "metric": "LOCAL_SSD_TOTAL_GB",
+   "limit": 10240.0,
+   "usage": 0.0
+  },
+  {
+   "metric": "INSTANCE_GROUPS",
+   "limit": 100.0,
+   "usage": 0.0
+  },
+  {
+   "metric": "INSTANCE_GROUP_MANAGERS",
+   "limit": 50.0,
+   "usage": 0.0
+  },
+  {
+   "metric": "INSTANCES",
+   "limit": 10500.0,
+   "usage": 11.0
+  },
+  {
+   "metric": "AUTOSCALERS",
+   "limit": 50.0,
+   "usage": 0.0
+  }
+ ],
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1"
+}

--- a/libcloud/test/compute/fixtures/gce/regions_us-central1_subnetworks.json
+++ b/libcloud/test/compute/fixtures/gce/regions_us-central1_subnetworks.json
@@ -1,0 +1,18 @@
+{
+ "kind": "compute#subnetworkList",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1/subnetworks",
+ "id": "projects/project_name/regions/us-central1/subnetworks",
+ "items": [
+  {
+   "kind": "compute#subnetwork",
+   "id": "4297043163355844284",
+   "creationTimestamp": "2016-03-25T05:34:27.209-07:00",
+   "gatewayAddress": "10.128.0.1",
+   "name": "cf-972cf02e6ad49112",
+   "network": "https://www.googleapis.com/compute/v1/projects/project_name/global/networks/cf",
+   "ipCidrRange": "10.128.0.0/20",
+   "region": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1",
+   "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1/subnetworks/cf-972cf02e6ad49112"
+  }
+ ]
+}

--- a/libcloud/test/compute/fixtures/gce/regions_us-central1_subnetworks_cf_972cf02e6ad49112.json
+++ b/libcloud/test/compute/fixtures/gce/regions_us-central1_subnetworks_cf_972cf02e6ad49112.json
@@ -1,0 +1,11 @@
+{
+ "kind": "compute#subnetwork",
+ "id": "4297043163355844284",
+ "creationTimestamp": "2016-03-25T05:34:27.209-07:00",
+ "gatewayAddress": "10.128.0.1",
+ "name": "cf-972cf02e6ad49112",
+ "network": "https://www.googleapis.com/compute/v1/projects/project_name/global/networks/cf",
+ "ipCidrRange": "10.128.0.0/20",
+ "region": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1/subnetworks/cf-972cf02e6ad49112"
+}

--- a/libcloud/test/compute/fixtures/gce/regions_us-central1_subnetworks_post.json
+++ b/libcloud/test/compute/fixtures/gce/regions_us-central1_subnetworks_post.json
@@ -1,0 +1,14 @@
+{
+  "id": "16064059851942653139",
+  "insertTime": "2013-06-26T12:21:40.299-07:00",
+  "kind": "compute#operation",
+  "name": "operation-regions_us-central1_subnetworks_post",
+  "operationType": "insert",
+  "progress": 0,
+  "region": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1/operations/operation-regions_us-central1_subnetworks_post",
+  "startTime": "2013-06-26T12:21:40.358-07:00",
+  "status": "PENDING",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1/subnetworks/cf-972cf02e6ad49112",
+  "user": "897001307951@developer.gserviceaccount.com"
+}

--- a/libcloud/test/compute/fixtures/gce/regions_us-east1.json
+++ b/libcloud/test/compute/fixtures/gce/regions_us-east1.json
@@ -1,0 +1,64 @@
+{
+ "kind": "compute#region",
+ "id": "1230",
+ "creationTimestamp": "2014-09-03T16:13:49.013-07:00",
+ "name": "us-east1",
+ "description": "us-east1",
+ "status": "UP",
+ "zones": [
+  "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-east1-b"
+ ],
+ "quotas": [
+  {
+   "metric": "CPUS",
+   "limit": 24.0,
+   "usage": 0.0
+  },
+  {
+   "metric": "DISKS_TOTAL_GB",
+   "limit": 10240.0,
+   "usage": 0.0
+  },
+  {
+   "metric": "STATIC_ADDRESSES",
+   "limit": 7.0,
+   "usage": 0.0
+  },
+  {
+   "metric": "IN_USE_ADDRESSES",
+   "limit": 23.0,
+   "usage": 0.0
+  },
+  {
+   "metric": "SSD_TOTAL_GB",
+   "limit": 2048.0,
+   "usage": 0.0
+  },
+  {
+   "metric": "LOCAL_SSD_TOTAL_GB",
+   "limit": 10240.0,
+   "usage": 0.0
+  },
+  {
+   "metric": "INSTANCE_GROUPS",
+   "limit": 100.0,
+   "usage": 0.0
+  },
+  {
+   "metric": "INSTANCE_GROUP_MANAGERS",
+   "limit": 50.0,
+   "usage": 0.0
+  },
+  {
+   "metric": "INSTANCES",
+   "limit": 240.0,
+   "usage": 0.0
+  },
+  {
+   "metric": "AUTOSCALERS",
+   "limit": 50.0,
+   "usage": 0.0
+  }
+ ],
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-east1"
+}

--- a/libcloud/test/compute/fixtures/gce/zones_asia-east1-b.json
+++ b/libcloud/test/compute/fixtures/gce/zones_asia-east1-b.json
@@ -1,0 +1,10 @@
+{
+ "kind": "compute#zone",
+ "id": "2220",
+ "creationTimestamp": "2014-05-30T18:35:16.575-07:00",
+ "name": "asia-east1-a",
+ "description": "asia-east1-a",
+ "status": "UP",
+ "region": "https://www.googleapis.com/compute/v1/projects/project_name/regions/asia-east1",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/asia-east1-a"
+}

--- a/libcloud/test/compute/fixtures/gce/zones_us-east1-b.json
+++ b/libcloud/test/compute/fixtures/gce/zones_us-east1-b.json
@@ -1,0 +1,10 @@
+{
+ "kind": "compute#zone",
+ "id": "2231",
+ "creationTimestamp": "2015-09-08T16:57:06.746-07:00",
+ "name": "us-east1-b",
+ "description": "us-east1-b",
+ "status": "UP",
+ "region": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-east1",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-east1-b"
+}

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -1,4 +1,4 @@
-# Licensed to the Apache Software Foundation (ASF) under one or more
+# License to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
 # The ASF licenses this file to You under the Apache License, Version 2.0
@@ -25,9 +25,9 @@ from libcloud.compute.drivers.gce import (GCENodeDriver, API_VERSION,
                                           GCEAddress, GCEBackendService,
                                           GCEFirewall, GCEForwardingRule,
                                           GCEHealthCheck, GCENetwork,
-                                          GCENodeImage, GCERoute,
+                                          GCENodeImage, GCERoute, GCERegion,
                                           GCETargetHttpProxy, GCEUrlMap,
-                                          GCEZone)
+                                          GCEZone, GCESubnetwork)
 from libcloud.common.google import (GoogleBaseAuthConnection,
                                     ResourceNotFoundError, ResourceExistsError,
                                     InvalidRequestError, GoogleBaseError)
@@ -128,6 +128,7 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
                         d.ex_list_forwarding_rules,
                         d.ex_list_healthchecks,
                         d.ex_list_networks,
+                        d.ex_list_subnetworks,
                         d.ex_list_project_images,
                         d.ex_list_regions,
                         d.ex_list_routes,
@@ -233,10 +234,72 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         self.assertEqual(len(routes), 3)
         self.assertTrue('lcdemoroute' in [route.name for route in routes])
 
+    def test_ex_list_subnetworks(self):
+        subnetworks = self.driver.ex_list_subnetworks()
+        self.assertEqual(len(subnetworks), 1)
+        self.assertEqual(subnetworks[0].name, 'cf-972cf02e6ad49112')
+        self.assertEqual(subnetworks[0].cidr, '10.128.0.0/20')
+        subnetworks = self.driver.ex_list_subnetworks('all')
+        self.assertEqual(len(subnetworks), 4)
+
+    def test_ex_create_subnetwork(self):
+        name = 'cf-972cf02e6ad49112'
+        cidr = '10.128.0.0/20'
+        network_name = 'cf'
+        network = self.driver.ex_get_network(network_name)
+        region_name = 'us-central1'
+        region = self.driver.ex_get_region(region_name)
+        # test by network/region name
+        subnet = self.driver.ex_create_subnetwork(name, cidr, network_name, region_name)
+        self.assertTrue(isinstance(subnet, GCESubnetwork))
+        self.assertTrue(isinstance(subnet.region, GCERegion))
+        self.assertTrue(isinstance(subnet.network, GCENetwork))
+        self.assertEqual(subnet.name, name)
+        self.assertEqual(subnet.cidr, cidr)
+        # test by network/region object
+        subnet = self.driver.ex_create_subnetwork(name, cidr, network, region)
+        self.assertTrue(isinstance(subnet, GCESubnetwork))
+        self.assertTrue(isinstance(subnet.region, GCERegion))
+        self.assertTrue(isinstance(subnet.network, GCENetwork))
+        self.assertEqual(subnet.name, name)
+        self.assertEqual(subnet.cidr, cidr)
+
+    def test_ex_destroy_subnetwork(self):
+        name = 'cf-972cf02e6ad49112'
+        region_name = 'us-central1'
+        region = self.driver.ex_get_region(region_name)
+        # delete with no region
+        self.assertTrue(self.driver.ex_destroy_subnetwork(name))
+        # delete with region name
+        self.assertTrue(self.driver.ex_destroy_subnetwork(name, region_name))
+        # delete with region object
+        self.assertTrue(self.driver.ex_destroy_subnetwork(name, region))
+
+    def test_ex_get_subnetwork(self):
+        name = 'cf-972cf02e6ad49112'
+        region_name = 'us-central1'
+        region = self.driver.ex_get_region(region_name)
+        # fetch by no region
+        subnetwork = self.driver.ex_get_subnetwork(name)
+        self.assertEqual(subnetwork.name, name)
+        # fetch by region name
+        subnetwork = self.driver.ex_get_subnetwork(name, region_name)
+        self.assertEqual(subnetwork.name, name)
+        # fetch by region object
+        subnetwork = self.driver.ex_get_subnetwork(name, region)
+        self.assertEqual(subnetwork.name, name)
+
     def test_ex_list_networks(self):
         networks = self.driver.ex_list_networks()
         self.assertEqual(len(networks), 3)
-        self.assertEqual(networks[0].name, 'default')
+        self.assertEqual(networks[0].name, 'cf')
+        self.assertEqual(networks[0].mode, 'auto')
+        self.assertEqual(len(networks[0].subnetworks), 4)
+        self.assertEqual(networks[1].name, 'custom')
+        self.assertEqual(networks[1].mode, 'custom')
+        self.assertEqual(len(networks[1].subnetworks), 1)
+        self.assertEqual(networks[2].name, 'default')
+        self.assertEqual(networks[2].mode, 'legacy')
 
     def test_list_nodes(self):
         nodes = self.driver.list_nodes()
@@ -478,6 +541,16 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         self.assertTrue(isinstance(network, GCENetwork))
         self.assertEqual(network.name, network_name)
         self.assertEqual(network.cidr, cidr)
+
+    def test_ex_create_network_bad_options(self):
+        network_name = 'lcnetwork'
+        cidr = '10.11.0.0/16'
+        self.assertRaises(ValueError, self.driver.ex_create_network,
+                          network_name, cidr, mode='auto')
+        self.assertRaises(ValueError, self.driver.ex_create_network,
+                          network_name, cidr, mode='foobar')
+        self.assertRaises(ValueError, self.driver.ex_create_network,
+                          network_name, None, mode='legacy')
 
     def test_ex_set_machine_type_notstopped(self):
         # get running node, change machine type
@@ -1573,6 +1646,10 @@ class GCEMockHttp(MockHttpTestCase):
             body = self.fixtures.load('setCommonInstanceMetadata_post.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
+    def _aggregated_subnetworks(self, method, url, body, headers):
+        body = self.fixtures.load('aggregated_subnetworks.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
     def _aggregated_addresses(self, method, url, body, headers):
         body = self.fixtures.load('aggregated_addresses.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
@@ -1731,6 +1808,10 @@ class GCEMockHttp(MockHttpTestCase):
             body = self.fixtures.load('global_networks_post.json')
         else:
             body = self.fixtures.load('global_networks.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _global_networks_cf(self, method, url, body, headers):
+        body = self.fixtures.load('global_networks_cf.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
     def _global_networks_default(self, method, url, body, headers):
@@ -1949,6 +2030,11 @@ class GCEMockHttp(MockHttpTestCase):
             body = self.fixtures.load('global_urlMaps_web_map.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
+    def _regions_us_central1_subnetworks_cf_972cf02e6ad49112(self, method, url, body, headers):
+        body = self.fixtures.load(
+            'regions_us-central1_subnetworks_cf_972cf02e6ad49112.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
     def _regions_us_central1_operations_operation_regions_us_central1_addresses_lcaddress_delete(
             self, method, url, body, headers):
         body = self.fixtures.load(
@@ -1965,6 +2051,12 @@ class GCEMockHttp(MockHttpTestCase):
             self, method, url, body, headers):
         body = self.fixtures.load(
             'operations_operation_regions_us-central1_addresses_post.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _regions_us_central1_operations_operation_regions_us_central1_subnetworks_post(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'operations_operation_regions_us-central1_subnetworks_post.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
     def _regions_us_central1_operations_operation_regions_us_central1_forwardingRules_post(
@@ -2232,6 +2324,30 @@ class GCEMockHttp(MockHttpTestCase):
             body = self.fixtures.load('global_addresses.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
+    def _regions_europe_west1(self, method, url, body, headers):
+        body = self.fixtures.load('regions_europe-west1.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _regions_asia_east1(self, method, url, body, headers):
+        body = self.fixtures.load('regions_asia-east1.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _regions_us_central1(self, method, url, body, headers):
+        body = self.fixtures.load('regions_us-central1.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _regions_us_east1(self, method, url, body, headers):
+        body = self.fixtures.load('regions_us-east1.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _regions_us_central1_subnetworks(self, method, url, body, headers):
+        if method == 'POST':
+            body = self.fixtures.load(
+                'regions_us-central1_subnetworks_post.json')
+        else:
+            body = self.fixtures.load('regions_us-central1_subnetworks.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
     def _regions_us_central1_addresses(self, method, url, body, headers):
         if method == 'POST':
             body = self.fixtures.load(
@@ -2382,6 +2498,14 @@ class GCEMockHttp(MockHttpTestCase):
 
     def _zones_asia_east_1a(self, method, url, body, headers):
         body = self.fixtures.load('zones_asia-east1-a.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _zones_asia_east1_b(self, method, url, body, headers):
+        body = self.fixtures.load('zones_asia-east1-b.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _zones_us_east1_b(self, method, url, body, headers):
+        body = self.fixtures.load('zones_us-east1-b.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
     def _zones_us_central1_a_diskTypes(self, method, url, body, headers):


### PR DESCRIPTION
## Adding support subnetworks to GCE driver
### Description

This PR adds support Google Compute Engine's subnetworks feature[1].  When this feature was introduced, Google suggested users begin using automatically allocated regional subnetworks versus a single global network. The GCE driver predates subnetworks, so the default is still set to create **legacy** networks, even though this is no longer recommended.

Subnetworks are a necessary prerequisite for other GCE networking features that will be added to libcloud shortly.

[1] https://cloud.google.com/compute/docs/subnetworks
### Status

I intend to leave this PR open for community review for 7 days and will merge it to trunk if there are no outstanding issues on 10-May-2016.
- done, ready for review
### Checklist (tick everything that applies)
- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
