### PR TITLE
Aliyun ecs： support listing security group attributes

### DIFF
--- a/libcloud/compute/drivers/ecs.py
+++ b/libcloud/compute/drivers/ecs.py
@@ -377,7 +377,23 @@ class ECSSecurityGroup(object):
         return ('<ECSSecurityGroup: id=%s, name=%s, driver=%s ...>' %
                 (self.id, self.name, self.driver.name))
 
+class ECSSecurityGroupAttribute(object):
+    
+    """
+    Security group attribute.
+    """
+    def __init__(self, ip_protocol=None, port_range=None,
+                source_group_id=None, policy=None, nic_type=None):
+        self.ip_protocol = ip_protocol
+        self.port_range = port_range
+        self.source_group_id = source_group_id
+        self.policy = policy
+        self.nic_type = nic_type
 
+    def __repr__(self):
+        return ('<ECSSecurityGroupAttribute: ip_protocol=%s ...>' %
+                (self.ip_protocol))
+        
 class ECSZone(object):
     """
     ECSZone used to represent an availability zone in a region.
@@ -827,6 +843,33 @@ class ECSDriver(NodeDriver):
             return sgs
         return self._request_multiple_pages(self.path, params,
                                             _parse_response)
+
+    def ex_list_security_group_attributes(self, group_id=None,
+                                          nic_type='internet'):
+        """
+        List security group attributes in the current region.
+
+        :keyword group_id: security group id.
+        :type ex_filters: ``str``
+
+        :keyword nic_type: internet|intranet.
+        :type nic_type: ``str``
+        
+        :return: a list of defined security group Attributes
+        :rtype: ``list`` of ``ECSSecurityGroupAttribute``
+        """
+        params = {'Action': 'DescribeSecurityGroupAttribute',
+                  'RegionId': self.region,
+                  'NicType': nic_type}
+
+        if group_id is None:
+            raise AttributeError('group_id is required')
+        params['SecurityGroupId'] = group_id
+
+        resp_object = self.connection.request(self.path, params).object
+        sga_elements = findall(resp_object, 'Permissions/Permission',
+                                  namespace=self.namespace)
+        return [self._to_security_group_attribute(el) for el in sga_elements]
 
     def ex_list_zones(self, region_id=None):
         """
@@ -1512,6 +1555,18 @@ class ECSDriver(NodeDriver):
         return ECSSecurityGroup(_id, name, description=description,
                                 driver=self, vpc_id=vpc_id,
                                 creation_time=creation_time)
+        
+    def _to_security_group_attribute(self, element):
+        ip_protocol = findtext(element, 'IpProtocol', namespace=self.namespace)
+        port_range = findtext(element, 'PortRange', namespace=self.namespace)
+        source_group_id = findtext(element, 'SourceGroupId', 
+                               namespace=self.namespace)
+        policy = findtext(element, 'Policy', namespace=self.namespace)
+        nic_type = findtext(element, 'NicType', namespace=self.namespace)
+        return ECSSecurityGroupAttribute(ip_protocol=ip_protocol,
+                                         port_range=port_range,
+                                         source_group_id=source_group_id,
+                                         policy=policy, nic_type=nic_type)
 
     def _to_zone(self, element):
         _id = findtext(element, 'ZoneId', namespace=self.namespace)

--- a/libcloud/compute/drivers/ecs.py
+++ b/libcloud/compute/drivers/ecs.py
@@ -377,13 +377,14 @@ class ECSSecurityGroup(object):
         return ('<ECSSecurityGroup: id=%s, name=%s, driver=%s ...>' %
                 (self.id, self.name, self.driver.name))
 
+
 class ECSSecurityGroupAttribute(object):
-    
+
     """
     Security group attribute.
     """
     def __init__(self, ip_protocol=None, port_range=None,
-                source_group_id=None, policy=None, nic_type=None):
+                 source_group_id=None, policy=None, nic_type=None):
         self.ip_protocol = ip_protocol
         self.port_range = port_range
         self.source_group_id = source_group_id
@@ -393,7 +394,8 @@ class ECSSecurityGroupAttribute(object):
     def __repr__(self):
         return ('<ECSSecurityGroupAttribute: ip_protocol=%s ...>' %
                 (self.ip_protocol))
-        
+
+
 class ECSZone(object):
     """
     ECSZone used to represent an availability zone in a region.
@@ -854,7 +856,7 @@ class ECSDriver(NodeDriver):
 
         :keyword nic_type: internet|intranet.
         :type nic_type: ``str``
-        
+
         :return: a list of defined security group Attributes
         :rtype: ``list`` of ``ECSSecurityGroupAttribute``
         """
