### PR TITLE
Libvirt/include sasl auth

### DIFF
--- a/libcloud/compute/drivers/libvirt_driver.py
+++ b/libcloud/compute/drivers/libvirt_driver.py
@@ -68,6 +68,12 @@ class LibvirtNodeDriver(NodeDriver):
         :param  uri: Hypervisor URI (e.g. vbox:///session, qemu:///system,
                      etc.).
         :type   uri: ``str``
+
+        :param  key: the username for a remote libvirtd server
+        :type   key: ``str``
+
+        :param  secret: the password for a remote libvirtd server
+        :type   key: ``str``
         """
         if not have_libvirt:
             raise RuntimeError('Libvirt driver requires \'libvirt\' Python ' +
@@ -88,6 +94,18 @@ class LibvirtNodeDriver(NodeDriver):
             self.connection = libvirt.openAuth(uri, auth, 0)
 
     def _cred_callback(self, cred, user_data):
+        """
+        Callback for the authentication scheme, which will provide username
+        and password for the login. Reference: ( http://bit.ly/1U5yyQg )
+
+        :param  cred: The credentials requested and the return
+        :type   cred: ``list``
+
+        :param  user_data: Custom data provided to the authentication routine
+        :type   user_data: ``list``
+
+        :rtype: ``int``
+        """
         for credential in cred:
             if credential[0] == libvirt.VIR_CRED_AUTHNAME:
                 credential[4] = self._key

--- a/libcloud/compute/drivers/libvirt_driver.py
+++ b/libcloud/compute/drivers/libvirt_driver.py
@@ -87,7 +87,7 @@ class LibvirtNodeDriver(NodeDriver):
         except libvirt.libvirtError:
             if key is None or secret is None:
                 raise RuntimeError('The remote Libvirt instance requires ' +
-                                   'authenication, please set \'key\' and ' +
+                                   'authentication, please set \'key\' and ' +
                                    '\'secret\' parameters')
             auth = [[libvirt.VIR_CRED_AUTHNAME, libvirt.VIR_CRED_PASSPHRASE],
                     self._cred_callback, None]


### PR DESCRIPTION
## include sasl auth to libvirt_driver
### Description

Adding SASL authentication to QEMU+tcp remote connections

Because this really annoyed me. We have about +100 KVM servers and I'd
just to iterate over them and get all the available nodes. Apply a few filters
and then return a list of nodes where the end user don't need to worry about
which KVM host his VM is running on and just be able to reboot it should he
need to.
### Status
- work in progress
### Checklist (tick everything that applies)
- [X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
