### PR TITLE
fix path to SUSE CA bundle

### DIFF
--- a/libcloud/security.py
+++ b/libcloud/security.py
@@ -63,6 +63,9 @@ CA_CERTS_PATH = [
 
     # opensuse/sles: openssl
     '/etc/ssl/ca-bundle.pem',
+
+    # SLES11 imported CA certificate
+    '/etc/ssl/certs/YaST-CA.pem',
 ]
 
 # Insert certifi CA bundle path to the front of Libcloud CA bundle search

--- a/libcloud/security.py
+++ b/libcloud/security.py
@@ -62,7 +62,7 @@ CA_CERTS_PATH = [
     '/usr/local/opt/curl-ca-bundle/share/ca-bundle.crt',
 
     # opensuse/sles: openssl
-    '/etc/ssl/certs/YaST-CA.pem',
+    '/etc/ssl/ca-bundle.pem',
 ]
 
 # Insert certifi CA bundle path to the front of Libcloud CA bundle search


### PR DESCRIPTION
## Changes Title (replace this with a logical title for your changes)
### Description

Fix the path to the SUSE CA bundle. The old path is a special CA file and not the CA bundle.
### Status
- done, ready for review
