### PR TITLE
[LIBCLOUD-839] IAM temporary credentials token support for ElasticLBDriver

### DIFF
--- a/libcloud/loadbalancer/drivers/elb.py
+++ b/libcloud/loadbalancer/drivers/elb.py
@@ -53,8 +53,9 @@ class ElasticLBDriver(Driver):
     connectionCls = ELBConnection
     signature_version = '4'
 
-    def __init__(self, access_id, secret, region):
-        super(ElasticLBDriver, self).__init__(access_id, secret)
+    def __init__(self, access_id, secret, region, token=None):
+        self.token = token
+        super(ElasticLBDriver, self).__init__(access_id, secret, token=token)
         self.region = region
         self.region_name = region
         self.connection.host = HOST % (region)
@@ -354,5 +355,10 @@ class ElasticLBDriver(Driver):
 
     def _ex_connection_class_kwargs(self):
         kwargs = super(ElasticLBDriver, self)._ex_connection_class_kwargs()
-        kwargs['signature_version'] = self.signature_version
+        if hasattr(self, 'token') and self.token is not None:
+            kwargs['token'] = self.token
+            kwargs['signature_version'] = '4'
+        else:
+            kwargs['signature_version'] = self.signature_version
+
         return kwargs

--- a/libcloud/test/loadbalancer/test_elb.py
+++ b/libcloud/test/loadbalancer/test_elb.py
@@ -36,6 +36,19 @@ class ElasticLBTests(unittest.TestCase):
 
         self.driver = ElasticLBDriver(*LB_ELB_PARAMS)
 
+    def test_instantiate_driver_with_token(self):
+        token = 'temporary_credentials_token'
+        driver = ElasticLBDriver(*LB_ELB_PARAMS, **{'token': token})
+        self.assertTrue(hasattr(driver, 'token'), 'Driver has no attribute token')
+        self.assertEquals(token, driver.token, "Driver token does not match with provided token")
+
+    def test_driver_with_token_signature_version(self):
+        token = 'temporary_credentials_token'
+        driver = ElasticLBDriver(*LB_ELB_PARAMS, **{'token': token})
+        kwargs = driver._ex_connection_class_kwargs()
+        self.assertIn('signature_version', kwargs)
+        self.assertEquals('4', kwargs['signature_version'], 'Signature version is not 4 with temporary credentials')
+
     def test_list_protocols(self):
         protocols = self.driver.list_protocols()
 

--- a/libcloud/test/loadbalancer/test_elb.py
+++ b/libcloud/test/loadbalancer/test_elb.py
@@ -46,7 +46,7 @@ class ElasticLBTests(unittest.TestCase):
         token = 'temporary_credentials_token'
         driver = ElasticLBDriver(*LB_ELB_PARAMS, **{'token': token})
         kwargs = driver._ex_connection_class_kwargs()
-        self.assertIn('signature_version', kwargs)
+        self.assertTrue(('signature_version' in kwargs), 'Driver has no attribute signature_version')
         self.assertEquals('4', kwargs['signature_version'], 'Signature version is not 4 with temporary credentials')
 
     def test_list_protocols(self):


### PR DESCRIPTION
## Connect to AWS ELB using IAM role temporary credentials
### Description

Current implementation of ElasticLBDriver driver doesn't support token parameter which is required for authentication using IAM temporary credentials.

Issue:
https://issues.apache.org/jira/browse/LIBCLOUD-839
### Status

done, ready for review
### Checklist (tick everything that applies)
- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
