### PR TITLE
Enhance get_list_of_xx calls by allowing for filter by network id

### DIFF
--- a/libcloud/common/openstack_identity.py
+++ b/libcloud/common/openstack_identity.py
@@ -1058,6 +1058,7 @@ class OpenStackIdentity_3_0_Connection(OpenStackIdentityConnection):
                                              missing required elements', e)
             body = 'code: %s body:%s' % (response.status, response.body)
         else:
+            body = 'code: %s body:%s' % (response.status, response.body)
             raise MalformedResponseError('Malformed response', body=body,
                                          driver=self.driver)
 

--- a/libcloud/common/openstack_identity.py
+++ b/libcloud/common/openstack_identity.py
@@ -780,8 +780,8 @@ class OpenStackIdentity_1_0_Connection(OpenStackIdentityConnection):
             self.auth_user_info = None
 
             if not self.auth_token:
-                raise MalformedResponseError('Missing X-Auth-Token in \
-                                              response headers')
+                raise MalformedResponseError('Missing X-Auth-Token in'
+                                             ' response headers')
 
         return self
 

--- a/libcloud/loadbalancer/drivers/dimensiondata.py
+++ b/libcloud/loadbalancer/drivers/dimensiondata.py
@@ -173,18 +173,26 @@ class DimensionDataLBDriver(Driver):
                    'listener_ip_address': ex_listener_ip_address}
         )
 
-    def list_balancers(self):
+    def list_balancers(self, network_id=None):
         """
-        List all loadbalancers inside a geography.
+        List all loadbalancers inside a geography or in given network.
 
         In Dimension Data terminology these are known as virtual listeners
 
+        :param network_id: UUID of Network Domain
+               if not None returns only balancers in the given network
+               if None then returns all pools for the organization
+        :type  network_id: ``str``
+
         :rtype: ``list`` of :class:`LoadBalancer`
         """
+        params = None
+        if ( network_id is not None ):
+            params = { "networkDomainId": network_id }
 
         return self._to_balancers(
             self.connection
-            .request_with_orgId_api_2('networkDomainVip/virtualListener')
+            .request_with_orgId_api_2('networkDomainVip/virtualListener', params=params)
             .object)
 
     def get_balancer(self, balancer_id):
@@ -685,15 +693,25 @@ class DimensionDataLBDriver(Driver):
             status=State.RUNNING
         )
 
-    def ex_get_pools(self):
+    def ex_get_pools(self, network_id=None):
         """
-        Get all of the pools inside the current geography
+        Get all of the pools inside the current geography or
+        in given network.
+
+        :param network_id: UUID of Network Domain
+               if not None returns only balancers in the given network
+               if None then returns all pools for the organization
+        :type  network_id: ``str``
 
         :return: Returns a ``list`` of type ``DimensionDataPool``
         :rtype: ``list`` of ``DimensionDataPool``
         """
+        params = None
+        if ( network_id is not None ):
+            params = { "networkDomainId": network_id }
+
         pools = self.connection \
-            .request_with_orgId_api_2('networkDomainVip/pool').object
+            .request_with_orgId_api_2('networkDomainVip/pool', params=params).object
         return self._to_pools(pools)
 
     def ex_get_pool(self, pool_id):
@@ -833,15 +851,24 @@ class DimensionDataLBDriver(Driver):
             response_code = findtext(result, 'responseCode', TYPES_URN)
             return response_code in ['IN_PROGRESS', 'OK']
 
-    def ex_get_nodes(self):
+    def ex_get_nodes(self, network_id=None):
         """
-        Get the nodes within this geography
+        Get the nodes within this geography or in given network.
+
+        :param network_id: UUID of Network Domain
+               if not None returns only balancers in the given network
+               if None then returns all pools for the organization
+        :type  network_id: ``str``
 
         :return: Returns an ``list`` of ``DimensionDataVIPNode``
         :rtype: ``list`` of ``DimensionDataVIPNode``
         """
+        params = None
+        if ( network_id is not None ):
+            params = { "networkDomainId": network_id }
+
         nodes = self.connection \
