### PR TITLE
refactored _parse_arp_table

### DIFF
--- a/libcloud/compute/drivers/libvirt_driver.py
+++ b/libcloud/compute/drivers/libvirt_driver.py
@@ -269,15 +269,14 @@ class LibvirtNodeDriver(NodeDriver):
             child = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                                      stderr=subprocess.PIPE)
             stdout, _ = child.communicate()
-            arp_table = self._parse_arp_table(arp_output=stdout)
+            arp_table = self._parse_ip_table_arp(arp_output=stdout)
         except OSError as e:
             if e.errno == 2:
                 cmd = ['ip', 'neigh']
                 child = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                                          stderr=subprocess.PIPE)
                 stdout, _ = child.communicate()
-                arp_table = self._parse_arp_table(arp_output=stdout,
-                                                  arp_cmd='ip')
+                arp_table = self._parse_ip_table_neigh(arp_output=stdout)
 
         for mac_address in mac_addresses:
             if mac_address in arp_table:
@@ -324,23 +323,41 @@ class LibvirtNodeDriver(NodeDriver):
 
         return result
 
-    def _parse_arp_table(self, arp_output, arp_cmd='arp'):
+    def _parse_ip_table_arp(self, arp_output):
         """
-        Parse arp command output and return a dictionary which maps mac address
+        Sets up the regexp for parsing out IP addresses from the 'arp -an'
+        command and pass it along to the parser function.
+
+        :return: Dictionary from the parsing funtion
+        :rtype: ``dict``
+        """
+        arp_regex = re.compile('.*?\((.*?)\) at (.*?)\s+')
+        return self._parse_mac_addr_table(arp_output, arp_regex)
+
+    def _parse_ip_table_neigh(self, ip_output):
+        """
+        Sets up the regexp for parsing out IP addresses from the 'ip neighbor'
+        command and pass it along to the parser function.
+
+        :return: Dictionary from the parsing funtion
+        :rtype: ``dict``
+        """
+        ip_regex = re.compile('(.*?)\s+.*lladdr\s+(.*?)\s+')
+        return self._parse_mac_addr_table(ip_output, ip_regex)
+
+    def _parse_mac_addr_table(self, cmd_output, mac_regex):
+        """
+        Parse the command output and return a dictionary which maps mac address
         to an IP address.
 
         :return: Dictionary which maps mac address to IP address.
         :rtype: ``dict``
         """
-        re_match = {}
-        re_match['arp'] = '.*?\((.*?)\) at (.*?)\s+'
-        re_match['ip'] = '(.*?)\s+.*lladdr\s+(.*?)\s+'
-        ip_mac = re.compile(re_match[arp_cmd])
-        lines = arp_output.split('\n')
+        lines = cmd_output.split('\n')
 
         arp_table = defaultdict(list)
         for line in lines:
-            match = ip_mac.match(line)
+            match = mac_regex.match(line)
 
             if not match:
                 continue

--- a/libcloud/test/compute/test_libvirt_driver.py
+++ b/libcloud/test/compute/test_libvirt_driver.py
@@ -21,11 +21,151 @@ from libcloud.compute.drivers.libvirt_driver import LibvirtNodeDriver
 from libcloud.test import unittest
 
 
