### PR TITLE
Lazy entry

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -40,10 +40,10 @@ with any of the Libcloud drivers.
 
     from pprint import pprint
 
-    from libcloud.compute.types import Provider
-    from libcloud.compute.providers import get_driver
+    import libcloud
+    
+    cls = libcloud.get_driver(libcloud.DriverType.COMPUTE, libcloud.DriverType.COMPUTE.RACKSPACE)
 
-    cls = get_driver(Provider.RACKSPACE)
 
 2. Instantiate the driver with your provider credentials
 
@@ -70,10 +70,10 @@ see provider-specific documentation and the driver docstrings.
 
     from pprint import pprint
 
-    from libcloud.compute.types import Provider
-    from libcloud.compute.providers import get_driver
-
-    cls = get_driver(Provider.RACKSPACE)
+    import libcloud
+    
+    cls = libcloud.get_driver(libcloud.DriverType.COMPUTE, libcloud.DriverType.COMPUTE.RACKSPACE)
+    
     driver = cls('my username', 'my api key')
 
     pprint(driver.list_sizes())

--- a/libcloud/__init__.py
+++ b/libcloud/__init__.py
@@ -34,7 +34,8 @@ from libcloud.dns.providers import Provider as DnsProvider
 from libcloud.dns.providers import get_driver as get_dns_driver
 
 from libcloud.loadbalancer.providers import Provider as LoadBalancerProvider
-from libcloud.loadbalancer.providers import get_driver as get_loadbalancer_driver
+from libcloud.loadbalancer.providers import get_driver as \
+    get_loadbalancer_driver
 
 from libcloud.storage.providers import Provider as StorageProvider
 from libcloud.storage.providers import get_driver as get_storage_driver

--- a/libcloud/__init__.py
+++ b/libcloud/__init__.py
@@ -21,24 +21,9 @@ libcloud provides a unified interface to the cloud computing resources.
 import os
 import codecs
 
-from libcloud.backup.providers import Provider as BackupProvider
-from libcloud.backup.providers import get_driver as get_backup_driver
-
-from libcloud.compute.providers import Provider as ComputeProvider
-from libcloud.compute.providers import get_driver as get_compute_driver
-
-from libcloud.container.providers import Provider as ContainerProvider
-from libcloud.container.providers import get_driver as get_container_driver
-
-from libcloud.dns.providers import Provider as DnsProvider
-from libcloud.dns.providers import get_driver as get_dns_driver
-
-from libcloud.loadbalancer.providers import Provider as LoadBalancerProvider
-from libcloud.loadbalancer.providers import get_driver as \
-    get_loadbalancer_driver
-
-from libcloud.storage.providers import Provider as StorageProvider
-from libcloud.storage.providers import get_driver as get_storage_driver
+from libcloud.base import DriverType  # NOQA
+from libcloud.base import DriverTypeFactoryMap  # NOQA
+from libcloud.base import get_driver  # NOQA
 
 
 __all__ = ['__version__', 'enable_debug']
@@ -94,40 +79,3 @@ def _init_once():
             paramiko.common.logging.basicConfig(level=paramiko.common.DEBUG)
 
 _init_once()
-
-
-class DriverType:
-    """ Backup-as-a-service driver """
-    BACKUP = BackupProvider
-
-    """ Compute-as-a-Service driver """
-    COMPUTE = ComputeProvider
-
-    """ Container-as-a-Service driver """
-    CONTAINER = ContainerProvider
-
-    """ DNS service provider driver """
-    DNS = DnsProvider
-
-    """ Load balancer provider-driver """
-    LOADBALANCER = LoadBalancerProvider
-
-    """ Storage-as-a-Service driver """
-    STORAGE = StorageProvider
-
-
-DriverTypeFactoryMap = {
-    DriverType.BACKUP: get_backup_driver,
-    DriverType.COMPUTE: get_compute_driver,
-    DriverType.CONTAINER: get_container_driver,
-    DriverType.DNS: get_dns_driver,
-    DriverType.LOADBALANCER: get_loadbalancer_driver,
-    DriverType.STORAGE: get_storage_driver
-}
-
-
-def get_driver(type, provider):
-    """
-    Get a driver
-    """
-    return DriverTypeFactoryMap[type](provider)

