### PR TITLE
Add certifi CA bundle path to Libcloud CA bundle search path if certifi is available

### DIFF
--- a/libcloud/security.py
+++ b/libcloud/security.py
@@ -36,6 +36,10 @@ VERIFY_SSL_CERT = True
 
 SSL_VERSION = ssl.PROTOCOL_TLSv1
 
+# True to use certifi CA bundle path when certifi library is available
+USE_CERTIFI = os.environ.get('LIBCLOUD_SSL_USE_CERTIFI', True)
+USE_CERTIFI = str(USE_CERTIFI).lower() in ['true', '1']
+
 # File containing one or more PEM-encoded CA certificates
 # concatenated together.
 CA_CERTS_PATH = [
@@ -60,6 +64,21 @@ CA_CERTS_PATH = [
     # opensuse/sles: openssl
     '/etc/ssl/certs/YaST-CA.pem',
 ]
+
+# Insert certifi CA bundle path to the front of Libcloud CA bundle search
+# path if certifi is available
+try:
+    import certifi
+except ImportError:
+    has_certifi = False
+else:
+    has_certifi = True
+
+if has_certifi and USE_CERTIFI:
+    certifi_ca_bundle_path = certifi.where()
+
+    if certifi_ca_bundle_path not in CA_CERTS_PATH:
+        CA_CERTS_PATH.insert(0, certifi_ca_bundle_path)
 
 # Allow user to explicitly specify which CA bundle to use, using an environment
 # variable

--- a/libcloud/security.py
+++ b/libcloud/security.py
@@ -76,9 +76,7 @@ else:
 
 if has_certifi and USE_CERTIFI:
     certifi_ca_bundle_path = certifi.where()
-
-    if certifi_ca_bundle_path not in CA_CERTS_PATH:
-        CA_CERTS_PATH.insert(0, certifi_ca_bundle_path)
+    CA_CERTS_PATH.insert(0, certifi_ca_bundle_path)
 
 # Allow user to explicitly specify which CA bundle to use, using an environment
 # variable

--- a/libcloud/test/test_httplib_ssl.py
+++ b/libcloud/test/test_httplib_ssl.py
@@ -152,6 +152,53 @@ class TestHttpLibSSLTests(unittest.TestCase):
         self.assertEqual(e.errno, 105)
         self.assertTrue('Some random error' in str(e))
 
+    def test_certifi_ca_bundle_in_search_path(self):
+        mock_certifi_ca_bundle_path = '/certifi/bundle/path'
+
+        # Certifi not available
+        import libcloud.security
+        reload(libcloud.security)
+
+        original_length = len(libcloud.security.CA_CERTS_PATH)
+
+        self.assertTrue(mock_certifi_ca_bundle_path not in
+                        libcloud.security.CA_CERTS_PATH)
+
+        # Certifi is available
+        mock_certifi = mock.Mock()
+        mock_certifi.where.return_value = mock_certifi_ca_bundle_path
+        sys.modules['certifi'] = mock_certifi
+
+        # Certifi CA bundle path should be injected at the begining of search list
+        import libcloud.security
+        reload(libcloud.security)
+
+        self.assertEqual(libcloud.security.CA_CERTS_PATH[0],
+                         mock_certifi_ca_bundle_path)
+        self.assertEqual(len(libcloud.security.CA_CERTS_PATH),
+                         (original_length + 1))
+
+        # Certifi is available, but USE_CERTIFI is set to False
+        os.environ['LIBCLOUD_SSL_USE_CERTIFI'] = 'false'
+
+        import libcloud.security
+        reload(libcloud.security)
+
+        self.assertTrue(mock_certifi_ca_bundle_path not in
+                        libcloud.security.CA_CERTS_PATH)
+        self.assertEqual(len(libcloud.security.CA_CERTS_PATH), original_length)
+
+        # And enabled
+        os.environ['LIBCLOUD_SSL_USE_CERTIFI'] = 'true'
+
+        import libcloud.security
+        reload(libcloud.security)
+
+        self.assertEqual(libcloud.security.CA_CERTS_PATH[0],
+                         mock_certifi_ca_bundle_path)
+        self.assertEqual(len(libcloud.security.CA_CERTS_PATH),
+                         (original_length + 1))
+
 
 if __name__ == '__main__':
     sys.exit(unittest.main())


### PR DESCRIPTION
This change will add certifi CA bundle path to Libcloud CA bundle search path if `certifi` library (https://pypi.python.org/pypi/certifi) is installed and available in the virtual environment / PYTHONPATH where Libcloud is used.

This path is injected into the CA bundle search path which means it has precedence over other paths.

This behavior is enabled by default, but it can be disabled by setting `LIBCLOUD_SSL_USE_CERTIFI` environment variable to `false` or any other non-truthy value.

Some context can be found in this PR - https://github.com/conda-forge/staged-recipes/pull/694, but even without it, I think that's a good change until we switch to `requests`.
## TODO
- [ ] Docs
