### PR TITLE
LIBCLOUD-830 Adding S3 support for cn-north-1

### DIFF
--- a/docs/storage/_supported_providers.rst
+++ b/docs/storage/_supported_providers.rst
@@ -18,6 +18,7 @@ Provider                      Documentation                                   Pr
 `Amazon S3 (ap-northeast-1)`_                                                 S3_AP_NORTHEAST1  single region driver         :mod:`libcloud.storage.drivers.s3`             :class:`S3APNE1StorageDriver`       
 `Amazon S3 (ap-northeast-2)`_                                                 S3_AP_NORTHEAST2  single region driver         :mod:`libcloud.storage.drivers.s3`             :class:`S3APNE2StorageDriver`       
 `Amazon S3 (ap-southeast-1)`_                                                 S3_AP_SOUTHEAST   single region driver         :mod:`libcloud.storage.drivers.s3`             :class:`S3APSEStorageDriver`        
+`Amazon S3 (cn-north-1)`_                                                     S3_CN_NORTH       single region driver         :mod:`libcloud.storage.drivers.s3`             :class:`S3CNNorthStorageDriver`      
 `Amazon S3 (eu-west-1)`_                                                      S3_EU_WEST        single region driver         :mod:`libcloud.storage.drivers.s3`             :class:`S3EUWestStorageDriver`      
 `Amazon S3 (standard)`_                                                       S3_RGW_OUTSCALE   single region driver         :mod:`libcloud.storage.drivers.s3`             :class:`S3RGWOutscaleStorageDriver` 
 `Amazon S3 (sa-east-1)`_                                                      S3_SA_EAST        single region driver         :mod:`libcloud.storage.drivers.s3`             :class:`S3SAEastStorageDriver`      
@@ -40,6 +41,7 @@ Provider                      Documentation                                   Pr
 .. _`Amazon S3 (ap-northeast-1)`: http://aws.amazon.com/s3/
 .. _`Amazon S3 (ap-northeast-2)`: http://aws.amazon.com/s3/
 .. _`Amazon S3 (ap-southeast-1)`: http://aws.amazon.com/s3/
+.. _`Amazon S3 (cn-north-1)`: http://www.amazonaws.cn/en/s3/
 .. _`Amazon S3 (eu-west-1)`: http://aws.amazon.com/s3/
 .. _`Amazon S3 (standard)`: http://aws.amazon.com/s3/
 .. _`Amazon S3 (sa-east-1)`: http://aws.amazon.com/s3/

--- a/libcloud/storage/drivers/s3.py
+++ b/libcloud/storage/drivers/s3.py
@@ -53,6 +53,7 @@ EXPIRATION_SECONDS = 15 * 60
 S3_US_STANDARD_HOST = 's3.amazonaws.com'
 S3_US_WEST_HOST = 's3-us-west-1.amazonaws.com'
 S3_US_WEST_OREGON_HOST = 's3-us-west-2.amazonaws.com'
+S3_CN_NORTH_HOST = 's3.cn-north-1.amazonaws.com.cn'
 S3_EU_WEST_HOST = 's3-eu-west-1.amazonaws.com'
 S3_AP_SOUTHEAST_HOST = 's3-ap-southeast-1.amazonaws.com'
 S3_AP_NORTHEAST1_HOST = 's3-ap-northeast-1.amazonaws.com'
@@ -939,6 +940,16 @@ class S3USWestOregonStorageDriver(S3StorageDriver):
     name = 'Amazon S3 (us-west-2)'
     connectionCls = S3USWestOregonConnection
     ex_location_name = 'us-west-2'
+
+
+class S3CNNorthConnection(S3Connection):
+    host = S3_CN_NORTH_HOST
+
+
+class S3CNNorthStorageDriver(S3StorageDriver):
+    name = 'Amazon S3 (cn-north-1)'
+    connectionCls = S3CNNorthConnection
+    ex_location_name = 'CN'
 
 
 class S3EUWestConnection(S3Connection):

--- a/libcloud/storage/providers.py
+++ b/libcloud/storage/providers.py
@@ -31,6 +31,8 @@ DRIVERS = {
     ('libcloud.storage.drivers.s3', 'S3USWestStorageDriver'),
     Provider.S3_US_WEST_OREGON:
     ('libcloud.storage.drivers.s3', 'S3USWestOregonStorageDriver'),
+    Provider.S3_CN_NORTH:
+    ('libcloud.storage.drivers.s3', 'S3CNNorthStorageDriver'),
     Provider.S3_EU_WEST:
     ('libcloud.storage.drivers.s3', 'S3EUWestStorageDriver'),
     Provider.S3_AP_SOUTHEAST:

--- a/libcloud/storage/types.py
+++ b/libcloud/storage/types.py
@@ -48,6 +48,7 @@ class Provider(object):
     :cvar S3: Amazon S3 US
     :cvar S3_AP_NORTHEAST_HOST: Amazon S3 Asia South East (Tokyo)
     :cvar S3_AP_SOUTHEAST_HOST: Amazon S3 Asia South East (Singapore)
+    :cvar S3_CN_NORTH: Amazon S3 CN North (Beijing)
     :cvar S3_EU_WEST: Amazon S3 EU West (Ireland)
     :cvar S3_US_WEST: Amazon S3 US West (Northern California)
     :cvar S3_US_WEST_OREGON: Amazon S3 US West 2 (Oregon)
@@ -71,6 +72,7 @@ class Provider(object):
     S3_AP_NORTHEAST1 = 's3_ap_northeast_1'
     S3_AP_NORTHEAST2 = 's3_ap_northeast_2'
     S3_AP_SOUTHEAST = 's3_ap_southeast'
+    S3_CN_NORTH = 's3_cn_north'
     S3_EU_WEST = 's3_eu_west'
     S3_SA_EAST = 's3_sa_east'
     S3_US_WEST = 's3_us_west'


### PR DESCRIPTION
## Add S3 support for AWS China (cn-north-1)
### Description

This PR adds S3 support for AWS China (cn-north-1)
### Status
- done, ready for review
### Checklist (tick everything that applies)
- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
