### PR TITLE
Add new FCU API support in Outscale EC2 driver

### DIFF
--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -6908,6 +6908,47 @@ class OutscaleNodeDriver(BaseEC2NodeDriver):
 
         return is_truncated, quota
 
+    def _to_product_types(self, elem):
+
+        product_types = []
+        for product_types_item in findall(element=elem,
+                                          xpath='productTypeSet/item',
+                                          namespace=OUTSCALE_NAMESPACE):
+            productTypeId = findtext(element=product_types_item,
+                                     xpath='productTypeId',
+                                     namespace=OUTSCALE_NAMESPACE)
+            description = findtext(element=product_types_item,
+                                   xpath='description',
+                                   namespace=OUTSCALE_NAMESPACE)
+            product_types.append({'productTypeId': productTypeId,
+                                  'description': description})
+
+        return product_types
+
+    def ex_describe_product_types(self, filters=None):
+        """
+        Describes Product Types.
+
+        :param      filters: The filters so that the response includes
+                             information for only certain quotas
+        :type       filters: ``dict``
+
+        :return:    A product types list
+        :rtype:     ``list``
+        """
+
+        params = {'Action': 'DescribeProductTypes'}
+
+        if filters:
+            params.update(self._build_filters(filters))
+
+        response = self.connection.request(self.path, params=params,
+                                           method='GET').object
+
+        product_types = self._to_product_types(response)
+
+        return product_types
+
 
 class OutscaleSASNodeDriver(OutscaleNodeDriver):
     """

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -6949,6 +6949,68 @@ class OutscaleNodeDriver(BaseEC2NodeDriver):
 
         return product_types
 
+    def _to_instance_types(self, elem):
+
+        instance_types = []
+        for instance_types_item in findall(element=elem,
+                                           xpath='instanceTypeSet/item',
+                                           namespace=OUTSCALE_NAMESPACE):
+            name = findtext(element=instance_types_item,
+                            xpath='name',
+                            namespace=OUTSCALE_NAMESPACE)
+            vcpu = findtext(element=instance_types_item,
+                            xpath='vcpu',
+                            namespace=OUTSCALE_NAMESPACE)
+            memory = findtext(element=instance_types_item,
+                              xpath='memory',
+                              namespace=OUTSCALE_NAMESPACE)
+            storageSize = findtext(element=instance_types_item,
+                                   xpath='storageSize',
+                                   namespace=OUTSCALE_NAMESPACE)
+            storageCount = findtext(element=instance_types_item,
+                                    xpath='storageCount',
+                                    namespace=OUTSCALE_NAMESPACE)
+            maxIpAddresses = findtext(element=instance_types_item,
+                                      xpath='maxIpAddresses',
+                                      namespace=OUTSCALE_NAMESPACE)
+            ebsOptimizedAvailable = findtext(element=instance_types_item,
+                                             xpath='ebsOptimizedAvailable',
+                                             namespace=OUTSCALE_NAMESPACE)
+            d = {'name': name,
+                 'vcpu': vcpu,
+                 'memory': memory,
+                 'storageSize': storageSize,
+                 'storageCount': storageCount,
+                 'maxIpAddresses': maxIpAddresses,
+                 'ebsOptimizedAvailable': ebsOptimizedAvailable}
+            instance_types.append(d)
+
+        return instance_types
+
+    def ex_describe_instance_types(self, filters=None):
+        """
+        Describes Instance Types.
+
+        :param      filters: The filters so that the response includes
+                             information for only instance types
+        :type       filters: ``dict``
+
+        :return:    A instance types list
+        :rtype:     ``list``
+        """
+
+        params = {'Action': 'DescribeInstanceTypes'}
+
+        if filters:
+            params.update(self._build_filters(filters))
+
+        response = self.connection.request(self.path, params=params,
+                                           method='GET').object
+
+        instance_types = self._to_instance_types(response)
+
+        return instance_types
+
 
 class OutscaleSASNodeDriver(OutscaleNodeDriver):
     """

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -6811,6 +6811,31 @@ class OutscaleNodeDriver(BaseEC2NodeDriver):
             sizes.append(NodeSize(driver=self, **attributes))
         return sizes
 
