### PR TITLE
Ceph S3 Outscale storage driver fixes

### DIFF
--- a/libcloud/storage/drivers/rgw.py
+++ b/libcloud/storage/drivers/rgw.py
@@ -72,12 +72,16 @@ class S3RGWStorageDriver(S3StorageDriver):
 
     def __init__(self, key, secret=None, secure=True, host=None, port=None,
                  api_version=None, region=S3_RGW_DEFAULT_REGION, **kwargs):
+
         if host is None:
             raise LibcloudError('host required', driver=self)
-        self.name = 'Ceph RGW S3 (%s)' % (region)
+
+        self.name = kwargs.pop('name', None)
+        if self.name is None:
+            self.name = 'Ceph RGW S3 (%s)' % (region)
+
         self.ex_location_name = region
         self.region_name = region
-
         self.signature_version = str(kwargs.pop('signature_version',
                                                 DEFAULT_SIGNATURE_VERSION))
 
@@ -86,10 +90,11 @@ class S3RGWStorageDriver(S3StorageDriver):
                              (self.signature_version))
 
         if self.signature_version == '2':
-            self.connectionCls = S3RGWOutscaleConnectionAWS2
+            self.connectionCls = S3RGWConnectionAWS2
         elif self.signature_version == '4':
-            self.connectionCls = S3RGWOutscaleConnectionAWS4
+            self.connectionCls = S3RGWConnectionAWS4
         self.connectionCls.host = host
+
         super(S3RGWStorageDriver, self).__init__(key, secret,
                                                  secure, host, port,
                                                  api_version, region,
@@ -101,14 +106,6 @@ class S3RGWStorageDriver(S3StorageDriver):
         return kwargs
 
 
-class S3RGWOutscaleConnectionAWS4(S3RGWConnectionAWS4):
-    pass
-
-
-class S3RGWOutscaleConnectionAWS2(S3RGWConnectionAWS2):
-    pass
-
-
 class S3RGWOutscaleStorageDriver(S3RGWStorageDriver):
 
     def __init__(self, key, secret=None, secure=True, host=None, port=None,
@@ -116,24 +113,8 @@ class S3RGWOutscaleStorageDriver(S3RGWStorageDriver):
                  **kwargs):
         if region not in S3_RGW_OUTSCALE_HOSTS_BY_REGION:
             raise LibcloudError('Unknown region (%s)' % (region), driver=self)
-
-        self.name = 'OUTSCALE Ceph RGW S3 (%s)' % (region)
-        self.ex_location_name = region
-        self.region_name = region
-        self.signature_version = str(kwargs.pop('signature_version',
-                                                DEFAULT_SIGNATURE_VERSION))
-
-        if self.signature_version not in ['2', '4']:
-            raise ValueError('Invalid signature_version: %s' %
-                             (self.signature_version))
-
-        if self.signature_version == '2':
-            self.connectionCls = S3RGWOutscaleConnectionAWS2
-        elif self.signature_version == '4':
-            self.connectionCls = S3RGWOutscaleConnectionAWS4
-
         host = S3_RGW_OUTSCALE_HOSTS_BY_REGION[region]
-        self.connectionCls.host = host
+        kwargs['name'] = 'OUTSCALE Ceph RGW S3 (%s)' % region
         super(S3RGWOutscaleStorageDriver, self).__init__(key, secret,
                                                          secure, host, port,
                                                          api_version, region,

--- a/libcloud/test/storage/test_rgw.py
+++ b/libcloud/test/storage/test_rgw.py
@@ -1,0 +1,73 @@
+import sys
+import unittest
+
+from libcloud.storage.drivers.rgw import S3RGWStorageDriver
+from libcloud.storage.drivers.rgw import S3RGWOutscaleStorageDriver
+from libcloud.storage.drivers.rgw import S3RGWConnectionAWS4
+from libcloud.storage.drivers.rgw import S3RGWConnectionAWS2
+
+from libcloud.test.secrets import STORAGE_S3_PARAMS
+
+
+class S3RGWTests(unittest.TestCase):
+    driver_type = S3RGWStorageDriver
+    driver_args = STORAGE_S3_PARAMS
+    default_host = 'localhost'
+
+    @classmethod
+    def create_driver(self):
+        return self.driver_type(*self.driver_args,
+                                signature_version='2',
+                                host=self.default_host)
+
+    def setUp(self):
+        self.driver = self.create_driver()
+
+    def test_connection_class_type(self):
+        res = self.driver.connectionCls is S3RGWConnectionAWS2
+        self.assertTrue(res, 'driver.connectionCls does not match!')
+
+    def test_connection_class_host(self):
+        host = self.driver.connectionCls.host
+        self.assertEqual(host, self.default_host)
+
+
+class S3RGWOutscaleTests(S3RGWTests):
+    driver_type = S3RGWOutscaleStorageDriver
+    default_host = 'osu.eu-west-2.outscale.com'
+
+    @classmethod
+    def create_driver(self):
+        return self.driver_type(*self.driver_args,
+                                signature_version='4')
+
+    def test_connection_class_type(self):
+        res = self.driver.connectionCls is S3RGWConnectionAWS4
+        self.assertTrue(res, 'driver.connectionCls does not match!')
+
+    def test_connection_class_host(self):
+        host = self.driver.connectionCls.host
+        self.assertEqual(host, self.default_host)
+
+
+class S3RGWOutscaleDoubleInstanceTests(S3RGWTests):
+    driver_type = S3RGWOutscaleStorageDriver
+    default_host = 'osu.eu-west-2.outscale.com'
+
+    @classmethod
+    def create_driver(self):
+        d = self.driver_type(*self.driver_args, signature_version='4')
+        self.driver_type(*self.driver_args, signature_version='2')
+        return d
+
+    def test_connection_class_type(self):
+        res = self.driver.connectionCls is S3RGWConnectionAWS4
+        self.assertTrue(res, 'driver.connectionCls does not match!')
+
+    def test_connection_class_host(self):
+        host = self.driver.connectionCls.host
+        self.assertEqual(host, self.default_host)
+
+
+if __name__ == '__main__':
+    sys.exit(unittest.main())


### PR DESCRIPTION
- Simplify the Outscale driver
- Remove unused Outscale connection classes
- Fix default signature v2 issue with the Outscale driver

Signed-off-by: Javier M. Mellid jmunhoz@igalia.com
