### PR TITLE
Allow setting of load balancer port to None

### DIFF
--- a/libcloud/loadbalancer/drivers/dimensiondata.py
+++ b/libcloud/loadbalancer/drivers/dimensiondata.py
@@ -98,16 +98,17 @@ class DimensionDataLBDriver(Driver):
         kwargs['region'] = self.selected_region
         return kwargs
 
-    def create_balancer(self, name, port, protocol, algorithm, members):
+    def create_balancer(self, name, port=None, protocol=None,
+                        algorithm=None, members=None):
         """
         Create a new load balancer instance
 
         :param name: Name of the new load balancer (required)
         :type  name: ``str``
 
-        :param port: Port the load balancer should listen on,
-                    defaults to 80 (required)
-        :type  port: ``str``
+        :param port: An integer in the range of 1-65535. If not supplied,
+                     it will be taken to mean 'Any Port'
+        :type  port: ``int``
 
         :param protocol: Loadbalancer protocol, defaults to http.
         :type  protocol: ``str``
@@ -121,8 +122,6 @@ class DimensionDataLBDriver(Driver):
         :rtype: :class:`LoadBalancer`
         """
         network_domain_id = self.network_domain_id
-        if port is None:
-            port = 80
         if protocol is None:
             protocol = 'http'
         if algorithm is None:
@@ -559,8 +558,8 @@ class DimensionDataLBDriver(Driver):
                                    network_domain_id,
                                    name,
                                    ex_description,
-                                   port,
-                                   pool,
+                                   port=None,
+                                   pool=None,
                                    listener_ip_address=None,
                                    persistence_profile=None,
                                    fallback_persistence_profile=None,
@@ -581,8 +580,9 @@ class DimensionDataLBDriver(Driver):
         :param ex_description: Description of the node (required)
         :type  ex_description: ``str``
 
-        :param port: Description of the node (required)
-        :type  port: ``str``
+        :param port: An integer in the range of 1-65535. If not supplied,
+                     it will be taken to mean 'Any Port'
+        :type  port: ``int``
 
         :param pool: The pool to use for the listener
         :type  pool: :class:`DimensionDataPool`
@@ -636,7 +636,8 @@ class DimensionDataLBDriver(Driver):
         if listener_ip_address is not None:
             ET.SubElement(create_node_elm, "listenerIpAddress").text = \
                 str(listener_ip_address)
-        ET.SubElement(create_node_elm, "port").text = str(port)
+        if port is not None:
+            ET.SubElement(create_node_elm, "port").text = str(port)
         ET.SubElement(create_node_elm, "enabled").text = 'true'
         ET.SubElement(create_node_elm, "connectionLimit") \
             .text = str(connection_limit)
@@ -644,8 +645,9 @@ class DimensionDataLBDriver(Driver):
             .text = str(connection_rate_limit)
         ET.SubElement(create_node_elm, "sourcePortPreservation") \
             .text = source_port_preservation
-        ET.SubElement(create_node_elm, "poolId") \
-            .text = pool.id
+        if pool is not None:
+            ET.SubElement(create_node_elm, "poolId") \
+                .text = pool.id
         if persistence_profile is not None:
             ET.SubElement(create_node_elm, "persistenceProfileId") \
                 .text = persistence_profile.id

--- a/libcloud/test/loadbalancer/test_dimensiondata.py
+++ b/libcloud/test/loadbalancer/test_dimensiondata.py
@@ -78,7 +78,7 @@ class DimensionDataTests(unittest.TestCase):
         self.assertEqual(balancer.name, 'test')
         self.assertEqual(balancer.id, '8334f461-0df0-42d5-97eb-f4678eb26bea')
         self.assertEqual(balancer.ip, '165.180.12.22')
-        self.assertEqual(balancer.port, 80)
+        self.assertEqual(balancer.port, None)
         self.assertEqual(balancer.extra['pool_id'], '9e6b496d-5261-4542-91aa-b50c7f569c54')
         self.assertEqual(balancer.extra['network_domain_id'], '1234')
 
@@ -162,6 +162,28 @@ class DimensionDataTests(unittest.TestCase):
             extra=None)
         member = self.driver.balancer_attach_member(balancer, member)
         self.assertEqual(member.id, '3dd806a2-c2c8-4c0c-9a4f-5219ea9266c0')
+
+    def test_balancer_attach_member_without_port(self):
+        extra = {'pool_id': '4d360b1f-bc2c-4ab7-9884-1f03ba2768f7',
+                 'network_domain_id': '1234'}
+        balancer = LoadBalancer(
+            id='234',
+            name='test',
+            state=State.RUNNING,
+            ip='1.2.3.4',
+            port=1234,
+            driver=self.driver,
+            extra=extra
+        )
+        member = Member(
+            id=None,
+            ip='112.12.2.2',
+            port=None,
+            balancer=balancer,
+            extra=None)
+        member = self.driver.balancer_attach_member(balancer, member)
+        self.assertEqual(member.id, '3dd806a2-c2c8-4c0c-9a4f-5219ea9266c0')
+        self.assertEqual(member.port, None)
 
     def test_balancer_detach_member(self):
         extra = {'pool_id': '4d360b1f-bc2c-4ab7-9884-1f03ba2768f7',
@@ -288,6 +310,32 @@ class DimensionDataTests(unittest.TestCase):
                 service_down_action=None,
                 slow_ramp_time=None
             ))
+        self.assertEqual(listener.id, '8334f461-0df0-42d5-97eb-f4678eb26bea')
+        self.assertEqual(listener.name, 'test')
+
+    def test_ex_create_virtual_listener_without_port(self):
+        listener = self.driver.ex_create_virtual_listener(
+            network_domain_id='12345',
+            name='test',
+            ex_description='test',
+            pool=DimensionDataPool(
+                id='1234',
+                name='test',
+                description='test',
+                status=State.RUNNING,
+                health_monitor_id=None,
+                load_balance_method=None,
+                service_down_action=None,
+                slow_ramp_time=None
+            ))
+        self.assertEqual(listener.id, '8334f461-0df0-42d5-97eb-f4678eb26bea')
+        self.assertEqual(listener.name, 'test')
+
+    def test_ex_create_virtual_listener_without_pool(self):
+        listener = self.driver.ex_create_virtual_listener(
+            network_domain_id='12345',
+            name='test',
+            ex_description='test')
         self.assertEqual(listener.id, '8334f461-0df0-42d5-97eb-f4678eb26bea')
         self.assertEqual(listener.name, 'test')
 


### PR DESCRIPTION
### Description

This is a replacement to PR #814 

The documentation for the Dimension Data Cloud REST API v2.2-20160222 states that a load balancer port can be an integer in the range of 1-65535 and, if not supplied, will be taken to mean 'Any Port'. This change fixes the Dimension Data driver to conform to the docs.
### Status
- done, ready for review
### Checklist (tick everything that applies)
- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
