### PR TITLE
auroradns: Set 'priority' key in extra dict instead of 'prio'.

### DIFF
--- a/libcloud/dns/drivers/auroradns.py
+++ b/libcloud/dns/drivers/auroradns.py
@@ -570,7 +570,7 @@ class AuroraDNSDriver(DNSDriver):
         extra['modified'] = record['modified']
         extra['disabled'] = record['disabled']
         extra['ttl'] = record['ttl']
-        extra['prio'] = record['prio']
+        extra['priority'] = record['prio']
 
         return Record(id=record['id'], name=name,
                       type=record['type'],

--- a/libcloud/test/dns/test_auroradns.py
+++ b/libcloud/test/dns/test_auroradns.py
@@ -61,6 +61,32 @@ class AuroraDNSDriverTests(LibcloudTestCase):
             self.assertEqual(data[param], params[param])
             self.assertEqual(data['name'], 'localhost')
 
+    def test_res_to_record(self):
+        res = {'id': 2,
+               'name': 'www',
+               'type': 'AAAA',
+               'content': '2001:db8:100',
+               'created': 1234,
+               'modified': 2345,
+               'disabled': False,
+               'ttl': 1800,
+               'prio': 10}
+
+        zone = Zone(id=1,
+                    domain='example.com',
+                    type=None,
+                    ttl=60,
+                    driver=self.driver)
+
+        record = self.driver._AuroraDNSDriver__res_to_record(zone, res)
+        self.assertEqual(res['name'], record.name)
+        self.assertEqual(res['ttl'], record.extra['ttl'])
+        self.assertEqual(res['prio'], record.extra['priority'])
+        self.assertEqual(res['type'], record.type)
+        self.assertEqual(res['content'], record.data)
+        self.assertEqual(zone, record.zone)
+        self.assertEqual(self.driver, record.driver)
+
     def test_list_zones(self):
         zones = self.driver.list_zones()
         self.assertEqual(len(zones), 2)
@@ -98,7 +124,7 @@ class AuroraDNSDriverTests(LibcloudTestCase):
         self.assertEquals(record.data, '127.0.0.1')
         self.assertEquals(record.type, RecordType.A)
         self.assertEquals(record.extra['ttl'], 900)
-        self.assertEquals(record.extra['prio'], None)
+        self.assertEquals(record.extra['priority'], None)
 
     def test_update_record(self):
         ttl = 900


### PR DESCRIPTION
The AuroraDNS API returns the DNS record priority as the field 'prio', but libcloud expects 'priority'.

In the AuroraDNS driver set the 'priority' key in the extra dictionary when parsing return values from the AuroraDNS API.

Also add a additional test to verify this behavior.
