### PR TITLE
Bugfix add trailing slashes for Docker hub API client

### DIFF
--- a/libcloud/container/utils/docker.py
+++ b/libcloud/container/utils/docker.py
@@ -114,7 +114,7 @@ class RegistryClient(object):
         :return: The details of the repository
         :rtype: ``object``
         """
-        path = '/v2/repositories/%s/%s' % (namespace, repository_name)
+        path = '/v2/repositories/%s/%s/' % (namespace, repository_name)
         response = self.connection.request(path)
         return response.object
 
@@ -134,7 +134,7 @@ class RegistryClient(object):
         :return: A container image
         :rtype: :class:`libcloud.container.base.ContainerImage`
         """
-        path = '/v2/repositories/%s/%s/tags/%s' \
+        path = '/v2/repositories/%s/%s/tags/%s/' \
                % (namespace, repository_name, tag)
         response = self.connection.request(path)
         return self._to_image(repository_name, response.object)


### PR DESCRIPTION
## Bugfix add trailing slashes for Docker hub API client
### Description

The following code snippet fails

``` python
from libcloud.container.utils.docker import HubClient
import libcloud.common.exceptions
import libcloud

with open('blah.txt','w') as boo:
    libcloud.enable_debug(boo)
    hub = HubClient()

    try:
        image = hub.get_image('tomcat', '8.0')
    except libcloud.common.exceptions.BaseHTTPError as error:
        print(dir(error))
        print("Waaaaah %s" % error.code)
```

You can see in the logfile 

```
# -------- begin 4377133392 request ----------
curl -i -X GET -H 'Host: registry.hub.docker.com' -H 'X-LC-Request-ID: 4377133392' -H 'Content-Type: application/json' -H 'Accept-Encoding: gzip,deflate' -H 'User-Agent: libcloud/1.0.0 ' --compress https://registry.hub.docker.com:443/v2/repositories/library/tomcat/tags/8.0
# -------- begin 4377133392:4377127320 response ----------
HTTP/1.1 301 MOVED PERMANENTLY
Transfer-Encoding: chunked
Strict-Transport-Security: max-age=31536000
Server: nginx/1.6.2
Location: https://registry.hub.docker.com/v2/repositories/library/tomcat/tags/8.0/
Date: Thu, 22 Sep 2016 00:21:23 GMT
X-Frame-Options: SAMEORIGIN
Content-Type: text/html; charset=utf-8

0

0

# -------- end 4377133392:4377127320 response ----------
```
### Status

Replace this: describe the PR status. Examples:
- done, ready for review
### Checklist (tick everything that applies)
- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)

cc @ArroyoNetworks 
