### PR TITLE
auroradns: Implement iterator for zones and records

### DIFF
--- a/libcloud/dns/drivers/auroradns.py
+++ b/libcloud/dns/drivers/auroradns.py
@@ -261,24 +261,23 @@ class AuroraDNSDriver(DNSDriver):
         AuroraDNSHealthCheckType.TCP: 'TCP'
     }
 
-    def list_zones(self):
-        zones = []
-
+    def iterate_zones(self):
         res = self.connection.request('/zones')
         for zone in res.parse_body():
-            zones.append(self.__res_to_zone(zone))
+            yield self.__res_to_zone(zone)
 
-        return zones
+    def list_zones(self):
+        return list(self.iterate_zones())
 
-    def list_records(self, zone):
+    def iterate_records(self, zone):
         self.connection.set_context({'resource': 'zone', 'id': zone.id})
-        records = []
         res = self.connection.request('/zones/%s/records' % zone.id)
 
         for record in res.parse_body():
-            records.append(self.__res_to_record(zone, record))
+            yield self.__res_to_record(zone, record)
 
-        return records
+    def list_records(self, zone):
+        return list(self.iterate_records(zone))
 
     def get_zone(self, zone_id):
         self.connection.set_context({'resource': 'zone', 'id': zone_id})

--- a/libcloud/test/dns/test_auroradns.py
+++ b/libcloud/test/dns/test_auroradns.py
@@ -90,6 +90,8 @@ class AuroraDNSDriverTests(LibcloudTestCase):
     def test_list_zones(self):
         zones = self.driver.list_zones()
         self.assertEqual(len(zones), 2)
+        for zone in zones:
+            self.assertTrue(zone.domain.startswith('auroradns'))
 
     def test_create_zone(self):
         zone = self.driver.create_zone('example.com')


### PR DESCRIPTION
By implementing iterate_zones() and iterate_records() you can
iterate over zones and records returned by the API.

The list_zones() and list_records() methods simply talk to the
iteration functions and create a list of it and return that.

The test cases should still match since they call the list functions
and those call the iterators on their turn.
