### PR TITLE
Add support for setting the VM admin password from vCloud 

### DIFF
--- a/libcloud/compute/drivers/vcloud.py
+++ b/libcloud/compute/drivers/vcloud.py
@@ -2011,6 +2011,21 @@ class VCloud_1_5_NodeDriver(VCloudNodeDriver):
         return res
 
     def ex_change_vm_admin_password(self, vapp_or_vm_id, ex_admin_password):
+        """
+        Changes the admin (or root) password of VM or VMs under the vApp. If
+        the vapp_or_vm_id param represents a link to an vApp all VMs that
+        are attached to this vApp will be modified.
+
+        :keyword    vapp_or_vm_id: vApp or VM ID that will be modified. If a
+                                   vApp ID is used here all attached VMs
+                                   will be modified
+        :type       vapp_or_vm_id: ``str``
+
+        :keyword    ex_admin_password: admin password to be used.
+        :type       ex_admin_password: ``str``
+
+        :rtype: ``None``
+        """
         if ex_admin_password is None:
             return
 

--- a/libcloud/compute/drivers/vcloud.py
+++ b/libcloud/compute/drivers/vcloud.py
@@ -1490,7 +1490,7 @@ class VCloud_1_5_NodeDriver(VCloudNodeDriver):
         self._change_vm_ipmode(vapp_href, ex_vm_ipmode)
 
         if ex_admin_password is not None:
-            self._change_vm_admin_password(vapp_href, ex_admin_password)
+            self.ex_change_vm_admin_password(vapp_href, ex_admin_password)
 
         # Power on the VM.
         if ex_deploy:
@@ -2010,7 +2010,7 @@ class VCloud_1_5_NodeDriver(VCloudNodeDriver):
             res.object.insert(i, e)
         return res
 
-    def _change_vm_admin_password(self, vapp_or_vm_id, ex_admin_password):
+    def ex_change_vm_admin_password(self, vapp_or_vm_id, ex_admin_password):
         if ex_admin_password is None:
             return
 

--- a/libcloud/compute/drivers/vcloud.py
+++ b/libcloud/compute/drivers/vcloud.py
@@ -2001,8 +2001,8 @@ class VCloud_1_5_NodeDriver(VCloudNodeDriver):
             # "section" section does not exist, insert it just
             # before "prev_section"
             for i, e in enumerate(res.object):
-                if e.tag == \
-                                '{http://www.vmware.com/vcloud/v1.5}%s' % prev_section:
+                tag = '{http://www.vmware.com/vcloud/v1.5}%s' % prev_section
+                if e.tag == tag:
                     break
             e = ET.Element(
                 '{http://www.vmware.com/vcloud/v1.5}%s' % section)
@@ -2030,10 +2030,9 @@ class VCloud_1_5_NodeDriver(VCloudNodeDriver):
             # must have AdminAutoLogonCount==0, even though
             # it might have AdminAutoLogonCount==1 when requesting it for
             # the first time.
-            auto_logon_enabled = res.object.find(
+            auto_logon = res.object.find(
                 fixxpath(res.object, "AdminAutoLogonEnabled"))
-            if (auto_logon_enabled is not None
-                and auto_logon_enabled.text=='false'):
+            if auto_logon is not None and auto_logon.text == 'false':
                 self._update_or_insert_section(res,
                                                "AdminAutoLogonCount",
                                                "ResetPasswordRequired",

--- a/libcloud/test/compute/test_vcloud.py
+++ b/libcloud/test/compute/test_vcloud.py
@@ -204,7 +204,7 @@ class VCloud_1_5_Tests(unittest.TestCase, TestCaseMixin):
             '/api/vApp/vapp-8c57a5b6-e61b-48ca-8a78-3b70ee65ef6a', ['changed1', 'changed2'])
 
     def test_change_vm_admin_password(self):
-        self.driver._change_vm_admin_password(
+        self.driver.ex_change_vm_admin_password(
             '/api/vApp/vapp-8c57a5b6-e61b-48ca-8a78-3b70ee65ef6a', "12345678")
 
     def test_is_node(self):

--- a/libcloud/test/compute/test_vcloud.py
+++ b/libcloud/test/compute/test_vcloud.py
@@ -203,6 +203,10 @@ class VCloud_1_5_Tests(unittest.TestCase, TestCaseMixin):
         self.driver._change_vm_names(
             '/api/vApp/vapp-8c57a5b6-e61b-48ca-8a78-3b70ee65ef6a', ['changed1', 'changed2'])
 
+    def test_change_vm_admin_password(self):
+        self.driver._change_vm_admin_password(
+            '/api/vApp/vapp-8c57a5b6-e61b-48ca-8a78-3b70ee65ef6a', "12345678")
+
     def test_is_node(self):
         self.assertTrue(self.driver._is_node(
             Node('testId', 'testNode', state=0, public_ips=[], private_ips=[], driver=self.driver)))


### PR DESCRIPTION
## Add support for setting the VM admin password from vCloud
### Description

These commits allow the user to establish the admin password of a virtual machine on its creation without having to connect to it. It uses the API provided by VMware and its VMware Tools.
### Status

Done and ready for review.
### Checklist (tick everything that applies)
- [X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [X] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
