### PR TITLE
OS create_snapshot posts optional keywords only when needed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,12 @@ Compute
   (GITHUB-857)
   [Allard Hoeve]
 
+- When creating volume snapshot, the arguments `name` and `description` are truely
+  optional when working with newer OpenStack versions. The OpenStack driver will now
+  only post thost arguments if they are non-`NoneType`.
+  (GITHUB-866)
+  [Allard Hoeve]
+
 Container
 ~~~~~~~~~
 

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -1668,10 +1668,10 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
         :type  volume: `StorageVolume`
 
         :param name: Name of snapshot (optional)
-        :type  name: `str`
+        :type  name: `str` | `NoneType`
 
         :param ex_description: Description of the snapshot (optional)
-        :type  ex_description: `str`
+        :type  ex_description: `str` | `NoneType`
 
         :param ex_force: Specifies if we create a snapshot that is not in
                          state `available`. For example `in-use`. Defaults
@@ -1680,10 +1680,13 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
 
         :rtype: :class:`VolumeSnapshot`
         """
-        data = {'snapshot': {'display_name': name,
-                             'display_description': ex_description,
-                             'volume_id': volume.id,
-                             'force': ex_force}}
+        data = {'snapshot': {'volume_id': volume.id, 'force': ex_force}}
+
+        if name is not None:
+            data['snapshot']['display_name'] = name
+
+        if ex_description is not None:
+            data['snapshot']['display_description'] = ex_description
 
         return self._to_snapshot(self.connection.request('/os-snapshots',
                                                          method='POST',

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -1509,6 +1509,19 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
                                              force=True)
         self.assertEqual(ret.id, '3fbbcccf-d058-4502-8844-6feeffdf4cb5')
 
+    def test_ex_create_snapshot_does_not_post_optional_parameters_if_none(self):
+        volume = self.driver.list_volumes()[0]
+        with patch.object(self.driver, '_to_snapshot'):
+            with patch.object(self.driver.connection, 'request') as mock_request:
+                self.driver.create_volume_snapshot(volume,
+                                                   name=None,
+                                                   ex_description=None,
+                                                   ex_force=True)
+
+        name, args, kwargs = mock_request.mock_calls[0]
+        self.assertFalse("display_name" in kwargs["data"]["snapshot"])
+        self.assertFalse("display_description" in kwargs["data"]["snapshot"])
+
     def test_destroy_volume_snapshot(self):
         if self.driver_type.type == 'rackspace':
             self.conn_classes[0].type = 'RACKSPACE'


### PR DESCRIPTION
## OS create_snapshot_volume does not post optional keywords if they are None
### Description

On never OpenStacks, posting None for `name` or `description` will return a 400 Bad Request.
### Status
- done, ready for review
### Checklist (tick everything that applies)
- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
