### PR TITLE
Add "WINDOWS" guestOsFeatures option.

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -1061,7 +1061,7 @@ class GCENodeDriver(NodeDriver):
         "windows-cloud": ["windows"],
     }
 
-    GUEST_OS_FEATURES = ['VIRTIO_SCSI_MULTIQUEUE']
+    GUEST_OS_FEATURES = ['VIRTIO_SCSI_MULTIQUEUE', 'WINDOWS']
 
     def __init__(self, user_id, key=None, datacenter=None, project=None,
                  auth_type=None, scopes=None, credential_file=None, **kwargs):
@@ -2219,7 +2219,7 @@ class GCENodeDriver(NodeDriver):
         :keywork  guest_os_features: Features of the guest operating system,
                                      valid for bootable images only. Possible
                                      values include \'VIRTIO_SCSI_MULTIQUEUE\'
-                                     if specified.
+                                     and \'WINDOWS\' if specified.
         :type     guest_os_features: ``list`` of ``str`` or ``None``
 
         :keyword  use_existing: If True and an image with the given name

--- a/libcloud/test/compute/fixtures/gce/projects_coreos-cloud_global_images.json
+++ b/libcloud/test/compute/fixtures/gce/projects_coreos-cloud_global_images.json
@@ -1330,6 +1330,9 @@
    "guestOsFeatures": [
     {
       "type": "VIRTIO_SCSI_MULTIQUEUE"
+    },
+    {
+      "type": "WINDOWS"
     }
    ],
    "sourceType": "RAW",

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -453,8 +453,10 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         description = 'CoreOS beta 522.3.0'
         name = 'coreos'
         family = 'coreos'
-        guest_os_features = ['VIRTIO_SCSI_MULTIQUEUE']
-        expected_features = [{'type': 'VIRTIO_SCSI_MULTIQUEUE'}]
+        guest_os_features = ['VIRTIO_SCSI_MULTIQUEUE', 'WINDOWS']
+        expected_features = [
+            {'type': 'VIRTIO_SCSI_MULTIQUEUE'},
+            {'type': 'WINDOWS'}]
         mock_request = mock.Mock()
         mock_request.side_effect = self.driver.connection.async_request
         self.driver.connection.async_request = mock_request
@@ -482,8 +484,10 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         url = 'gs://storage.core-os.net/coreos/amd64-generic/247.0.0/coreos_production_gce.tar.gz'
         description = 'CoreOS beta 522.3.0'
         family = 'coreos'
-        guest_os_features = ['VIRTIO_SCSI_MULTIQUEUE']
-        expected_features = [{'type': 'VIRTIO_SCSI_MULTIQUEUE'}]
+        guest_os_features = ['VIRTIO_SCSI_MULTIQUEUE', 'WINDOWS']
+        expected_features = [
+            {'type': 'VIRTIO_SCSI_MULTIQUEUE'},
+            {'type': 'WINDOWS'}]
         image = self.driver.ex_copy_image(name, url, description=description,
                                           family=family,
                                           guest_os_features=guest_os_features)


### PR DESCRIPTION
"WINDOWS" is a valid guestOsFeatures option in the Compute Beta API.
### Description

Adding a new option to a list of values accepted by the API.
### Status
- done, ready for review
### Checklist (tick everything that applies)
- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
