### PR TITLE
LIBCLOUD-606 Can not connect to AWS with IAM role temporary credentials

### DIFF
--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -5398,7 +5398,12 @@ class BaseEC2NodeDriver(NodeDriver):
 
     def _ex_connection_class_kwargs(self):
         kwargs = super(BaseEC2NodeDriver, self)._ex_connection_class_kwargs()
-        kwargs['signature_version'] = self.signature_version
+        if self.token is None:
+            kwargs['signature_version'] = self.signature_version
+        else:
+            kwargs['token'] = self.token
+            # Force signature_version 4 for tokens or auth breaks
+            kwargs['signature_version'] = '4'
         return kwargs
 
     def _to_nodes(self, object, xpath):
@@ -6335,7 +6340,7 @@ class EC2NodeDriver(BaseEC2NodeDriver):
     }
 
     def __init__(self, key, secret=None, secure=True, host=None, port=None,
-                 region='us-east-1', **kwargs):
+                 region='us-east-1', token=None, **kwargs):
         if hasattr(self, '_region'):
             region = self._region
 
@@ -6345,6 +6350,7 @@ class EC2NodeDriver(BaseEC2NodeDriver):
 
         details = REGION_DETAILS[region]
         self.region_name = region
+        self.token = token
         self.api_name = details['api_name']
         self.country = details['country']
         self.signature_version = details.get('signature_version',

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -5398,7 +5398,7 @@ class BaseEC2NodeDriver(NodeDriver):
 
     def _ex_connection_class_kwargs(self):
         kwargs = super(BaseEC2NodeDriver, self)._ex_connection_class_kwargs()
-        if hasattr(self, 'token') and  self.token is not None:
+        if hasattr(self, 'token') and self.token is not None:
             kwargs['token'] = self.token
             # Force signature_version 4 for tokens or auth breaks
             kwargs['signature_version'] = '4'

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -5398,12 +5398,13 @@ class BaseEC2NodeDriver(NodeDriver):
 
     def _ex_connection_class_kwargs(self):
         kwargs = super(BaseEC2NodeDriver, self)._ex_connection_class_kwargs()
-        if self.token is None:
-            kwargs['signature_version'] = self.signature_version
-        else:
+        if hasattr(self, 'token') and  self.token is not None:
             kwargs['token'] = self.token
             # Force signature_version 4 for tokens or auth breaks
             kwargs['signature_version'] = '4'
+        else:
+            kwargs['signature_version'] = self.signature_version
+
         return kwargs
 
     def _to_nodes(self, object, xpath):

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -85,6 +85,21 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
         self.driver = EC2NodeDriver(*EC2_PARAMS,
                                     **{'region': self.region})
 
+    def test_instantiate_driver_with_token(self):
+        token = 'temporary_credentials_token'
+        driver = EC2NodeDriver(*EC2_PARAMS, **{'region': self.region, 'token': token})
+        self.assertTrue(hasattr(driver, 'token'), 'Driver has no attribute token')
+        self.assertEquals(token, driver.token, "Driver token does not match with provided token")
+
+    def test_driver_with_token_signature_version(self):
+        token = 'temporary_credentials_token'
+        driver = EC2NodeDriver(*EC2_PARAMS, **{'region': self.region, 'token': token})
+        kwargs = driver._ex_connection_class_kwargs()
+        self.assertIn('signature_version', kwargs)
+        self.assertEquals('4', kwargs['signature_version'], 'Signature version is not 4 with temporary credentials')
+
+
+
     def test_create_node(self):
         image = NodeImage(id='ami-be3adfd7',
                           name=self.image_name,

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -98,8 +98,6 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
         self.assertIn('signature_version', kwargs)
         self.assertEquals('4', kwargs['signature_version'], 'Signature version is not 4 with temporary credentials')
 
-
-
     def test_create_node(self):
         image = NodeImage(id='ami-be3adfd7',
                           name=self.image_name,


### PR DESCRIPTION
## Connect to AWS using temporary IAM role credentials
### Description

Can not connect to AWS with IAM role temporary credentials. Doesn't seem like the supplied token is in the header

From: [LIBCLOUD-606](https://issues.apache.org/jira/browse/LIBCLOUD-606)
### Status

done, ready for review
### Checklist (tick everything that applies)
- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