+class virConnect:
+    """
+    A stub/Mock implementation of the libvirt.virConnect class returned by
+    the libvirt.openX calles
+    """
+    def stub(self, *args, **kwargs):
+        return 0
+
+    def __init__(self):
+        stub = self.stub
+        fnt = [
+            '_dispatchCloseCallback',
+            '_dispatchDomainEventAgentLifecycleCallback',
+            '_dispatchDomainEventBalloonChangeCallback',
+            '_dispatchDomainEventBlockJobCallback',
+            '_dispatchDomainEventCallbacks',
+            '_dispatchDomainEventDeviceAddedCallback',
+            '_dispatchDomainEventDeviceRemovalFailedCallback',
+            '_dispatchDomainEventDeviceRemovedCallback',
+            '_dispatchDomainEventDiskChangeCallback',
+            '_dispatchDomainEventGenericCallback',
+            '_dispatchDomainEventGraphicsCallback',
+            '_dispatchDomainEventIOErrorCallback',
+            '_dispatchDomainEventIOErrorReasonCallback',
+            '_dispatchDomainEventJobCompletedCallback',
+            '_dispatchDomainEventLifecycleCallback',
+            '_dispatchDomainEventMigrationIterationCallback',
+            '_dispatchDomainEventPMSuspendCallback',
+            '_dispatchDomainEventPMSuspendDiskCallback',
+            '_dispatchDomainEventPMWakeupCallback',
+            '_dispatchDomainEventRTCChangeCallback',
+            '_dispatchDomainEventTrayChangeCallback',
+            '_dispatchDomainEventTunableCallback',
+            '_dispatchDomainEventWatchdogCallback',
+            '_dispatchNetworkEventLifecycleCallback',
+            '_o', 'allocPages', 'baselineCPU', 'c_pointer', 'changeBegin',
+            'changeCommit', 'changeRollback', 'close', 'compareCPU',
+            'createLinux', 'createXML', 'createXMLWithFiles', 'defineXML',
+            'defineXMLFlags', 'domainEventDeregister',
+            'domainEventDeregisterAny', 'domainEventRegister',
+            'domainEventRegisterAny', 'domainListGetStats',
+            'domainXMLFromNative', 'domainXMLToNative',
+            'findStoragePoolSources', 'getAllDomainStats', 'getCPUMap',
+            'getCPUModelNames', 'getCPUStats', 'getCapabilities',
+            'getCellsFreeMemory',
+            'getDomainCapabilities',
+            'getFreeMemory',
+            'getFreePages',
+            'getHostname',
+            'getInfo',
+            'getLibVersion',
+            'getMaxVcpus',
+            'getMemoryParameters',
+            'getMemoryStats',
+            'getSecurityModel',
+            'getSysinfo',
+            'getType',
+            'getURI',
+            'getVersion',
+            'interfaceDefineXML',
+            'interfaceLookupByMACString',
+            'interfaceLookupByName',
+            'isAlive',
+            'isEncrypted',
+            'isSecure',
+            'listAllDevices',
+            'listAllDomains',
+            'listAllInterfaces',
+            'listAllNWFilters',
+            'listAllNetworks',
+            'listAllSecrets',
+            'listAllStoragePools',
+            'listDefinedDomains',
+            'listDefinedInterfaces',
+            'listDefinedNetworks',
+            'listDefinedStoragePools',
+            'listDevices',
+            'listDomainsID',
+            'listInterfaces',
+            'listNWFilters',
+            'listNetworks',
+            'listSecrets',
+            'listStoragePools',
+            'lookupByID',
+            'lookupByName',
+            'lookupByUUID',
+            'lookupByUUIDString',
+            'networkCreateXML',
+            'networkDefineXML',
+            'networkEventDeregisterAny',
+            'networkEventRegisterAny',
+            'networkLookupByName',
+            'networkLookupByUUID',
+            'networkLookupByUUIDString',
+            'newStream',
+            'nodeDeviceCreateXML',
+            'nodeDeviceLookupByName',
+            'nodeDeviceLookupSCSIHostByWWN',
+            'numOfDefinedDomains',
+            'numOfDefinedInterfaces',
+            'numOfDefinedNetworks',
+            'numOfDefinedStoragePools',
+            'numOfDevices',
+            'numOfDomains',
+            'numOfInterfaces',
+            'numOfNWFilters',
+            'numOfNetworks',
+            'numOfSecrets',
+            'numOfStoragePools',
+            'nwfilterDefineXML',
+            'nwfilterLookupByName',
+            'nwfilterLookupByUUID',
+            'nwfilterLookupByUUIDString',
+            'registerCloseCallback',
+            'restore',
+            'restoreFlags',
+            'saveImageDefineXML',
+            'saveImageGetXMLDesc',
+            'secretDefineXML',
+            'secretLookupByUUID',
+            'secretLookupByUUIDString',
+            'secretLookupByUsage',
+            'setKeepAlive',
+            'setMemoryParameters',
+            'storagePoolCreateXML',
+            'storagePoolDefineXML',
+            'storagePoolLookupByName',
+            'storagePoolLookupByUUID',
+            'storagePoolLookupByUUIDString',
+            'storageVolLookupByKey',
+            'storageVolLookupByPath',
+            'suspendForDuration',
+            'unregisterCloseCallback',
+            'virConnGetLastError',
+            'virConnResetLastError'
+        ]
+        for f in fnt:
+            self.__dict__[f] = stub
+
+
 class LibvirtNodeDriverTestCase(LibvirtNodeDriver, unittest.TestCase):
     def __init__(self, argv=None):
         unittest.TestCase.__init__(self, argv)
         self._uri = 'qemu:///system'
-        self.connection = None
+        self.connection = virConnect()
 
     def _assert_arp_table(self, arp_table):
         self.assertIn('52:54:00:bc:f9:6c', arp_table)

--- a/libcloud/test/compute/test_libvirt_driver.py
+++ b/libcloud/test/compute/test_libvirt_driver.py
@@ -21,21 +21,21 @@ from libcloud.compute.drivers.libvirt_driver import LibvirtNodeDriver
 from libcloud.test import unittest
 
 
-class LibvirtNodeDriverTestCase( unittest.TestCase):
-    
-
-    def setUp(self):
-        self.driver = LibvirtNodeDriver('')
+class LibvirtNodeDriverTestCase(LibvirtNodeDriver, unittest.TestCase):
+    def __init__(self, argv=None):
+        unittest.TestCase.__init__(self,argv)
+        self._uri = 'qemu:///system'
+        self.connection = None
 
     def _assert_arp_table(self, arp_table):
         self.assertIn('52:54:00:bc:f9:6c', arp_table)
         self.assertIn('52:54:00:04:89:51', arp_table)
         self.assertIn('52:54:00:c6:40:ec', arp_table)
         self.assertIn('52:54:00:77:1c:83', arp_table)
