### PR TITLE
[LIBCLOUD-833] and [LIBCLOUD-834](workaround)

### DIFF
--- a/libcloud/storage/drivers/s3.py
+++ b/libcloud/storage/drivers/s3.py
@@ -950,10 +950,11 @@ class S3CNNorthConnection(SignedAWSConnection, BaseS3Connection):
     def __init__(self, user_id, key, secure=True, host=None, port=None,
                  url=None, timeout=None, proxy_url=None, token=None,
                  retry_delay=None, backoff=None):
-        super(S3CNNorthConnection, self).__init__(user_id, key, secure, host,
-                                                  port, url, timeout, proxy_url,
-                                                  token, retry_delay, backoff,
-                                                  4)  # force version 4
+        super(S3CNNorthConnection, self).__init__(
+            user_id, key, secure, host,
+            port, url, timeout, proxy_url,
+            token, retry_delay, backoff,
+            4)  # force version 4
 
 
 class S3CNNorthStorageDriver(S3StorageDriver):

--- a/libcloud/storage/drivers/s3.py
+++ b/libcloud/storage/drivers/s3.py
@@ -244,7 +244,7 @@ class BaseS3StorageDriver(StorageDriver):
         :rtype: ``list`` of :class:`Object`
         """
         return list(self.iterate_container_objects(container,
-                    ex_prefix=ex_prefix))
+                                                   ex_prefix=ex_prefix))
 
     def iterate_container_objects(self, container, ex_prefix=None):
         """
@@ -846,7 +846,7 @@ class BaseS3StorageDriver(StorageDriver):
 
     def _to_containers(self, obj, xpath):
         for element in obj.findall(fixxpath(xpath=xpath,
-                                   namespace=self.namespace)):
+                                            namespace=self.namespace)):
             yield self._to_container(element)
 
     def _to_objs(self, obj, xpath, container):
@@ -942,14 +942,25 @@ class S3USWestOregonStorageDriver(S3StorageDriver):
     ex_location_name = 'us-west-2'
 
 
-class S3CNNorthConnection(S3Connection):
+class S3CNNorthConnection(SignedAWSConnection, BaseS3Connection):
     host = S3_CN_NORTH_HOST
+    service_name = 's3'
+    version = API_VERSION
+
+    def __init__(self, user_id, key, secure=True, host=None, port=None,
+                 url=None, timeout=None, proxy_url=None, token=None,
+                 retry_delay=None, backoff=None):
+        super(S3CNNorthConnection, self).__init__(user_id, key, secure, host,
+                                                  port, url, timeout, proxy_url,
+                                                  token, retry_delay, backoff,
+                                                  4)  # force version 4
 
 
 class S3CNNorthStorageDriver(S3StorageDriver):
     name = 'Amazon S3 (cn-north-1)'
     connectionCls = S3CNNorthConnection
-    ex_location_name = 'CN'
+    ex_location_name = 'cn-north-1'
+    region_name = 'cn-north-1'
 
 
 class S3EUWestConnection(S3Connection):

--- a/libcloud/storage/drivers/s3.py
+++ b/libcloud/storage/drivers/s3.py
@@ -961,6 +961,8 @@ class S3CNNorthStorageDriver(S3StorageDriver):
     connectionCls = S3CNNorthConnection
     ex_location_name = 'cn-north-1'
     region_name = 'cn-north-1'
+    # v4 auth and multipart_upload currently do not work.
+    supports_s3_multipart_upload = False
 
 
 class S3EUWestConnection(S3Connection):
@@ -1016,6 +1018,8 @@ class S3APNE2StorageDriver(S3StorageDriver):
     connectionCls = S3APNE2Connection
     ex_location_name = 'ap-northeast-2'
     region_name = 'ap-northeast-2'
+    # v4 auth and multipart_upload currently do not work.
+    supports_s3_multipart_upload = False
 
 
 class S3SAEastConnection(S3Connection):


### PR DESCRIPTION
## Changes Title (replace this with a logical title for your changes)
### Description

[LIBCLOUD-833] - The AWS China region requires V4 authentication. Set the auth version to v4 allowing the region to function.

 [LIBCLOUD-834](workaround) - With V4 auth enabled the upload_via_stream function does not work and fails with an "InvalidCreds" error. This work around disables the supports_s3_multipart_upload section allow files to be uploaded to V4 regions.

For more information on contributing, please see [Contributing](http://libcloud.readthedocs.org/en/latest/development.html#contributing)
section of our documentation.
### Status

Replace this: describe the PR status. Examples:
-  ready for review
### Checklist (tick everything that applies)
- [X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
