### PR TITLE
[LIBCLOUD-843] Added fetch tags support in elb driver

### DIFF
--- a/libcloud/loadbalancer/base.py
+++ b/libcloud/loadbalancer/base.py
@@ -222,19 +222,6 @@ class Driver(BaseDriver):
         raise NotImplementedError(
             'get_balancer not implemented for this driver')
 
-    def get_tags(self, balancer_id):
-        """
-        Return a dict of tag/value
-
-        :param balancer_id: id of a load balancer you want to fetch tags for
-        :type  balancer_id: ``str``
-
-        :rtype: ``dict``
-        """
-
-        raise NotImplementedError(
-            'get_tags not implemented for this driver')
-
     def update_balancer(self, balancer, **kwargs):
         """
         Sets the name, algorithm, protocol, or port on a load balancer.

--- a/libcloud/loadbalancer/base.py
+++ b/libcloud/loadbalancer/base.py
@@ -222,6 +222,19 @@ class Driver(BaseDriver):
         raise NotImplementedError(
             'get_balancer not implemented for this driver')
 
+    def get_tags(self, balancer_id):
+        """
+        Return a dict of tag/value
+
+        :param balancer_id: id of a load balancer you want to fetch tags for
+        :type  balancer_id: ``str``
+
+        :rtype: ``dict``
+        """
+
+        raise NotImplementedError(
+            'get_tags not implemented for this driver')
+
     def update_balancer(self, balancer, **kwargs):
         """
         Sets the name, algorithm, protocol, or port on a load balancer.

--- a/libcloud/loadbalancer/drivers/elb.py
+++ b/libcloud/loadbalancer/drivers/elb.py
@@ -69,11 +69,8 @@ class ElasticLBDriver(Driver):
         balancers = self._to_balancers(data)
 
         if ex_fetch_tags:
-            for lb in balancers:
-                tags = lb.extra.get('tags', {})
-                tags.update(self.get_tags(lb.id))
-                if tags:
-                    lb.extra['tags'] = tags
+            for balancer in balancers:
+                self._ex_populate_balancer_tags(balancer)
 
         return balancers
 
@@ -116,21 +113,18 @@ class ElasticLBDriver(Driver):
         self.connection.request(ROOT, params=params)
         return True
 
-    def get_balancer(self, balancer_id):
+    def get_balancer(self, balancer_id, ex_fetch_tags=False):
         params = {
             'Action': 'DescribeLoadBalancers',
             'LoadBalancerNames.member.1': balancer_id
         }
         data = self.connection.request(ROOT, params=params).object
-        return self._to_balancers(data)[0]
+        balancer = self._to_balancers(data)[0]
 
