### PR TITLE
[LIBCLOUD-852] Support filtering in ec2 list_volumes

### DIFF
--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -2892,13 +2892,37 @@ class BaseEC2NodeDriver(NodeDriver):
                     )
         return locations
 
-    def list_volumes(self, node=None):
+    def list_volumes(self, node=None, ex_filters=None):
+        """
+        List volumes
+        @inherits: :class:`NodeDriver.list_volumes`
+
+        Node parameter is used to filter the list of volumes
+        that should be returned.  Only volumes attached to
+        the corresponding node will be returned.
+
+        Ex_filters parameter is used to filter the list of
+        images that should be returned. Only images matching
+        the filter will be returned.
+
+        :param      node: Instance of ``Node``
+        :type       node: :class: `Node`
+
+        :param      ex_filters: Filter by
+        :type       ex_filters: ``dict``
+
+        :rtype: ``list`` of :class:`StorageVolume`
+        """
+
         params = {
             'Action': 'DescribeVolumes',
         }
         if node:
-            filters = {'attachment.instance-id': node.id}
-            params.update(self._build_filters(filters))
+            if ex_filters is None:
+                ex_filters = {}
+            ex_filters.update({'attachment.instance-id': node.id})
+        if ex_filters:
+            params.update(self._build_filters(ex_filters))
 
         response = self.connection.request(self.path, params=params).object
         volumes = [self._to_volume(el) for el in response.findall(


### PR DESCRIPTION
## Support filtering in EC2 list_volumes
### Description

There currently is not a way to filter volumes in the EC2 driver list_volumes.  This is a useful feature for identifying volumes with certain attributes - e.g. orphaned volumes.  The filtering param is already implicitly used in list_volumes to specify an attached instance-id, if node arg is provided.  This change allows additional explicit filters to be provided.

The particular issue I have run into motivating this change is - if I create a volume using create_volume and immediately attach it to a node using attach_volume I occasionally run into errors where the volume was created but is not yet ready for attachment.  I can use list_volumes to fetch everything and filter on my end, but I'd rather filter server side as I am with list_images and other similar functions.

I also added a docstring. 
### Status

done, ready for review
### Checklist (tick everything that applies)
- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