--- a/libcloud/__init__.py
+++ b/libcloud/__init__.py
@@ -18,12 +18,19 @@ libcloud provides a unified interface to the cloud computing resources.
 
 :var __version__: Current version of libcloud
 """
+import os
+import codecs
+
+from libcloud.backup.providers import Provider as BackupProvider
+from libcloud.compute.providers import Provider as ComputeProvider
+from libcloud.container.providers import Provider as ContainerProvider
+from libcloud.dns.providers import Provider as DnsProvider
+from libcloud.loadbalancer.providers import Provider as LoadBalancerProvider
+from libcloud.storage.providers import Provider as StorageProvider
+
 
 __all__ = ['__version__', 'enable_debug']
 __version__ = '1.0.0'
-
-import os
-import codecs
 
 try:
     import paramiko
@@ -75,3 +82,31 @@ def _init_once():
             paramiko.common.logging.basicConfig(level=paramiko.common.DEBUG)
 
 _init_once()
+
+
+class DriverType:
+    """ Backup-as-a-service driver """
+    BACKUP = BackupProvider
+
+    """ Compute-as-a-Service driver """
+    COMPUTE = ComputeProvider
+
+    """ Container-as-a-Service driver """
+    CONTAINER = ContainerProvider
+
+    """ DNS service provider driver """
+    DNS = DnsProvider
+
+    """ Load balancer provider-driver """
+    LOADBALANCER = LoadBalancerProvider
+
+    """ Storage-as-a-Service driver """
+    STORAGE = StorageProvider
+
+
+def get_driver(provider):
+    """
+
+    Get a driver
+    """
+    pass

--- a/libcloud/__init__.py
+++ b/libcloud/__init__.py
@@ -22,11 +22,22 @@ import os
 import codecs
 
 from libcloud.backup.providers import Provider as BackupProvider
+from libcloud.backup.providers import get_driver as get_backup_driver
+
 from libcloud.compute.providers import Provider as ComputeProvider
+from libcloud.compute.providers import get_driver as get_compute_driver
+
 from libcloud.container.providers import Provider as ContainerProvider
+from libcloud.container.providers import get_driver as get_container_driver
+
 from libcloud.dns.providers import Provider as DnsProvider
+from libcloud.dns.providers import get_driver as get_dns_driver
+
 from libcloud.loadbalancer.providers import Provider as LoadBalancerProvider
+from libcloud.loadbalancer.providers import get_driver as get_loadbalancer_driver
+
 from libcloud.storage.providers import Provider as StorageProvider
+from libcloud.storage.providers import get_driver as get_storage_driver
 
 
 __all__ = ['__version__', 'enable_debug']
@@ -104,9 +115,18 @@ class DriverType:
     STORAGE = StorageProvider
 
 
-def get_driver(provider):
-    """
+DriverTypeFactoryMap = {
+    DriverType.BACKUP: get_backup_driver,
+    DriverType.COMPUTE: get_compute_driver,
+    DriverType.CONTAINER: get_container_driver,
+    DriverType.DNS: get_dns_driver,
+    DriverType.LOADBALANCER: get_loadbalancer_driver,
+    DriverType.STORAGE: get_storage_driver
+}
 
+
+def get_driver(type, provider):
+    """
     Get a driver
     """
-    pass
+    return DriverTypeFactoryMap[type](provider)

