### PR TITLE
Add libcloud support for image guest os features.

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -4756,7 +4756,7 @@ class GCENodeDriver(NodeDriver):
         :type   family: ``str``
 
         :param  guest_os_features: The features of the guest operating system.
-        :type   guest_os_features: ``list`` of ``str`` or ``None``
+        :type   guest_os_features: ``list`` of ``dict`` or ``None``
 
         :return:  NodeImage object based on provided information or None if an
                   image with that name is not found.

--- a/libcloud/test/compute/fixtures/gce/projects_coreos-cloud_global_images.json
+++ b/libcloud/test/compute/fixtures/gce/projects_coreos-cloud_global_images.json
@@ -1327,6 +1327,11 @@
    "name": "coreos-beta-522-3-0-v20141226",
    "description": "CoreOS beta 522.3.0",
    "family": "coreos",
+   "guestOsFeatures": [
+    {
+      "type": "VIRTIO_SCSI_MULTIQUEUE"
+    }
+   ],
    "sourceType": "RAW",
    "rawDisk": {
     "source": "",

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -15,9 +15,10 @@
 """
 Tests for Google Compute Engine Driver
 """
+import datetime
+import mock
 import sys
 import unittest
-import datetime
 
 from libcloud.utils.py3 import httplib
 from libcloud.compute.drivers.gce import (GCENodeDriver, API_VERSION,
@@ -449,13 +450,32 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
 
     def test_ex_create_image(self):
         volume = self.driver.ex_get_volume('lcdisk')
-        image = self.driver.ex_create_image('coreos', volume)
+        description = 'CoreOS beta 522.3.0'
+        name = 'coreos'
+        family = 'coreos'
+        guest_os_features = ['VIRTIO_SCSI_MULTIQUEUE']
+        expected_features = [{'type': 'VIRTIO_SCSI_MULTIQUEUE'}]
+        mock_request = mock.Mock()
+        mock_request.side_effect = self.driver.connection.async_request
+        self.driver.connection.async_request = mock_request
+
+        image = self.driver.ex_create_image(
+            name, volume, description=description, family='coreos',
+            guest_os_features=guest_os_features)
         self.assertTrue(isinstance(image, GCENodeImage))
-        self.assertTrue(image.name.startswith('coreos'))
-        self.assertEqual(image.extra['description'], 'CoreOS beta 522.3.0')
-        self.assertEqual(image.extra['family'], 'coreos')
-        self.assertEqual(image.extra['guestOsFeatures'],
-                         [{'type': 'VIRTIO_SCSI_MULTIQUEUE'}])
+        self.assertTrue(image.name.startswith(name))
+        self.assertEqual(image.extra['description'], description)
+        self.assertEqual(image.extra['family'], family)
+        self.assertEqual(image.extra['guestOsFeatures'], expected_features)
+        expected_data = {'description': description,
+                         'family': family,
+                         'guestOsFeatures': expected_features,
+                         'name': name,
+                         'sourceDisk': volume.extra['selfLink'],
+                         'zone': volume.extra['zone'].name}
+        mock_request.assert_called_once_with('/global/images',
+                                             data=expected_data,
+                                             method='POST')
 
     def test_ex_create_firewall(self):
         firewall_name = 'lcfirewall'

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -454,6 +454,8 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         self.assertTrue(image.name.startswith('coreos'))
         self.assertEqual(image.extra['description'], 'CoreOS beta 522.3.0')
         self.assertEqual(image.extra['family'], 'coreos')
+        self.assertEqual(image.extra['guestOsFeatures'],
+                         [{'type': 'VIRTIO_SCSI_MULTIQUEUE'}])
 
     def test_ex_create_firewall(self):
         firewall_name = 'lcfirewall'
@@ -1350,11 +1352,14 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         url = 'gs://storage.core-os.net/coreos/amd64-generic/247.0.0/coreos_production_gce.tar.gz'
         description = 'CoreOS beta 522.3.0'
         family = 'coreos'
+        guest_os_features = [{'type': 'VIRTIO_SCSI_MULTIQUEUE'}]
         image = self.driver.ex_copy_image(name, url, description=description,
-                                          family=family)
+                                          family=family,
+                                          guest_os_features=guest_os_features)
         self.assertTrue(image.name.startswith(name))
         self.assertEqual(image.extra['description'], description)
         self.assertEqual(image.extra['family'], family)
+        self.assertEqual(image.extra['guestOsFeatures'], guest_os_features)
 
     def test_ex_get_route(self):
         route_name = 'lcdemoroute'


### PR DESCRIPTION
Image "guestOsFeature" support during image copy and creation.
### Description

We are introducing a new optional property on the image resource known as "guestOsFeature". The feature is available in the alpha API and is needed to optimize virtual machine settings during instance creation. The only value currently supported (if specified) is "VIRTIO_SCSI_MULTIQUEUE".
### Status

Done, ready for review
### Checklist (tick everything that applies)
- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
