### PR TITLE
Bug fix on None type for return for DimensionDataBackupDriver

### DIFF
--- a/libcloud/backup/drivers/dimensiondata.py
+++ b/libcloud/backup/drivers/dimensiondata.py
@@ -516,6 +516,8 @@ class DimensionDataBackupDriver(BackupDriver):
         """
         if not isinstance(target, BackupTarget):
             target = self.ex_get_target_by_id(target)
+            if target is None:
+                return
         response = self.connection.request_with_orgId_api_1(
             'server/%s/backup' % (target.address),
             method='GET').object

--- a/libcloud/common/dimensiondata.py
+++ b/libcloud/common/dimensiondata.py
@@ -470,7 +470,8 @@ class DimensionDataConnection(ConnectionUserAndKey):
                                                    data, headers,
                                                    method).object
         yield paged_resp
-        paged_resp = paged_resp or {}
+        if len(paged_resp) <= 0:
+            raise StopIteration
 
         while int(paged_resp.get('pageCount')) >= \
                 int(paged_resp.get('pageSize')):

--- a/libcloud/compute/drivers/dimensiondata.py
+++ b/libcloud/compute/drivers/dimensiondata.py
@@ -2292,7 +2292,7 @@ class DimensionDataNodeDriver(NodeDriver):
         return DimensionDataTag(
             asset_type=findtext(element, 'assetType', TYPES_URN),
             asset_id=findtext(element, 'assetId', TYPES_URN),
-            asset_name=findtext(element, 'assetId', TYPES_URN),
+            asset_name=findtext(element, 'assetName', TYPES_URN),
             datacenter=findtext(element, 'datacenterId', TYPES_URN),
             key=tag_key,
             value=findtext(element, 'value', TYPES_URN)

--- a/libcloud/test/backup/fixtures/dimensiondata/server_server_NOBACKUP.xml
+++ b/libcloud/test/backup/fixtures/dimensiondata/server_server_NOBACKUP.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<servers xmlns="urn:didata.com:api:cloud:types" pageNumber="1" pageCount="1" totalCount="1" pageSize="250">
+    <server id="5a32d6e4-9707-4813-a269-56ab4d989f4d" datacenterId="NA9">
+        <name>Production Web Server MCP 2</name>
+        <description>Server to host our main web application.</description>
+        <operatingSystem id="WIN2008S32" displayName="WIN2008S/32" family="WINDOWS" />
+        <cpu count="2" speed="STANDARD" coresPerSocket="1" />
+        <memoryGb>4</memoryGb>
+        <disk id="c2e1f199-116e-4dbc-9960-68720b832b0a" scsiId="0" sizeGb="50" speed="STANDARD" state="NORMAL" />
+        <networkInfo networkDomainId="553f26b6-2a73-42c3-a78b-6116f11291d0">
+            <primaryNic id="5e869800-df7b-4626-bcbf-8643b8be11fd" privateIpv4="10.0.4.8" ipv6="2607:f480:1111:1282:2960:fb72:7154:6160" vlanId="bc529e20-dc6f-42ba-be20-0ffe44d1993f" vlanName="Production VLAN" state="NORMAL" />
+        </networkInfo>
+        <backup assetId="91002e08-8dc1-47a1-ad33-04f501c06f87" servicePlan="Advanced" state="NORMAL" />
+        <monitoring monitoringId="11039" servicePlan="ESSENTIALS" state="NORMAL" />
+        <softwareLabel>MSSQL2008R2S</softwareLabel>
+        <sourceImageId>3ebf3c0f-90fe-4a8b-8585-6e65b316592c</sourceImageId>
+        <createTime>2015-12-02T10:31:33.000Z</createTime>
+        <deployed>true</deployed>
+        <started>true</started>
+        <state>PENDING_CHANGE</state>
+        <progress>
+            <action>SHUTDOWN_SERVER</action>
+            <requestTime>2015-12-02T11:07:40.000Z</requestTime>
+            <userName>devuser1</userName>
+        </progress>
+        <vmwareTools versionStatus="CURRENT" runningStatus="RUNNING" apiVersion="9354" />
+        <virtualHardware version="vmx-08" upToDate="false" />
+    </server>
+</servers>

--- a/libcloud/test/backup/test_dimensiondata.py
+++ b/libcloud/test/backup/test_dimensiondata.py
@@ -133,6 +133,12 @@ class DimensionDataTests(unittest.TestCase, TestCaseMixin):
         self.assertEqual(len(client.alert.notify_list), 2)
         self.assertTrue(isinstance(client.alert.notify_list, list))
 
+    def test_ex_get_backup_details_for_target_NOBACKUP(self):
+        target = self.driver.list_targets()[0].address
+        DimensionDataMockHttp.type = 'NOBACKUP'
+        response = self.driver.ex_get_backup_details_for_target(target)
+        self.assertTrue(response is None)
+
     def test_ex_cancel_target_job(self):
         target = self.driver.list_targets()[0]
         response = self.driver.ex_get_backup_details_for_target(target)
@@ -425,6 +431,12 @@ class DimensionDataMockHttp(MockHttp):
 
         else:
             raise ValueError("Unknown Method {0}".format(method))
+
+    def _caas_2_2_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_server_e75ead52_692f_4314_8725_c8a4f4d13a87_NOBACKUP(
+            self, method, url, body, headers):
+        assert(method == 'GET')
+        body = self.fixtures.load('server_server_NOBACKUP.xml')
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
     def _oec_0_9_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_e75ead52_692f_4314_8725_c8a4f4d13a87_backup_EXISTS(
             self, method, url, body, headers):

--- a/libcloud/test/compute/fixtures/dimensiondata/server_server_paginated_empty.xml
+++ b/libcloud/test/compute/fixtures/dimensiondata/server_server_paginated_empty.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="UTF-8"?><servers xmlns="urn:didata.com:api:cloud:types" pageNumber="1" pageCount="0" totalCount="0" pageSize="250"/>

--- a/libcloud/test/compute/test_dimensiondata.py
+++ b/libcloud/test/compute/test_dimensiondata.py
@@ -102,6 +102,26 @@ class DimensionDataTests(unittest.TestCase, TestCaseMixin):
         ret = self.driver.list_nodes()
         self.assertEqual(len(ret), 9)
 
+    def test_paginated_mcp2_call_EMPTY(self):
+        # cache org
+        self.driver.connection._get_orgId()
+        DimensionDataMockHttp.type = 'EMPTY'
+        node_list_generator = self.driver.connection.paginated_request_with_orgId_api_2('server/server')
+        empty_node_list = []
+        for node_list in node_list_generator:
+            empty_node_list.extend(node_list)
+        self.assertTrue(len(empty_node_list) == 0)
+
+    def test_paginated_mcp2_call_PAGED_THEN_EMPTY(self):
+        # cache org
+        self.driver.connection._get_orgId()
+        DimensionDataMockHttp.type = 'PAGED_THEN_EMPTY'
+        node_list_generator = self.driver.connection.paginated_request_with_orgId_api_2('server/server')
+        final_node_list = []
+        for node_list in node_list_generator:
+            final_node_list.extend(node_list)
+        self.assertTrue(len(final_node_list) == 2)
+
     def test_paginated_mcp2_call_with_page_size(self):
         # cache org
         self.driver.connection._get_orgId()
@@ -1359,6 +1379,21 @@ class DimensionDataMockHttp(MockHttp):
             'server_server.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
+    def _caas_2_2_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_server_EMPTY(self, method, url, body, headers):
+        body = self.fixtures.load(
+            'server_server_paginated_empty.xml')
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+
+    def _caas_2_2_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_server_PAGED_THEN_EMPTY(self, method, url, body, headers):
+        if 'pageNumber=2' in url:
+            body = self.fixtures.load(
+                'server_server_paginated_empty.xml')
+            return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+        else:
+            body = self.fixtures.load(
+                'server_server_paginated.xml')
+            return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+
     def _caas_2_2_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_server_PAGINATED(self, method, url, body, headers):
         if 'pageNumber=2' in url:
             body = self.fixtures.load(
@@ -1368,6 +1403,12 @@ class DimensionDataMockHttp(MockHttp):
             body = self.fixtures.load(
                 'server_server_paginated.xml')
             return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+
+    def _caas_2_2_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_server_PAGINATEDEMPTY(self, method, url, body, headers):
+        print("In empty")
+        body = self.fixtures.load(
+            'server_server_paginated_empty.xml')
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
     def _caas_2_2_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_server_ALLFILTERS(self, method, url, body, headers):
         (_, params) = url.split('?')

--- a/libcloud/test/compute/test_dimensiondata.py
+++ b/libcloud/test/compute/test_dimensiondata.py
@@ -1405,7 +1405,6 @@ class DimensionDataMockHttp(MockHttp):
             return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
     def _caas_2_2_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_server_server_PAGINATEDEMPTY(self, method, url, body, headers):
-        print("In empty")
         body = self.fixtures.load(
             'server_server_paginated_empty.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])


### PR DESCRIPTION
## Bug fixes on returning None if a BackupTarget can't be found when calling ex_get_backup_details_for_target and paginated MCP2 calls
### Description

Currently if a backup doesn't exists on a target, we return None, since we're using this value in getting a backup target we end up throwing an error
Also after linting, it looks like paginated responses were erroring out if paginated responses were empty.
### Status

ready for review
### Checklist (tick everything that applies)
- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