--- a/libcloud/base.py
+++ b/libcloud/base.py
@@ -64,8 +64,8 @@ DriverTypeFactoryMap = {
 
 
 class DriverTypeNotFoundError(KeyError):
-    def __init__(self):
-        self.message = "Driver type not found."
+    def __init__(self, type):
+        self.message = "Driver type '%s' not found." % type
 
     def __repr__(self):
         return self.message
@@ -78,4 +78,4 @@ def get_driver(type, provider):
     try:
         return DriverTypeFactoryMap[type](provider)
     except KeyError:
-        raise DriverTypeNotFoundError()
+        raise DriverTypeNotFoundError(type)

--- a/libcloud/base.py
+++ b/libcloud/base.py
@@ -1,0 +1,81 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from libcloud.backup.providers import Provider as BackupProvider
+from libcloud.backup.providers import get_driver as get_backup_driver
+
+from libcloud.compute.providers import Provider as ComputeProvider
+from libcloud.compute.providers import get_driver as get_compute_driver
+
+from libcloud.container.providers import Provider as ContainerProvider
+from libcloud.container.providers import get_driver as get_container_driver
+
+from libcloud.dns.providers import Provider as DnsProvider
+from libcloud.dns.providers import get_driver as get_dns_driver
+
+from libcloud.loadbalancer.providers import Provider as LoadBalancerProvider
+from libcloud.loadbalancer.providers import get_driver as \
+    get_loadbalancer_driver
+
+from libcloud.storage.providers import Provider as StorageProvider
+from libcloud.storage.providers import get_driver as get_storage_driver
+
+
+class DriverType(object):
+    """ Backup-as-a-service driver """
+    BACKUP = BackupProvider
+
+    """ Compute-as-a-Service driver """
+    COMPUTE = ComputeProvider
+
+    """ Container-as-a-Service driver """
+    CONTAINER = ContainerProvider
+
+    """ DNS service provider driver """
+    DNS = DnsProvider
+
+    """ Load balancer provider-driver """
+    LOADBALANCER = LoadBalancerProvider
+
+    """ Storage-as-a-Service driver """
+    STORAGE = StorageProvider
+
+
+DriverTypeFactoryMap = {
+    DriverType.BACKUP: get_backup_driver,
+    DriverType.COMPUTE: get_compute_driver,
+    DriverType.CONTAINER: get_container_driver,
+    DriverType.DNS: get_dns_driver,
+    DriverType.LOADBALANCER: get_loadbalancer_driver,
+    DriverType.STORAGE: get_storage_driver
+}
+
+
+class DriverTypeNotFoundError(KeyError):
+    def __init__(self):
+        self.message = "Driver type not found."
+
+    def __repr__(self):
+        return self.message
+
+
+def get_driver(type, provider):
+    """
+    Get a driver
+    """
+    try:
+        return DriverTypeFactoryMap[type](provider)
+    except KeyError:
+        raise DriverTypeNotFoundError()

--- a/libcloud/test/container/fixtures/docker/mac_124/create_image.json
+++ b/libcloud/test/container/fixtures/docker/mac_124/create_image.json
@@ -1,0 +1,1 @@
+{"status":"Download complete","progressDetail":{},"id":"cf55d61f5307b7a18a45980971d6cfd40b737dd661879c4a6b3f2aecc3bc37b0"}

--- a/libcloud/test/container/fixtures/docker/mac_124/create_image.json
+++ b/libcloud/test/container/fixtures/docker/mac_124/create_image.json
@@ -1,1 +1,0 @@
-{"status":"Download complete","progressDetail":{},"id":"cf55d61f5307b7a18a45980971d6cfd40b737dd661879c4a6b3f2aecc3bc37b0"}

--- a/libcloud/test/test_init.py
+++ b/libcloud/test/test_init.py
@@ -24,6 +24,7 @@ try:
 except ImportError:
     have_paramiko = False
 
+import libcloud
 from libcloud import _init_once
 from libcloud.common.base import LoggingHTTPConnection
 from libcloud.common.base import LoggingHTTPSConnection
@@ -56,6 +57,9 @@ class TestUtils(unittest.TestCase):
             paramiko_log_level = logger.getEffectiveLevel()
             self.assertEqual(paramiko_log_level, logging.DEBUG)
 
+    def test_factory(self):
+        driver = libcloud.get_driver(libcloud.DriverType.COMPUTE, libcloud.DriverType.COMPUTE.EC2)
+        self.assertEqual(driver.__name__, 'EC2NodeDriver')
 
 if __name__ == '__main__':
     sys.exit(unittest.main())

--- a/libcloud/test/test_init.py
+++ b/libcloud/test/test_init.py
@@ -26,6 +26,7 @@ except ImportError:
 
 import libcloud
 from libcloud import _init_once
+from libcloud.base import DriverTypeNotFoundError
 from libcloud.common.base import LoggingHTTPConnection
 from libcloud.common.base import LoggingHTTPSConnection
 
@@ -60,6 +61,10 @@ class TestUtils(unittest.TestCase):
     def test_factory(self):
         driver = libcloud.get_driver(libcloud.DriverType.COMPUTE, libcloud.DriverType.COMPUTE.EC2)
         self.assertEqual(driver.__name__, 'EC2NodeDriver')
+
+    def test_raises_error(self):
+        with self.assertRaises(DriverTypeNotFoundError):
+            libcloud.get_driver('potato', 'potato')
 
 if __name__ == '__main__':
     sys.exit(unittest.main())

--- a/libcloud/utils/py3.py
+++ b/libcloud/utils/py3.py
@@ -64,7 +64,11 @@ if sys.version_info >= (3, 2) and sys.version_info < (3, 3):
     PY32 = True
 
 if PY2_pre_279 or PY3_pre_32:
-    from backports.ssl_match_hostname import match_hostname, CertificateError  # NOQA
+    try:
+        from backports.ssl_match_hostname import match_hostname, CertificateError  # NOQA
+    except ImportError:
+        import warnings
+        warnings.warn("Missing backports.ssl_match_hostname package")
 else:
     # ssl module in Python >= 3.2 includes match hostname function
     from ssl import match_hostname, CertificateError  # NOQA

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,18 @@ try:
 except ImportError:
     has_epydoc = False
 
-import libcloud.utils
-from libcloud.utils.dist import get_packages, get_data_files
+# Mock out the backports module incase an import is requested.
+class MockBackports:
+    def match_hostname():
+        pass
+
+    def CertificateError():
+        pass
+
+sys.modules['backports.ssl_match_hostname'] = MockBackports
+
+import libcloud.utils  # NOQA
+from libcloud.utils.dist import get_packages, get_data_files  # NOQA
 
 libcloud.utils.SHOW_DEPRECATION_WARNING = False
 

--- a/setup.py
+++ b/setup.py
@@ -28,15 +28,6 @@ try:
 except ImportError:
     has_epydoc = False
 
-# Mock out the backports module incase an import is requested.
-class MockBackports:
-    def match_hostname():
-        pass
-
-    def CertificateError():
-        pass
-
-sys.modules['backports.ssl_match_hostname'] = MockBackports
 
 import libcloud.utils  # NOQA
 from libcloud.utils.dist import get_packages, get_data_files  # NOQA


### PR DESCRIPTION
## Introduce a convenience method to the libcloud module for getting drivers
### Description

I find the current mechanism for fetching drivers a little cumbersome, 2 namespaces to import. After using the `requests` library I really like the module `__init__` accessors for common attributes. The most common factory is `get_driver` and the most common enum is the Provider enum.

This code allows for this example:

``` python
import libcloud
cls = libcloud.get_driver(libcloud.DriverType.COMPUTE, libcloud.DriverType.COMPUTE.RACKSPACE)
```
### Status
- done, ready for review
### Checklist (tick everything that applies)
- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
