### PR TITLE
Update copy image logic to match create image.

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -1061,6 +1061,8 @@ class GCENodeDriver(NodeDriver):
         "windows-cloud": ["windows"],
     }
 
+    GUEST_OS_FEATURES = ['VIRTIO_SCSI_MULTIQUEUE']
+
     def __init__(self, user_id, key=None, datacenter=None, project=None,
                  auth_type=None, scopes=None, credential_file=None, **kwargs):
         """
@@ -2251,14 +2253,13 @@ class GCENodeDriver(NodeDriver):
         else:
             raise ValueError('Source must be instance of StorageVolume or URI')
         if guest_os_features:
-            possible_features = ['VIRTIO_SCSI_MULTIQUEUE']
             image_data['guestOsFeatures'] = []
             for feature in guest_os_features:
-                if feature in possible_features:
+                if feature in self.GUEST_OS_FEATURES:
                     image_data['guestOsFeatures'].append({'type': feature})
                 else:
                     raise ValueError('Features must be one of %s'
-                                     % ','.join(possible_features))
+                                     % ','.join(self.GUEST_OS_FEATURES))
         request = '/global/images'
 
         try:
@@ -2316,14 +2317,13 @@ class GCENodeDriver(NodeDriver):
         }
 
         if guest_os_features:
-            possible_features = ['VIRTIO_SCSI_MULTIQUEUE']
             image_data['guestOsFeatures'] = []
             for feature in guest_os_features:
-                if feature in possible_features:
+                if feature in self.GUEST_OS_FEATURES:
                     image_data['guestOsFeatures'].append({'type': feature})
                 else:
                     raise ValueError('Features must be one of %s'
-                                     % ','.join(possible_features))
+                                     % ','.join(self.GUEST_OS_FEATURES))
 
         request = '/global/images'
         self.connection.async_request(request, method='POST',

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -2237,7 +2237,6 @@ class GCENodeDriver(NodeDriver):
         :rtype:   :class:`GCENodeImage`
 
         """
-        possible_features = ['VIRTIO_SCSI_MULTIQUEUE']
         image_data = {}
         image_data['name'] = name
         image_data['description'] = description
@@ -2252,6 +2251,7 @@ class GCENodeDriver(NodeDriver):
         else:
             raise ValueError('Source must be instance of StorageVolume or URI')
         if guest_os_features:
+            possible_features = ['VIRTIO_SCSI_MULTIQUEUE']
             image_data['guestOsFeatures'] = []
             for feature in guest_os_features:
                 if feature in possible_features:
@@ -2274,6 +2274,60 @@ class GCENodeDriver(NodeDriver):
             if not use_existing:
                 raise e
 
