### PR TITLE
[FIX] CloudStack: Values with wildcards will fail signature validation

### DIFF
--- a/libcloud/common/cloudstack.py
+++ b/libcloud/common/cloudstack.py
@@ -80,7 +80,7 @@ class CloudStackConnection(ConnectionUserAndKey, PollingConnection):
         pairs = []
         for pair in signature:
             key = urlquote(str(pair[0]), safe='[]')
-            value = urlquote(str(pair[1]), safe='[]')
+            value = urlquote(str(pair[1]), safe='[]*')
             item = '%s=%s' % (key, value)
             pairs .append(item)
 


### PR DESCRIPTION
### Description

Thanks to a small bug in the request signer the signature will be invalid for any request with any value containing a wildcard; it should be considered 'safe'.

This is identical to apache/cloudstack-cloudmonkey@38b68fb
### Status
- done, ready for review
