### PR TITLE
[WIP] Support POST requests in cloudstack create_node (LIBCLOUD-822)

### DIFF
--- a/libcloud/test/common/test_cloudstack.py
+++ b/libcloud/test/common/test_cloudstack.py
@@ -120,7 +120,7 @@ class CloudStackCommonTest(unittest.TestCase):
 
         connection = CloudStackConnection('fnord', 'abracadabra')
         for case in cases:
-            params = connection._add_default_params(case[0])
+            params = connection._add_default_params(case[0], None)
             self.assertEqual(connection._make_signature(params), b(case[1]))
 
 

--- a/libcloud/test/common/test_cloudstack.py
+++ b/libcloud/test/common/test_cloudstack.py
@@ -94,10 +94,14 @@ class CloudStackCommonTest(unittest.TestCase):
             (
                 {
                     'command': 'listVirtualMachines'
+                    'response': 'json',
+                    'apiKey': self.connection.user_id,
                 }, 'z/a9Y7J52u48VpqIgiwaGUMCso0='
             ), (
                 {
                     'command': 'deployVirtualMachine',
+                    'response': 'json',
+                    'apiKey': self.connection.user_id,
                     'name': 'fred',
                     'displayname': 'George',
                     'serviceofferingid': 5,
@@ -108,6 +112,8 @@ class CloudStackCommonTest(unittest.TestCase):
             ), (
                 {
                     'command': 'deployVirtualMachine',
+                    'response': 'json',
+                    'apiKey': self.connection.user_id,
                     'name': 'fred',
                     'displayname': 'George+Ringo',
                     'serviceofferingid': 5,
@@ -119,9 +125,8 @@ class CloudStackCommonTest(unittest.TestCase):
         ]
 
         connection = CloudStackConnection('fnord', 'abracadabra')
-        for case in cases:
-            params = connection._add_default_params(case[0], None)
-            self.assertEqual(connection._make_signature(params), b(case[1]))
+        for params, sig in cases:
+            self.assertEqual(connection._make_signature(params, None), b(sig))
 
 
 class CloudStackMockHttp(MockHttpTestCase):

--- a/libcloud/test/common/test_cloudstack.py
+++ b/libcloud/test/common/test_cloudstack.py
@@ -120,7 +120,7 @@ class CloudStackCommonTest(unittest.TestCase):
 
         connection = CloudStackConnection('fnord', 'abracadabra')
         for case in cases:
-            params = connection.add_default_params(case[0])
+            params = connection._add_default_params(case[0])
             self.assertEqual(connection._make_signature(params), b(case[1]))
 
 


### PR DESCRIPTION
## Support POST requests in cloudstack create_node
### Description

This allows sending longer parameter values (like ex_user_data) that
would not fit into the request line limit.
### Status

This is an initial proposal, tests are not adapted yet but I tested it manually. I'm not really happy with the abstraction layers yet.
### Checklist (tick everything that applies)
- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