+        return self.ex_get_image(name)
+
+    def ex_copy_image(self, name, url, description=None, family=None,
+                      guest_os_features=None):
+        """
+        Copy an image to your image collection.
+
+        :param  name: The name of the image
+        :type   name: ``str``
+
+        :param  url: The URL to the image. The URL can start with `gs://`
+        :param  url: ``str``
+
+        :param  description: The description of the image
+        :type   description: ``str``
+
+        :param  family: The family of the image
+        :type   family: ``str``
+
+        :param  guest_os_features: The features of the guest operating system.
+        :type   guest_os_features: ``list`` of ``str`` or ``None``
+
+        :return:  NodeImage object based on provided information or None if an
+                  image with that name is not found.
+        :rtype:   :class:`NodeImage` or ``None``
+        """
+
+        # The URL for an image can start with gs://
+        if url.startswith('gs://'):
+            url = url.replace('gs://', 'https://storage.googleapis.com/', 1)
+
+        image_data = {
+            'name': name,
+            'description': description,
+            'family': family,
+            'sourceType': 'RAW',
+            'rawDisk': {
+                'source': url,
+            },
+        }
+
+        if guest_os_features:
+            possible_features = ['VIRTIO_SCSI_MULTIQUEUE']
+            image_data['guestOsFeatures'] = []
+            for feature in guest_os_features:
+                if feature in possible_features:
+                    image_data['guestOsFeatures'].append({'type': feature})
+                else:
+                    raise ValueError('Features must be one of %s'
+                                     % ','.join(possible_features))
+
+        request = '/global/images'
+        self.connection.async_request(request, method='POST',
+                                      data=image_data)
         return self.ex_get_image(name)
 
     def ex_create_route(self, name, dest_range, priority=500,
@@ -4737,53 +4791,6 @@ class GCENodeDriver(NodeDriver):
         except ResourceNotFoundError:
             return None
         return self._to_zone(response)
-
-    def ex_copy_image(self, name, url, description=None, family=None,
-                      guest_os_features=None):
-        """
-        Copy an image to your image collection.
-
-        :param  name: The name of the image
-        :type   name: ``str``
-
-        :param  url: The URL to the image. The URL can start with `gs://`
-        :param  url: ``str``
-
-        :param  description: The description of the image
-        :type   description: ``str``
-
-        :param  family: The family of the image
-        :type   family: ``str``
-
-        :param  guest_os_features: The features of the guest operating system.
-        :type   guest_os_features: ``list`` of ``dict`` or ``None``
-
-        :return:  NodeImage object based on provided information or None if an
-                  image with that name is not found.
-        :rtype:   :class:`NodeImage` or ``None``
-        """
-
-        # The URL for an image can start with gs://
-        if url.startswith('gs://'):
-            url = url.replace('gs://', 'https://storage.googleapis.com/', 1)
-
-        image_data = {
-            'name': name,
-            'description': description,
-            'family': family,
-            'sourceType': 'RAW',
-            'rawDisk': {
-                'source': url,
-            },
-        }
-
-        if guest_os_features:
-            image_data['guestOsFeatures'] = guest_os_features
-
-        request = '/global/images'
-        self.connection.async_request(request, method='POST',
-                                      data=image_data)
-        return self.ex_get_image(name)
 
     def _ex_connection_class_kwargs(self):
         return {'auth_type': self.auth_type,

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -477,6 +477,21 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
                                              data=expected_data,
                                              method='POST')
 
+    def test_ex_copy_image(self):
+        name = 'coreos'
+        url = 'gs://storage.core-os.net/coreos/amd64-generic/247.0.0/coreos_production_gce.tar.gz'
+        description = 'CoreOS beta 522.3.0'
+        family = 'coreos'
+        guest_os_features = ['VIRTIO_SCSI_MULTIQUEUE']
+        expected_features = [{'type': 'VIRTIO_SCSI_MULTIQUEUE'}]
+        image = self.driver.ex_copy_image(name, url, description=description,
+                                          family=family,
+                                          guest_os_features=guest_os_features)
+        self.assertTrue(image.name.startswith(name))
+        self.assertEqual(image.extra['description'], description)
+        self.assertEqual(image.extra['family'], family)
+        self.assertEqual(image.extra['guestOsFeatures'], expected_features)
+
     def test_ex_create_firewall(self):
         firewall_name = 'lcfirewall'
         allowed = [{'IPProtocol': 'tcp', 'ports': ['4567']}]
@@ -1366,20 +1381,6 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         self.assertEqual(image.extra['family'], family)
 
         self.assertRaises(ResourceNotFoundError, self.driver.ex_get_image_from_family, 'nofamily')
-
-    def test_ex_copy_image(self):
-        name = 'coreos'
-        url = 'gs://storage.core-os.net/coreos/amd64-generic/247.0.0/coreos_production_gce.tar.gz'
-        description = 'CoreOS beta 522.3.0'
-        family = 'coreos'
-        guest_os_features = [{'type': 'VIRTIO_SCSI_MULTIQUEUE'}]
-        image = self.driver.ex_copy_image(name, url, description=description,
-                                          family=family,
-                                          guest_os_features=guest_os_features)
-        self.assertTrue(image.name.startswith(name))
-        self.assertEqual(image.extra['description'], description)
-        self.assertEqual(image.extra['family'], family)
-        self.assertEqual(image.extra['guestOsFeatures'], guest_os_features)
 
     def test_ex_get_route(self):
         route_name = 'lcdemoroute'


### PR DESCRIPTION
Image "guestOsFeatures" should behave the same during image copy and creation.
### Description
- Unify "guestOsFeatures" logic in image copy and create.
- Moved image copy next to image create because they are highly related.
### Status

done, ready for review
### Checklist (tick everything that applies)
- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