-        self.assertEqual(arp_table['52:54:00:bc:f9:6c'], '1.2.10.80')
-        self.assertEqual(arp_table['52:54:00:04:89:51'], '1.2.10.33')
-        self.assertEqual(arp_table['52:54:00:c6:40:ec'], '1.2.10.97')
-        self.assertEqual(arp_table['52:54:00:77:1c:83'], '1.2.10.40')
+        self.assertIn('1.2.10.80', arp_table['52:54:00:bc:f9:6c'])
+        self.assertIn('1.2.10.33', arp_table['52:54:00:04:89:51'])
+        self.assertIn('1.2.10.97', arp_table['52:54:00:c6:40:ec'])
+        self.assertIn('1.2.10.40', arp_table['52:54:00:77:1c:83'])
 
     def test_arp_map(self):
         arp_output_str = """? (1.2.10.80) at 52:54:00:bc:f9:6c [ether] on br0
@@ -43,7 +43,7 @@ class LibvirtNodeDriverTestCase( unittest.TestCase):
 ? (1.2.10.97) at 52:54:00:c6:40:ec [ether] on br0
 ? (1.2.10.40) at 52:54:00:77:1c:83 [ether] on br0
 """
-        arp_table = self.driver._parse_ip_table_arp(arp_output_str)
+        arp_table = self._parse_ip_table_arp(arp_output_str)
         self._assert_arp_table(arp_table)
 
     def test_ip_map(self):
@@ -52,7 +52,7 @@ class LibvirtNodeDriverTestCase( unittest.TestCase):
 1.2.10.97 dev br0 lladdr 52:54:00:c6:40:ec DELAY
 1.2.10.40 dev br0 lladdr 52:54:00:77:1c:83 STALE
 """
-        arp_table = self.driver._parse_ip_table_neigh(arp_output_str)
+        arp_table = self._parse_ip_table_neigh(arp_output_str)
         self._assert_arp_table(arp_table)
 
 if __name__ == '__main__':

--- a/libcloud/test/compute/test_libvirt_driver.py
+++ b/libcloud/test/compute/test_libvirt_driver.py
@@ -23,7 +23,7 @@ from libcloud.test import unittest
 
 class LibvirtNodeDriverTestCase(LibvirtNodeDriver, unittest.TestCase):
     def __init__(self, argv=None):
-        unittest.TestCase.__init__(self,argv)
+        unittest.TestCase.__init__(self, argv)
         self._uri = 'qemu:///system'
         self.connection = None
 

--- a/libcloud/test/compute/test_libvirt_driver.py
+++ b/libcloud/test/compute/test_libvirt_driver.py
@@ -1,0 +1,59 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+from libcloud.compute.drivers.libvirt_driver import LibvirtNodeDriver
+
+
+from libcloud.test import unittest
+
+
+class LibvirtNodeDriverTestCase( unittest.TestCase):
+    
+
+    def setUp(self):
+        self.driver = LibvirtNodeDriver('')
+
+    def _assert_arp_table(self, arp_table):
+        self.assertIn('52:54:00:bc:f9:6c', arp_table)
+        self.assertIn('52:54:00:04:89:51', arp_table)
+        self.assertIn('52:54:00:c6:40:ec', arp_table)
+        self.assertIn('52:54:00:77:1c:83', arp_table)
+        self.assertEqual(arp_table['52:54:00:bc:f9:6c'], '1.2.10.80')
+        self.assertEqual(arp_table['52:54:00:04:89:51'], '1.2.10.33')
+        self.assertEqual(arp_table['52:54:00:c6:40:ec'], '1.2.10.97')
+        self.assertEqual(arp_table['52:54:00:77:1c:83'], '1.2.10.40')
+
+    def test_arp_map(self):
+        arp_output_str = """? (1.2.10.80) at 52:54:00:bc:f9:6c [ether] on br0
+? (1.2.10.33) at 52:54:00:04:89:51 [ether] on br0
+? (1.2.10.97) at 52:54:00:c6:40:ec [ether] on br0
+? (1.2.10.40) at 52:54:00:77:1c:83 [ether] on br0
+"""
+        arp_table = self.driver._parse_ip_table_arp(arp_output_str)
+        self._assert_arp_table(arp_table)
+
+    def test_ip_map(self):
+        arp_output_str = """1.2.10.80 dev br0 lladdr 52:54:00:bc:f9:6c STALE
+1.2.10.33 dev br0 lladdr 52:54:00:04:89:51 REACHABLE
+1.2.10.97 dev br0 lladdr 52:54:00:c6:40:ec DELAY
+1.2.10.40 dev br0 lladdr 52:54:00:77:1c:83 STALE
+"""
+        arp_table = self.driver._parse_ip_table_neigh(arp_output_str)
+        self._assert_arp_table(arp_table)
+
+if __name__ == '__main__':
+    sys.exit(unittest.main())


### PR DESCRIPTION
refactoring of the arp table parsing for libvirt
### Description

passing each command output to their own parsing function
and add unittest for parsing the tables
### Status
- done, ready for review
### Checklist (tick everything that applies)
- [X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [X] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)

split _parse_arp_table into 1 general and 2 specialized functions