+    def ex_modify_instance_keypair(self, instance_id, key_name=None):
+        """
+        Modifies the keypair associated with a specified instance.
+        Once the modification done, you must restart the instance.
+
+        :param      instance_id: The ID of the instance
+        :type       instance_id: ``string``
+
+        :param      key_name: The name of the keypair
+        :type       key_name: ``string``
+        """
+
+        params = {'Action': 'ModifyInstanceKeypair'}
+
+        params.update({'instanceId': instance_id})
+
+        if key_name is not None:
+            params.update({'keyName': key_name})
+
+        response = self.connection.request(self.path, params=params,
+                                           method='GET').object
+
+        return (findtext(element=response, xpath='return',
+                         namespace=OUTSCALE_NAMESPACE) == 'true')
+
     def _to_quota(self, elem):
         """
         To Quota

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -86,6 +86,10 @@ NAMESPACE = 'http://ec2.amazonaws.com/doc/%s/' % (API_VERSION)
 DEFAULT_EUCA_API_VERSION = '3.3.0'
 EUCA_NAMESPACE = 'http://msgs.eucalyptus.com/%s' % (DEFAULT_EUCA_API_VERSION)
 
+# Outscale Constants
+DEFAULT_OUTSCALE_API_VERSION = '2016-04-01'
+OUTSCALE_NAMESPACE = 'http://api.outscale.com/wsdl/fcuext/2014-04-15/'
+
 """
 Sizes must be hardcoded, because Amazon doesn't provide an API to fetch them.
 From http://aws.amazon.com/ec2/instance-types/

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -6908,6 +6908,43 @@ class OutscaleNodeDriver(BaseEC2NodeDriver):
 
         return is_truncated, quota
 
+    def _to_product_type(self, elem):
+
+        productTypeId = findtext(element=elem, xpath='productTypeId',
+                                 namespace=OUTSCALE_NAMESPACE)
+        description = findtext(element=elem, xpath='description',
+                               namespace=OUTSCALE_NAMESPACE)
+
+        return {'productTypeId': productTypeId,
+                'description': description}
+
+    def ex_get_product_type(self, image_id, snapshot_id=None):
+        """
+        Get the product type of a specified OMI or snapshot.
+
+        :param      image_id: The ID of the OMI
+        :type       image_id: ``string``
+
+        :param      snapshot_id: The ID of the snapshot
+        :type       snapshot_id: ``string``
+
+        :return:    A product type
+        :rtype:     ``dict``
+        """
+
+        params = {'Action': 'GetProductType'}
+
+        params.update({'ImageId': image_id})
+        if snapshot_id is not None:
+            params.update({'SnapshotId': snapshot_id})
+
+        response = self.connection.request(self.path, params=params,
+                                           method='GET').object
+
+        product_type = self._to_product_type(response)
+
+        return product_type
+
     def _to_product_types(self, elem):
 
         product_types = []

--- a/libcloud/test/compute/fixtures/fcu/ex_describe_instance_types.xml
+++ b/libcloud/test/compute/fixtures/fcu/ex_describe_instance_types.xml
@@ -1,0 +1,33 @@
+<DescribeInstanceTypesResponse
+    xmlns="http://api.outscale.com/wsdl/fcuext/2014-04-15/">
+    <requestId>0556395e-4fe3-4cc1-80cb-c98b9f44ca4b</requestId>
+    <instanceTypeSet>
+        <item>
+            <name>og4.4xlarge</name>
+            <vcpu>24</vcpu>
+            <memory>193273528320</memory>
+            <storageSize>412316860416</storageSize>
+            <storageCount>1</storageCount>
+            <maxIpAddresses>30</maxIpAddresses>
+            <ebsOptimizedAvailable>true</ebsOptimizedAvailable>
+        </item>
+        <item>
+            <name>m3.large</name>
+            <vcpu>2</vcpu>
+            <memory>8050966528</memory>
+            <storageSize>34359738368</storageSize>
+            <storageCount>1</storageCount>
+            <maxIpAddresses>10</maxIpAddresses>
+            <ebsOptimizedAvailable>false</ebsOptimizedAvailable>
+        </item>
+        <item>
+            <name>oc2.8xlarge</name>
+            <vcpu>15</vcpu>
+            <memory>68718428160</memory>
+            <storageSize>901943132160</storageSize>
+            <storageCount>4</storageCount>
+            <maxIpAddresses>30</maxIpAddresses>
+            <ebsOptimizedAvailable>false</ebsOptimizedAvailable>
+        </item>
+    </instanceTypeSet>
+</DescribeInstanceTypesResponse>

