### PR TITLE
docs: Update AuroraCompute examples

### DIFF
--- a/docs/compute/drivers/auroracompute.rst
+++ b/docs/compute/drivers/auroracompute.rst
@@ -41,6 +41,20 @@ With these credentials you can instantiate a driver:
    :language: python
 
 
+Create a Virtual Machine (node)
+-------------------------------
+
+Creating a Virtual Machine on AuroraCompute using libcloud works the same as on any
+other platform. This example is just to show exactly that.
+
+This example will create a Virtual Machine in Amsterdam. Should you want to create
+one in one of our other regions you should take a look at the example below which
+shows how to use our different regions.
+
+.. literalinclude:: /examples/compute/auroracompute/create_node.py
+   :language: python
+
+
 Using a different region
 ------------------------
 

--- a/docs/examples/compute/auroracompute/create_node.py
+++ b/docs/examples/compute/auroracompute/create_node.py
@@ -1,0 +1,22 @@
+from libcloud.compute.types import Provider
+from libcloud.compute.providers import get_driver
+
+apikey = 'mykey'
+secretkey = 'mysecret'
+
+Driver = get_driver(Provider.AURORACOMPUTE)
+driver = Driver(key=apikey, secret=secretkey)
+
+images = driver.list_images()
+sizes = driver.list_sizes()
+
+# Find a Agile Offering with 2GB of Memory
+size = [s for s in sizes if s.ram == 2048 and s.name.startswith('Agile')][0]
+
+# Search for the Ubuntu 16.04 image
+image = [i for i in images if i.name == 'Ubuntu 16.04'][0]
+
+# Create the new Virtual Machine
+node = driver.create_node(image=image, size=size)
+
+print(node)


### PR DESCRIPTION
Might be a bit redundant, but gives end-users a overview on a single
page.

Easy for people to refer to.
