### PR TITLE
Updated create_volume routine in the cloudstack.py file to support ex_volume_type

### DIFF
--- a/libcloud/compute/drivers/cloudstack.py
+++ b/libcloud/compute/drivers/cloudstack.py
@@ -2111,7 +2111,7 @@ class CloudStackNodeDriver(CloudStackDriverMixIn, NodeDriver):
 
         return projects
 
-    def create_volume(self, size, name, location=None, snapshot=None, 
+    def create_volume(self, size, name, location=None, snapshot=None,
                       ex_volume_type=None):
         """
         Creates a data volume

--- a/libcloud/compute/drivers/cloudstack.py
+++ b/libcloud/compute/drivers/cloudstack.py
@@ -2111,17 +2111,28 @@ class CloudStackNodeDriver(CloudStackDriverMixIn, NodeDriver):
 
         return projects
 
-    def create_volume(self, size, name, location=None, snapshot=None):
+    def create_volume(self, size, name, location=None, snapshot=None, 
+                      ex_volume_type=None):
         """
         Creates a data volume
         Defaults to the first location
         """
-        for diskOffering in self.ex_list_disk_offerings():
-            if diskOffering.size == size or diskOffering.customizable:
-                break
+        if ex_volume_type is None:
+            for diskOffering in self.ex_list_disk_offerings():
+                if diskOffering.size == size or diskOffering.customizable:
+                    break
+            else:
+                raise LibcloudError(
+                    'Disk offering with size=%s not found' % size)
         else:
-            raise LibcloudError(
-                'Disk offering with size=%s not found' % size)
+            for diskOffering in self.ex_list_disk_offerings():
+                if diskOffering.name == ex_volume_type:
+                    if not diskOffering.customizable:
+                        size = diskOffering.size
+                    break
+            else:
+                raise LibcloudError(
+                    'Volume type with name=%s not found' % ex_volume_type)
 
         if location is None:
             location = self.list_locations()[0]

--- a/libcloud/test/compute/fixtures/cloudstack/createVolume_withvolumetype.json
+++ b/libcloud/test/compute/fixtures/cloudstack/createVolume_withvolumetype.json
@@ -1,0 +1,1 @@
+{ "createvolumeresponse" : {"id":"60338035-92fb-4d27-98d4-b60ad4b38b87","jobid":"createvolumejob"} }

--- a/libcloud/test/compute/fixtures/cloudstack/listDiskOfferings_withvolumetype.json
+++ b/libcloud/test/compute/fixtures/cloudstack/listDiskOfferings_withvolumetype.json
@@ -1,0 +1,1 @@
+{ "listdiskofferingsresponse" : { "count":1 ,"diskoffering" : [  {"id":"6345e3b7-227e-4209-8f8c-1f94219696e6","name":"Disk offer 1","displaytext":"Disk offer 1 display name","disksize":10,"created":"2012-04-24T16:35:55+0200","iscustomized":false}  ] } }

--- a/libcloud/test/compute/fixtures/cloudstack/listZones_withvolumetype.json
+++ b/libcloud/test/compute/fixtures/cloudstack/listZones_withvolumetype.json
@@ -1,0 +1,1 @@
+{ "listzonesresponse" : { "zone" : [  {"id":1,"name":"Sydney","networktype":"Advanced","securitygroupsenabled":false} ] } }

--- a/libcloud/test/compute/test_cloudstack.py
+++ b/libcloud/test/compute/test_cloudstack.py
@@ -559,11 +559,12 @@ class CloudStackCommonTestCase(TestCaseMixin):
         CloudStackMockHttp.fixture_tag = 'withvolumetype'
 
         volumeName = 'vol-0'
-        location = self.driver.list_locations()[0]
-        volumeType = self.ex_list_disk_offerings()[0]
+        volLocation = self.driver.list_locations()[0]
+        diskOffering = self.driver.ex_list_disk_offerings()[0]
+        volumeType = diskOffering.name
 
-        volume = self.driver.create_volume(10, volumeName, locationi,
-                     ex_volume_type=volumeType)
+        volume = self.driver.create_volume(10, volumeName, location=volLocation,
+                                           ex_volume_type=volumeType)
 
         self.assertEqual(volumeName, volume.name)
 

--- a/libcloud/test/compute/test_cloudstack.py
+++ b/libcloud/test/compute/test_cloudstack.py
@@ -544,6 +544,29 @@ class CloudStackCommonTestCase(TestCaseMixin):
 
         self.assertEqual(volumeName, volume.name)
 
+    def test_create_volume_no_matching_volume_type(self):
+        """If the ex_disk_type does not exit, then an exception should be
+        thrown."""
+
+        location = self.driver.list_locations()[0]
+
+        self.assertRaises(
+            LibcloudError,
+            self.driver.create_volume,
+            'vol-0', location, 11, ex_volume_type='FooVolumeType')
+
+    def test_create_volume_with_defined_volume_type(self):
+        CloudStackMockHttp.fixture_tag = 'withvolumetype'
+
+        volumeName = 'vol-0'
+        location = self.driver.list_locations()[0]
+        volumeType = self.ex_list_disk_offerings()[0]
+
+        volume = self.driver.create_volume(10, volumeName, locationi,
+                     ex_volume_type=volumeType)
+
+        self.assertEqual(volumeName, volume.name)
+
     def test_attach_volume(self):
         node = self.driver.list_nodes()[0]
         volumeName = 'vol-0'


### PR DESCRIPTION
## Updated create_volume routine in the cloudstack.py file to support ex_volume_type
### Description

As part of the deployment of an internal cloud using CloudStack, we discovered that
one cannot use the "DiskOffering" capability of CloudStack to select volumes with
specific attributes. When reviewing the OpenStack portion of the library, this is
supported using the ex_volume_type variable in the call to create_volume.

The CloudStack DiskOffering capability is required for this deployment, so the create_volume
routing in cloudstack.py was updated to add this as an option using the same variable name
as used for OpenStack.

When a DiskOffering is specified, the input size to create_volume is over-riden by the 
size of the DiskOffering, unless the DiskOffering size is customizable. This was chosen
to minimize errors, as if someone calls create_volume with the ex_volume_type option,
then it is likely that is what they want, even if the specified size is different from the request.
### Status
- done, ready for review
### Checklist (tick everything that applies)
- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
