### PR TITLE
Libvirt/lookup node by uuid or by name

### DIFF
--- a/libcloud/compute/drivers/libvirt_driver.py
+++ b/libcloud/compute/drivers/libvirt_driver.py
@@ -180,7 +180,8 @@ class LibvirtNodeDriver(NodeDriver):
         """
         Retrieve Node object for a domain with a provided uuid.
 
-        :type uuid: ``str``
+        :param  uuid: Uuid of the domain.
+        :type   uuid: ``str``
         """
         domain = self._get_domain_for_uuid(uuid=uuid)
         node = self._to_node(domain=domain)
@@ -190,7 +191,8 @@ class LibvirtNodeDriver(NodeDriver):
         """
         Retrieve Node object for a domain with a provided name.
 
-        :type name: ``str``
+        :param  name: Name of the domain.
+        :type   name: ``str``
         """
         domain = self._get_domain_for_name(name=name)
         node = self._to_node(domain=domain)

--- a/libcloud/compute/drivers/libvirt_driver.py
+++ b/libcloud/compute/drivers/libvirt_driver.py
@@ -176,6 +176,26 @@ class LibvirtNodeDriver(NodeDriver):
         domain = self._get_domain_for_node(node=node)
         return domain.resume() == 0
 
+    def ex_get_node_by_uuid(self, uuid):
+        """
+        Retrieve Node object for a domain with a provided uuid.
+
+        :type uuid: ``str``
+        """
+        domain = self._get_domain_for_uuid(uuid=uuid)
+        node = self._to_node(domain=domain)
+        return node
+
+    def ex_get_node_by_name(self, name):
+        """
+        Retrieve Node object for a domain with a provided name.
+
+        :type name: ``str``
+        """
+        domain = self._get_domain_for_name(name=name)
+        node = self._to_node(domain=domain)
+        return node
+
     def ex_take_node_screenshot(self, node, directory, screen=0):
         """
         Take a screenshot of a monitoring of a running instance.
@@ -342,6 +362,20 @@ class LibvirtNodeDriver(NodeDriver):
         Return libvirt domain object for the provided node.
         """
         domain = self.connection.lookupByUUIDString(node.uuid)
+        return domain
+
+    def _get_domain_for_uuid(self, uuid):
+        """
+        Return libvirt domain object for the provided uuid.
+        """
+        domain = self.connection.lookupByUUIDString(uuid)
+        return domain
+
+    def _get_domain_for_name(self, name):
+        """
+        Return libvirt domain object for the provided name.
+        """
+        domain = self.connection.lookupByName(name)
         return domain
 
     def _get_entries(self, element):


### PR DESCRIPTION
## Libvirt/lookup node by uuid or by name
### Description

Currently for libvirt driver, there is no API to get a node by node's uuid or name, so I added ex_get_node_by_uuid and ex_get_node_by_name function and functions it calls to support return the specific node.
### Status
- done, ready for review
### Checklist (tick everything that applies)
- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
