### PR TITLE
[LIBCLOUD-848] Fix NameError - 'body' is not defined

### DIFF
--- a/libcloud/common/openstack_identity.py
+++ b/libcloud/common/openstack_identity.py
@@ -1058,6 +1058,7 @@ class OpenStackIdentity_3_0_Connection(OpenStackIdentityConnection):
                                              missing required elements', e)
             body = 'code: %s body:%s' % (response.status, response.body)
         else:
+            body = 'code: %s body:%s' % (response.status, response.body)
             raise MalformedResponseError('Malformed response', body=body,
                                          driver=self.driver)
 


### PR DESCRIPTION
## Fix the NameError caused by missing 'body' variable
### Description

Small change to add, but would be a big help. When a response from Openstack fails, the missing 'body' variable caused an uncaught exception. I remedied this by adding the body variable, similar to what was done above the else statement.
### Status
- done, ready for review
### Checklist (tick everything that applies)
- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] [Link to Jira](https://issues.apache.org/jira/browse/LIBCLOUD-848)
