### PR TITLE
Fix incorrect doc string type information.

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -4369,7 +4369,7 @@ class GCENodeDriver(NodeDriver):
 
         :param  ex_project_list: The name of the project to list for images.
                                  Examples include: 'debian-cloud'.
-        :type   ex_project_List: ``str``, ``list`` of ``str``, or ``None``
+        :type   ex_project_list: ``list`` of ``str``, or ``None``
 
         :param  ex_standard_projects: If true, check in standard projects if
                                       the image is not found.


### PR DESCRIPTION
Fix type information in doc string.
### Description

The get from family function iterates through the project list. If you
pass in a string, it will iterate through the string instead of considering
the string a list with one element.
### Status

done, ready for review
### Checklist (tick everything that applies)
- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