@@ -868,7 +870,7 @@ class ECSDriver(NodeDriver):
 
         resp_object = self.connection.request(self.path, params).object
         sga_elements = findall(resp_object, 'Permissions/Permission',
-                                  namespace=self.namespace)
+                               namespace=self.namespace)
         return [self._to_security_group_attribute(el) for el in sga_elements]
 
     def ex_list_zones(self, region_id=None):
@@ -1555,12 +1557,12 @@ class ECSDriver(NodeDriver):
         return ECSSecurityGroup(_id, name, description=description,
                                 driver=self, vpc_id=vpc_id,
                                 creation_time=creation_time)
-        
+
     def _to_security_group_attribute(self, element):
         ip_protocol = findtext(element, 'IpProtocol', namespace=self.namespace)
         port_range = findtext(element, 'PortRange', namespace=self.namespace)
-        source_group_id = findtext(element, 'SourceGroupId', 
-                               namespace=self.namespace)
+        source_group_id = findtext(element, 'SourceGroupId',
+                                   namespace=self.namespace)
         policy = findtext(element, 'Policy', namespace=self.namespace)
         nic_type = findtext(element, 'NicType', namespace=self.namespace)
         return ECSSecurityGroupAttribute(ip_protocol=ip_protocol,

--- a/libcloud/test/compute/fixtures/ecs/describe_security_group_attributes.xml
+++ b/libcloud/test/compute/fixtures/ecs/describe_security_group_attributes.xml
@@ -1,0 +1,26 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<DescribeSecurityGroupsResponse>
+	<RequestId>94D38899-626D-434A-891F-7E1F77A81525</RequestId>
+	<TotalCount>4</TotalCount>
+	<PageNumber>1</PageNumber>
+	<PageSize>10</PageSize>
+	<RegionId>cn-hangzhou </RegionId>
+	<SecurityGroups>
+		<SecurityGroup>
+			<SecurityGroupId>sg-F876FF7BA</SecurityGroupId>
+			<Description>Test</Description>
+		</SecurityGroup>
+		<SecurityGroup>
+			<SecurityGroupId>sg-086FFC27A</SecurityGroupId>
+			<Description>test00212</Description>
+		</SecurityGroup>
+		<SecurityGroup>
+			<SecurityGroupId>sg-BA4B7975B</SecurityGroupId>
+			<Description>cn-hangzhou test group</Description>
+		</SecurityGroup>
+		<SecurityGroup>
+			<SecurityGroupId>sg-35F20777C</SecurityGroupId>
+			<Description>cn-hangzhou test group</Description>
+		</SecurityGroup>
+	</SecurityGroups>
+</DescribeSecurityGroupsResponse>

--- a/libcloud/test/compute/test_ecs.py
+++ b/libcloud/test/compute/test_ecs.py
@@ -917,6 +917,14 @@ class ECSMockHttp(MockHttpTestCase):
         self.assertUrlContainsQueryParams(url, params)
         resp_body = self.fixtures.load('delete_security_group_by_id.xml')
         return (httplib.OK, resp_body, {}, httplib.responses[httplib.OK])
+    
+    def _list_sgas_DescribeSecurityGroupAttributes(self, method, url, body, headers):
+        params = {'RegionId': self.test.region,
+                  'SecurityGroupId': 'sg-fakeSecurityGroupId',
+                  'NicType': 'internet'}
+        self.assertUrlContainsQueryParams(url, params)
+        resp_body = self.fixtures.load('describe_security_group_attributes.xml')
+        return (httplib.OK, resp_body, {}, httplib.responses[httplib.OK])
 
     def _DescribeZones(self, method, url, body, headers):
         resp_body = self.fixtures.load('describe_zones.xml')

--- a/libcloud/test/compute/test_ecs.py
+++ b/libcloud/test/compute/test_ecs.py
@@ -917,7 +917,7 @@ class ECSMockHttp(MockHttpTestCase):
         self.assertUrlContainsQueryParams(url, params)
         resp_body = self.fixtures.load('delete_security_group_by_id.xml')
         return (httplib.OK, resp_body, {}, httplib.responses[httplib.OK])
-    
+
     def _list_sgas_DescribeSecurityGroupAttributes(self, method, url, body, headers):
         params = {'RegionId': self.test.region,
                   'SecurityGroupId': 'sg-fakeSecurityGroupId',


### PR DESCRIPTION
## Aliyun ecs： support listing security group attributes
### Description

Currently for Aliyun ECS, you cannot list security group attributes through ecs deriver. 
That means you have to login in to check  user's authorization. 
For example, users only from 192.168.1.1-192.168.1.100  can access the specified VM. 
### Status
- work in progress
- done, ready for review

@see Aliyun-ECS-API-Reference: http://pan.baidu.com/s/1gfnYBhL