-    def get_tags(self, balancer_id):
-        params = {
-            'Action': 'DescribeTags',
-            'LoadBalancerNames.member.1': balancer_id
-        }
-        data = self.connection.request(ROOT, params=params).object
-        return self._to_tags(data)
+        if ex_fetch_tags:
+            balancer = self._ex_populate_balancer_tags(balancer)
+
+        return balancer
 
     def balancer_attach_compute_node(self, balancer, node):
         params = {
@@ -393,3 +387,19 @@ class ElasticLBDriver(Driver):
             kwargs['signature_version'] = self.signature_version
 
         return kwargs
+
+    def _ex_list_balancer_tags(self, balancer_id):
+        params = {
+            'Action': 'DescribeTags',
+            'LoadBalancerNames.member.1': balancer_id
+        }
+        data = self.connection.request(ROOT, params=params).object
+        return self._to_tags(data)
+
+    def _ex_populate_balancer_tags(self, balancer):
+        tags = balancer.extra.get('tags', {})
+        tags.update(self._ex_list_balancer_tags(balancer.id))
+        if tags:
+            balancer.extra['tags'] = tags
+
+        return balancer

--- a/libcloud/test/loadbalancer/fixtures/elb/describe_tags.xml
+++ b/libcloud/test/loadbalancer/fixtures/elb/describe_tags.xml
@@ -1,0 +1,18 @@
+<DescribeTagsResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2012-06-01/">
+    <DescribeTagsResult>
+        <TagDescriptions>
+            <member>
+                <Tags>
+                    <member>
+                        <Value>lima</Value>
+                        <Key>project</Key>
+                    </member>
+                </Tags>
+                <LoadBalancerName>tests</LoadBalancerName>
+            </member>
+        </TagDescriptions>
+    </DescribeTagsResult>
+    <ResponseMetadata>
+        <RequestId>07b1ecbc-1100-11e3-acaf-dd7edEXAMPLE</RequestId>
+    </ResponseMetadata>
+</DescribeTagsResponse>

--- a/libcloud/test/loadbalancer/test_elb.py
+++ b/libcloud/test/loadbalancer/test_elb.py
@@ -63,6 +63,21 @@ class ElasticLBTests(unittest.TestCase):
         self.assertEqual(balancers[0].id, 'tests')
         self.assertEqual(balancers[0].name, 'tests')
 
+    def test_list_balancers_with_tags(self):
+        balancers = self.driver.list_balancers(ex_fetch_tags=True)
+
+        self.assertEqual(len(balancers), 1)
+        self.assertEqual(balancers[0].id, 'tests')
+        self.assertEqual(balancers[0].name, 'tests')
+        self.assertTrue(('tags' in balancers[0].extra), 'No tags dict found in balancer.extra')
+        self.assertEqual(balancers[0].extra['tags']['project'], 'lima')
+
+    def test_get_tags(self):
+        tags = self.driver.get_tags('tests')
+
+        self.assertEqual(len(tags), 1)
+        self.assertEqual(tags['project'], 'lima')
+
     def test_get_balancer(self):
         balancer = self.driver.get_balancer(balancer_id='tests')
 
@@ -151,6 +166,10 @@ class ElasticLBMockHttp(MockHttpTestCase):
 
     def _2012_06_01_DescribeLoadBalancers(self, method, url, body, headers):
         body = self.fixtures.load('describe_load_balancers.xml')
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+
+    def _2012_06_01_DescribeTags(self, method, url, body, headers):
+        body = self.fixtures.load('describe_tags.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
     def _2012_06_01_CreateLoadBalancer(self, method, url, body, headers):

--- a/libcloud/test/loadbalancer/test_elb.py
+++ b/libcloud/test/loadbalancer/test_elb.py
@@ -72,8 +72,8 @@ class ElasticLBTests(unittest.TestCase):
         self.assertTrue(('tags' in balancers[0].extra), 'No tags dict found in balancer.extra')
         self.assertEqual(balancers[0].extra['tags']['project'], 'lima')
 
-    def test_get_tags(self):
-        tags = self.driver.get_tags('tests')
+    def test_list_balancer_tags(self):
+        tags = self.driver._ex_list_balancer_tags('tests')
 
         self.assertEqual(len(tags), 1)
         self.assertEqual(tags['project'], 'lima')
@@ -84,6 +84,23 @@ class ElasticLBTests(unittest.TestCase):
         self.assertEqual(balancer.id, 'tests')
         self.assertEqual(balancer.name, 'tests')
         self.assertEqual(balancer.state, State.UNKNOWN)
+
+    def test_get_balancer_with_tags(self):
+        balancer = self.driver.get_balancer(balancer_id='tests', ex_fetch_tags=True)
+
+        self.assertEqual(balancer.id, 'tests')
+        self.assertEqual(balancer.name, 'tests')
+        self.assertTrue(('tags' in balancer.extra), 'No tags dict found in balancer.extra')
+        self.assertEqual(balancer.extra['tags']['project'], 'lima')
+
+    def test_populate_balancer_tags(self):
+        balancer = self.driver.get_balancer(balancer_id='tests')
+        balancer = self.driver._ex_populate_balancer_tags(balancer)
+
+        self.assertEqual(balancer.id, 'tests')
+        self.assertEqual(balancer.name, 'tests')
+        self.assertTrue(('tags' in balancer.extra), 'No tags dict found in balancer.extra')
+        self.assertEqual(balancer.extra['tags']['project'], 'lima')
 
     def test_destroy_balancer(self):
         balancer = self.driver.get_balancer(balancer_id='tests')


### PR DESCRIPTION
## Fetch tags support in ELB driver
### Description

Currently ELB driver doesn't provide a way to fetch tags for load balancer instance(s). Appropriate method calling DescribeTags AWS API action is implemented to address this.

Issue:
https://issues.apache.org/jira/browse/LIBCLOUD-843
### Status

done, ready for review
### Checklist (tick everything that applies)
- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
