### PR TITLE
[LIBCLOUD-835] Fix caching of Google auth tokens

### DIFF
--- a/libcloud/common/google.py
+++ b/libcloud/common/google.py
@@ -688,7 +688,7 @@ class GoogleOAuth2Credential(object):
         """
         filename = os.path.realpath(os.path.expanduser(self.credential_file))
         data = json.dumps(self.token)
-        with os.fdopen(os.open(filename, os.O_CREAT | os.O_WRONLY,
+        with os.fdopen(os.open(filename, os.O_CREAT | os.O_WRONLY | os.O_TRUNC,
                                int('600', 8)), 'w') as f:
             f.write(data)
 


### PR DESCRIPTION
## Fix corruption bug in Google auth token caching
### Description

The `GoogleOAuth2Credential. _write_token_to_file()` method writes a copy of the latest OAuth token to disk. Prior to this fix, the token was being written to disk without truncating the file first, which is fine in the case where the new token has the same number of characters (or more) as the old one. However, in some situations Google OAuth returns a shorter token string, which was causing the library to crash when loading the corrupted token.
### Status

Fixed, needs tests.
### Checklist (tick everything that applies)
- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)

_write_token_to_file was not zeroing the file before writing
a new token, causing corruption.

FIXES: LIBCLOUD-835
