### PR TITLE
[LIBCLOUD-820] added check if libvirt uri is local

### DIFF
--- a/libcloud/compute/drivers/libvirt_driver.py
+++ b/libcloud/compute/drivers/libvirt_driver.py
@@ -257,6 +257,10 @@ class LibvirtNodeDriver(NodeDriver):
             # Only Linux is supported atm
             return result
 
+        if '///' not in self._uri:
+            # Only local libvirtd is supported atm
+            return result
+
         mac_addresses = self._get_mac_addresses_for_domain(domain=domain)
 
         cmd = ['arp', '-an']

--- a/libcloud/compute/drivers/libvirt_driver.py
+++ b/libcloud/compute/drivers/libvirt_driver.py
@@ -267,16 +267,17 @@ class LibvirtNodeDriver(NodeDriver):
         try:
             cmd = ['arp', '-an']
             child = subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                                 stderr=subprocess.PIPE)
+                                     stderr=subprocess.PIPE)
             stdout, _ = child.communicate()
             arp_table = self._parse_arp_table(arp_output=stdout)
         except OSError as e:
             if e.errno == 2:
                 cmd = ['ip', 'neigh']
                 child = subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                                 stderr=subprocess.PIPE)
+                                         stderr=subprocess.PIPE)
                 stdout, _ = child.communicate()
-                arp_table = self._parse_arp_table(arp_output=stdout,re_match='(.*?)\s+.*lladdr\s+(.*?)\s+')
+                arp_table = self._parse_arp_table(arp_output=stdout,
+                                                  arp_cmd='ip')
 
         for mac_address in mac_addresses:
             if mac_address in arp_table:
@@ -323,7 +324,7 @@ class LibvirtNodeDriver(NodeDriver):
 
         return result
 
-    def _parse_arp_table(self, arp_output, re_match='.*?\((.*?)\) at (.*?)\s+'):
+    def _parse_arp_table(self, arp_output, arp_cmd='arp'):
         """
         Parse arp command output and return a dictionary which maps mac address
         to an IP address.
@@ -331,7 +332,10 @@ class LibvirtNodeDriver(NodeDriver):
         :return: Dictionary which maps mac address to IP address.
         :rtype: ``dict``
         """
-        ip_mac = re.compile(re_match)
+        re_match = {}
+        re_match['arp'] = '.*?\((.*?)\) at (.*?)\s+'
+        re_match['ip'] = '(.*?)\s+.*lladdr\s+(.*?)\s+'
+        ip_mac = re.compile(re_match[arp_cmd])
         lines = arp_output.split('\n')
 
         arp_table = defaultdict(list)


### PR DESCRIPTION
## [LIBCLOUD-820](https://issues.apache.org/jira/browse/LIBCLOUD-820) added check if libvirt uri is local
### Description

without this listing nodes on a remote libvirtd server will fail to
lookup the IPs in the arp cache.
### Status
- done, ready for review
### Checklist (tick everything that applies)
- [X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [X] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
