### PR TITLE
auroradns: Change valid record types and implement listing

### DIFF
--- a/libcloud/dns/drivers/auroradns.py
+++ b/libcloud/dns/drivers/auroradns.py
@@ -250,9 +250,12 @@ class AuroraDNSDriver(DNSDriver):
         RecordType.MX: 'MX',
         RecordType.NS: 'NS',
         RecordType.SOA: 'SOA',
-        RecordType.SPF: 'SPF',
         RecordType.SRV: 'SRV',
         RecordType.TXT: 'TXT',
+        RecordType.DS: 'DS',
+        RecordType.PTR: 'PTR',
+        RecordType.SSHFP: 'SSHFP',
+        RecordType.TLSA: 'TLSA'
     }
 
     HEALTHCHECK_TYPE_MAP = {
@@ -336,6 +339,13 @@ class AuroraDNSDriver(DNSDriver):
                                                           record.id),
                                 method='DELETE')
         return True
+
+    def list_record_types(self):
+        types = []
+        for record_type in self.RECORD_TYPE_MAP.keys():
+            types.append(record_type)
+
+        return types
 
     def update_record(self, record, name, type, data, extra=None):
         rdata = {}

--- a/libcloud/test/dns/test_auroradns.py
+++ b/libcloud/test/dns/test_auroradns.py
@@ -87,6 +87,22 @@ class AuroraDNSDriverTests(LibcloudTestCase):
         self.assertEqual(zone, record.zone)
         self.assertEqual(self.driver, record.driver)
 
+    def test_record_types(self):
+        types = self.driver.list_record_types()
+        self.assertEqual(len(types), 12)
+        self.assertTrue(RecordType.A in types)
+        self.assertTrue(RecordType.AAAA in types)
+        self.assertTrue(RecordType.MX in types)
+        self.assertTrue(RecordType.NS in types)
+        self.assertTrue(RecordType.SOA in types)
+        self.assertTrue(RecordType.TXT in types)
+        self.assertTrue(RecordType.CNAME in types)
+        self.assertTrue(RecordType.SRV in types)
+        self.assertTrue(RecordType.DS in types)
+        self.assertTrue(RecordType.SSHFP in types)
+        self.assertTrue(RecordType.PTR in types)
+        self.assertTrue(RecordType.TLSA in types)
+
     def test_list_zones(self):
         zones = self.driver.list_zones()
         self.assertEqual(len(zones), 2)


### PR DESCRIPTION
This commit changes the supported record types by Aurora DNS and it also
supports listing the valid record types.

It merely returns the keys of the RECORD_TYPE_MAP dict which is already
available. In the future Aurora DNS should return this in a API call
so this is no longer a static dictionary.

This dict also contained a type 'SPF', which is not valid. SPF records
are defined as TXT records in DNS. Remove this from the list of valid
record types.

Further it adds support for the SSHFP, DS, TLSA and PTR type since
they are also supported.

Also add tests to verify if this functions returns the proper values
