### PR TITLE
Libcloud 845 delete tags

### DIFF
--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -4310,7 +4310,8 @@ class BaseEC2NodeDriver(NodeDriver):
                   'ResourceId.0': resource.id}
         for i, key in enumerate(tags):
             params['Tag.%d.Key' % i] = key
-            params['Tag.%d.Value' % i] = tags[key]
+            if tags[key] != None:
+                params['Tag.%d.Value' % i] = tags[key]
 
         res = self.connection.request(self.path,
                                       params=params.copy()).object

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -4310,7 +4310,7 @@ class BaseEC2NodeDriver(NodeDriver):
                   'ResourceId.0': resource.id}
         for i, key in enumerate(tags):
             params['Tag.%d.Key' % i] = key
-            if tags[key] != None:
+            if tags[key] is not None:
                 params['Tag.%d.Value' % i] = tags[key]
 
         res = self.connection.request(self.path,

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -681,11 +681,11 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
     def test_ex_delete_tags(self):
         node = Node('i-4382922a', None, None, None, None, self.driver)
         self.driver.ex_delete_tags(node, {'sample': 'tag'})
-    
+
     def test_ex_delete_tags2(self):
         node = Node('i-4382922a', None, None, None, None, self.driver)
         self.driver.ex_create_tags(node, {'sample': 'another tag'})
-        self.driver.ex_delete_tags(node, {'sample':None})
+        self.driver.ex_delete_tags(node, {'sample': None})
 
     def test_ex_describe_addresses_for_node(self):
         node1 = Node('i-4382922a', None, None, None, None, self.driver)

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -681,6 +681,11 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
     def test_ex_delete_tags(self):
         node = Node('i-4382922a', None, None, None, None, self.driver)
         self.driver.ex_delete_tags(node, {'sample': 'tag'})
+    
+    def test_ex_delete_tags2(self):
+        node = Node('i-4382922a', None, None, None, None, self.driver)
+        self.driver.ex_create_tags(node, {'sample': 'another tag'})
+        self.driver.ex_delete_tags(node, {'sample':None})
 
     def test_ex_describe_addresses_for_node(self):
         node1 = Node('i-4382922a', None, None, None, None, self.driver)


### PR DESCRIPTION
Support deleting tags without values

ex_delete_tags won't delete a tag without the value - it passes 'None' as a string.

Modified ex_delete_tags to check for None as a passed Value of a tag and if found don't supply Tag.%d.Value to params (and on to EC2 API). See http://docs.aws.amazon.com/AWSEC2/latest/CommandLineReference/ApiReference-cmd-DeleteTags.html For API Reference - Value is not required and if supplied must match for tag to be deleted. By always passing a value, a tag cannot be deleted if you don't know it's value.

Status: done, ready for review

Checklist: 
- [x ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