-            .request_with_orgId_api_2('networkDomainVip/node').object
+            .request_with_orgId_api_2('networkDomainVip/node', params=params).object
         return self._to_nodes(nodes)
 
     def ex_get_node(self, node_id):

--- a/libcloud/loadbalancer/drivers/dimensiondata.py
+++ b/libcloud/loadbalancer/drivers/dimensiondata.py
@@ -173,22 +173,22 @@ class DimensionDataLBDriver(Driver):
                    'listener_ip_address': ex_listener_ip_address}
         )
 
-    def list_balancers(self, network_id=None):
+    def list_balancers(self, ex_network_domain_id=None):
         """
         List all loadbalancers inside a geography or in given network.
 
         In Dimension Data terminology these are known as virtual listeners
 
-        :param network_id: UUID of Network Domain
+        :param ex_network_domain_id: UUID of Network Domain
                if not None returns only balancers in the given network
                if None then returns all pools for the organization
-        :type  network_id: ``str``
+        :type  ex_network_domain_id: ``str``
 
         :rtype: ``list`` of :class:`LoadBalancer`
         """
         params = None
-        if ( network_id is not None ):
-            params = { "networkDomainId": network_id }
+        if ex_network_domain_id is not None:
+            params = { "networkDomainId": ex_network_domain_id }
 
         return self._to_balancers(
             self.connection
@@ -693,22 +693,22 @@ class DimensionDataLBDriver(Driver):
             status=State.RUNNING
         )
 
-    def ex_get_pools(self, network_id=None):
+    def ex_get_pools(self, ex_network_domain_id=None):
         """
         Get all of the pools inside the current geography or
         in given network.
 
-        :param network_id: UUID of Network Domain
+        :param ex_network_domain_id: UUID of Network Domain
                if not None returns only balancers in the given network
                if None then returns all pools for the organization
-        :type  network_id: ``str``
+        :type  ex_network_domain_id: ``str``
 
         :return: Returns a ``list`` of type ``DimensionDataPool``
         :rtype: ``list`` of ``DimensionDataPool``
         """
         params = None
-        if ( network_id is not None ):
-            params = { "networkDomainId": network_id }
+        if ex_network_domain_id is not None:
+            params = { "networkDomainId": ex_network_domain_id }
 
         pools = self.connection \
             .request_with_orgId_api_2('networkDomainVip/pool', params=params).object
@@ -851,21 +851,21 @@ class DimensionDataLBDriver(Driver):
             response_code = findtext(result, 'responseCode', TYPES_URN)
             return response_code in ['IN_PROGRESS', 'OK']
 
-    def ex_get_nodes(self, network_id=None):
+    def ex_get_nodes(self, ex_network_domain_id=None):
         """
         Get the nodes within this geography or in given network.
 
-        :param network_id: UUID of Network Domain
+        :param ex_network_domain_id: UUID of Network Domain
                if not None returns only balancers in the given network
                if None then returns all pools for the organization
-        :type  network_id: ``str``
+        :type  ex_network_domain_id: ``str``
 
         :return: Returns an ``list`` of ``DimensionDataVIPNode``
         :rtype: ``list`` of ``DimensionDataVIPNode``
         """
         params = None
-        if ( network_id is not None ):
-            params = { "networkDomainId": network_id }
+        if ex_network_domain_id is not None:
+            params = { "networkDomainId": ex_network_domain_id }
 
         nodes = self.connection \
             .request_with_orgId_api_2('networkDomainVip/node', params=params).object

--- a/libcloud/loadbalancer/drivers/dimensiondata.py
+++ b/libcloud/loadbalancer/drivers/dimensiondata.py
@@ -188,12 +188,12 @@ class DimensionDataLBDriver(Driver):
         """
         params = None
         if ex_network_domain_id is not None:
-            params = { "networkDomainId": ex_network_domain_id }
+            params = {"networkDomainId": ex_network_domain_id}
 
         return self._to_balancers(
             self.connection
-            .request_with_orgId_api_2('networkDomainVip/virtualListener', params=params)
-            .object)
+            .request_with_orgId_api_2('networkDomainVip/virtualListener', \
+            params=params).object)
 
     def get_balancer(self, balancer_id):
         """
