### PR TITLE
Fix cloudstack user data on Python 3

### DIFF
--- a/libcloud/compute/drivers/cloudstack.py
+++ b/libcloud/compute/drivers/cloudstack.py
@@ -1633,7 +1633,7 @@ class CloudStackNodeDriver(CloudStackDriverMixIn, NodeDriver):
             server_params['keypair'] = ex_key_name
 
         if ex_user_data:
-            ex_user_data = base64.b64encode(b(ex_user_data).decode('ascii'))
+            ex_user_data = base64.b64encode(b(ex_user_data)).decode('ascii')
             server_params['userdata'] = ex_user_data
 
         if ex_security_groups:

--- a/libcloud/test/__init__.py
+++ b/libcloud/test/__init__.py
@@ -259,6 +259,7 @@ class MockHttpTestCase(MockHttp, unittest.TestCase):
             self.assertDictEqual(params, expected_params)
         else:
             for key, value in expected_params.items():
+                self.assertIn(key, params)
                 self.assertEqual(params[key], value)
 
 

--- a/libcloud/test/compute/test_cloudstack.py
+++ b/libcloud/test/compute/test_cloudstack.py
@@ -221,6 +221,18 @@ class CloudStackCommonTestCase(TestCaseMixin):
         self.assertEqual(node.name, 'test')
         self.assertEqual(node.extra['key_name'], 'foobar')
 
+    def test_create_node_ex_userdata(self):
+        size = self.driver.list_sizes()[0]
+        image = self.driver.list_images()[0]
+        location = self.driver.list_locations()[0]
+        CloudStackMockHttp.fixture_tag = 'deploykeyname'
+        node = self.driver.create_node(name='test',
+                                       location=location,
+                                       image=image,
+                                       size=size,
+                                       ex_userdata='foobar')
+        self.assertEqual(node.name, 'test')
+
     def test_create_node_project(self):
         size = self.driver.list_sizes()[0]
         image = self.driver.list_images()[0]

--- a/libcloud/test/compute/test_cloudstack.py
+++ b/libcloud/test/compute/test_cloudstack.py
@@ -222,6 +222,7 @@ class CloudStackCommonTestCase(TestCaseMixin):
         self.assertEqual(node.extra['key_name'], 'foobar')
 
     def test_create_node_ex_userdata(self):
+        self.driver.path = '/test/path/userdata'
         size = self.driver.list_sizes()[0]
         image = self.driver.list_images()[0]
         location = self.driver.list_locations()[0]
@@ -1280,6 +1281,11 @@ class CloudStackMockHttp(MockHttpTestCase):
             fixture = command + '_' + self.fixture_tag + '.json'
             body, obj = self._load_fixture(fixture)
             return (httplib.OK, body, obj, httplib.responses[httplib.OK])
+
+    def _test_path_userdata(self, method, url, body, headers):
+        if 'deployVirtualMachine' in url:
+            self.assertUrlContainsQueryParams(url, {'userdata': 'Zm9vYmFy'})
+        return self._test_path(method, url, body, headers)
 
     def _cmd_queryAsyncJobResult(self, jobid):
         fixture = 'queryAsyncJobResult' + '_' + str(jobid) + '.json'


### PR DESCRIPTION
## Fix cloudstack user data on Python 3
### Description

A wrongly nested string decode caused a TypeError as b64encode
expects a byte string in Python 3 and conversely the url parameter
needs to be a normal string.
### Status

done
### Checklist (tick everything that applies)
- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
