### PR TITLE
Fix image undeprecation in GCE

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -3879,22 +3879,25 @@ class GCENodeDriver(NodeDriver):
             raise ValueError('state must be one of %s'
                              % ','.join(possible_states))
 
-        image_data = {
-            'state': state,
-            'replacement': replacement.extra['selfLink'],
-        }
+        if state == 'ACTIVE':
+            image_data = {}
+        else:
+            image_data = {
+                'state': state,
+                'replacement': replacement.extra['selfLink'],
+            }
+            for attribute, value in [('deprecated', deprecated),
+                                     ('obsolete', obsolete),
+                                     ('deleted', deleted)]:
+                if value is None:
+                    continue
 
-        for attribute, value in [('deprecated', deprecated),
-                                 ('obsolete', obsolete),
-                                 ('deleted', deleted)]:
-            if value is None:
-                continue
-
-            try:
-                timestamp_to_datetime(value)
-            except:
-                raise ValueError('%s must be an RFC3339 timestamp' % attribute)
-            image_data[attribute] = value
+                try:
+                    timestamp_to_datetime(value)
+                except:
+                    raise ValueError('%s must be an RFC3339 timestamp'
+                                     % attribute)
+                image_data[attribute] = value
 
         request = '/global/images/%s/deprecate' % (image.name)
 


### PR DESCRIPTION
## Fix image undeprecation in GCE
### Description

An empty request body in a deprecation POST request will undeprecate the image. Specifying the "ACTIVE" state preserves the current "DEPRECATE" default.
### Status
- done, ready for review
### Checklist (tick everything that applies)
- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
