### PR TITLE
Fix case where node does not exist on OpenStack

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,11 @@ Compute
   (GITHUB-857)
   [Allard Hoeve]
 
+- When fetching the node details of a non-existing node, OpenStack would raise a
+  `BaseHTTPError` instead of returning `None`, as was intended. Fixed tests and code.
+  (GITHUB-864)
+  [Allard Hoeve]
+
 Container
 ~~~~~~~~~
 

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -15,6 +15,7 @@
 """
 OpenStack driver
 """
+from libcloud.common.exceptions import BaseHTTPError
 from libcloud.utils.iso8601 import parse_date
 
 try:
@@ -322,9 +323,12 @@ class OpenStackNodeDriver(NodeDriver, OpenStackDriverMixin):
             node_id = node_id.id
 
         uri = '/servers/%s' % (node_id)
-        resp = self.connection.request(uri, method='GET')
-        if resp.status == httplib.NOT_FOUND:
-            return None
+        try:
+            resp = self.connection.request(uri, method='GET')
+        except BaseHTTPError as e:
+            if e.code == httplib.NOT_FOUND:
+                return None
+            raise
 
         return self._to_node_from_obj(resp.object)
 

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -1131,7 +1131,7 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
 
     def test_ex_get_node_details_returns_none_if_node_does_not_exist(self):
         node = self.driver.ex_get_node_details('does-not-exist')
-        self.assertIsNone(node)
+        self.assertTrue(node is None)
 
     def test_ex_get_size(self):
         size_id = '7'

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -1129,6 +1129,10 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
         self.assertEqual(node.id, '12064')
         self.assertEqual(node.name, 'lc-test')
 
+    def test_ex_get_node_details_returns_none_if_node_does_not_exist(self):
+        node = self.driver.ex_get_node_details('does-not-exist')
+        self.assertIsNone(node)
+
     def test_ex_get_size(self):
         size_id = '7'
         size = self.driver.ex_get_size(size_id)
@@ -1561,6 +1565,9 @@ class OpenStack_1_1_MockHttp(MockHttpTestCase):
     def _v1_1_slug_servers_detail_ERROR_STATE_NO_IMAGE_ID(self, method, url, body, headers):
         body = self.fixtures.load('_servers_detail_ERROR_STATE.json')
         return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
+
+    def _v2_1337_servers_does_not_exist(self, *args, **kwargs):
+        return httplib.NOT_FOUND, None, {}, httplib.responses[httplib.NOT_FOUND]
 
     def _v1_1_slug_flavors_detail(self, method, url, body, headers):
         body = self.fixtures.load('_flavors_detail.json')


### PR DESCRIPTION
## Fix OpenStack `ex_get_node_details` for non-existing nodes
### Description

```
Fix case where node does not exist on OpenStack

  - Add case where the node does not exist on OS
  - Fix code that tries to return None if the node does not exist
```
### Status
- done, ready for review
### Checklist (tick everything that applies)
- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
