### PR TITLE
auroradns: The 'extra' parameter in update_record() should be optional

### DIFF
--- a/libcloud/dns/drivers/auroradns.py
+++ b/libcloud/dns/drivers/auroradns.py
@@ -338,7 +338,7 @@ class AuroraDNSDriver(DNSDriver):
                                 method='DELETE')
         return True
 
-    def update_record(self, record, name, type, data, extra):
+    def update_record(self, record, name, type, data, extra=None):
         rdata = {}
 
         if name is not None:


### PR DESCRIPTION
In base update_record() is defined with extra=None but this was not properly
done in the Aurora DNS driver.

Update the method signature so that it matches the base DNS driver of libcloud.
