### PR TITLE
Add the ability to specify primary and secondary DNS for a node

### DIFF
--- a/libcloud/compute/drivers/dimensiondata.py
+++ b/libcloud/compute/drivers/dimensiondata.py
@@ -129,7 +129,9 @@ class DimensionDataNodeDriver(NodeDriver):
                     ex_memory_gb=None,
                     ex_cpu_specification=None,
                     ex_is_started=True, ex_additional_nics_vlan=None,
-                    ex_additional_nics_ipv4=None, **kwargs):
+                    ex_additional_nics_ipv4=None,
+                    ex_primary_dns=None,
+                    ex_secondary_dns=None, **kwargs):
         """
         Create a new DimensionData node
 
@@ -187,6 +189,14 @@ class DimensionDataNodeDriver(NodeDriver):
         :keyword    ex_additional_nics_ipv4: (MCP2 Only) List of additional
                                               nics to add by ipv4 address
         :type       ex_additional_nics_ipv4: ``list`` of ``str``
+
+        :keyword    ex_primary_dns: The node's primary DNS
+
+        :type       ex_primary_dns: ``str``
+
+        :keyword    ex_secondary_dns: The node's secondary DNS
+
+        :type       ex_secondary_dns: ``str``
 
         :return: The newly created :class:`Node`.
         :rtype: :class:`Node`
@@ -267,6 +277,14 @@ class DimensionDataNodeDriver(NodeDriver):
             elif ex_additional_nics_vlan is not None:
                 raise TypeError("ex_additional_nics_vlan"
                                 "must be None or tuple/list")
+
+        if ex_primary_dns:
+            dns_elm = ET.SubElement(server_elm, "primaryDns")
+            dns_elm.text = ex_primary_dns
+
+        if ex_secondary_dns:
+            dns_elm = ET.SubElement(server_elm, "secondaryDns")
+            dns_elm.text = ex_secondary_dns
 
         response = self.connection.request_with_orgId_api_2(
             'server/deployServer',

--- a/libcloud/test/compute/test_dimensiondata.py
+++ b/libcloud/test/compute/test_dimensiondata.py
@@ -432,6 +432,21 @@ class DimensionDataTests(unittest.TestCase, TestCaseMixin):
                                     ex_additional_nics_vlan='badstring',
                                     ex_is_started=False)
 
+    def test_create_node_mcp2_indicate_dns(self):
+        rootPw = NodeAuthPassword('pass123')
+        image = self.driver.list_images()[0]
+        node = self.driver.create_node(name='test2',
+                                       image=image,
+                                       auth=rootPw,
+                                       ex_description='test node dns',
+                                       ex_network_domain='fakenetworkdomain',
+                                       ex_primary_ipv4='10.0.0.1',
+                                       ex_primary_dns='8.8.8.8',
+                                       ex_secondary_dns='8.8.4.4',
+                                       ex_is_started=False)
+        self.assertEqual(node.id, 'e75ead52-692f-4314-8725-c8a4f4d13a87')
+        self.assertEqual(node.extra['status'].action, 'DEPLOY_SERVER')
+
     def test_ex_shutdown_graceful(self):
         node = Node(id='11', name=None, state=None,
                     public_ips=None, private_ips=None, driver=self.driver)


### PR DESCRIPTION
### Description

This change adds two arguments to the create_node() method of the
dimensiondata driver. These arguments, ex_primary_dns and
ex_secondary_dns, allow the client to set the node's DNS servers
at launch time.
### Status

Done, ready for review
### Checklist (tick everything that applies)
- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