--- a/libcloud/test/compute/fixtures/fcu/ex_describe_product_types.xml
+++ b/libcloud/test/compute/fixtures/fcu/ex_describe_product_types.xml
@@ -1,0 +1,18 @@
+<DescribeProductTypesResponse
+    xmlns="http://api.outscale.com/wsdl/fcuext/2014-04-15/">
+    <requestId>6f5287ac-2833-43d5-8675-b1ffd7b658d3</requestId>
+    <productTypeSet>
+        <item>
+            <productTypeId>0001</productTypeId>
+            <description>Linux/UNIX</description>
+        </item>
+        <item>
+            <productTypeId>0002</productTypeId>
+            <description>Windows</description>
+        </item>
+        <item>
+            <productTypeId>0003</productTypeId>
+            <description>MapR</description>
+        </item>
+    </productTypeSet>
+</DescribeProductTypesResponse>

--- a/libcloud/test/compute/fixtures/fcu/ex_describe_quota.xml
+++ b/libcloud/test/compute/fixtures/fcu/ex_describe_quota.xml
@@ -1,0 +1,53 @@
+<DescribeQuotaResponse
+    xmlns="http://api.outscale.com/wsdl/fcuext/2014-04-15/">
+    <requestId>31ef7689-2521-445f-b634-2a5e3e66f699</requestId>
+    <isTruncated>true</isTruncated>
+    <referenceQuotaSet>
+        <item>
+            <reference>global</reference>
+            <quotaSet>
+                <item>
+                    <ownerId>366866344682</ownerId>
+                    <name>vm_limit</name>
+                    <displayName>VM Limit</displayName>
+                    <description>Maximum number of VM this user can own</description>
+                    <groupName>Compute</groupName>
+                    <maxQuotaValue>20</maxQuotaValue>
+                    <usedQuotaValue>1</usedQuotaValue>
+                </item>
+                <item>
+                    <ownerId>366866344682</ownerId>
+                    <name>core_limit</name>
+                    <displayName>Core Limit</displayName>
+                    <description>Maximum number of total cores (virtual core)</description>
+                    <groupName>Compute</groupName>
+                    <maxQuotaValue>800</maxQuotaValue>
+                    <usedQuotaValue>2</usedQuotaValue>
+                </item>
+                <item>
+                    <ownerId>366866344682</ownerId>
+                    <name>memory_limit</name>
+                    <displayName>Memory Limit</displayName>
+                    <description>Maximum number of total memory (GiB)</description>
+                    <groupName>Compute</groupName>
+                    <maxQuotaValue>4880</maxQuotaValue>
+                    <usedQuotaValue>7</usedQuotaValue>
+                </item>
+            </quotaSet>
+        </item>
+        <item>
+            <reference>vpc-00000000</reference>
+            <quotaSet>
+                <item>
+                    <ownerId>366866344682</ownerId>
+                    <name>sg_limit</name>
+                    <displayName>Security Groups Limit</displayName>
+                    <description>Maximum number of security groups</description>
+                    <groupName>Security Groups</groupName>
+                    <maxQuotaValue>100</maxQuotaValue>
+                    <usedQuotaValue>2</usedQuotaValue>
+                </item>
+            </quotaSet>
+        </item>
+    </referenceQuotaSet>
+</DescribeQuotaResponse>

--- a/libcloud/test/compute/fixtures/fcu/ex_get_product_type.xml
+++ b/libcloud/test/compute/fixtures/fcu/ex_get_product_type.xml
@@ -1,0 +1,6 @@
+<GetProductTypeResponse
+    xmlns="http://api.outscale.com/wsdl/fcuext/2014-04-15/">
+    <requestId>e37f7876-8379-4505-8c3c-73c500e34257</requestId>
+    <productTypeId>0002</productTypeId>
+    <description>Windows</description>
+</GetProductTypeResponse>

