### PR TITLE
[LIBCLOUD-842] - Fix for AzureBlobStorage not allowing upload with 400 error (https://…

### DIFF
--- a/libcloud/common/azure.py
+++ b/libcloud/common/azure.py
@@ -112,6 +112,8 @@ class AzureConnection(ConnectionUserAndKey):
 
     responseCls = AzureResponse
     rawResponseCls = AzureRawResponse
+    skip_host = False
+    skip_accept_encoding = False
 
     def add_default_params(self, params):
         return params

--- a/libcloud/common/base.py
+++ b/libcloud/common/base.py
@@ -532,6 +532,8 @@ class Connection(object):
     retry_delay = None
 
     allow_insecure = True
+    skip_host = True
+    skip_accept_encoding = True
 
     def __init__(self, secure=True, host=None, port=None, url=None,
                  timeout=None, proxy_url=None, retry_delay=None, backoff=None):
@@ -778,6 +780,9 @@ class Connection(object):
         else:
             headers.update({'Host': self.host})
 
+        skip_host = self.skip_host
+        skip_accept_encoding = self.skip_accept_encoding
+
         if data:
             data = self.encode_data(data)
             headers['Content-Length'] = str(len(data))
@@ -808,8 +813,8 @@ class Connection(object):
             # instead of dealing with splitting and sending the file ourselves?
             if raw:
                 self.connection.putrequest(method, url,
-                                           skip_host=1,
-                                           skip_accept_encoding=1)
+                                            skip_host=skip_host,
+                                            skip_accept_encoding=skip_accept_encoding)
 
                 for key, value in list(headers.items()):
                     self.connection.putheader(key, str(value))

--- a/libcloud/common/base.py
+++ b/libcloud/common/base.py
@@ -118,6 +118,7 @@ class HTTPResponse(httplib.HTTPResponse):
     # In particular this happens on S3 when calls are made to get_object to
     # objects that don't exist.
     # This applies the behaviour from 2.7, fixing the hangs.
+
     def read(self, amt=None):
         if self.fp is None:
             return ''
@@ -354,6 +355,7 @@ class LoggingConnection():
 
         # this is evil. laugh with me. ha arharhrhahahaha
         class fakesock(object):
+
             def __init__(self, s):
                 self.s = s
 
@@ -812,9 +814,11 @@ class Connection(object):
             # @TODO: Should we just pass File object as body to request method
             # instead of dealing with splitting and sending the file ourselves?
             if raw:
-                self.connection.putrequest(method, url,
-                                            skip_host=skip_host,
-                                            skip_accept_encoding=skip_accept_encoding)
+                self.connection.putrequest(
+                    method,
+                    url,
+                    skip_host=skip_host,
+                    skip_accept_encoding=skip_accept_encoding)
 
                 for key, value in list(headers.items()):
                     self.connection.putheader(key, str(value))
@@ -1055,6 +1059,7 @@ class ConnectionKey(Connection):
     """
     Base connection class which accepts a single ``key`` argument.
     """
+
     def __init__(self, key, secure=True, host=None, port=None, url=None,
                  timeout=None, proxy_url=None, backoff=None, retry_delay=None):
         """
@@ -1074,6 +1079,7 @@ class CertificateConnection(Connection):
     """
     Base connection class which accepts a single ``cert_file`` argument.
     """
+
     def __init__(self, cert_file, secure=True, host=None, port=None, url=None,
                  proxy_url=None, timeout=None, backoff=None, retry_delay=None):
         """


### PR DESCRIPTION
## Fixes https://issues.apache.org/jira/browse/LIBCLOUD-842 AzureBlobStorage not allowing upload with 400 error
### Description

Fix for AzureBlobStorage not allowing upload with 400 error (https://issues.apache.org/jira/browse/LIBCLOUD-842). The issue was created when a fix for "AWSRequestSignerAlgorithmV4" (https://github.com/apache/libcloud/commit/4bff0f076776e6d59945381c1e2969826131fc11) was added. This caused the heads "host" and "accept_encoding" to be removed from the requests to AzureBlobStorage. The Fix retains the current functionality and sets the headers on for Azure.
### Status

Replace this: describe the PR status. Examples:
- work done
- tested using script provided on https://issues.apache.org/jira/browse/LIBCLOUD-842
### Checklist (tick everything that applies)
- [X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)

…issues.apache.org/jira/browse/LIBCLOUD-842). The issue was created when a fix for "AWSRequestSignerAlgorithmV4" (https://github.com/apache/libcloud/commit/4bff0f076776e6d59945381c1e2969826131fc11) was added. This caused the heads "host" and "accept_encoding" to be removed from the requests to AzureBlobStorage. The Fix retains the current functionality and sets the headers on for Azure.