@@ -708,10 +708,11 @@ class DimensionDataLBDriver(Driver):
         """
         params = None
         if ex_network_domain_id is not None:
-            params = { "networkDomainId": ex_network_domain_id }
+            params = {"networkDomainId": ex_network_domain_id}
 
         pools = self.connection \
-            .request_with_orgId_api_2('networkDomainVip/pool', params=params).object
+            .request_with_orgId_api_2('networkDomainVip/pool', \
+            params=params).object
         return self._to_pools(pools)
 
     def ex_get_pool(self, pool_id):
@@ -865,10 +866,11 @@ class DimensionDataLBDriver(Driver):
         """
         params = None
         if ex_network_domain_id is not None:
-            params = { "networkDomainId": ex_network_domain_id }
+            params = {"networkDomainId": ex_network_domain_id}
 
         nodes = self.connection \
-            .request_with_orgId_api_2('networkDomainVip/node', params=params).object
+            .request_with_orgId_api_2('networkDomainVip/node', \
+            params=params).object
         return self._to_nodes(nodes)
 
     def ex_get_node(self, node_id):

--- a/libcloud/loadbalancer/drivers/dimensiondata.py
+++ b/libcloud/loadbalancer/drivers/dimensiondata.py
@@ -192,8 +192,8 @@ class DimensionDataLBDriver(Driver):
 
         return self._to_balancers(
             self.connection
-            .request_with_orgId_api_2('networkDomainVip/virtualListener', \
-            params=params).object)
+            .request_with_orgId_api_2('networkDomainVip/virtualListener',
+                                      params=params).object)
 
     def get_balancer(self, balancer_id):
         """
@@ -711,8 +711,8 @@ class DimensionDataLBDriver(Driver):
             params = {"networkDomainId": ex_network_domain_id}
 
         pools = self.connection \
-            .request_with_orgId_api_2('networkDomainVip/pool', \
-            params=params).object
+            .request_with_orgId_api_2('networkDomainVip/pool',
+                                      params=params).object
         return self._to_pools(pools)
 
     def ex_get_pool(self, pool_id):
@@ -869,8 +869,8 @@ class DimensionDataLBDriver(Driver):
             params = {"networkDomainId": ex_network_domain_id}
 
         nodes = self.connection \
-            .request_with_orgId_api_2('networkDomainVip/node', \
-            params=params).object
+            .request_with_orgId_api_2('networkDomainVip/node',
+                                      params=params).object
         return self._to_nodes(nodes)
 
     def ex_get_node(self, node_id):


### PR DESCRIPTION
Enhance get_list_of_xx calls by allowing for filter by network id

Description

While developing utils using libcloud, I found that there were several routines in the LoadBalancer driver that just did not seem right. Specifically, these were the "get a list of XXX"-type routines. I felt (and others agreed) that it was "less than ideal" that these routines all defaulted to "return EVERYTHING from your company across ALL networks". Initially, I assumed that it would filter by network (since I had already told the LB Driver what my network Id was. However, in testing my util, I found that it return LoadBalancers (in my case) from networks that I had never heard of.

Therefore, I created this PR. The interface changes are BACKWARDS compatible.
For example:
def list_balancers(self) ==> def list_balancers(self, network_id=None)

Status

This code has been tested to show that:

by default, the original all-encompassing lists are returned.
using the new parameter, a list that only applies to the given network id is returned.
I do have several more tests that I want to run. I won't be able to get to those until 8/31/16 though.

Checklist (tick everything that applies)

I will get to these (and update the PR as needed) on the 31st.
I just wanted to get you this code as soon as possible.

 Code linting (required, can be done after the PR checks)

 Documentation
 Tests
 ICLA (required for bigger changes)
NOTE: We took this "concept" and applied to all the places that WE needed. This may apply to the compute and backup drivers as well.
