### PR TITLE
loadbalancer/rackspace/list_balancers: add params

### DIFF
--- a/libcloud/loadbalancer/drivers/rackspace.py
+++ b/libcloud/loadbalancer/drivers/rackspace.py
@@ -349,7 +349,8 @@ class RackspaceLBDriver(Driver, OpenStackDriverMixin):
         return self._to_protocols_with_default_ports(
             self.connection.request('/loadbalancers/protocols').object)
 
-    def list_balancers(self, ex_member_address=None):
+    def list_balancers(self, ex_member_address=None, ex_status=None,
+                       ex_changes_since=None, ex_params={}):
         """
         @inherits: :class:`Driver.list_balancers`
 
@@ -357,11 +358,32 @@ class RackspaceLBDriver(Driver, OpenStackDriverMixin):
                                   If provided, only the load balancers which
                                   have this member attached will be returned.
         :type ex_member_address: ``str``
+
+        :param ex_status: Optional. Filter balancers by status
+        :type ex_status: ``str``
+
+        :param ex_changes_since: Optional. List all load balancers that have
+                                 changed since the specified date/time
+        :type ex_changes_since: ``str``
+
+        :param ex_params: Optional. Set parameters to be submitted to the API
+                          in the query string
+        :type ex_params: ``dict``
         """
+
         params = {}
 
         if ex_member_address:
             params['nodeaddress'] = ex_member_address
+
+        if ex_status:
+            params['status'] = ex_status
+
+        if ex_changes_since:
+            params['changes-since'] = ex_changes_since
+
+        for key, value in ex_params.items():
+            params[key] = value
 
         return self._to_balancers(
             self.connection.request('/loadbalancers', params=params).object)


### PR DESCRIPTION
## Load Balancer / Rackspace: allow params on listing load balancers
### Description

Allow to set params to be submitted in the query string to API request.
By default, Rackspace API [return a maximum of 100 items at a time](https://developer.rackspace.com/docs/cloud-load-balancers/v1/developer-guide/#paginated-collections).
This change allow to set "offset" in the params, to paginate requests.
Ex. `list_balancers(ex_params={'offset': 100})`
### Status
- done, ready for review
### Checklist
- [X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) 
- [X] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
