### PR TITLE
Implement block storage APIs for DigitalOcean

### DIFF
--- a/docs/compute/_supported_methods_block_storage.rst
+++ b/docs/compute/_supported_methods_block_storage.rst
@@ -14,7 +14,7 @@ Provider                              list volumes create volume destroy volume 
 `CloudSigma (API v2.0)`_              no           no            no             no            no            no             no             
 `CloudStack`_                         yes          yes           yes            yes           yes           no             yes            
 `Cloudwatt`_                          yes          yes           yes            yes           yes           yes            yes            
-`DigitalOcean`_                       no           no            no             no            no            no             no             
+`DigitalOcean`_                       yes          yes           yes            yes           yes           no             no             
 `DimensionData`_                      no           no            no             no            no            no             no             
 `Amazon EC2`_                         yes          yes           yes            yes           yes           yes            yes            
 `Enomaly Elastic Computing Platform`_ no           no            no             no            no            no             no             

--- a/libcloud/compute/drivers/digitalocean.py
+++ b/libcloud/compute/drivers/digitalocean.py
@@ -27,6 +27,7 @@ from libcloud.common.types import InvalidCredsError
 from libcloud.compute.types import Provider, NodeState
 from libcloud.compute.base import NodeImage, NodeSize, NodeLocation, KeyPair
 from libcloud.compute.base import Node, NodeDriver
