### PR TITLE
GCE: Add support for creating multiple nodes on a subnetwork

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -2590,12 +2590,11 @@ class GCENodeDriver(NodeDriver):
             size = self.ex_get_size(size, location)
         if not hasattr(ex_network, 'name'):
             ex_network = self.ex_get_network(ex_network)
-        if ex_subnetwork:
-            if not hasattr(ex_subnetwork, 'name'):
-                ex_subnetwork = \
-                    self.ex_get_subnetwork(ex_subnetwork,
-                                           region=self._get_region_from_zone(
-                                               location))
+        if ex_subnetwork and not hasattr(ex_subnetwork, 'name'):
+            ex_subnetwork = \
+                self.ex_get_subnetwork(ex_subnetwork,
+                                       region=self._get_region_from_zone(
+                                           location))
         if ex_image_family:
             image = self.ex_get_image_from_family(ex_image_family)
         if image and not hasattr(image, 'name'):

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -5166,7 +5166,8 @@ class GCENodeDriver(NodeDriver):
             if not ex_disk_type:
                 ex_disk_type = 'pd-standard'
             if not hasattr(ex_disk_type, 'name'):
-                ex_disk_type = self.ex_get_disktype(ex_disk_type, zone=location)
+                ex_disk_type = self.ex_get_disktype(ex_disk_type,
+                                                    zone=location)
             disks = [{'boot': True,
                       'type': 'PERSISTENT',
                       'mode': 'READ_WRITE',

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -2802,12 +2802,11 @@ class GCENodeDriver(NodeDriver):
             size = self.ex_get_size(size, location)
         if not hasattr(ex_network, 'name'):
             ex_network = self.ex_get_network(ex_network)
-        if ex_subnetwork:
-            if not hasattr(ex_subnetwork, 'name'):
-                ex_subnetwork = \
-                    self.ex_get_subnetwork(ex_subnetwork,
-                                           region=self._get_region_from_zone(
-                                               location))
+        if ex_subnetwork and if not hasattr(ex_subnetwork, 'name'):
+            ex_subnetwork = \
+                self.ex_get_subnetwork(ex_subnetwork,
+                                       region=self._get_region_from_zone(
+                                           location))
         if ex_image_family:
             image = self.ex_get_image_from_family(ex_image_family)
         if image and not hasattr(image, 'name'):

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -2802,7 +2802,7 @@ class GCENodeDriver(NodeDriver):
             size = self.ex_get_size(size, location)
         if not hasattr(ex_network, 'name'):
             ex_network = self.ex_get_network(ex_network)
-        if ex_subnetwork and if not hasattr(ex_subnetwork, 'name'):
+        if ex_subnetwork and not hasattr(ex_subnetwork, 'name'):
             ex_subnetwork = \
                 self.ex_get_subnetwork(ex_subnetwork,
                                        region=self._get_region_from_zone(

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -2640,6 +2640,7 @@ class GCENodeDriver(NodeDriver):
 
     def ex_create_multiple_nodes(self, base_name, size, image, number,
                                  location=None, ex_network='default',
+                                 ex_subnetwork=None,
                                  ex_tags=None, ex_metadata=None,
                                  ignore_errors=True, use_existing_disk=True,
                                  poll_interval=2, external_ip='ephemeral',
@@ -2802,6 +2803,12 @@ class GCENodeDriver(NodeDriver):
             size = self.ex_get_size(size, location)
         if not hasattr(ex_network, 'name'):
             ex_network = self.ex_get_network(ex_network)
+        if ex_subnetwork:
+            if not hasattr(ex_subnetwork, 'name'):
+                ex_subnetwork = \
+                    self.ex_get_subnetwork(ex_subnetwork,
+                                           region=self._get_region_from_zone(
+                                               location))
         if ex_image_family:
             image = self.ex_get_image_from_family(ex_image_family)
         if image and not hasattr(image, 'name'):
@@ -2813,6 +2820,7 @@ class GCENodeDriver(NodeDriver):
                       'image': image,
                       'location': location,
                       'network': ex_network,
+                      'subnetwork': ex_subnetwork,
                       'tags': ex_tags,
                       'metadata': ex_metadata,
                       'ignore_errors': ignore_errors,
@@ -5158,7 +5166,7 @@ class GCENodeDriver(NodeDriver):
             if not ex_disk_type:
                 ex_disk_type = 'pd-standard'
             if not hasattr(ex_disk_type, 'name'):
-                ex_disk_type = self.ex_get_disktype(ex_disk_type)
+                ex_disk_type = self.ex_get_disktype(ex_disk_type, zone=location)
             disks = [{'boot': True,
                       'type': 'PERSISTENT',
                       'mode': 'READ_WRITE',
@@ -5321,7 +5329,8 @@ class GCENodeDriver(NodeDriver):
             ex_disks_gce_struct=node_attrs['ex_disks_gce_struct'],
             ex_nic_gce_struct=node_attrs['ex_nic_gce_struct'],
             ex_on_host_maintenance=node_attrs['ex_on_host_maintenance'],
-            ex_automatic_restart=node_attrs['ex_automatic_restart'])
+            ex_automatic_restart=node_attrs['ex_automatic_restart'],
+            ex_subnetwork=node_attrs['subnetwork'])
 
         try:
             node_res = self.connection.request(


### PR DESCRIPTION
## Add support for creating multiple nodes on a subnetwork
### Description

Currently for GCE, the multi node creation API does not support creating multiple nodes on a subnetwork. I have made changes to the ex_create_multiple_nodes function and the functions it calls to support creation of nodes on a given subnetwork. If subnetwork is None, the changes fall back to legacy network behavior on GCE so it is backwards compatible. There was one change to _create_node_req that was needed to get disk types which is simply passing in the location provided as an argument to ex_get_disktype.
### Status
- ready for review
### Checklist (tick everything that applies)
- [X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [X] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
