### PR TITLE
Correct word usage and Fix broken relative link.

### DIFF
--- a/docs/compute/pricing.rst
+++ b/docs/compute/pricing.rst
@@ -29,10 +29,10 @@ Where does the Libcloud pricing data come from?
 -----------------------------------------------
 
 Most of the providers don't provide pricing information via the API which means
-most of the pricing information is scrapped directly from the provider
+most of the pricing information is scraped directly from the provider
 websites.
 
-Pricing data which is scrapped from the provider websites is located in a
+Pricing data which is scraped from the provider websites is located in a
 JSON file (``data/pricing.json``) which is bundled with each release. This
 pricing data is only updated once you install a new release which means it
 could be out of date.

--- a/docs/other/using-libcloud-in-multithreaded-and-async-environments.rst
+++ b/docs/other/using-libcloud-in-multithreaded-and-async-environments.rst
@@ -43,7 +43,7 @@ You need to do two things when you want to use Libcloud with gevent:
 * Create a separate driver instance for each Greenlet. This is necessary
   because a driver instance reuses the same Connection class.
 
-For an example see :doc:`Efficiently download multiple files using gevent </storage/examples.html>`.
+For an example see :doc:`Efficiently download multiple files using gevent </storage/examples>`.
 
 Using Libcloud with Twisted
 ---------------------------

--- a/docs/other/using-libcloud-in-multithreaded-and-async-environments.rst
+++ b/docs/other/using-libcloud-in-multithreaded-and-async-environments.rst
@@ -43,7 +43,7 @@ You need to do two things when you want to use Libcloud with gevent:
 * Create a separate driver instance for each Greenlet. This is necessary
   because a driver instance reuses the same Connection class.
 
-For an example see :doc:`Efficiently download multiple files using gevent </storage/examples.html#efficiently-download-multiple-files-using-gevent>`.
+For an example see :doc:`Efficiently download multiple files using gevent </storage/examples.html#efficiently-download-multiple-files-using-gevent>`__.
 
 Using Libcloud with Twisted
 ---------------------------

--- a/docs/other/using-libcloud-in-multithreaded-and-async-environments.rst
+++ b/docs/other/using-libcloud-in-multithreaded-and-async-environments.rst
@@ -43,7 +43,7 @@ You need to do two things when you want to use Libcloud with gevent:
 * Create a separate driver instance for each Greenlet. This is necessary
   because a driver instance reuses the same Connection class.
 
-For an example see :doc:`Efficiently download multiple files using gevent`</storage/examples.html#efficiently-download-multiple-files-using-gevent>.
+For an example see :doc:`Efficiently download multiple files using gevent </storage/examples.html#efficiently-download-multiple-files-using-gevent>`.
 
 Using Libcloud with Twisted
 ---------------------------

--- a/docs/other/using-libcloud-in-multithreaded-and-async-environments.rst
+++ b/docs/other/using-libcloud-in-multithreaded-and-async-environments.rst
@@ -43,7 +43,7 @@ You need to do two things when you want to use Libcloud with gevent:
 * Create a separate driver instance for each Greenlet. This is necessary
   because a driver instance reuses the same Connection class.
 
-For an example see :doc:`Efficiently download multiple files using gevent </storage/examples.html#efficiently-download-multiple-files-using-gevent>`__.
+For an example see :doc:`Efficiently download multiple files using gevent </storage/examples.html>`.
 
 Using Libcloud with Twisted
 ---------------------------

--- a/docs/other/using-libcloud-in-multithreaded-and-async-environments.rst
+++ b/docs/other/using-libcloud-in-multithreaded-and-async-environments.rst
@@ -43,7 +43,7 @@ You need to do two things when you want to use Libcloud with gevent:
 * Create a separate driver instance for each Greenlet. This is necessary
   because a driver instance reuses the same Connection class.
 
-For an example see Efficiently download multiple files using gevent.
+For an example see :doc:`Efficiently download multiple files using gevent`</storage/examples.html#efficiently-download-multiple-files-using-gevent>.
 
 Using Libcloud with Twisted
 ---------------------------


### PR DESCRIPTION
## Correct word usage.
### Description

Noticed incorrect word usage. Past tense of scrape is `scraped`; not `scrapped`.
Fixed broken relative markdown link where Sphinx relative link should have been.
### Status
- done, ready for review
### Checklist (tick everything that applies)
- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
