### PR TITLE
StorageVolumeSnapshot now has a .name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,13 @@ Compute
   (GITHUB-857)
   [Allard Hoeve]
 
+- StorageVolumeSnapshot now has an attribute `name` that has the name of the snapshot
+  if the provider supports it. This used to be `.extra['name']`, but that is inconsistent
+  with `Node` and `StorageVolume`. The `extra` dict still holds `name` for backwards
+  compatibility.
+  (GITHUB-867)
+  [Allard Hoeve]
+
 Container
 ~~~~~~~~~
 

--- a/libcloud/compute/base.py
+++ b/libcloud/compute/base.py
@@ -559,7 +559,7 @@ class VolumeSnapshot(object):
     A base VolumeSnapshot class to derive from.
     """
     def __init__(self, id, driver, size=None, extra=None, created=None,
-                 state=None):
+                 state=None, name=None):
         """
         VolumeSnapshot constructor.
 
@@ -583,6 +583,9 @@ class VolumeSnapshot(object):
         :param      state: A string representing the state the snapshot is
                            in. See `libcloud.compute.types.StorageVolumeState`.
         :type       state: ``str``
+
+        :param      name: A string representing the name of the snapshot
+        :type       name: ``str``
         """
         self.id = id
         self.driver = driver
@@ -590,6 +593,7 @@ class VolumeSnapshot(object):
         self.extra = extra or {}
         self.created = created
         self.state = state
+        self.name = name
 
     def destroy(self):
         """
@@ -600,8 +604,8 @@ class VolumeSnapshot(object):
         return self.driver.destroy_volume_snapshot(snapshot=self)
 
     def __repr__(self):
-        return ('<VolumeSnapshot id=%s size=%s driver=%s state=%s>' %
-                (self.id, self.size, self.driver.name, self.state))
+        return ('<VolumeSnapshot "%s" id=%s size=%s driver=%s state=%s>' %
+                (self.name, self.id, self.size, self.driver.name, self.state))
 
 
 class KeyPair(object):

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -5601,7 +5601,8 @@ class BaseEC2NodeDriver(NodeDriver):
                               driver=self,
                               extra=extra,
                               created=created,
-                              state=state)
+                              state=state,
+                              name=name)
 
     def _to_key_pairs(self, elems):
         key_pairs = [self._to_key_pair(elem=elem) for elem in elems]

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -710,7 +710,8 @@ class GCESnapshot(VolumeSnapshot):
     def __init__(self, id, name, size, status, driver, extra=None,
                  created=None):
         self.status = status
-        super(GCESnapshot, self).__init__(id, driver, size, extra, created, name=name)
+        super(GCESnapshot, self).__init__(id, driver, size, extra,
+                                          created, name=name)
 
 
 class GCETargetHttpProxy(UuidMixin):

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -709,9 +709,8 @@ class GCERegion(UuidMixin):
 class GCESnapshot(VolumeSnapshot):
     def __init__(self, id, name, size, status, driver, extra=None,
                  created=None):
-        self.name = name
         self.status = status
-        super(GCESnapshot, self).__init__(id, driver, size, extra, created)
+        super(GCESnapshot, self).__init__(id, driver, size, extra, created, name=name)
 
 
 class GCETargetHttpProxy(UuidMixin):

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -2191,7 +2191,8 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
 
         snapshot = VolumeSnapshot(id=data['id'], driver=self,
                                   size=data['size'], extra=extra,
-                                  created=created_dt, state=state)
+                                  created=created_dt, state=state,
+                                  name=display_name)
         return snapshot
 
     def _to_size(self, api_flavor, price=None, bandwidth=None):

--- a/libcloud/compute/drivers/rackspace.py
+++ b/libcloud/compute/drivers/rackspace.py
@@ -242,7 +242,8 @@ class RackspaceNodeDriver(OpenStack_1_1_NodeDriver):
                                   size=api_node['size'],
                                   extra=extra,
                                   created=created_td,
-                                  state=state)
+                                  state=state,
+                                  name=api_node['displayName'])
         return snapshot
 
     def _ex_connection_class_kwargs(self):

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -903,6 +903,7 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
         self.assertEqual('Daily Backup', snaps[0].extra['description'])
 
         self.assertEqual('snap-18349159', snaps[1].id)
+        self.assertEqual('DB Backup 1', snaps[1].name)
         self.assertEqual(VolumeSnapshotState.AVAILABLE, snaps[1].state)
         self.assertEqual('vol-b5a2c1v9', snaps[1].extra['volume_id'])
         self.assertEqual(15, snaps[1].size)

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -1049,6 +1049,7 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         snapshot_name = 'lcsnapshot'
         volume = self.driver.ex_get_volume('lcdisk')
         snapshot = volume.snapshot(snapshot_name)
+
         self.assertEqual(snapshot.name, snapshot_name)
         self.assertEqual(snapshot.size, '10')
 

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -1468,6 +1468,7 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
         self.assertEqual(snapshots[0].created, datetime.datetime(2012, 2, 29, 3, 50, 7, tzinfo=UTC))
         self.assertEqual(snapshots[0].extra['created'], "2012-02-29T03:50:07Z")
         self.assertEqual(snapshots[0].extra['name'], 'snap-001')
+        self.assertEqual(snapshots[0].name, 'snap-001')
         self.assertEqual(snapshots[0].state, VolumeSnapshotState.AVAILABLE)
 
         # invalid date is parsed as None


### PR DESCRIPTION
## StorageVolumeSnapshot now has an attribute .name
### Description

StorageVolumeSnapshot is the last object that normally has a name, that does not actually have an attribute `.name`. This PR adds that attribute. It leaves the `.extra['name']` though, for backwards-compatibility.
### Status
- done, ready for review
### Checklist (tick everything that applies)
- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
