### PR TITLE
auroracompute: Add Barcelona (Spain) region to driver

### DIFF
--- a/docs/compute/drivers/auroracompute.rst
+++ b/docs/compute/drivers/auroracompute.rst
@@ -11,6 +11,7 @@ The datacenters / availability zones are located in:
 - Miami (US)
 - Los Angelos (US)
 - Tokyo (JP)
+- Barcelona (ES)
 
 
 .. figure:: /_static/images/provider_logos/pcextreme.png

--- a/libcloud/compute/drivers/auroracompute.py
+++ b/libcloud/compute/drivers/auroracompute.py
@@ -28,6 +28,7 @@ class AuroraComputeRegion(object):
     MIA = 'Miami'
     LAX = 'Los Angeles'
     TYO = 'Tokyo'
+    BCN = 'Barcelona'
 
 
 REGION_ENDPOINT_MAP = {
@@ -35,7 +36,8 @@ REGION_ENDPOINT_MAP = {
     AuroraComputeRegion.RTD: '/rtd',
     AuroraComputeRegion.MIA: '/mia',
     AuroraComputeRegion.LAX: '/lax',
-    AuroraComputeRegion.TYO: '/tyo'
+    AuroraComputeRegion.TYO: '/tyo',
+    AuroraComputeRegion.BCN: '/bcn'
 }
 
 


### PR DESCRIPTION
This PR only adds a new region to the Aurora Compute driver, it does not change functionality of it.

Barcelona is the soon to open new region of Aurora Compute and we would like to have it supported in libcloud prior to launch which is ~2 weeks away