--- a/libcloud/test/compute/fixtures/fcu/ex_modify_instance_keypair.xml
+++ b/libcloud/test/compute/fixtures/fcu/ex_modify_instance_keypair.xml
@@ -1,0 +1,5 @@
+<ModifyInstanceKeypairResponse
+    xmlns="http://api.outscale.com/wsdl/fcuext/2014-04-15/">
+    <requestId>9be5a40b-5f0a-4761-89fb-770eada0c865</requestId>
+    <return>true</return>
+</ModifyInstanceKeypairResponse>

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -1814,6 +1814,10 @@ class FCUMockHttp(EC2MockHttp):
         body = self.fixtures.load('ex_get_product_type.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
+    def _ModifyInstanceKeypair(self, method, url, body, headers):
+        body = self.fixtures.load('ex_modify_instance_keypair.xml')
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+
 
 class OutscaleFCUTests(LibcloudTestCase):
 
@@ -1854,6 +1858,10 @@ class OutscaleFCUTests(LibcloudTestCase):
         product_type = self.driver.ex_get_product_type('ami-29ab9e54')
         self.assertTrue(product_type['productTypeId'] == '0002')
         self.assertTrue(product_type['description'] == 'Windows')
+
+    def test_ex_modify_instance_keypair(self):
+        r = self.driver.ex_modify_instance_keypair('i-57292bc5', 'key_name')
+        self.assertTrue(r)
 
 
 if __name__ == '__main__':

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -1810,6 +1810,10 @@ class FCUMockHttp(EC2MockHttp):
         body = self.fixtures.load('ex_describe_instance_types.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
+    def _GetProductType(self, method, url, body, headers):
+        body = self.fixtures.load('ex_get_product_type.xml')
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+
 
 class OutscaleFCUTests(LibcloudTestCase):
 
@@ -1845,6 +1849,11 @@ class OutscaleFCUTests(LibcloudTestCase):
         self.assertTrue('oc2.8xlarge' in it.keys())
         self.assertTrue('68718428160' in it.values())
         self.assertTrue(it['m3.large'] == '8050966528')
+
+    def test_ex_get_product_type(self):
+        product_type = self.driver.ex_get_product_type('ami-29ab9e54')
+        self.assertTrue(product_type['productTypeId'] == '0002')
+        self.assertTrue(product_type['description'] == 'Windows')
 
 
 if __name__ == '__main__':

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -1806,6 +1806,10 @@ class FCUMockHttp(EC2MockHttp):
         body = self.fixtures.load('ex_describe_product_types.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
+    def _DescribeInstanceTypes(self, method, url, body, headers):
+        body = self.fixtures.load('ex_describe_instance_types.xml')
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+
 
 class OutscaleFCUTests(LibcloudTestCase):
 
@@ -1831,6 +1835,16 @@ class OutscaleFCUTests(LibcloudTestCase):
         self.assertTrue('0001' in pt.keys())
         self.assertTrue('MapR' in pt.values())
         self.assertTrue(pt['0002'] == 'Windows')
+
+    def test_ex_describe_instance_instance_types(self):
+        instance_types = self.driver.ex_describe_instance_types()
+        it = {}
+        for e in instance_types:
+            it[e['name']] = e['memory']
+        self.assertTrue('og4.4xlarge' in it.keys())
+        self.assertTrue('oc2.8xlarge' in it.keys())
+        self.assertTrue('68718428160' in it.values())
+        self.assertTrue(it['m3.large'] == '8050966528')
 
 
 if __name__ == '__main__':

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -1802,6 +1802,10 @@ class FCUMockHttp(EC2MockHttp):
         body = self.fixtures.load('ex_describe_quota.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
+    def _DescribeProductTypes(self, method, url, body, headers):
+        body = self.fixtures.load('ex_describe_product_types.xml')
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+
 
 class OutscaleFCUTests(LibcloudTestCase):
 
@@ -1818,6 +1822,15 @@ class OutscaleFCUTests(LibcloudTestCase):
         self.assertTrue(is_truncated == 'true')
         self.assertTrue('global' in quota.keys())
         self.assertTrue('vpc-00000000' in quota.keys())
+
+    def test_ex_describe_product_types(self):
+        product_types = self.driver.ex_describe_product_types()
+        pt = {}
+        for e in product_types:
+            pt[e['productTypeId']] = e['description']
+        self.assertTrue('0001' in pt.keys())
+        self.assertTrue('MapR' in pt.values())
+        self.assertTrue(pt['0002'] == 'Windows')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add libcloud support for the following new APIs available in the Flexible Computing Unit (FCU)
- DescribeInstanceTypes
- DescribeProductTypes
- GetProductType
- DescribeQuota
- ModifyInstanceKeypair

The patchset includes tests and fixtures for the new APIs.

Signed-off-by: Javier M. Mellid jmunhoz@igalia.com