+from libcloud.compute.base import StorageVolume
 
 __all__ = [
     'DigitalOceanNodeDriver',
@@ -352,6 +353,10 @@ class DigitalOcean_v2_NodeDriver(DigitalOcean_v2_BaseDriver,
         data = self._paginated_request('/v2/sizes', 'sizes')
         return list(map(self._to_size, data))
 
+    def list_volumes(self):
+        data = self._paginated_request('/v2/volumes', 'volumes')
+        return list(map(self._to_volume, data))
+
     def create_node(self, name, size, image, location, ex_create_attr=None,
                     ex_ssh_key_ids=None, ex_user_data=None):
         """
@@ -570,6 +575,16 @@ class DigitalOcean_v2_NodeDriver(DigitalOcean_v2_BaseDriver,
                  'created_at': data['created_at']}
         return NodeImage(id=data['id'], name=data['name'], driver=self,
                          extra=extra)
+
+    def _to_volume(self, data):
+        extra = {'created_at': data['created_at'],
+                 'droplet_ids': data['droplet_ids'],
+                 'region': data['region'],
+                 'region_slug': data['region']['slug']}
+
+        return StorageVolume(id=data['id'], name=data['name'],
+                             size=data['size_gigabytes'], driver=self,
+                             extra=extra)
 
     def _to_location(self, data):
         return NodeLocation(id=data['slug'], name=data['name'], country=None,

--- a/libcloud/test/compute/fixtures/digitalocean_v2/attach_volume.json
+++ b/libcloud/test/compute/fixtures/digitalocean_v2/attach_volume.json
@@ -1,0 +1,34 @@
+{
+  "action": {
+    "region_slug": "nyc1",
+    "region": {
+      "available": true,
+      "features": [
+        "private_networking",
+        "backups",
+        "ipv6",
+        "metadata"
+      ],
+      "sizes": [
+        "512mb",
+        "1gb",
+        "2gb",
+        "4gb",
+        "8gb",
+        "16gb",
+        "32gb",
+        "48gb",
+        "64gb"
+      ],
+      "slug": "nyc1",
+      "name": "New York 1"
+    },
+    "resource_type": "backend",
+    "resource_id": null,
+    "completed_at": null,
+    "started_at": "2016-06-06T21:01:30Z",
+    "type": "attach_volume",
+    "status": "in-progress",
+    "id": 110956293
+  }
+}

--- a/libcloud/test/compute/fixtures/digitalocean_v2/create_volume.json
+++ b/libcloud/test/compute/fixtures/digitalocean_v2/create_volume.json
@@ -1,0 +1,32 @@
+{
+  "volume": {
+    "created_at": "2016-06-06T20:51:04Z",
+    "size_gigabytes": 4,
+    "description": "Block store for examples",
+    "name": "example",
+    "droplet_ids": [],
+    "region": {
+      "available": true,
+      "features": [
+        "private_networking",
+        "backups",
+        "ipv6",
+        "metadata"
+      ],
+      "sizes": [
+        "512mb",
+        "1gb",
+        "2gb",
+        "4gb",
+        "8gb",
+        "16gb",
+        "32gb",
+        "48gb",
+        "64gb"
+      ],
+      "slug": "nyc1",
+      "name": "New York 1"
+    },
+    "id": "62766883-2c28-11e6-b8e6-000f53306ae1"
+  }
+}

--- a/libcloud/test/compute/fixtures/digitalocean_v2/detach_volume.json
+++ b/libcloud/test/compute/fixtures/digitalocean_v2/detach_volume.json
@@ -1,0 +1,34 @@
+{
+  "action": {
+    "region_slug": "nyc1",
+    "region": {
+      "available": true,
+      "features": [
+        "private_networking",
+        "backups",
+        "ipv6",
+        "metadata"
+      ],
+      "sizes": [
+        "512mb",
+        "1gb",
+        "2gb",
+        "4gb",
+        "8gb",
+        "16gb",
+        "32gb",
+        "48gb",
+        "64gb"
+      ],
+      "slug": "nyc1",
+      "name": "New York 1"
+    },
+    "resource_type": "backend",
+    "resource_id": null,
+    "completed_at": null,
+    "started_at": "2016-06-06T21:02:20Z",
+    "type": "detach_volume",
+    "status": "in-progress",
+    "id": 110956599
+  }
+}

--- a/libcloud/test/compute/fixtures/digitalocean_v2/list_volumes.json
+++ b/libcloud/test/compute/fixtures/digitalocean_v2/list_volumes.json
@@ -1,0 +1,38 @@
+{
+  "volumes": [
+    {
+      "size_gigabytes": 4,
+      "region": {
+        "slug": "nyc1",
+        "sizes": [
+          "512mb",
+          "1gb",
+          "2gb",
+          "4gb",
+          "8gb",
+          "16gb",
+          "32gb",
+          "48gb",
+          "64gb"
+        ],
+        "name": "New York 1",
+        "features": [
+          "private_networking",
+          "backups",
+          "ipv6",
+          "metadata"
+        ],
+        "available": true
+      },
+      "name": "example",
+      "id": "62766883-2c28-11e6-b8e6-000f53306ae1",
+      "droplet_ids": [],
+      "description": "Block store for examples",
+      "created_at": "2016-06-06T20:51:04Z"
+    }
+  ],
+  "links": {},
+  "meta": {
+    "total": 1
+  }
+}

--- a/libcloud/test/compute/fixtures/digitalocean_v2/list_volumes_empty.json
+++ b/libcloud/test/compute/fixtures/digitalocean_v2/list_volumes_empty.json
@@ -1,0 +1,7 @@
+{
+  "volumes": [],
+  "links": {},
+  "meta": {
+    "total": 0
+  }
+}


### PR DESCRIPTION
## Implement block storage APIs for DigitalOcean
### Description

DigitalOcean has a new block storage feature in beta. The API docs are [available here](https://developers.digitalocean.com/documentation/v2/block-storage-beta/). This PR implements the block storage API calls in the DigitalOcean driver.

A few things to keep in mind at this point:
- Block storage is currently only available to users enrolled in the beta. Block storage API calls will fail for other users.
- Block storage is not yet available in all DigitalOcean regions.
- DigitalOcean block storage does not support snapshots, so snapshot-related APIs are still unimplemented.
### Status

Done, ready for review.
### Checklist (tick everything that applies)
- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
