### PR TITLE
Libvirt/libvirt node driver cleanup and tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,7 @@ install:
   - pip install --upgrade "pip<8.0.0"
   - pip install "virtualenv<14.0.0"
   - pip install "tox>=2.3.0,<2.4"
+  - pip install mock
   - TOX_ENV=py$TRAVIS_PYTHON_VERSION
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,6 @@ install:
   - pip install --upgrade "pip<8.0.0"
   - pip install "virtualenv<14.0.0"
   - pip install "tox>=2.3.0,<2.4"
-  - pip install mock
   - TOX_ENV=py$TRAVIS_PYTHON_VERSION
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ addons:
   apt:
     packages:
       - graphviz
+      - python-libvirt
 
 matrix:
   fast_finish: true

--- a/libcloud/compute/drivers/libvirt_driver.py
+++ b/libcloud/compute/drivers/libvirt_driver.py
@@ -82,7 +82,7 @@ class LibvirtNodeDriver(NodeDriver):
         self._uri = uri
         self._key = key
         self._secret = secret
-        if '+tcp' in self._uri:
+        if uri is not None and '+tcp' in self._uri:
             if key is None and secret is None:
                 raise RuntimeError('The remote Libvirt instance requires ' +
                                    'authentication, please set \'key\' and ' +
@@ -92,8 +92,8 @@ class LibvirtNodeDriver(NodeDriver):
             self.connection = libvirt.openAuth(uri, auth, 0)
         else:
             self.connection = libvirt.open(uri)
-        if self.connection is None:
-            raise RuntimeError('Unable to establish a connection to libvirtd')
+        if uri is None:
+            self._uri = self.connection.getInfo()
 
     def _cred_callback(self, cred, user_data):
         """

--- a/libcloud/compute/drivers/libvirt_driver.py
+++ b/libcloud/compute/drivers/libvirt_driver.py
@@ -82,16 +82,18 @@ class LibvirtNodeDriver(NodeDriver):
         self._uri = uri
         self._key = key
         self._secret = secret
-        try:
-            self.connection = libvirt.open(uri)
-        except libvirt.libvirtError:
-            if key is None or secret is None:
+        if '+tcp' in self._uri:
+            if key is None and secret is None:
                 raise RuntimeError('The remote Libvirt instance requires ' +
                                    'authentication, please set \'key\' and ' +
                                    '\'secret\' parameters')
             auth = [[libvirt.VIR_CRED_AUTHNAME, libvirt.VIR_CRED_PASSPHRASE],
                     self._cred_callback, None]
             self.connection = libvirt.openAuth(uri, auth, 0)
+        else:
+            self.connection = libvirt.open(uri)
+        if self.connection is None:
+            raise RuntimeError('Unable to establish a connection to libvirtd')
 
     def _cred_callback(self, cred, user_data):
         """

--- a/libcloud/test/compute/test_libvirt_driver.py
+++ b/libcloud/test/compute/test_libvirt_driver.py
@@ -16,129 +16,26 @@
 import sys
 
 from libcloud.compute.drivers.libvirt_driver import LibvirtNodeDriver
-from libcloud.compute.base import NodeState
-from libcloud.compute.types import Provider
 
 
 from libcloud.test import unittest
+from unittest import mock
 
 
-class virConnect:
-    """
-    A stub/Mock implementation of the libvirt.virConnect class returned by
-    the libvirt.openX calles
-    """
-    def __stub(self, *args, **kwargs):
-        return 0
-
-    def __yes(self, *args, **kwargs):
-        return True
-
-    def __ary(self, *args, **kwargs):
-        return []
-
-    def __init__(self):
-        stub = self.__stub
-        yes = self.__yes
-        ary = self.__ary
-        fnt = [
-            '_dispatchCloseCallback',
-            '_dispatchDomainEventAgentLifecycleCallback',
-            '_dispatchDomainEventBalloonChangeCallback',
-            '_dispatchDomainEventBlockJobCallback',
-            '_dispatchDomainEventCallbacks',
-            '_dispatchDomainEventDeviceAddedCallback',
-            '_dispatchDomainEventDeviceRemovalFailedCallback',
-            '_dispatchDomainEventDeviceRemovedCallback',
-            '_dispatchDomainEventDiskChangeCallback',
-            '_dispatchDomainEventGenericCallback',
-            '_dispatchDomainEventGraphicsCallback',
-            '_dispatchDomainEventIOErrorCallback',
-            '_dispatchDomainEventIOErrorReasonCallback',
-            '_dispatchDomainEventJobCompletedCallback',
-            '_dispatchDomainEventLifecycleCallback',
-            '_dispatchDomainEventMigrationIterationCallback',
-            '_dispatchDomainEventPMSuspendCallback',
-            '_dispatchDomainEventPMSuspendDiskCallback',
-            '_dispatchDomainEventPMWakeupCallback',
-            '_dispatchDomainEventRTCChangeCallback',
-            '_dispatchDomainEventTrayChangeCallback',
-            '_dispatchDomainEventTunableCallback',
-            '_dispatchDomainEventWatchdogCallback',
-            '_dispatchNetworkEventLifecycleCallback',
-            '_o', 'allocPages', 'baselineCPU', 'c_pointer', 'changeBegin',
-            'changeCommit', 'changeRollback', 'close', 'compareCPU',
-            'createLinux', 'createXML', 'createXMLWithFiles', 'defineXML',
-            'defineXMLFlags', 'domainEventDeregister',
-            'domainEventDeregisterAny', 'domainEventRegister',
-            'domainEventRegisterAny', 'domainListGetStats',
-            'domainXMLFromNative', 'domainXMLToNative',
-            'findStoragePoolSources', 'getAllDomainStats', 'getCPUMap',
-            'getCPUModelNames', 'getCPUStats', 'getCapabilities',
-            'getCellsFreeMemory', 'getDomainCapabilities', 'getFreeMemory',
-            'getFreePages', 'getHostname', 'getInfo', 'getLibVersion',
-            'getMaxVcpus', 'getMemoryParameters', 'getMemoryStats',
-            'getSecurityModel', 'getSysinfo', 'getType', 'getURI',
-            'getVersion', 'interfaceDefineXML', 'interfaceLookupByMACString',
-            'interfaceLookupByName', 'isAlive', 'isEncrypted', 'isSecure',
-            'listAllDevices', 'listAllDomains', 'listAllInterfaces',
-            'listAllNWFilters', 'listAllNetworks', 'listAllSecrets',
-            'listAllStoragePools', 'listDefinedDomains',
-            'listDefinedInterfaces', 'listDefinedNetworks',
-            'listDefinedStoragePools', 'listDevices', 'listDomainsID',
-            'listInterfaces', 'listNWFilters', 'listNetworks', 'listSecrets',
-            'listStoragePools', 'lookupByID', 'lookupByName', 'lookupByUUID',
-            'lookupByUUIDString', 'networkCreateXML', 'networkDefineXML',
-            'networkEventDeregisterAny', 'networkEventRegisterAny',
-            'networkLookupByName', 'networkLookupByUUID',
-            'networkLookupByUUIDString', 'newStream', 'nodeDeviceCreateXML',
-            'nodeDeviceLookupByName', 'nodeDeviceLookupSCSIHostByWWN',
-            'numOfDefinedDomains', 'numOfDefinedInterfaces',
-            'numOfDefinedNetworks', 'numOfDefinedStoragePools', 'numOfDevices',
-            'numOfDomains', 'numOfInterfaces', 'numOfNWFilters',
-            'numOfNetworks', 'numOfSecrets', 'numOfStoragePools',
-            'nwfilterDefineXML', 'nwfilterLookupByName',
-            'nwfilterLookupByUUID', 'nwfilterLookupByUUIDString',
-            'registerCloseCallback', 'restore', 'restoreFlags',
-            'saveImageDefineXML', 'saveImageGetXMLDesc', 'secretDefineXML',
-            'secretLookupByUUID', 'secretLookupByUUIDString',
-            'secretLookupByUsage', 'setKeepAlive', 'setMemoryParameters',
-            'storagePoolCreateXML', 'storagePoolDefineXML',
-            'storagePoolLookupByName', 'storagePoolLookupByUUID',
-            'storagePoolLookupByUUIDString', 'storageVolLookupByKey',
-            'storageVolLookupByPath', 'suspendForDuration',
-            'unregisterCloseCallback', 'virConnGetLastError',
-            'virConnResetLastError'
-        ]
-        for f in fnt:
-            if f.startswith('is'):
-                self.__dict__[f] = yes
-            elif f.startswith('list'):
-                self.__dict__[f] = ary
-            else:
-                self.__dict__[f] = stub
-
-
-class LibvirtNodeDriverTestCase(LibvirtNodeDriver, unittest.TestCase):
-    type = Provider.LIBVIRT
-    name = 'Libvirt'
-    website = 'http://libvirt.org/'
-
-    NODE_STATE_MAP = {
-        0: NodeState.TERMINATED,  # no state
-        1: NodeState.RUNNING,  # domain is running
-        2: NodeState.PENDING,  # domain is blocked on resource
-        3: NodeState.TERMINATED,  # domain is paused by user
-        4: NodeState.TERMINATED,  # domain is being shut down
-        5: NodeState.TERMINATED,  # domain is shut off
-        6: NodeState.UNKNOWN,  # domain is crashed
-        7: NodeState.UNKNOWN,  # domain is suspended by guest power management
-    }
-
-    def __init__(self, argv=None):
-        unittest.TestCase.__init__(self, argv)
-        self._uri = 'qemu:///system'
-        self.connection = virConnect()
+@mock.patch('libcloud.compute.drivers.libvirt_driver.libvirt', autospec=True)
+class LibvirtNodeDriverTestCase(unittest.TestCase):
+    arp_output_str = """? (1.2.10.80) at 52:54:00:bc:f9:6c [ether] on br0
+? (1.2.10.33) at 52:54:00:04:89:51 [ether] on br0
+? (1.2.10.97) at 52:54:00:c6:40:ec [ether] on br0
+? (1.2.10.40) at 52:54:00:77:1c:83 [ether] on br0"""
+    ip_output_str = """1.2.10.80 dev br0 lladdr 52:54:00:bc:f9:6c STALE
+1.2.10.33 dev br0 lladdr 52:54:00:04:89:51 REACHABLE
+1.2.10.97 dev br0 lladdr 52:54:00:c6:40:ec DELAY
+1.2.10.40 dev br0 lladdr 52:54:00:77:1c:83 STALE"""
+    bad_output_str = """1.2.10.80 dev br0  52:54:00:bc:f9:6c STALE
+1.2.10.33 dev br0 lladdr 52:54:00:04:89:51 REACHABLE
+1.2.10.97 dev br0 lladdr
+1.2.10.40 dev br0 lladdr 52:54:00:77:1c:83 STALE"""
 
     def _assert_arp_table(self, arp_table):
         self.assertIn('52:54:00:bc:f9:6c', arp_table)
@@ -150,44 +47,28 @@ class LibvirtNodeDriverTestCase(LibvirtNodeDriver, unittest.TestCase):
         self.assertIn('1.2.10.97', arp_table['52:54:00:c6:40:ec'])
         self.assertIn('1.2.10.40', arp_table['52:54:00:77:1c:83'])
 
-    def test_arp_map(self):
-        arp_output_str = """? (1.2.10.80) at 52:54:00:bc:f9:6c [ether] on br0
-? (1.2.10.33) at 52:54:00:04:89:51 [ether] on br0
-? (1.2.10.97) at 52:54:00:c6:40:ec [ether] on br0
-? (1.2.10.40) at 52:54:00:77:1c:83 [ether] on br0
-"""
-        arp_table = self._parse_ip_table_arp(arp_output_str)
+    def test_arp_map(self, *args, **keywargs):
+        driver = LibvirtNodeDriver('')
+        arp_table = driver._parse_ip_table_arp(self.arp_output_str)
         self._assert_arp_table(arp_table)
 
-    def test_ip_map(self):
-        arp_output_str = """1.2.10.80 dev br0 lladdr 52:54:00:bc:f9:6c STALE
-1.2.10.33 dev br0 lladdr 52:54:00:04:89:51 REACHABLE
-1.2.10.97 dev br0 lladdr 52:54:00:c6:40:ec DELAY
-1.2.10.40 dev br0 lladdr 52:54:00:77:1c:83 STALE
-"""
-        arp_table = self._parse_ip_table_neigh(arp_output_str)
+    def test_ip_map(self, *args, **keywargs):
+        driver = LibvirtNodeDriver('')
+        arp_table = driver._parse_ip_table_neigh(self.ip_output_str)
         self._assert_arp_table(arp_table)
 
-    def test_bad_map(self):
-        arp_output_str = """1.2.10.80 dev br0  52:54:00:bc:f9:6c STALE
-1.2.10.33 dev br0 lladdr 52:54:00:04:89:51 REACHABLE
-1.2.10.97 dev br0 lladdr
-1.2.10.40 dev br0 lladdr 52:54:00:77:1c:83 STALE
-"""
-        arp_table = self._parse_ip_table_neigh(arp_output_str)
+    def test_bad_map(self, *args, **keywargs):
+        driver = LibvirtNodeDriver('')
+        arp_table = driver._parse_ip_table_neigh(self.bad_output_str)
         # we should at least get the correctly formatted lines
         self.assertEqual(len(arp_table), 2)
-        arp_output_str = """? (1.2.10.80) at 52:54:00:bc:f9:6c [ether] on br0
-? (1.2.10.33) at 52:54:00:04:89:51 [ether] on br0
-? (1.2.10.97) at 52:54:00:c6:40:ec [ether] on br0
-? (1.2.10.40) at 52:54:00:77:1c:83 [ether] on br0
-"""
-        arp_table = self._parse_ip_table_neigh(arp_output_str)
+        arp_table = driver._parse_ip_table_neigh(self.arp_output_str)
         # nothing should match if the wrong output is sent
         self.assertEqual(len(arp_table), 0)
 
-    def test_list_nodes(self):
-        nodes = self.list_nodes()
+    def test_list_nodes(self, *args, **keywargs):
+        driver = LibvirtNodeDriver('')
+        nodes = driver.list_nodes()
         self.assertEqual(type([]), type(nodes))
         self.assertEqual(len(nodes), 0)
 

--- a/libcloud/test/compute/test_libvirt_driver.py
+++ b/libcloud/test/compute/test_libvirt_driver.py
@@ -21,7 +21,7 @@ from libcloud.utils.py3 import unittest2_required
 
 from libcloud.test import unittest
 if unittest2_required:
-    from unittest2 import mock
+    import mock
 else:
     from unittest import mock
 

--- a/libcloud/test/compute/test_libvirt_driver.py
+++ b/libcloud/test/compute/test_libvirt_driver.py
@@ -16,10 +16,14 @@
 import sys
 
 from libcloud.compute.drivers.libvirt_driver import LibvirtNodeDriver
+from libcloud.utils.py3 import unittest2_required
 
 
 from libcloud.test import unittest
-from unittest import mock
+if unittest2_required:
+    from unittest2 import mock
+else:
+    from unittest import mock
 
 
 @mock.patch('libcloud.compute.drivers.libvirt_driver.libvirt', autospec=True)

--- a/libcloud/test/compute/test_libvirt_driver.py
+++ b/libcloud/test/compute/test_libvirt_driver.py
@@ -16,6 +16,8 @@
 import sys
 
 from libcloud.compute.drivers.libvirt_driver import LibvirtNodeDriver
+from libcloud.compute.base import NodeState
+from libcloud.compute.types import Provider
 
 
 from libcloud.test import unittest
@@ -26,11 +28,19 @@ class virConnect:
     A stub/Mock implementation of the libvirt.virConnect class returned by
     the libvirt.openX calles
     """
-    def stub(self, *args, **kwargs):
+    def __stub(self, *args, **kwargs):
         return 0
 
+    def __yes(self, *args, **kwargs):
+        return True
+
+    def __ary(self, *args, **kwargs):
+        return []
+
     def __init__(self):
-        stub = self.stub
+        stub = self.__stub
+        yes = self.__yes
+        ary = self.__ary
         fnt = [
             '_dispatchCloseCallback',
             '_dispatchDomainEventAgentLifecycleCallback',
@@ -65,103 +75,66 @@ class virConnect:
             'domainXMLFromNative', 'domainXMLToNative',
             'findStoragePoolSources', 'getAllDomainStats', 'getCPUMap',
             'getCPUModelNames', 'getCPUStats', 'getCapabilities',
-            'getCellsFreeMemory',
-            'getDomainCapabilities',
-            'getFreeMemory',
-            'getFreePages',
-            'getHostname',
-            'getInfo',
-            'getLibVersion',
-            'getMaxVcpus',
-            'getMemoryParameters',
-            'getMemoryStats',
-            'getSecurityModel',
-            'getSysinfo',
-            'getType',
-            'getURI',
-            'getVersion',
-            'interfaceDefineXML',
-            'interfaceLookupByMACString',
-            'interfaceLookupByName',
-            'isAlive',
-            'isEncrypted',
-            'isSecure',
-            'listAllDevices',
-            'listAllDomains',
-            'listAllInterfaces',
-            'listAllNWFilters',
-            'listAllNetworks',
-            'listAllSecrets',
-            'listAllStoragePools',
-            'listDefinedDomains',
-            'listDefinedInterfaces',
-            'listDefinedNetworks',
-            'listDefinedStoragePools',
-            'listDevices',
-            'listDomainsID',
-            'listInterfaces',
-            'listNWFilters',
-            'listNetworks',
-            'listSecrets',
-            'listStoragePools',
-            'lookupByID',
-            'lookupByName',
-            'lookupByUUID',
-            'lookupByUUIDString',
-            'networkCreateXML',
-            'networkDefineXML',
-            'networkEventDeregisterAny',
-            'networkEventRegisterAny',
-            'networkLookupByName',
-            'networkLookupByUUID',
-            'networkLookupByUUIDString',
-            'newStream',
-            'nodeDeviceCreateXML',
-            'nodeDeviceLookupByName',
-            'nodeDeviceLookupSCSIHostByWWN',
-            'numOfDefinedDomains',
-            'numOfDefinedInterfaces',
-            'numOfDefinedNetworks',
-            'numOfDefinedStoragePools',
-            'numOfDevices',
-            'numOfDomains',
-            'numOfInterfaces',
-            'numOfNWFilters',
-            'numOfNetworks',
-            'numOfSecrets',
-            'numOfStoragePools',
-            'nwfilterDefineXML',
-            'nwfilterLookupByName',
-            'nwfilterLookupByUUID',
-            'nwfilterLookupByUUIDString',
-            'registerCloseCallback',
-            'restore',
-            'restoreFlags',
-            'saveImageDefineXML',
-            'saveImageGetXMLDesc',
-            'secretDefineXML',
-            'secretLookupByUUID',
-            'secretLookupByUUIDString',
-            'secretLookupByUsage',
-            'setKeepAlive',
-            'setMemoryParameters',
-            'storagePoolCreateXML',
-            'storagePoolDefineXML',
-            'storagePoolLookupByName',
-            'storagePoolLookupByUUID',
-            'storagePoolLookupByUUIDString',
-            'storageVolLookupByKey',
-            'storageVolLookupByPath',
-            'suspendForDuration',
-            'unregisterCloseCallback',
-            'virConnGetLastError',
+            'getCellsFreeMemory', 'getDomainCapabilities', 'getFreeMemory',
+            'getFreePages', 'getHostname', 'getInfo', 'getLibVersion',
+            'getMaxVcpus', 'getMemoryParameters', 'getMemoryStats',
+            'getSecurityModel', 'getSysinfo', 'getType', 'getURI',
+            'getVersion', 'interfaceDefineXML', 'interfaceLookupByMACString',
+            'interfaceLookupByName', 'isAlive', 'isEncrypted', 'isSecure',
+            'listAllDevices', 'listAllDomains', 'listAllInterfaces',
+            'listAllNWFilters', 'listAllNetworks', 'listAllSecrets',
+            'listAllStoragePools', 'listDefinedDomains',
+            'listDefinedInterfaces', 'listDefinedNetworks',
+            'listDefinedStoragePools', 'listDevices', 'listDomainsID',
+            'listInterfaces', 'listNWFilters', 'listNetworks', 'listSecrets',
+            'listStoragePools', 'lookupByID', 'lookupByName', 'lookupByUUID',
+            'lookupByUUIDString', 'networkCreateXML', 'networkDefineXML',
+            'networkEventDeregisterAny', 'networkEventRegisterAny',
+            'networkLookupByName', 'networkLookupByUUID',
+            'networkLookupByUUIDString', 'newStream', 'nodeDeviceCreateXML',
+            'nodeDeviceLookupByName', 'nodeDeviceLookupSCSIHostByWWN',
+            'numOfDefinedDomains', 'numOfDefinedInterfaces',
+            'numOfDefinedNetworks', 'numOfDefinedStoragePools', 'numOfDevices',
+            'numOfDomains', 'numOfInterfaces', 'numOfNWFilters',
+            'numOfNetworks', 'numOfSecrets', 'numOfStoragePools',
+            'nwfilterDefineXML', 'nwfilterLookupByName',
+            'nwfilterLookupByUUID', 'nwfilterLookupByUUIDString',
+            'registerCloseCallback', 'restore', 'restoreFlags',
+            'saveImageDefineXML', 'saveImageGetXMLDesc', 'secretDefineXML',
+            'secretLookupByUUID', 'secretLookupByUUIDString',
+            'secretLookupByUsage', 'setKeepAlive', 'setMemoryParameters',
+            'storagePoolCreateXML', 'storagePoolDefineXML',
+            'storagePoolLookupByName', 'storagePoolLookupByUUID',
+            'storagePoolLookupByUUIDString', 'storageVolLookupByKey',
+            'storageVolLookupByPath', 'suspendForDuration',
+            'unregisterCloseCallback', 'virConnGetLastError',
             'virConnResetLastError'
         ]
         for f in fnt:
-            self.__dict__[f] = stub
+            if f.startswith('is'):
+                self.__dict__[f] = yes
+            elif f.startswith('list'):
+                self.__dict__[f] = ary
+            else:
+                self.__dict__[f] = stub
 
 
 class LibvirtNodeDriverTestCase(LibvirtNodeDriver, unittest.TestCase):
+    type = Provider.LIBVIRT
+    name = 'Libvirt'
+    website = 'http://libvirt.org/'
+
+    NODE_STATE_MAP = {
+        0: NodeState.TERMINATED,  # no state
+        1: NodeState.RUNNING,  # domain is running
+        2: NodeState.PENDING,  # domain is blocked on resource
+        3: NodeState.TERMINATED,  # domain is paused by user
+        4: NodeState.TERMINATED,  # domain is being shut down
+        5: NodeState.TERMINATED,  # domain is shut off
+        6: NodeState.UNKNOWN,  # domain is crashed
+        7: NodeState.UNKNOWN,  # domain is suspended by guest power management
+    }
+
     def __init__(self, argv=None):
         unittest.TestCase.__init__(self, argv)
         self._uri = 'qemu:///system'
@@ -194,6 +167,29 @@ class LibvirtNodeDriverTestCase(LibvirtNodeDriver, unittest.TestCase):
 """
         arp_table = self._parse_ip_table_neigh(arp_output_str)
         self._assert_arp_table(arp_table)
+
+    def test_bad_map(self):
+        arp_output_str = """1.2.10.80 dev br0  52:54:00:bc:f9:6c STALE
+1.2.10.33 dev br0 lladdr 52:54:00:04:89:51 REACHABLE
+1.2.10.97 dev br0 lladdr
+1.2.10.40 dev br0 lladdr 52:54:00:77:1c:83 STALE
+"""
+        arp_table = self._parse_ip_table_neigh(arp_output_str)
+        # we should at least get the correctly formatted lines
+        self.assertEqual(len(arp_table), 2)
+        arp_output_str = """? (1.2.10.80) at 52:54:00:bc:f9:6c [ether] on br0
+? (1.2.10.33) at 52:54:00:04:89:51 [ether] on br0
+? (1.2.10.97) at 52:54:00:c6:40:ec [ether] on br0
+? (1.2.10.40) at 52:54:00:77:1c:83 [ether] on br0
+"""
+        arp_table = self._parse_ip_table_neigh(arp_output_str)
+        # nothing should match if the wrong output is sent
+        self.assertEqual(len(arp_table), 0)
+
+    def test_list_nodes(self):
+        nodes = self.list_nodes()
+        self.assertEqual(type([]), type(nodes))
+        self.assertEqual(len(nodes), 0)
 
 if __name__ == '__main__':
     sys.exit(unittest.main())

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ deps =
     lockfile
     py{2.5,2.6,2.7}: paramiko
     py{2.5,2.6}: unittest2
+    py{2.5,2.6,2.7}: mock
 set-env =
     COVERALLS_REPO_TOKEN = GAB5ZuovdsVEFxSIyZE8YhDYU886iGW54
 commands = cp libcloud/test/secrets.py-dist libcloud/test/secrets.py
@@ -42,6 +43,7 @@ deps = -r{toxinidir}/requirements-tests.txt
        lxml
 [testenv:py2.7-lxml]
 deps = -r{toxinidir}/requirements-tests.txt
+       mock
        lxml
 [testenv:pypypy-lxml]
 deps = -r{toxinidir}/requirements-tests.txt

--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,7 @@ deps = -r{toxinidir}/requirements-tests.txt
 [testenv:py2.6-lxml]
 deps = -r{toxinidir}/requirements-tests.txt
        unittest2
+       mock
        paramiko
        lxml
 [testenv:py2.7-lxml]


### PR DESCRIPTION
## Extra tests for libvirt_driver and cleaner driver creation
### Description

Code clean up and added more tests for the libvirt_driver module.
Cleaner driver creation with less console output when using SASL
authentication.
### Status
- done, ready for review
### Checklist (tick everything that applies)
- [X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [X] Documentation
- [X] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
