### PR TITLE
Add ex_stop_node to OS driver

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,10 @@ Compute
   (GITHUB-857)
   [Allard Hoeve]
 
+- Added `ex_stop_node` to the OpenStack driver.
+  (GITHUB-865)
+  [Allard Hoeve]
+
 Container
 ~~~~~~~~~
 

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -2403,29 +2403,29 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
         return node.extra['metadata']
 
     def ex_pause_node(self, node):
-        uri = '/servers/%s/action' % (node.id)
-        data = {'pause': None}
-        resp = self.connection.request(uri, method='POST', data=data)
-        return resp.status == httplib.ACCEPTED
+        return self._post_simple_node_action(node, 'pause')
 
     def ex_unpause_node(self, node):
-        uri = '/servers/%s/action' % (node.id)
-        data = {'unpause': None}
-        resp = self.connection.request(uri, method='POST', data=data)
-        return resp.status == httplib.ACCEPTED
+        return self._post_simple_node_action(node, 'unpause')
+
+    def ex_stop_node(self, node):
+        return self._post_simple_node_action(node, 'os-stop')
 
     def ex_suspend_node(self, node):
-        uri = '/servers/%s/action' % (node.id)
-        data = {'suspend': None}
-        resp = self.connection.request(uri, method='POST', data=data)
-        return resp.status == httplib.ACCEPTED
+        return self._post_simple_node_action(node, 'suspend')
 
     def ex_resume_node(self, node):
-        uri = '/servers/%s/action' % (node.id)
-        data = {'resume': None}
-        resp = self.connection.request(uri, method='POST', data=data)
-        return resp.status == httplib.ACCEPTED
+        return self._post_simple_node_action(node, 'resume')
 
+    def _post_simple_node_action(self, node, action):
+        """ Post a simple, data-less action to the OS node action endpoint
+        :param `Node` node:
+        :param str action: the action to call
+        :return `bool`: a boolean that indicates success
+        """
+        uri = '/servers/{}/action'.format(node.id)
+        resp = self.connection.request(uri, method='POST', data={action: None})
+        return resp.status == httplib.ACCEPTED
 
 class OpenStack_1_1_FloatingIpPool(object):
     """

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -2423,7 +2423,7 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
         :param str action: the action to call
         :return `bool`: a boolean that indicates success
         """
-        uri = '/servers/{}/action'.format(node.id)
+        uri = '/servers/{node_id}/action'.format(node_id=node.id)
         resp = self.connection.request(uri, method='POST', data={action: None})
         return resp.status == httplib.ACCEPTED
 

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -2427,6 +2427,7 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
         resp = self.connection.request(uri, method='POST', data={action: None})
         return resp.status == httplib.ACCEPTED
 
+
 class OpenStack_1_1_FloatingIpPool(object):
     """
     Floating IP Pool info.

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -1433,6 +1433,14 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
         ret = self.driver.ex_unpause_node(node)
         self.assertTrue(ret is True)
 
+    def test_ex_stop_node(self):
+        node = Node(
+            id='12063', name=None, state=None,
+            public_ips=None, private_ips=None, driver=self.driver,
+        )
+        ret = self.driver.ex_stop_node(node)
+        self.assertTrue(ret is True)
+
     def test_ex_suspend_node(self):
         node = Node(
             id='12063', name=None, state=None,


### PR DESCRIPTION
## Add ex_stop_node to OS driver
### Description

Current OpenStack driver can suspend, but not stop a node. This PR adds that.
### Status
- done, ready for review
### Checklist (tick everything that applies)
- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
