### PR TITLE
Create volume is more robust on newer OpenStacks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,18 @@
 ﻿Changelog
 =========
 
+Changes in Apache Libcloud 1.2.2
+
+Compute
+~~~~~~~
+
+- When creating volumes on OpenStack with defaults for `location` or `volume_type`,
+  newer OpenStack versions would throw errors. The OpenStack driver will now only
+  post those arguments if non-`NoneType`.
+  (GITHUB-857)
+  [Allard Hoeve]
+
+
 Changes in Apache Libcloud 1.2.1
 --------------------------------
 

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -206,12 +206,16 @@ class OpenStackNodeDriver(NodeDriver, OpenStackDriverMixin):
             'display_name': name,
             'display_description': name,
             'size': size,
-            'volume_type': ex_volume_type,
             'metadata': {
                 'contents': name,
             },
-            'availability_zone': location
         }
+
+        if ex_volume_type:
+            volume['volume_type'] = ex_volume_type
+
+        if location:
+            volume['availability_zone'] = location
 
         if snapshot:
             volume['snapshot_id'] = snapshot.id

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -984,6 +984,30 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
         self.assertEqual(volume.name, 'test')
         self.assertEqual(volume.size, 1)
 
+    def test_create_volume_passes_location_to_request_only_if_not_none(self):
+        with patch.object(self.driver.connection, 'request') as mock_request:
+            self.driver.create_volume(1, 'test', location='mylocation')
+            name, args, kwargs = mock_request.mock_calls[0]
+            self.assertEqual(kwargs["data"]["volume"]["availability_zone"], "mylocation")
+
+    def test_create_volume_does_not_pass_location_to_request_if_none(self):
+        with patch.object(self.driver.connection, 'request') as mock_request:
+            self.driver.create_volume(1, 'test')
+            name, args, kwargs = mock_request.mock_calls[0]
+            self.assertFalse("availability_zone" in kwargs["data"]["volume"])
+
+    def test_create_volume_passes_volume_type_to_request_only_if_not_none(self):
+        with patch.object(self.driver.connection, 'request') as mock_request:
+            self.driver.create_volume(1, 'test', ex_volume_type='myvolumetype')
+            name, args, kwargs = mock_request.mock_calls[0]
+            self.assertEqual(kwargs["data"]["volume"]["volume_type"], "myvolumetype")
+
+    def test_create_volume_does_not_pass_volume_type_to_request_if_none(self):
+        with patch.object(self.driver.connection, 'request') as mock_request:
+            self.driver.create_volume(1, 'test')
+            name, args, kwargs = mock_request.mock_calls[0]
+            self.assertFalse("volume_type" in kwargs["data"]["volume"])
+
     def test_destroy_volume(self):
         volume = self.driver.ex_get_volume(
             'cd76a3a1-c4ce-40f6-9b9f-07a61508938d')


### PR DESCRIPTION
## Make create_volume more robust on newer OpenStacks
### Description

On newer OpenStacks, things will fail if you do not provide `location` or if you do not provide `ex_volume_type`. The driver will pass the default `None` values to `self.driver.request`, which serializes them to `null`, which is an invalid value for `/os-volumes/` on newer incarnations of OpenStack.

This PR makes it so the OpenStack driver does not include these fields if they are None, so they are not refused by OpenStack's validation.
### Status
- done, ready for review
### Checklist (tick everything that applies)
- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
