### PR TITLE
Add OpenStackIdentity_3_0_Connection child class to manage auth with OpenID access tokens

### DIFF
--- a/libcloud/common/openstack_identity.py
+++ b/libcloud/common/openstack_identity.py
@@ -1383,6 +1383,17 @@ class OpenStackIdentity_3_0_Connection_OIDC_access_token(
         OpenStackIdentity_3_0_Connection):
     """
     Connection class for Keystone API v3.x. using OpenID Connect tokens
+
+    The OIDC token must be set in the self.key attribute.
+
+    The identity provider name required to get the full path
+    must be set in the self.user_id attribute.
+
+    The protocol name required to get the full path
+    must be set in the self.tenant_name attribute.
+
+    The user must be scoped to the first project accessible with the
+    specified access token (usually there are only one)
     """
 
     responseCls = OpenStackAuthResponse
@@ -1476,11 +1487,6 @@ class OpenStackIdentity_3_0_Connection_OIDC_access_token(
     def _get_unscoped_token_from_oidc_token(self):
         """
         Get unscoped token from OIDC access token
-        The OIDC token must be set in the self.key attribute.
-        The identity provider name required to get the full path
-        must be set in the self.user_id attribute.
-        The protocol name required to get the full path
-        must be set in the self.tenant_name attribute.
         """
         path = ('/v3/OS-FEDERATION/identity_providers/%s/protocols/%s/auth' %
                 (self.user_id, self.tenant_name))
@@ -1505,7 +1511,7 @@ class OpenStackIdentity_3_0_Connection_OIDC_access_token(
 
     def _get_project_id(self, token):
         """
-        Get the first project ID accessible with the specified token
+        Get the first project ID accessible with the specified access token
         """
         path = '/v3/OS-FEDERATION/projects'
         response = self.request(path,

--- a/libcloud/common/openstack_identity.py
+++ b/libcloud/common/openstack_identity.py
@@ -1380,7 +1380,7 @@ class OpenStackIdentity_3_0_Connection(OpenStackIdentityConnection):
 
 
 class OpenStackIdentity_3_0_Connection_OIDC_access_token(
-          OpenStackIdentity_3_0_Connection):
+        OpenStackIdentity_3_0_Connection):
     """
     Connection class for Keystone API v3.x. using OpenID Connect tokens
     """

--- a/libcloud/common/openstack_identity.py
+++ b/libcloud/common/openstack_identity.py
@@ -70,7 +70,7 @@ __all__ = [
     'OpenStackIdentity_1_1_Connection',
     'OpenStackIdentity_2_0_Connection',
     'OpenStackIdentity_3_0_Connection',
-    'OpenStackIdentity_3_0_Connection_OIDC',
+    'OpenStackIdentity_3_0_Connection_OIDC_access_token',
 
     'get_class_for_auth_version'
 ]

--- a/libcloud/common/openstack_identity.py
+++ b/libcloud/common/openstack_identity.py
@@ -43,7 +43,7 @@ AUTH_VERSIONS_WITH_EXPIRES = [
     '2.0_password',
     '3.0',
     '3.x_password',
-    '3.x_oidc'
+    '3.x_oidc_access_token'
 ]
 
 # How many seconds to subtract from the auth token expiration time before
@@ -1379,7 +1379,7 @@ class OpenStackIdentity_3_0_Connection(OpenStackIdentityConnection):
         return role
 
 
-class OpenStackIdentity_3_0_Connection_OIDC(OpenStackIdentity_3_0_Connection):
+class OpenStackIdentity_3_0_Connection_OIDC_access_token(OpenStackIdentity_3_0_Connection):
     """
     Connection class for Keystone API v3.x. using OpenID Connect tokens
     """
@@ -1474,13 +1474,15 @@ class OpenStackIdentity_3_0_Connection_OIDC(OpenStackIdentity_3_0_Connection):
 
     def _get_unscoped_token_from_oidc_token(self):
         """
-        Get unscoped token from OIDC token
+        Get unscoped token from OIDC access token
         The OIDC token must be set in the self.key attribute.
         The identity provider name required to get the full path
+        must be set in the self.user_id attribute.
+        The protocol name required to get the full path
         must be set in the self.tenant_name attribute.
         """
-        path = ('/v3/OS-FEDERATION/identity_providers/%s/protocols/oidc/auth' %
-                self.tenant_name)
+        path = ('/v3/OS-FEDERATION/identity_providers/%s/protocols/%s/auth' %
+                (self.user_id, self.tenant_name))
         response = self.request(path,
                                 headers={'Content-Type': 'application/json',
                                          'Authorization': 'Bearer %s' %
@@ -1539,8 +1541,8 @@ def get_class_for_auth_version(auth_version):
         cls = OpenStackIdentity_2_0_Connection
     elif auth_version == '3.x_password':
         cls = OpenStackIdentity_3_0_Connection
-    elif auth_version == '3.x_oidc':
-        cls = OpenStackIdentity_3_0_Connection_OIDC
+    elif auth_version == '3.x_oidc_access_token':
+        cls = OpenStackIdentity_3_0_Connection_OIDC_access_token
     else:
         raise LibcloudError('Unsupported Auth Version requested')
 

--- a/libcloud/common/openstack_identity.py
+++ b/libcloud/common/openstack_identity.py
@@ -42,7 +42,8 @@ AUTH_VERSIONS_WITH_EXPIRES = [
     '2.0_apikey',
     '2.0_password',
     '3.0',
-    '3.x_password'
+    '3.x_password',
+    '3.x_oidc'
 ]
 
 # How many seconds to subtract from the auth token expiration time before
@@ -69,6 +70,7 @@ __all__ = [
     'OpenStackIdentity_1_1_Connection',
     'OpenStackIdentity_2_0_Connection',
     'OpenStackIdentity_3_0_Connection',
+    'OpenStackIdentity_3_0_Connection_OIDC',
 
     'get_class_for_auth_version'
 ]
@@ -1377,6 +1379,151 @@ class OpenStackIdentity_3_0_Connection(OpenStackIdentityConnection):
         return role
 
 
+class OpenStackIdentity_3_0_Connection_OIDC(OpenStackIdentity_3_0_Connection):
+    """
+    Connection class for Keystone API v3.x. using OpenID Connect tokens
+    """
+
+    responseCls = OpenStackAuthResponse
+    name = 'OpenStack Identity API v3.x with OIDC support'
+    auth_version = '3.0'
+
+    def get_unscoped_token_from_oidc_token(self):
+        """
+        Get unscoped token from OIDC token
+        The OIDC token must be set in the self.key attribute.
+        The identity provider name required to get the full path
+        must be set in the self.tenant_name attribute.
+        """
+        path = ('/v3/OS-FEDERATION/identity_providers/%s/protocols/oidc/auth' %
+                self.tenant_name)
+        response = self.request(path,
+                                headers={'Content-Type': 'application/json',
+                                         'Authorization': 'Bearer %s' %
+                                         self.key},
+                                method='GET')
+
+        if response.status == httplib.UNAUTHORIZED:
+            # Invalid credentials
+            raise InvalidCredsError()
+        elif response.status in [httplib.OK, httplib.CREATED]:
+            if 'x-subject-token' in response.headers:
+                return response.headers['x-subject-token']
+            else:
+                raise MalformedResponseError('No x-subject-token returned',
+                                             driver=self.driver)
+        else:
+            raise MalformedResponseError('Malformed response',
+                                         driver=self.driver)
+
+    def get_project_id(self, token):
+        """
+        Get the first project ID accessible with the specified token
+        """
+        path = '/v3/OS-FEDERATION/projects'
+        response = self.request(path,
+                                headers={'Content-Type': 'application/json',
+                                         'X-Auth-Token': token},
+                                method='GET')
+
+        if response.status == httplib.UNAUTHORIZED:
+            # Invalid credentials
+            raise InvalidCredsError()
+        elif response.status in [httplib.OK, httplib.CREATED]:
+            try:
+                body = json.loads(response.body)
+                return body["projects"][0]["id"]
+            except Exception:
+                e = sys.exc_info()[1]
+                raise MalformedResponseError('Failed to parse JSON', e)
+        else:
+            raise MalformedResponseError('Malformed response',
+                                         driver=self.driver)
+
+    def authenticate(self, force=False):
+        """
+        Perform authentication.
+        """
+        if not self._is_authentication_needed(force=force):
+            return self
+
+        subject_token = self.get_unscoped_token_from_oidc_token()
+        project_id = self.get_project_id(subject_token)
+
+        data = {
+            'auth': {
+                'identity': {
+                    'methods': ['token'],
+                    'token': {
+                        'id': subject_token
+                    }
+                }
+            }
+        }
+
+        if self.token_scope == OpenStackIdentityTokenScope.PROJECT:
+            # Scope token to project (tenant)
+            data['auth']['scope'] = {
+                'project': {
+                    'id': project_id
+                }
+            }
+        elif self.token_scope == OpenStackIdentityTokenScope.DOMAIN:
+            # Scope token to domain
+            data['auth']['scope'] = {
+                'domain': {
+                    'name': self.domain_name
+                }
+            }
+        elif self.token_scope == OpenStackIdentityTokenScope.UNSCOPED:
+            pass
+        else:
+            raise ValueError('Token needs to be scoped either to project or '
+                             'a domain')
+
+        data = json.dumps(data)
+        response = self.request('/v3/auth/tokens', data=data,
+                                headers={'Content-Type': 'application/json'},
+                                method='POST')
+
+        if response.status == httplib.UNAUTHORIZED:
+            # Invalid credentials
+            raise InvalidCredsError()
+        elif response.status in [httplib.OK, httplib.CREATED]:
+            headers = response.headers
+
+            try:
+                body = json.loads(response.body)
+            except Exception:
+                e = sys.exc_info()[1]
+                raise MalformedResponseError('Failed to parse JSON', e)
+
+            try:
+                roles = self._to_roles(body['token']['roles'])
+            except Exception:
+                e = sys.exc_info()[1]
+                roles = []
+
+            try:
+                expires = body['token']['expires_at']
+
+                self.auth_token = headers['x-subject-token']
+                self.auth_token_expires = parse_date(expires)
+                # Note: catalog is not returned for unscoped tokens
+                self.urls = body['token'].get('catalog', None)
+                self.auth_user_info = None
+                self.auth_user_roles = roles
+            except KeyError:
+                e = sys.exc_info()[1]
+                raise MalformedResponseError('Auth JSON response is \
+                                             missing required elements', e)
+            body = 'code: %s body:%s' % (response.status, response.body)
+        else:
+            raise MalformedResponseError('Malformed response', body=body,
+                                         driver=self.driver)
+
+        return self
+
 def get_class_for_auth_version(auth_version):
     """
     Retrieve class for the provided auth version.
@@ -1391,6 +1538,8 @@ def get_class_for_auth_version(auth_version):
         cls = OpenStackIdentity_2_0_Connection
     elif auth_version == '3.x_password':
         cls = OpenStackIdentity_3_0_Connection
+    elif auth_version == '3.x_oidc':
+        cls = OpenStackIdentity_3_0_Connection_OIDC
     else:
         raise LibcloudError('Unsupported Auth Version requested')
 

--- a/libcloud/common/openstack_identity.py
+++ b/libcloud/common/openstack_identity.py
@@ -1379,7 +1379,8 @@ class OpenStackIdentity_3_0_Connection(OpenStackIdentityConnection):
         return role
 
 
-class OpenStackIdentity_3_0_Connection_OIDC_access_token(OpenStackIdentity_3_0_Connection):
+class OpenStackIdentity_3_0_Connection_OIDC_access_token(
+          OpenStackIdentity_3_0_Connection):
     """
     Connection class for Keystone API v3.x. using OpenID Connect tokens
     """

--- a/libcloud/test/common/test_openstack_identity.py
+++ b/libcloud/test/common/test_openstack_identity.py
@@ -30,6 +30,7 @@ from libcloud.common.openstack_identity import get_class_for_auth_version
 from libcloud.common.openstack_identity import OpenStackServiceCatalog
 from libcloud.common.openstack_identity import OpenStackIdentity_2_0_Connection
 from libcloud.common.openstack_identity import OpenStackIdentity_3_0_Connection
+from libcloud.common.openstack_identity import OpenStackIdentity_3_0_Connection_OIDC_access_token
 from libcloud.common.openstack_identity import OpenStackIdentityUser
 from libcloud.compute.drivers.openstack import OpenStack_1_0_NodeDriver
 
@@ -424,6 +425,30 @@ class OpenStackIdentity_3_0_ConnectionTests(unittest.TestCase):
         self.assertTrue(result)
 
 
+class OpenStackIdentity_3_0_Connection_OIDC_access_tokenTests(
+        unittest.TestCase):
+    def setUp(self):
+        mock_cls = OpenStackIdentity_3_0_MockHttp
+        mock_cls.type = None
+        OpenStackIdentity_3_0_Connection_OIDC_access_token.conn_classes = (mock_cls, mock_cls)
+
+        self.auth_instance = OpenStackIdentity_3_0_Connection_OIDC_access_token(auth_url='http://none',
+                                                                                user_id='idp',
+                                                                                key='token',
+                                                                                tenant_name='oidc',
+                                                                                domain_name='test_domain')
+        self.auth_instance.auth_token = 'mock'
+
+    def test_authenticate(self):
+        auth = OpenStackIdentity_3_0_Connection_OIDC_access_token(auth_url='http://none',
+                                                                  user_id='idp',
+                                                                  key='token',
+                                                                  token_scope='project',
+                                                                  tenant_name="oidc",
+                                                                  domain_name='test_domain')
+        auth.authenticate()
+
+
 class OpenStackServiceCatalogTestCase(unittest.TestCase):
     fixtures = ComputeFileFixtures('openstack')
 
@@ -587,9 +612,10 @@ class OpenStackIdentity_3_0_MockHttp(MockHttp):
         if method == 'POST':
             status = httplib.OK
             data = json.loads(body)
-            if data['auth']['identity']['password']['user']['domain']['name'] != 'test_domain' or \
-                    data['auth']['scope']['project']['domain']['name'] != 'test_domain':
-                status = httplib.UNAUTHORIZED
+            if 'password' in data['auth']['identity']:
+                if data['auth']['identity']['password']['user']['domain']['name'] != 'test_domain' or \
+                        data['auth']['scope']['project']['domain']['name'] != 'test_domain':
+                    status = httplib.UNAUTHORIZED
 
             body = ComputeFileFixtures('openstack').load('_v3__auth.json')
             headers = self.json_content_headers.copy()
@@ -669,6 +695,19 @@ class OpenStackIdentity_3_0_MockHttp(MockHttp):
             return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
         raise NotImplementedError()
 
+    def _v3_OS_FEDERATION_identity_providers_idp_protocols_oidc_auth(self, method, url, body, headers):
+        if method == 'GET':
+            headers = self.json_content_headers.copy()
+            headers['x-subject-token'] = '00000000000000000000000000000000'
+            return (httplib.OK, body, headers, httplib.responses[httplib.OK])
+        raise NotImplementedError()
+
+    def _v3_OS_FEDERATION_projects(self, method, url, body, headers):
+        if method == 'GET':
+            # get user projects
+            body = json.dumps({"projects": [{"id": "project_id"}]})
+            return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
+        raise NotImplementedError()
 
 if __name__ == '__main__':
     sys.exit(unittest.main())


### PR DESCRIPTION
## Add OpenStackIdentity_3_0_Connection child class to manage auth with OpenID access tokens
### Description

The class OpenStackIdentity_3_0_Connection_OIDC_access_token has been added to enable OpenStack driver to manage OpenID access tokens to get access to an OpenStack site.

http://docs.openstack.org/developer/keystone/extensions/openidc.html
### Status
- done, ready for review
### Checklist (tick everything that applies)
- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
