### PR TITLE
[LIBCLOUD-827] Add support for automatic SNI

### DIFF
--- a/libcloud/test/test_httplib_ssl.py
+++ b/libcloud/test/test_httplib_ssl.py
@@ -16,6 +16,7 @@
 import os
 import sys
 import os.path
+import ssl
 import socket
 
 import mock
@@ -109,8 +110,17 @@ class TestHttpLibSSLTests(unittest.TestCase):
 
     @mock.patch('socket.create_connection', mock.MagicMock())
     @mock.patch('socket.socket', mock.MagicMock())
-    @mock.patch('ssl.wrap_socket')
-    def test_connect_throws_friendly_error_message_on_ssl_wrap_connection_reset_by_peer(self, mock_wrap_socket):
+    def test_connect_throws_friendly_error_message_on_ssl_wrap_connection_reset_by_peer(self):
+
+        mock_wrap_socket = None
+
+        if getattr(ssl, 'SSLContext', None):
+            ssl.SSLContext.wrap_socket = mock.MagicMock()
+            mock_wrap_socket = ssl.SSLContext.wrap_socket
+        else:
+            ssl.wrap_socket = mock.MagicMock()
+            mock_wrap_socket = ssl.wrap_socket
+
         # Test that we re-throw a more friendly error message in case
         # "connection reset by peer" error occurs when trying to establish a
         # SSL connection

--- a/libcloud/test/test_httplib_ssl.py
+++ b/libcloud/test/test_httplib_ssl.py
@@ -114,7 +114,7 @@ class TestHttpLibSSLTests(unittest.TestCase):
 
         mock_wrap_socket = None
 
-        if getattr(ssl, 'SSLContext', None):
+        if getattr(ssl, 'HAS_SNI', False):
             ssl.SSLContext.wrap_socket = mock.MagicMock()
             mock_wrap_socket = ssl.SSLContext.wrap_socket
         else:


### PR DESCRIPTION
## 827 - Add Support for automatic SNI
### Description

Adds support for automatic SNI using the hostname
supplied to connect to.

Python SSL has had SNI support for around six years
(https://hg.python.org/cpython/rev/846c0e1342d0/) 

We need to convert old ssl socket wrap into a context
to effect this.
### Status
- done, ready for review
### Checklist (tick everything that applies)
- [X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [N/A] Documentation
- [X] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [N/A] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
