### PR TITLE
OpenStack - ex_create_floating_ip: set the "pool" in the returned object

### DIFF
--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -2325,10 +2325,11 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
 
         data = resp.object['floating_ip']
         id = data['id']
+        ip_pool_ = data.get('pool')
         ip_address = data['ip']
         return OpenStack_1_1_FloatingIpAddress(id=id,
                                                ip_address=ip_address,
-                                               pool=None,
+                                               pool=ip_pool_,
                                                node_id=None,
                                                driver=self)
 


### PR DESCRIPTION
## OpenStack: ex_create_floating_ip(): set the "pool" in the returned object
### Description

I've added the name of the IP pool from which the IP was created instead of always setting this value to `None`.
### Status
- done, ready for review
### Checklist (tick everything that applies)
- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide)
- [ ] ~~Documentation~~
- [ ] ~~[Tests](http://libcloud.readthedocs.org/en/latest/testing.html)~~
- [ ] ~~[ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)~~
