### PR TITLE
Cloudstack: add migrating state to node and volume

### DIFF
--- a/libcloud/compute/drivers/cloudstack.py
+++ b/libcloud/compute/drivers/cloudstack.py
@@ -1235,6 +1235,7 @@ class CloudStackNodeDriver(CloudStackDriverMixIn, NodeDriver):
     NODE_STATE_MAP = {
         'Running': NodeState.RUNNING,
         'Starting': NodeState.REBOOTING,
+        'Migrating': NodeState.MIGRATING,
         'Stopped': NodeState.STOPPED,
         'Stopping': NodeState.PENDING,
         'Destroyed': NodeState.TERMINATED,
@@ -1251,7 +1252,8 @@ class CloudStackNodeDriver(CloudStackDriverMixIn, NodeDriver):
         'Allocated': StorageVolumeState.AVAILABLE,
         'Ready': StorageVolumeState.AVAILABLE,
         'Snapshotting': StorageVolumeState.BACKUP,
-        'UploadError': StorageVolumeState.ERROR
+        'UploadError': StorageVolumeState.ERROR,
+        'Migrating': StorageVolumeState.MIGRATING
     }
 
     def __init__(self, key, secret=None, secure=True, host=None,

--- a/libcloud/compute/types.py
+++ b/libcloud/compute/types.py
@@ -271,6 +271,7 @@ class NodeState(Type):
     ERROR = 'error'
     PAUSED = 'paused'
     RECONFIGURING = 'reconfiguring'
+    MIGRATING = 'migrating'
 
 
 class StorageVolumeState(Type):
@@ -286,6 +287,7 @@ class StorageVolumeState(Type):
     BACKUP = 'backup'
     ATTACHING = 'attaching'
     UNKNOWN = 'unknown'
+    MIGRATING = 'migrating'
 
 
 class VolumeSnapshotState(Type):


### PR DESCRIPTION
## Add `migrating` state to Cloudstack Node and Volume
### Description

The node and volume state list are missing the `migrating` one, either for live migration or offline migration of a VM.
### Status
- done, ready for review
### Checklist (tick everything that applies)
- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
