### PR TITLE
[Docker] Add network_mode and label params to deploy_container

### DIFF
--- a/libcloud/container/drivers/docker.py
+++ b/libcloud/container/drivers/docker.py
@@ -296,7 +296,8 @@ class DockerContainerDriver(ContainerDriver):
                          volumes=None, volumes_from=None,
                          network_disabled=False, entrypoint=None,
                          cpu_shares=None, working_dir='', domainname=None,
-                         memswap_limit=0, port_bindings=None):
+                         memswap_limit=0, port_bindings=None,
+                         network_mode='bridge', labels=None):
         """
         Deploy an installed container image
 
@@ -348,6 +349,8 @@ class DockerContainerDriver(ContainerDriver):
             'MemorySwap': memswap_limit,
             'PublishAllPorts': True,
             'PortBindings': port_bindings,
+            'NetworkMode': network_mode,
+            'Labels': labels,
         }
 
         data = json.dumps(payload)


### PR DESCRIPTION
## Add network_mode and label params to deploy_container function within Docker driver
### Description

This PR adds `network_mode` and `label` params to the deploy_container function within the Docker container driver. Labels are particularly useful for Swarm's (anti-)affinity rules. The previous and default behaviour should not be affected.
### Status
- done, ready for review
### Checklist (tick everything that applies)
- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
