### PR TITLE
New Feature - Edit Dimension Data Firewall Rule

### DIFF
--- a/libcloud/common/dimensiondata.py
+++ b/libcloud/common/dimensiondata.py
@@ -833,11 +833,20 @@ class DimensionDataFirewallAddress(object):
         self.any_ip = any_ip
         self.ip_address = ip_address
         self.ip_prefix_size = ip_prefix_size
+        self.port_list_id = port_list_id
         self.port_begin = port_begin
         self.port_end = port_end
         self.address_list_id = address_list_id
         self.port_list_id = port_list_id
 
+    def __repr__(self):
+        return (
+            '<DimensionDataFirewallAddress: any_ip=%s, ip_address=%s, '
+            'ip_prefix_size=%s, port_begin=%s, port_end=%s, '
+            'address_list_id=%s, port_list_id=%s>'
+            % (self.any_ip, self.ip_address, self.ip_prefix_size,
+               self.port_begin, self.port_end, self.address_list_id,
+               self.port_list_id))
 
 class DimensionDataNatRule(object):
     """

--- a/libcloud/common/dimensiondata.py
+++ b/libcloud/common/dimensiondata.py
@@ -1633,7 +1633,7 @@ class DimensionDataPortList(object):
     """
 
     def __init__(self, id, name, description, port_collection,
-                 child_port_list_lists,
+                 child_portlist_list,
                  state, create_time):
         """"
         Initialize an instance of :class:`DimensionDataPortList`
@@ -1650,8 +1650,8 @@ class DimensionDataPortList(object):
         :param port_collection: Collection of DimensionDataPort
         :type  port_collection: ``List``
 
-        :param child_port_list_lists: Collection of DimensionDataChildPort
-        :type  child_port_list_lists: ``List``
+        :param child_portlist_list: Collection of DimensionDataChildPort
+        :type  child_portlist_list: ``List``
 
         :param state: Port list state
         :type  state: ``str``
@@ -1663,16 +1663,17 @@ class DimensionDataPortList(object):
         self.name = name
         self.description = description
         self.port_collection = port_collection
-        self.child_port_list_lists = child_port_list_lists
+        self.child_portlist_list = child_portlist_list
         self.state = state
         self.create_time = create_time
 
     def __repr__(self):
         return (
             "<DimensionDataPortList: id=%s, name=%s, description=%s, "
-            "port_collection=%s, child_port_list=%s, state=%s, create_time=%s>"
+            "port_collection=%s, child_portlist_list=%s, state=%s, "
+            "create_time=%s>"
             % (self.id, self.name, self.description,
-               self.port_collection, self.child_port_list, self.state,
+               self.port_collection, self.child_portlist_list, self.state,
                self.create_time))
 
 

--- a/libcloud/common/dimensiondata.py
+++ b/libcloud/common/dimensiondata.py
@@ -672,9 +672,9 @@ class DimensionDataNetworkDomain(object):
 
     def __repr__(self):
         return (('<DimensionDataNetworkDomain: id=%s, name=%s, '
-                 'description=%s, location=%s, status=%s>')
+                 'description=%s, location=%s, status=%s, plan=%s>')
                 % (self.id, self.name, self.description, self.location,
-                   self.status))
+                   self.status, self.plan))
 
 
 class DimensionDataPublicIpBlock(object):

--- a/libcloud/common/dimensiondata.py
+++ b/libcloud/common/dimensiondata.py
@@ -848,6 +848,7 @@ class DimensionDataFirewallAddress(object):
                self.port_begin, self.port_end, self.address_list_id,
                self.port_list_id))
 
+
 class DimensionDataNatRule(object):
     """
     An IP NAT rule in a network domain
@@ -1519,3 +1520,232 @@ class DimensionDataTagKey(object):
     def __repr__(self):
         return (('<DimensionDataTagKey: name=%s>')
                 % (self.name))
+
+
+class DimensionDataIpAddressList(object):
+    """
+    DimensionData IP Address list
+    """
+
+    def __init__(self, id, name, description, ip_version,
+                 ip_address_collection,
+                 state, create_time, child_ip_address_lists=None):
+        """"
+        Initialize an instance of :class:`DimensionDataIpAddressList`
+
+        :param id: GUID of the IP Address List key
+        :type  id: ``str``
+
+        :param name: Name of the IP Address List
+        :type  name: ``str``
+
+        :param description: Description of the IP Address List
+        :type  description: ``str``
+
+        :param ip_version: IP version. E.g. IPV4, IPV6
+        :type  ip_version: ``str``
+
+        :param ip_address_collection: Collection of DimensionDataIpAddress
+        :type  ip_address_collection: ``List``
+
+        :param state: IP Address list state
+        :type  state: ``str``
+
+        :param create_time: IP Address List created time
+        :type  create_time: ``date time``
+
+        :param child_ip_address_lists: List of IP address list to be included
+        :type  child_ip_address_lists: List
+        of :class:'DimensionDataIpAddressList'
+        """
+        self.id = id
+        self.name = name
+        self.description = description
+        self.ip_version = ip_version
+        self.ip_address_collection = ip_address_collection
+        self.state = state
+        self.create_time = create_time
+        self.child_ip_address_lists = child_ip_address_lists
+
+    def __repr__(self):
+        return ('<DimensionDataIpAddressList: id=%s, name=%s, description=%s, '
+                'ip_version=%s, ip_address_collection=%s, state=%s, '
+                'create_time=%s, child_ip_address_lists=%s>'
+                % (self.id, self.name, self.description, self.ip_version,
+                   self.ip_address_collection, self.state, self.create_time,
+                   self.child_ip_address_lists))
+
+
+class DimensionDataChildIpAddressList(object):
+    """
+    DimensionData Child IP Address list
+    """
+
+    def __init__(self, id, name):
+        """"
+        Initialize an instance of :class:`DimensionDataChildIpAddressList`
+
+        :param id: GUID of the IP Address List key
+        :type  id: ``str``
+
+        :param name: Name of the IP Address List
+        :type  name: ``str``
+
+        """
+        self.id = id
+        self.name = name
+
+    def __repr__(self):
+        return ('<DimensionDataChildIpAddressList: id=%s, name=%s>'
+                % (self.id, self.name))
+
+
+class DimensionDataIpAddress(object):
+    """
+    A representation of IP Address in Dimension Data
+    """
+
+    def __init__(self, begin, end=None, prefix_size=None):
+        """
+        Initialize an instance of :class:`DimensionDataIpAddress`
+
+        :param begin: IP Address Begin
+        :type  begin: ``str``
+
+        :param end: IP Address end
+        :type  end: ``str``
+
+        :param prefixSize: IP Address prefix size
+        :type  prefixSize: ``int``
+        """
+        self.begin = begin
+        self.end = end
+        self.prefix_size = prefix_size
+
+    def __repr__(self):
+        return ('<DimensionDataIpAddress: begin=%s, end=%s, prefix_size=%s>'
+                % (self.begin, self.end, self.prefix_size))
+
+
+class DimensionDataPortList(object):
+    """
+    DimensionData Port list
+    """
+
+    def __init__(self, id, name, description, port_collection,
+                 child_port_list_lists,
+                 state, create_time):
+        """"
+        Initialize an instance of :class:`DimensionDataPortList`
+
+        :param id: GUID of the Port List key
+        :type  id: ``str``
+
+        :param name: Name of the Port List
+        :type  name: ``str``
+
+        :param description: Description of the Port List
+        :type  description: ``str``
+
+        :param port_collection: Collection of DimensionDataPort
+        :type  port_collection: ``List``
+
+        :param child_port_list_lists: Collection of DimensionDataChildPort
+        :type  child_port_list_lists: ``List``
+
+        :param state: Port list state
+        :type  state: ``str``
+
+        :param create_time: Port List created time
+        :type  create_time: ``date time``
+        """
+        self.id = id
+        self.name = name
+        self.description = description
+        self.port_collection = port_collection
+        self.child_port_list_lists = child_port_list_lists
+        self.state = state
+        self.create_time = create_time
+
+    def __repr__(self):
+        return (
+            "<DimensionDataPortList: id=%s, name=%s, description=%s, "
+            "port_collection=%s, child_port_list=%s, state=%s, create_time=%s>"
+            % (self.id, self.name, self.description,
+               self.port_collection, self.child_port_list, self.state,
+               self.create_time))
+
+
+class DimensionDataChildPortList(object):
+    """
+    DimensionData Child Port list
+    """
+
+    def __init__(self, id, name):
+        """"
+        Initialize an instance of :class:`DimensionDataChildIpAddressList`
+
+        :param id: GUID of the child port list key
+        :type  id: ``str``
+
+        :param name: Name of the child port List
+        :type  name: ``str``
+
+        """
+        self.id = id
+        self.name = name
+
+    def __repr__(self):
+        return ('<DimensionDataChildPortList: id=%s, name=%s>'
+                % (self.id, self.name))
+
+
+class DimensionDataPort(object):
+    """
+    A representation of Port in Dimension Data
+    """
+
+    def __init__(self, begin, end=None):
+        """
+        Initialize an instance of :class:`DimensionDataPort`
+
+        :param begin: Port Number Begin
+        :type  begin: ``str``
+
+        :param end: Port Number end
+        :type  end: ``str``
+        """
+        self.begin = begin
+        self.end = end
+
+    def __repr__(self):
+        return ('<DimensionDataPort: begin=%s, end=%s>'
+                % (self.begin, self.end))
+
+
+class DimensionDataNic(object):
+    """
+    A representation of Network Adapter in Dimension Data
+    """
+
+    def __init__(self, private_ip_v4=None, vlan=None, network_adapter=None):
+        """
+        Initialize an instance of :class:`DimensionDataNic`
+
+        :param private_ip_v4: IPv4
+        :type  private_ip_v4: ``str``
+
+        :param vlan: Network VLAN
+        :type  vlan: class: DimensionDataVlan or ``str``
+
+        :param network_adapter: Network Adapter Name
+        :type  network_adapter: ``str``
+        """
+        self.private_ip_v4 = private_ip_v4
+        self.vlan = vlan
+        self.network_adapter_name = network_adapter
+
+    def __repr__(self):
+        return ('<DimensionDataNic: private_ip_v4=%s, vlan=%s,'
+                'network_adapter=%s>'
+                % (self.private_ip_v4, self.vlan, self.network_adapter))

--- a/libcloud/common/dimensiondata.py
+++ b/libcloud/common/dimensiondata.py
@@ -1729,7 +1729,8 @@ class DimensionDataNic(object):
     A representation of Network Adapter in Dimension Data
     """
 
-    def __init__(self, private_ip_v4=None, vlan=None, network_adapter=None):
+    def __init__(self, private_ip_v4=None, vlan=None,
+                 network_adapter_name=None):
         """
         Initialize an instance of :class:`DimensionDataNic`
 
@@ -1739,14 +1740,14 @@ class DimensionDataNic(object):
         :param vlan: Network VLAN
         :type  vlan: class: DimensionDataVlan or ``str``
 
-        :param network_adapter: Network Adapter Name
-        :type  network_adapter: ``str``
+        :param network_adapter_name: Network Adapter Name
+        :type  network_adapter_name: ``str``
         """
         self.private_ip_v4 = private_ip_v4
         self.vlan = vlan
-        self.network_adapter_name = network_adapter
+        self.network_adapter_name = network_adapter_name
 
     def __repr__(self):
         return ('<DimensionDataNic: private_ip_v4=%s, vlan=%s,'
-                'network_adapter=%s>'
-                % (self.private_ip_v4, self.vlan, self.network_adapter))
+                'network_adapter_name=%s>'
+                % (self.private_ip_v4, self.vlan, self.network_adapter_name))

--- a/libcloud/compute/drivers/dimensiondata.py
+++ b/libcloud/compute/drivers/dimensiondata.py
@@ -3416,9 +3416,9 @@ class DimensionDataNodeDriver(NodeDriver):
         for port in findall(element, 'port', TYPES_URN):
             ports.append(self._to_port(element=port))
 
-        child_port_list_lists = []
+        child_portlist_list = []
         for child in findall(element, 'childPortList', TYPES_URN):
-            child_port_list_lists.append(
+            child_portlist_list.append(
                 self._to_child_port_list(element=child))
 
         return DimensionDataPortList(
@@ -3426,7 +3426,7 @@ class DimensionDataNodeDriver(NodeDriver):
             name=findtext(element, 'name', TYPES_URN),
             description=findtext(element, 'description', TYPES_URN),
             port_collection=ports,
-            child_port_list_lists=child_port_list_lists,
+            child_portlist_list=child_portlist_list,
             state=findtext(element, 'state', TYPES_URN),
             create_time=findtext(element, 'createTime', TYPES_URN)
         )

--- a/libcloud/compute/drivers/dimensiondata.py
+++ b/libcloud/compute/drivers/dimensiondata.py
@@ -1489,7 +1489,7 @@ class DimensionDataNodeDriver(NodeDriver):
         >>> # Get dimension data driver
         >>> libcloud.security.VERIFY_SSL_CERT = True
         >>> cls = get_driver(Provider.DIMENSIONDATA)
-        >>> # driver = cls('myusername','mypassword', region='dd-au')
+        >>> driver = cls('myusername','mypassword', region='dd-au')
         >>>
         >>> # Get location
         >>> location = driver.ex_get_location_by_id(id='AU9')
@@ -2650,7 +2650,7 @@ class DimensionDataNodeDriver(NodeDriver):
                                                  end='190.2.2.108')
         >>> ipAddress_3 = DimensionDataIpAddress(begin='190.2.2.0',
                                                  prefix_size='24')
-        >>> ip_address_collection = {ipAddress_1, ipAddress_2, ipAddress_3}
+        >>> ip_address_collection = [ipAddress_1, ipAddress_2, ipAddress_3]
         >>>
         >>> # Create IPAddressList
         >>> result = driver.ex_create_ip_address_list(
@@ -2774,7 +2774,7 @@ class DimensionDataNodeDriver(NodeDriver):
         >>>                                      end='190.2.2.108')
         >>> ipAddress_3 = DimensionDataIpAddress(
         >>>                   begin='190.2.2.0', prefix_size='24')
-        >>> ip_address_collection = {ipAddress_1, ipAddress_2, ipAddress_3}
+        >>> ip_address_collection = [ipAddress_1, ipAddress_2, ipAddress_3]
         >>>
         >>> # Edit IP Address List
         >>> ip_address_list_id = '5e7c323f-c885-4e4b-9a27-94c44217dbd3'
@@ -2993,7 +2993,7 @@ class DimensionDataNodeDriver(NodeDriver):
         >>> # Port Collection
         >>> port_1 = DimensionDataPort(begin='1000')
         >>> port_2 = DimensionDataPort(begin='1001', end='1003')
-        >>> port_collection = {port_1, port_2}
+        >>> port_collection = [port_1, port_2]
         >>>
         >>> # Create Port List
         >>> new_portlist = driver.ex_create_portlist(
@@ -3087,7 +3087,7 @@ class DimensionDataNodeDriver(NodeDriver):
         >>> # Port Collection
         >>> port_1 = DimensionDataPort(begin='4200')
         >>> port_2 = DimensionDataPort(begin='4201', end='4210')
-        >>> port_collection = {port_1, port_2}
+        >>> port_collection = [port_1, port_2]
         >>>
         >>> # Edit Port List
         >>> editPortlist = driver.ex_get_portlist(

--- a/libcloud/compute/drivers/dimensiondata.py
+++ b/libcloud/compute/drivers/dimensiondata.py
@@ -44,7 +44,6 @@ from libcloud.common.dimensiondata import DimensionDataIpAddress
 from libcloud.common.dimensiondata import DimensionDataPortList
 from libcloud.common.dimensiondata import DimensionDataPort
 from libcloud.common.dimensiondata import DimensionDataChildPortList
-from libcloud.common.dimensiondata import DimensionDataNic
 from libcloud.common.dimensiondata import NetworkDomainServicePlan
 from libcloud.common.dimensiondata import DimensionDataTagKey
 from libcloud.common.dimensiondata import DimensionDataTag

--- a/libcloud/compute/drivers/dimensiondata.py
+++ b/libcloud/compute/drivers/dimensiondata.py
@@ -1481,6 +1481,44 @@ class DimensionDataNodeDriver(NodeDriver):
         """
         Edit a firewall rule
 
+        >>> from pprint import pprint
+        >>> from libcloud.compute.types import Provider
+        >>> from libcloud.compute.providers import get_driver
+        >>> import libcloud.security
+        >>>
+        >>> # Get dimension data driver
+        >>> libcloud.security.VERIFY_SSL_CERT = True
+        >>> cls = get_driver(Provider.DIMENSIONDATA)
+        >>> # driver = cls('myusername','mypassword', region='dd-au')
+        >>>
+        >>> # Get location
+        >>> location = driver.ex_get_location_by_id(id='AU9')
+        >>>
+        >>> # Get network domain by location
+        >>> networkDomainName = "Baas QA"
+        >>> network_domains = driver.ex_list_network_domains(location=location)
+        >>> my_network_domain = [d for d in network_domains if d.name ==
+                              networkDomainName][0]
+        >>>
+        >>>
+        >>> # List firewall rules
+        >>> firewall_rules = driver.ex_list_firewall_rules(my_network_domain)
+        >>>
+        >>> # Get Firewall Rule by name
+        >>> pprint("List specific firewall rule by name")
+        >>> fire_rule_under_test = (list(filter(lambda x: x.name ==
+                                   'My_New_Firewall_Rule', firewall_rules))[0])
+        >>> pprint(fire_rule_under_test.source)
+        >>> pprint(fire_rule_under_test.destination)
+        >>>
+        >>> # Edit Firewall
+        >>> fire_rule_under_test.destination.address_list_id =
+                '5e7c323f-c885-4e4b-9a27-94c44217dbd3'
+        >>> fire_rule_under_test.destination.port_list_id =
+                'b6557c5a-45fa-4138-89bd-8fe68392691b'
+        >>> result = driver.ex_edit_firewall_rule(fire_rule_under_test, 'LAST')
+        >>> pprint(result)
+
         :param rule: (required) The rule in which to create
         :type  rule: :class:`DimensionDataFirewallRule`
 
@@ -2496,6 +2534,30 @@ class DimensionDataNodeDriver(NodeDriver):
         """
         List IP Address List by network domain ID specified
 
+        >>> from pprint import pprint
+        >>> from libcloud.compute.types import Provider
+        >>> from libcloud.compute.providers import get_driver
+        >>> import libcloud.security
+        >>>
+        >>> # Get dimension data driver
+        >>> libcloud.security.VERIFY_SSL_CERT = True
+        >>> cls = get_driver(Provider.DIMENSIONDATA)
+        >>> driver = cls('myusername','mypassword', region='dd-au')
+        >>>
+        >>> # Get location
+        >>> location = driver.ex_get_location_by_id(id='AU9')
+        >>>
+        >>> # Get network domain by location
+        >>> networkDomainName = "Baas QA"
+        >>> network_domains = driver.ex_list_network_domains(location=location)
+        >>> my_network_domain = [d for d in network_domains if d.name ==
+                              networkDomainName][0]
+        >>>
+        >>> # List IP Address List of network domain
+        >>> ipaddresslist_list = driver.ex_list_ip_address_list(
+        >>>     ex_network_domain=my_network_domain)
+        >>> pprint(ipaddresslist_list)
+
         :param  ex_network_domain: The network domain or network domain ID
         :type   ex_network_domain: :class:`DimensionDataNetworkDomain` or 'str'
 
@@ -2512,6 +2574,32 @@ class DimensionDataNodeDriver(NodeDriver):
                                ex_ip_address_list_name):
         """
         Get IP Address List by name in network domain specified
+
+        >>> from pprint import pprint
+        >>> from libcloud.compute.types import Provider
+        >>> from libcloud.compute.providers import get_driver
+        >>> import libcloud.security
+        >>>
+        >>> # Get dimension data driver
+        >>> libcloud.security.VERIFY_SSL_CERT = True
+        >>> cls = get_driver(Provider.DIMENSIONDATA)
+        >>> driver = cls('myusername','mypassword', region='dd-au')
+        >>>
+        >>> # Get location
+        >>> location = driver.ex_get_location_by_id(id='AU9')
+        >>>
+        >>> # Get network domain by location
+        >>> networkDomainName = "Baas QA"
+        >>> network_domains = driver.ex_list_network_domains(location=location)
+        >>> my_network_domain = [d for d in network_domains if d.name ==
+                              networkDomainName][0]
+        >>>
+        >>> # Get IP Address List by Name
+        >>> ipaddresslist_list_by_name = driver.ex_get_ip_address_list(
+        >>>     ex_network_domain=my_network_domain,
+        >>>     ex_ip_address_list_name='My_IP_AddressList_1')
+        >>> pprint(ipaddresslist_list_by_name)
+
 
         :param  ex_network_domain: (required) The network domain or network
                                    domain ID in which ipaddresslist resides.
@@ -2535,6 +2623,47 @@ class DimensionDataNodeDriver(NodeDriver):
                                   child_ip_address_list=None):
         """
         Create IP Address List. IP Address list.
+
+        >>> from pprint import pprint
+        >>> from libcloud.compute.types import Provider
+        >>> from libcloud.compute.providers import get_driver
+        >>> from libcloud.common.dimensiondata import DimensionDataIpAddress
+        >>> import libcloud.security
+        >>>
+        >>> # Get dimension data driver
+        >>> libcloud.security.VERIFY_SSL_CERT = True
+        >>> cls = get_driver(Provider.DIMENSIONDATA)
+        >>> driver = cls('myusername','mypassword', region='dd-au')
+        >>>
+        >>> # Get location
+        >>> location = driver.ex_get_location_by_id(id='AU9')
+        >>>
+        >>> # Get network domain by location
+        >>> networkDomainName = "Baas QA"
+        >>> network_domains = driver.ex_list_network_domains(location=location)
+        >>> my_network_domain = [d for d in network_domains if d.name ==
+                              networkDomainName][0]
+        >>>
+        >>> # IP Address collection
+        >>> ipAddress_1 = DimensionDataIpAddress(begin='190.2.2.100')
+        >>> ipAddress_2 = DimensionDataIpAddress(begin='190.2.2.106',
+                                                 end='190.2.2.108')
+        >>> ipAddress_3 = DimensionDataIpAddress(begin='190.2.2.0',
+                                                 prefix_size='24')
+        >>> ip_address_collection = {ipAddress_1, ipAddress_2, ipAddress_3}
+        >>>
+        >>> # Create IPAddressList
+        >>> result = driver.ex_create_ip_address_list(
+        >>>     ex_network_domain=my_network_domain,
+        >>>     name='My_IP_AddressList_2',
+        >>>     ip_version='IPV4',
+        >>>     description='Test only',
+        >>>     ip_address_collection=ip_address_collection,
+        >>>     child_ip_address_list='08468e26-eeb3-4c3d-8ff2-5351fa6d8a04'
+        >>> )
+        >>>
+        >>> pprint(result)
+
 
         :param  ex_network_domain: The network domain or network domain ID
         :type   ex_network_domain: :class:`DimensionDataNetworkDomain` or 'str'
@@ -2628,6 +2757,35 @@ class DimensionDataNodeDriver(NodeDriver):
         """
         Edit IP Address List. IP Address list.
 
+        >>> from pprint import pprint
+        >>> from libcloud.compute.types import Provider
+        >>> from libcloud.compute.providers import get_driver
+        >>> from libcloud.common.dimensiondata import DimensionDataIpAddress
+        >>> import libcloud.security
+        >>>
+        >>> # Get dimension data driver
+        >>> libcloud.security.VERIFY_SSL_CERT = True
+        >>> cls = get_driver(Provider.DIMENSIONDATA)
+        >>> driver = cls('myusername','mypassword', region='dd-au')
+        >>>
+        >>> # IP Address collection
+        >>> ipAddress_1 = DimensionDataIpAddress(begin='190.2.2.100')
+        >>> ipAddress_2 = DimensionDataIpAddress(begin='190.2.2.106',
+        >>>                                      end='190.2.2.108')
+        >>> ipAddress_3 = DimensionDataIpAddress(
+        >>>                   begin='190.2.2.0', prefix_size='24')
+        >>> ip_address_collection = {ipAddress_1, ipAddress_2, ipAddress_3}
+        >>>
+        >>> # Edit IP Address List
+        >>> ip_address_list_id = '5e7c323f-c885-4e4b-9a27-94c44217dbd3'
+        >>> result = driver.ex_edit_ip_address_list(
+        >>>      ex_ip_address_list=ip_address_list_id,
+        >>>      description="Edit Test",
+        >>>      ip_address_collection=ip_address_collection,
+        >>>      child_ip_address_lists=None
+        >>>      )
+        >>> pprint(result)
+
         :param    ex_ip_address_list:  (required) IpAddressList object or
                                        IpAddressList ID
         :type     ex_ip_address_list: :class:'DimensionDataIpAddressList'
@@ -2700,8 +2858,22 @@ class DimensionDataNodeDriver(NodeDriver):
         """
         Delete IP Address List by ID
 
+        >>> from pprint import pprint
+        >>> from libcloud.compute.types import Provider
+        >>> from libcloud.compute.providers import get_driver
+        >>> import libcloud.security
+        >>>
+        >>> # Get dimension data driver
+        >>> libcloud.security.VERIFY_SSL_CERT = True
+        >>> cls = get_driver(Provider.DIMENSIONDATA)
+        >>> driver = cls('myusername','mypassword', region='dd-au')
+        >>>
+        >>> ip_address_list_id = '5e7c323f-c885-4e4b-9a27-94c44217dbd3'
+        >>> result = driver.ex_delete_ip_address_list(ip_address_list_id)
+        >>> pprint(result)
+
         :param    ex_ip_address_list:  IP Address List object or IP Address
-        List ID (required)
+                                        List ID (required)
         :type     ex_ip_address_list: :class:'DimensionDataIpAddressList'
                     or ``str``
 
@@ -2721,9 +2893,34 @@ class DimensionDataNodeDriver(NodeDriver):
         response_code = findtext(response, 'responseCode', TYPES_URN)
         return response_code in ['IN_PROGRESS', 'OK']
 
-    def ex_list_port_list(self, ex_network_domain):
+    def ex_list_portlist(self, ex_network_domain):
         """
-        List Port List by network domain ID specified
+        List Portlist by network domain ID specified
+
+        >>> from pprint import pprint
+        >>> from libcloud.compute.types import Provider
+        >>> from libcloud.compute.providers import get_driver
+        >>> import libcloud.security
+        >>>
+        >>> # Get dimension data driver
+        >>> libcloud.security.VERIFY_SSL_CERT = True
+        >>> cls = get_driver(Provider.DIMENSIONDATA)
+        >>> driver = cls('myusername','mypassword', region='dd-au')
+        >>>
+        >>> # Get location
+        >>> location = driver.ex_get_location_by_id(id='AU9')
+        >>>
+        >>> # Get network domain by location
+        >>> networkDomainName = "Baas QA"
+        >>> network_domains = driver.ex_list_network_domains(location=location)
+        >>> my_network_domain = [d for d in network_domains if d.name ==
+        >>>                                               networkDomainName][0]
+        >>>
+        >>> # List portlist
+        >>> portLists = driver.ex_list_portlist(
+        >>>     ex_network_domain=my_network_domain)
+        >>> pprint(portLists)
+        >>>
 
         :param  ex_network_domain: The network domain or network domain ID
         :type   ex_network_domain: :class:`DimensionDataNetworkDomain` or 'str'
@@ -2737,27 +2934,76 @@ class DimensionDataNodeDriver(NodeDriver):
             'network/portList', params=params).object
         return self._to_port_lists(response)
 
-    def ex_get_port_list(self, ex_port_list):
+    def ex_get_portlist(self, ex_portlist_id):
         """
         Get Port List
 
-        :param  ex_port_list: The ex_port_list or ex_port_list ID
-        :type   ex_port_list: :class:`DimensionDataNetworkDomain` or 'str'
+        >>> from pprint import pprint
+        >>> from libcloud.compute.types import Provider
+        >>> from libcloud.compute.providers import get_driver
+        >>> import libcloud.security
+        >>>
+        >>> # Get dimension data driver
+        >>> libcloud.security.VERIFY_SSL_CERT = True
+        >>> cls = get_driver(Provider.DIMENSIONDATA)
+        >>> driver = cls('myusername','mypassword', region='dd-au')
+        >>>
+        >>> # Get specific portlist by ID
+        >>> portlist_id = '27dd8c66-80ff-496b-9f54-2a3da2fe679e'
+        >>> portlist = driver.ex_get_portlist(portlist_id)
+        >>> pprint(portlist)
+
+        :param  ex_portlist_id: The ex_port_list or ex_port_list ID
+        :type   ex_portlist_id: :class:`DimensionDataNetworkDomain` or 'str'
 
         :return:  DimensionDataPortList object
         :rtype:  :class:`DimensionDataPort`
         """
 
-        url_path = ('network/portList/%s' % self._port_list_to_port_list_id(
-            ex_port_list))
+        url_path = ('network/portList/%s' % ex_portlist_id)
         response = self.connection.request_with_orgId_api_2(
             url_path).object
         return self._to_port_list(response)
 
-    def ex_create_port_list(self, ex_network_domain, name, description,
-                            port_collection, child_port_list_lists=None):
+    def ex_create_portlist(self, ex_network_domain, name, description,
+                           port_collection, child_portlist_list=None):
         """
         Create Port List.
+
+        >>> from pprint import pprint
+        >>> from libcloud.compute.types import Provider
+        >>> from libcloud.compute.providers import get_driver
+        >>> from libcloud.common.dimensiondata import DimensionDataPort
+        >>> import libcloud.security
+        >>>
+        >>> # Get dimension data driver
+        >>> libcloud.security.VERIFY_SSL_CERT = True
+        >>> cls = get_driver(Provider.DIMENSIONDATA)
+        >>> driver = cls('myusername','mypassword', region='dd-au')
+        >>>
+        >>> # Get location
+        >>> location = driver.ex_get_location_by_id(id='AU9')
+        >>>
+        >>> # Get network domain by location
+        >>> networkDomainName = "Baas QA"
+        >>> network_domains = driver.ex_list_network_domains(location=location)
+        >>> my_network_domain = [d for d in network_domains if d.name ==
+                              networkDomainName][0]
+        >>>
+        >>> # Port Collection
+        >>> port_1 = DimensionDataPort(begin='1000')
+        >>> port_2 = DimensionDataPort(begin='1001', end='1003')
+        >>> port_collection = {port_1, port_2}
+        >>>
+        >>> # Create Port List
+        >>> new_portlist = driver.ex_create_portlist(
+        >>>     ex_network_domain=my_network_domain,
+        >>>     name='MyPortListX',
+        >>>     description="Test only",
+        >>>     port_collection=port_collection,
+        >>>     child_portlist_list={'a9cd4984-6ff5-4f93-89ff-8618ab642bb9'}
+        >>>     )
+        >>> pprint(new_portlist)
 
         :param    ex_network_domain:  (required) The network domain in
                                        which to create PortList. Provide
@@ -2773,9 +3019,9 @@ class DimensionDataNodeDriver(NodeDriver):
         :param    port_collection:  List of Port Address
         :type     port_collection: :``str``
 
-        :param    child_port_list_lists:  Child Port List to be included in
-                                          this Port List
-        :type     child_port_list_lists: :``str`` or ''list of
+        :param    child_portlist_list:  List of Child Portlist to be
+                                        included in this Port List
+        :type     child_portlist_list: :``str`` or ''list of
                                          :class:'DimensionDataChildPortList'
 
         :return: result of operation
@@ -2807,8 +3053,8 @@ class DimensionDataNodeDriver(NodeDriver):
             if port.end:
                 p.set('end', port.end)
 
-        if child_port_list_lists is not None:
-            for child in child_port_list_lists:
+        if child_portlist_list is not None:
+            for child in child_portlist_list:
                 ET.SubElement(
                     new_port_list,
                     'childPortListId'
@@ -2822,24 +3068,52 @@ class DimensionDataNodeDriver(NodeDriver):
         response_code = findtext(response, 'responseCode', TYPES_URN)
         return response_code in ['IN_PROGRESS', 'OK']
 
-    def ex_edit_port_list(self, ex_port_list, description,
-                          port_collection, child_port_list_lists=None):
+    def ex_edit_portlist(self, ex_portlist, description,
+                         port_collection, child_portlist_list=None):
         """
         Edit Port List.
 
-        :param    ex_port_list:  Port List to be edited
+        >>> from pprint import pprint
+        >>> from libcloud.compute.types import Provider
+        >>> from libcloud.compute.providers import get_driver
+        >>> from libcloud.common.dimensiondata import DimensionDataPort
+        >>> import libcloud.security
+        >>>
+        >>> # Get dimension data driver
+        >>> libcloud.security.VERIFY_SSL_CERT = True
+        >>> cls = get_driver(Provider.DIMENSIONDATA)
+        >>> driver = cls('myusername','mypassword', region='dd-au')
+        >>>
+        >>> # Port Collection
+        >>> port_1 = DimensionDataPort(begin='4200')
+        >>> port_2 = DimensionDataPort(begin='4201', end='4210')
+        >>> port_collection = {port_1, port_2}
+        >>>
+        >>> # Edit Port List
+        >>> editPortlist = driver.ex_get_portlist(
+            '27dd8c66-80ff-496b-9f54-2a3da2fe679e')
+        >>>
+        >>> result = driver.ex_edit_portlist(
+        >>>     ex_portlist=editPortlist.id,
+        >>>     description="Make Changes in portlist",
+        >>>     port_collection=port_collection,
+        >>>     child_portlist_list={'a9cd4984-6ff5-4f93-89ff-8618ab642bb9'}
+        >>> )
+        >>> pprint(result)
+
+        :param    ex_portlist:  Port List to be edited
                                         (required)
-        :type      ex_port_list: :``str`` or :class:'DimensionDataPortList'
+        :type      ex_portlist: :``str`` or :class:'DimensionDataPortList'
 
         :param    description:  Port List Description
         :type      description: :``str``
 
-        :param    port_collection:  List of Port Address
+        :param    port_collection:  List of Ports
         :type      port_collection: :``str``
 
-        :param    child_port_list_lists:  Child Port List to be included in
+        :param    child_portlist_list:  Child PortList to be included in
                                           this IP Address List
-        :type      child_port_list_lists: :``list`` of
+        :type      child_portlist_list: :``list`` of
                                           :class'DimensionDataChildPortList'
                                           or ''str''
 
@@ -2850,7 +3124,7 @@ class DimensionDataNodeDriver(NodeDriver):
         existing_port_address_list = ET.Element(
             'editPortList',
             {
-                "id": self._port_list_to_port_list_id(ex_port_list),
+                "id": self._port_list_to_port_list_id(ex_portlist),
                 'xmlns': TYPES_URN,
                 'xmlns:xsi': "http://www.w3.org/2001/XMLSchema-instance"
             })
@@ -2870,8 +3144,8 @@ class DimensionDataNodeDriver(NodeDriver):
             if port.end:
                 p.set('end', port.end)
 
-        if child_port_list_lists is not None:
-            for child in child_port_list_lists:
+        if child_portlist_list is not None:
+            for child in child_portlist_list:
                 ET.SubElement(
                     existing_port_address_list,
                     'childPortListId'
@@ -2891,11 +3165,27 @@ class DimensionDataNodeDriver(NodeDriver):
         response_code = findtext(response, 'responseCode', TYPES_URN)
         return response_code in ['IN_PROGRESS', 'OK']
 
-    def ex_delete_port_list(self, ex_port_list):
+    def ex_delete_portlist(self, ex_portlist):
         """
         Delete Port List
-        :param    ex_port_list:  Port List to be deleted
-        :type     ex_port_list: :``str`` or :class:'DimensionDataPortList'
+
+        >>> from pprint import pprint
+        >>> from libcloud.compute.types import Provider
+        >>> from libcloud.compute.providers import get_driver
+        >>> import libcloud.security
+        >>>
+        >>> # Get dimension data driver
+        >>> libcloud.security.VERIFY_SSL_CERT = True
+        >>> cls = get_driver(Provider.DIMENSIONDATA)
+        >>> driver = cls('myusername','mypassword', region='dd-au')
+        >>>
+        >>> # Delete Port List
+        >>> portlist_id = '157531ce-77d4-493c-866b-d3d3fc4a912a'
+        >>> response = driver.ex_delete_portlist(portlist_id)
+        >>> pprint(response)
+
+        :param    ex_portlist:  Port List to be deleted
+        :type     ex_portlist: :``str`` or :class:'DimensionDataPortList'
 
         :rtype: ``bool``
         """
@@ -2903,7 +3193,7 @@ class DimensionDataNodeDriver(NodeDriver):
         delete_port_list = ET.Element(
             'deletePortList',
             {'xmlns': TYPES_URN,
-             'id': self._port_list_to_port_list_id(ex_port_list)})
+             'id': self._port_list_to_port_list_id(ex_portlist)})
 
         response = self.connection.request_with_orgId_api_2(
             'network/deletePortList',

--- a/libcloud/compute/drivers/dimensiondata.py
+++ b/libcloud/compute/drivers/dimensiondata.py
@@ -38,6 +38,13 @@ from libcloud.common.dimensiondata import DimensionDataFirewallRule
 from libcloud.common.dimensiondata import DimensionDataFirewallAddress
 from libcloud.common.dimensiondata import DimensionDataNatRule
 from libcloud.common.dimensiondata import DimensionDataAntiAffinityRule
+from libcloud.common.dimensiondata import DimensionDataIpAddressList
+from libcloud.common.dimensiondata import DimensionDataChildIpAddressList
+from libcloud.common.dimensiondata import DimensionDataIpAddress
+from libcloud.common.dimensiondata import DimensionDataPortList
+from libcloud.common.dimensiondata import DimensionDataPort
+from libcloud.common.dimensiondata import DimensionDataChildPortList
+from libcloud.common.dimensiondata import DimensionDataNic
 from libcloud.common.dimensiondata import NetworkDomainServicePlan
 from libcloud.common.dimensiondata import DimensionDataTagKey
 from libcloud.common.dimensiondata import DimensionDataTag
@@ -1470,6 +1477,113 @@ class DimensionDataNodeDriver(NodeDriver):
         rule.id = rule_id
         return rule
 
+    def ex_edit_firewall_rule(self, rule, position,
+                              relative_rule_for_position=None):
+        """
+        Edit a firewall rule
+
+        :param rule: (required) The rule in which to create
+        :type  rule: :class:`DimensionDataFirewallRule`
+
+        :param position: (required) There are two types of positions
+                         with position_relative_to_rule arg and without it
+                         With: 'BEFORE' or 'AFTER'
+                         Without: 'FIRST' or 'LAST'
+        :type  position: ``str``
+
+        :param relative_rule_for_position: (optional) The rule or rule name in
+                                           which to decide the relative rule
+                                           for positioning.
+        :type  relative_rule_for_position:
+            :class:`DimensionDataFirewallRule` or ``str``
+
+        :rtype: ``bool``
+        """
+
+        positions_without_rule = ('FIRST', 'LAST')
+        positions_with_rule = ('BEFORE', 'AFTER')
+
+        edit_node = ET.Element('editFirewallRule',
+                               {'xmlns': TYPES_URN, 'id': rule.id})
+        ET.SubElement(edit_node, "action").text = rule.action
+        ET.SubElement(edit_node, "protocol").text = rule.protocol
+
+        # Source address
+        source = ET.SubElement(edit_node, "source")
+        if rule.source.address_list_id is not None:
+            source_ip = ET.SubElement(source, 'ipAddressListId')
+            source_ip.text = rule.source.address_list_id
+        else:
+            source_ip = ET.SubElement(source, 'ip')
+            if rule.source.any_ip:
+                source_ip.set('address', 'ANY')
+            else:
+                source_ip.set('address', rule.source.ip_address)
+                if rule.source.ip_prefix_size is not None:
+                    source_ip.set('prefixSize',
+                                  str(rule.source.ip_prefix_size))
+
+        # Setup source port rule
+        if rule.source.port_list_id is not None:
+            source_port = ET.SubElement(source, 'portListId')
+            source_port.text = rule.source.port_list_id
+        else:
+            if rule.source.port_begin is not None:
+                source_port = ET.SubElement(source, 'port')
+                source_port.set('begin', rule.source.port_begin)
+            if rule.source.port_end is not None:
+                source_port.set('end', rule.source.port_end)
+        # Setup destination port rule
+        dest = ET.SubElement(edit_node, "destination")
+        if rule.destination.address_list_id is not None:
+            dest_ip = ET.SubElement(dest, 'ipAddressListId')
+            dest_ip.text = rule.destination.address_list_id
+        else:
+            dest_ip = ET.SubElement(dest, 'ip')
+            if rule.destination.any_ip:
+                dest_ip.set('address', 'ANY')
+            else:
+                dest_ip.set('address', rule.destination.ip_address)
+                if rule.destination.ip_prefix_size is not None:
+                    dest_ip.set('prefixSize', rule.destination.ip_prefix_size)
+        if rule.destination.port_list_id is not None:
+            dest_port = ET.SubElement(dest, 'portListId')
+            dest_port.text = rule.destination.port_list_id
+        else:
+            if rule.destination.port_begin is not None:
+                dest_port = ET.SubElement(dest, 'port')
+                dest_port.set('begin', rule.destination.port_begin)
+            if rule.destination.port_end is not None:
+                dest_port.set('end', rule.destination.port_end)
+        # Set up positioning of rule
+        ET.SubElement(edit_node, "enabled").text = str(rule.enabled).lower()
+        placement = ET.SubElement(edit_node, "placement")
+        if relative_rule_for_position is not None:
+            if position not in positions_with_rule:
+                raise ValueError("When position_relative_to_rule is specified"
+                                 " position must be %s"
+                                 % ', '.join(positions_with_rule))
+            if isinstance(relative_rule_for_position,
+                          DimensionDataFirewallRule):
+                rule_name = relative_rule_for_position.name
+            else:
+                rule_name = relative_rule_for_position
+            placement.set('relativeToRule', rule_name)
+        else:
+            if position not in positions_without_rule:
+                raise ValueError("When position_relative_to_rule is not"
+                                 " specified position must be %s"
+                                 % ', '.join(positions_without_rule))
+        placement.set('position', position)
+
+        response = self.connection.request_with_orgId_api_2(
+            'network/editFirewallRule',
+            method='POST',
+            data=ET.tostring(edit_node)).object
+
+        response_code = findtext(response, 'responseCode', TYPES_URN)
+        return response_code in ['IN_PROGRESS', 'OK']
+
     def ex_get_firewall_rule(self, network_domain, rule_id):
         locations = self.list_locations()
         rule = self.connection.request_with_orgId_api_2(
@@ -2379,6 +2493,427 @@ class DimensionDataNodeDriver(NodeDriver):
             % (datacenter_id, start_date, end_date))
         return self._format_csv(result.response)
 
+    def ex_list_ip_address_list(self, ex_network_domain):
+        """
+        List IP Address List by network domain ID specified
+
+        :param  ex_network_domain: The network domain or network domain ID
+        :type   ex_network_domain: :class:`DimensionDataNetworkDomain` or 'str'
+
+        :return: a list of DimensionDataIpAddressList objects
+        :rtype: ``list`` of :class:`DimensionDataIpAddressList`
+        """
+        params = {'networkDomainId': self._network_domain_to_network_domain_id(
+            ex_network_domain)}
+        response = self.connection.request_with_orgId_api_2(
+            'network/ipAddressList', params=params).object
+        return self._to_ip_address_lists(response)
+
+    def ex_get_ip_address_list(self, ex_network_domain,
+                               ex_ip_address_list_name):
+        """
+        Get IP Address List by name in network domain specified
+
+        :param  ex_network_domain: (required) The network domain or network
+                                   domain ID in which ipaddresslist resides.
+        :type   ex_network_domain: :class:`DimensionDataNetworkDomain` or 'str'
+
+        :param    ex_ip_address_list_name: (required) Get 'IP Address List' by
+                                            name
+        :type     ex_ip_address_list_name: :``str``
+
+        :return: a list of DimensionDataIpAddressList objects
+        :rtype: ``list`` of :class:`DimensionDataIpAddressList`
+        """
+
+        ip_address_lists = self.ex_list_ip_address_list(ex_network_domain)
+        return list(filter(lambda x: x.name == ex_ip_address_list_name,
+                           ip_address_lists))
+
+    def ex_create_ip_address_list(self, ex_network_domain, name,
+                                  description,
+                                  ip_version, ip_address_collection,
+                                  child_ip_address_list=None):
+        """
+        Create IP Address List. IP Address list.
+
+        :param  ex_network_domain: The network domain or network domain ID
+        :type   ex_network_domain: :class:`DimensionDataNetworkDomain` or 'str'
+
+        :param    name:  IP Address List Name (required)
+        :type      name: :``str``
+
+        :param    description:  IP Address List Description (optional)
+        :type      description: :``str``
+
+        :param    ip_version:  IP Version of ip address (required)
+        :type      ip_version: :``str``
+
+        :param    ip_address_collection:  List of IP Address. At least one
+                                          ipAddress element or one
+                                          childIpAddressListId element must
+                                          be provided.
+        :type      ip_address_collection: :``str``
+
+        :param    child_ip_address_list:  Child IP Address List or id to be
+                                          included in this IP Address List.
+                                          At least one ipAddress or
+                                          one childIpAddressListId
+                                          must be provided.
+        :type     child_ip_address_list:
+                        :class:'DimensionDataChildIpAddressList` or `str``
+
+        :return: a list of DimensionDataIpAddressList objects
+        :rtype: ``list`` of :class:`DimensionDataIpAddressList`
+        """
+        if (ip_address_collection is None and
+                child_ip_address_list is None):
+            raise ValueError("At least one ipAddress element or one "
+                             "childIpAddressListId element must be "
+                             "provided.")
+
+        create_ip_address_list = ET.Element('createIpAddressList',
+                                            {'xmlns': TYPES_URN})
+        ET.SubElement(
+            create_ip_address_list,
+            'networkDomainId'
+        ).text = self._network_domain_to_network_domain_id(ex_network_domain)
+
+        ET.SubElement(
+            create_ip_address_list,
+            'name'
+        ).text = name
+
+        ET.SubElement(
+            create_ip_address_list,
+            'description'
+        ).text = description
+
+        ET.SubElement(
+            create_ip_address_list,
+            'ipVersion'
+        ).text = ip_version
+
+        for ip in ip_address_collection:
+            ip_address = ET.SubElement(
+                create_ip_address_list,
+                'ipAddress',
+            )
+            ip_address.set('begin', ip.begin)
+
+            if ip.end:
+                ip_address.set('end', ip.end)
+
+            if ip.prefix_size:
+                ip_address.set('prefixSize', ip.prefix_size)
+
+        if child_ip_address_list is not None:
+            ET.SubElement(
+                create_ip_address_list,
+                'childIpAddressListId'
+            ).text = \
+                self._child_ip_address_list_to_child_ip_address_list_id(
+                    child_ip_address_list)
+
+        response = self.connection.request_with_orgId_api_2(
+            'network/createIpAddressList',
+            method='POST',
+            data=ET.tostring(create_ip_address_list)).object
+
+        response_code = findtext(response, 'responseCode', TYPES_URN)
+        return response_code in ['IN_PROGRESS', 'OK']
+
+    def ex_edit_ip_address_list(self, ex_ip_address_list, description,
+                                ip_address_collection,
+                                child_ip_address_lists=None):
+        """
+        Edit IP Address List. IP Address list.
+
+        :param    ex_ip_address_list:  (required) IpAddressList object or
+                                       IpAddressList ID
+        :type     ex_ip_address_list: :class:'DimensionDataIpAddressList'
+                    or ``str``
+
+        :param    description:  IP Address List Description
+        :type      description: :``str``
+
+        :param    ip_address_collection:  List of IP Address
+        :type     ip_address_collection: ''list'' of
+                                         :class:'DimensionDataIpAddressList'
+
+        :param   child_ip_address_lists:  Child IP Address List or id to be
+                                          included in this IP Address List
+        :type    child_ip_address_lists:  ``list`` of
+                                    :class:'DimensionDataChildIpAddressList'
+                                    or ``str``
+
+        :return: a list of DimensionDataIpAddressList objects
+        :rtype: ``list`` of :class:`DimensionDataIpAddressList`
+        """
+        edit_ip_address_list = ET.Element(
+            'editIpAddressList',
+            {'xmlns': TYPES_URN,
+             "id": self._ip_address_list_to_ip_address_list_id(
+                 ex_ip_address_list),
+             'xmlns:xsi': "http://www.w3.org/2001/XMLSchema-instance"
+             })
+
+        ET.SubElement(
+            edit_ip_address_list,
+            'description'
+        ).text = description
+
+        for ip in ip_address_collection:
+            ip_address = ET.SubElement(
+                edit_ip_address_list,
+                'ipAddress',
+            )
+            ip_address.set('begin', ip.begin)
+
+            if ip.end:
+                ip_address.set('end', ip.end)
+
+            if ip.prefix_size:
+                ip_address.set('prefixSize', ip.prefix_size)
+
+        if child_ip_address_lists is not None:
+            ET.SubElement(
+                edit_ip_address_list,
+                'childIpAddressListId'
+            ).text = self._child_ip_address_list_to_child_ip_address_list_id(
+                child_ip_address_lists)
+        else:
+            ET.SubElement(
+                edit_ip_address_list,
+                'childIpAddressListId',
+                {'xsi:nil': 'true'}
+            )
+
+        response = self.connection.request_with_orgId_api_2(
+            'network/editIpAddressList',
+            method='POST',
+            data=ET.tostring(edit_ip_address_list)).object
+
+        response_code = findtext(response, 'responseCode', TYPES_URN)
+        return response_code in ['IN_PROGRESS', 'OK']
+
+    def ex_delete_ip_address_list(self, ex_ip_address_list):
+        """
+        Delete IP Address List by ID
+
+        :param    ex_ip_address_list:  IP Address List object or IP Address
+        List ID (required)
+        :type     ex_ip_address_list: :class:'DimensionDataIpAddressList'
+                    or ``str``
+
+        :rtype: ``bool``
+        """
+
+        delete_ip_address_list = \
+            ET.Element('deleteIpAddressList', {'xmlns': TYPES_URN, 'id': self
+                       ._ip_address_list_to_ip_address_list_id(
+                           ex_ip_address_list)})
+
+        response = self.connection.request_with_orgId_api_2(
+            'network/deleteIpAddressList',
+            method='POST',
+            data=ET.tostring(delete_ip_address_list)).object
+
+        response_code = findtext(response, 'responseCode', TYPES_URN)
+        return response_code in ['IN_PROGRESS', 'OK']
+
+    def ex_list_port_list(self, ex_network_domain):
+        """
+        List Port List by network domain ID specified
+
+        :param  ex_network_domain: The network domain or network domain ID
+        :type   ex_network_domain: :class:`DimensionDataNetworkDomain` or 'str'
+
+        :return: a list of DimensionDataPortList objects
+        :rtype: ``list`` of :class:`DimensionDataPortList`
+        """
+        params = {'networkDomainId':
+                  self._network_domain_to_network_domain_id(ex_network_domain)}
+        response = self.connection.request_with_orgId_api_2(
+            'network/portList', params=params).object
+        return self._to_port_lists(response)
+
+    def ex_get_port_list(self, ex_port_list):
+        """
+        Get Port List
+
+        :param  ex_port_list: The ex_port_list or ex_port_list ID
+        :type   ex_port_list: :class:`DimensionDataNetworkDomain` or 'str'
+
+        :return:  DimensionDataPortList object
+        :rtype:  :class:`DimensionDataPort`
+        """
+
+        url_path = ('network/portList/%s' % self._port_list_to_port_list_id(
+            ex_port_list))
+        response = self.connection.request_with_orgId_api_2(
+            url_path).object
+        return self._to_port_list(response)
+
+    def ex_create_port_list(self, ex_network_domain, name, description,
+                            port_collection, child_port_list_lists=None):
+        """
+        Create Port List.
+
+        :param    ex_network_domain:  (required) The network domain in
+                                       which to create PortList. Provide
+                                       networkdomain object or its id.
+        :type      ex_network_domain: :``str``
+
+        :param    name:  Port List Name
+        :type     name: :``str``
+
+        :param    description:  IP Address List Description
+        :type     description: :``str``
+
+        :param    port_collection:  List of Port Address
+        :type     port_collection: :``str``
+
+        :param    child_port_list_lists:  Child Port List to be included in
+                                          this Port List
+        :type     child_port_list_lists: :``str`` or ''list of
+                                         :class:'DimensionDataChildPortList'
+
+        :return: result of operation
+        :rtype: ``bool``
+        """
+        new_port_list = ET.Element('createPortList', {'xmlns': TYPES_URN})
+        ET.SubElement(
+            new_port_list,
+            'networkDomainId'
+        ).text = self._network_domain_to_network_domain_id(ex_network_domain)
+
+        ET.SubElement(
+            new_port_list,
+            'name'
+        ).text = name
+
+        ET.SubElement(
+            new_port_list,
+            'description'
+        ).text = description
+
+        for port in port_collection:
+            p = ET.SubElement(
+                new_port_list,
+                'port'
+            )
+            p.set('begin', port.begin)
+
+            if port.end:
+                p.set('end', port.end)
+
+        if child_port_list_lists is not None:
+            for child in child_port_list_lists:
+                ET.SubElement(
+                    new_port_list,
+                    'childPortListId'
+                ).text = self._child_port_list_to_child_port_list_id(child)
+
+        response = self.connection.request_with_orgId_api_2(
+            'network/createPortList',
+            method='POST',
+            data=ET.tostring(new_port_list)).object
+
+        response_code = findtext(response, 'responseCode', TYPES_URN)
+        return response_code in ['IN_PROGRESS', 'OK']
+
+    def ex_edit_port_list(self, ex_port_list, description,
+                          port_collection, child_port_list_lists=None):
+        """
+        Edit Port List.
+
+        :param    ex_port_list:  Port List to be edited
+                                        (required)
+        :type      ex_port_list: :``str`` or :class:'DimensionDataPortList'
+
+        :param    description:  Port List Description
+        :type      description: :``str``
+
+        :param    port_collection:  List of Port Address
+        :type      port_collection: :``str``
+
+        :param    child_port_list_lists:  Child Port List to be included in
+                                          this IP Address List
+        :type      child_port_list_lists: :``list`` of
+                                          :class'DimensionDataChildPortList'
+                                          or ''str''
+
+        :return: a list of DimensionDataPortList objects
+        :rtype: ``list`` of :class:`DimensionDataPortList`
+        """
+
+        existing_port_address_list = ET.Element(
+            'editPortList',
+            {
+                "id": self._port_list_to_port_list_id(ex_port_list),
+                'xmlns': TYPES_URN,
+                'xmlns:xsi': "http://www.w3.org/2001/XMLSchema-instance"
+            })
+
+        ET.SubElement(
+            existing_port_address_list,
+            'description'
+        ).text = description
+
+        for port in port_collection:
+            p = ET.SubElement(
+                existing_port_address_list,
+                'port'
+            )
+            p.set('begin', port.begin)
+
+            if port.end:
+                p.set('end', port.end)
+
+        if child_port_list_lists is not None:
+            for child in child_port_list_lists:
+                ET.SubElement(
+                    existing_port_address_list,
+                    'childPortListId'
+                ).text = self._child_port_list_to_child_port_list_id(child)
+        else:
+            ET.SubElement(
+                existing_port_address_list,
+                'childPortListId',
+                {'xsi:nil': 'true'}
+            )
+
+        response = self.connection.request_with_orgId_api_2(
+            'network/editPortList',
+            method='POST',
+            data=ET.tostring(existing_port_address_list)).object
+
+        response_code = findtext(response, 'responseCode', TYPES_URN)
+        return response_code in ['IN_PROGRESS', 'OK']
+
+    def ex_delete_port_list(self, ex_port_list):
+        """
+        Delete Port List
+        :param    ex_port_list:  Port List to be deleted
+        :type     ex_port_list: :``str`` or :class:'DimensionDataPortList'
+
+        :rtype: ``bool``
+        """
+
+        delete_port_list = ET.Element(
+            'deletePortList',
+            {'xmlns': TYPES_URN,
+             'id': self._port_list_to_port_list_id(ex_port_list)})
+
+        response = self.connection.request_with_orgId_api_2(
+            'network/deletePortList',
+            method='POST',
+            data=ET.tostring(delete_port_list)).object
+
+        response_code = findtext(response, 'responseCode', TYPES_URN)
+        return response_code in ['IN_PROGRESS', 'OK']
+
     def _format_csv(self, http_response):
         text = http_response.read()
         lines = str.splitlines(ensure_string(text))
@@ -2828,12 +3363,95 @@ class DimensionDataNodeDriver(NodeDriver):
                                     TYPES_URN))
         return s
 
+    def _to_ip_address_lists(self, object):
+        ip_address_lists = []
+        for element in findall(object, 'ipAddressList', TYPES_URN):
+            ip_address_lists.append(self._to_ip_address_list(element))
+
+        return ip_address_lists
+
+    def _to_ip_address_list(self, element):
+        ipAddresses = []
+        for ip in findall(element, 'ipAddress', TYPES_URN):
+            ipAddresses.append(self._to_ip_address(ip))
+
+        child_ip_address_lists = []
+        for child_ip_list in findall(element, 'childIpAddressList',
+                                     TYPES_URN):
+            child_ip_address_lists.append(self
+                                          ._to_child_ip_list(child_ip_list))
+
+        return DimensionDataIpAddressList(
+            id=element.get('id'),
+            name=findtext(element, 'name', TYPES_URN),
+            description=findtext(element, 'description', TYPES_URN),
+            ip_version=findtext(element, 'ipVersion', TYPES_URN),
+            ip_address_collection=ipAddresses,
+            state=findtext(element, 'state', TYPES_URN),
+            create_time=findtext(element, 'createTime', TYPES_URN),
+            child_ip_address_lists=child_ip_address_lists
+        )
+
+    def _to_child_ip_list(self, element):
+        return DimensionDataChildIpAddressList(
+            id=element.get('id'),
+            name=element.get('name')
+        )
+
+    def _to_ip_address(self, element):
+        return DimensionDataIpAddress(
+            begin=element.get('begin'),
+            end=element.get('end'),
+            prefix_size=element.get('prefixSize')
+        )
+
+    def _to_port_lists(self, object):
+        port_lists = []
+        for element in findall(object, 'portList', TYPES_URN):
+            port_lists.append(self._to_port_list(element))
+
+        return port_lists
+
+    def _to_port_list(self, element):
+        ports = []
+        for port in findall(element, 'port', TYPES_URN):
+            ports.append(self._to_port(element=port))
+
+        child_port_list_lists = []
+        for child in findall(element, 'childPortList', TYPES_URN):
+            child_port_list_lists.append(
+                self._to_child_port_list(element=child))
+
+        return DimensionDataPortList(
+            id=element.get('id'),
+            name=findtext(element, 'name', TYPES_URN),
+            description=findtext(element, 'description', TYPES_URN),
+            port_collection=ports,
+            child_port_list_lists=child_port_list_lists,
+            state=findtext(element, 'state', TYPES_URN),
+            create_time=findtext(element, 'createTime', TYPES_URN)
+        )
+
     def _image_needs_auth(self, image):
         if not isinstance(image, NodeImage):
             image = self.ex_get_image_by_id(image)
         if image.extra['isCustomerImage'] and image.extra['OS_type'] == 'UNIX':
             return False
         return True
+
+    @staticmethod
+    def _to_port(element):
+        return DimensionDataPort(
+            begin=element.get('begin'),
+            end=element.get('end')
+        )
+
+    @staticmethod
+    def _to_child_port_list(element):
+        return DimensionDataChildPortList(
+            id=element.get('id'),
+            name=element.get('name')
+        )
 
     @staticmethod
     def _get_node_state(state, started, action):
@@ -2880,6 +3498,28 @@ class DimensionDataNodeDriver(NodeDriver):
     @staticmethod
     def _tag_key_to_tag_key_name(tag_key):
         return dd_object_to_id(tag_key, DimensionDataTagKey, id_value='name')
+
+    @staticmethod
+    def _ip_address_list_to_ip_address_list_id(ip_addr_list):
+        return dd_object_to_id(ip_addr_list, DimensionDataIpAddressList,
+                               id_value='id')
+
+    @staticmethod
+    def _child_ip_address_list_to_child_ip_address_list_id(child_ip_addr_list):
+        return dd_object_to_id(child_ip_addr_list,
+                               DimensionDataChildIpAddressList,
+                               id_value='id')
+
+    @staticmethod
+    def _port_list_to_port_list_id(port_list):
+        return dd_object_to_id(port_list, DimensionDataPortList,
+                               id_value='id')
+
+    @staticmethod
+    def _child_port_list_to_child_port_list_id(child_port_list):
+        return dd_object_to_id(child_port_list,
+                               DimensionDataChildPortList,
+                               id_value='id')
 
     @staticmethod
     def _str2bool(string):

--- a/libcloud/test/compute/fixtures/dimensiondata/ip_address_list_create.xml
+++ b/libcloud/test/compute/fixtures/dimensiondata/ip_address_list_create.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<response
+        requestId="na9_20160321T074626030-0400_7e9fffe7-190b-46f2-9107- 9d52fe57d0ad"
+        xmlns="urn:didata.com:api:cloud:types">
+    <operation>CREATE_IP_ADDRESS_LIST</operation>
+    <responseCode>OK</responseCode>
+    <message>IP Address List 'myAddressList' has been created.</message>
+    <info name="ipAddressListId" value="9e6b496d-5261-4542-91aa-b50c7f569c54"/>
+</response>

--- a/libcloud/test/compute/fixtures/dimensiondata/ip_address_list_delete.xml
+++ b/libcloud/test/compute/fixtures/dimensiondata/ip_address_list_delete.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<response
+        requestId="na9_20160321T074626030-0400_7e9fffe7-190b-46f2-9107- 9d52fe57d0ad"
+        xmlns="urn:didata.com:api:cloud:types">
+    <operation>DELETE_IP_ADDRESS_LIST</operation>
+    <responseCode>OK</responseCode>
+    <message>IP Address List with Id 84e34850-595d-436e-a885-7cd37edb24a4 has
+        been deleted.
+    </message>
+</response>

--- a/libcloud/test/compute/fixtures/dimensiondata/ip_address_list_edit.xml
+++ b/libcloud/test/compute/fixtures/dimensiondata/ip_address_list_edit.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<response
+        requestId="na9_20160321T074626030-0400_7e9fffe7-190b-46f2-9107- 9d52fe57d0ad"
+        xmlns="urn:didata.com:api:cloud:types">
+    <operation>EDIT_IP_ADDRESS_LIST</operation>
+    <responseCode>OK</responseCode>
+    <message>IP Address List 'MyIpAddressList' has been edited
+        successfully.
+    </message>
+</response>

--- a/libcloud/test/compute/fixtures/dimensiondata/ip_address_lists.xml
+++ b/libcloud/test/compute/fixtures/dimensiondata/ip_address_lists.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ipAddressLists xmlns="urn:didata.com:api:cloud:types" pageNumber="1" pageCount="4" totalCount="4" pageSize="250">
+    <ipAddressList id="0291ef78-4059-4bc1-b433-3f6ad698dc41">
+        <name>TestIPList2</name>
+        <description>Test web server IP addresses list</description>
+        <ipVersion>IPV4</ipVersion>
+        <ipAddress begin="190.1.1.0"/>
+        <ipAddress begin="190.1.1.3"/>
+        <ipAddress begin="190.1.1.10" end="190.1.1.20"/>
+        <ipAddress begin="190.1.2.0" prefixSize="24"/>
+        <state>NORMAL</state>
+        <createTime>2016-09-01T01:19:53.000Z</createTime>
+    </ipAddressList>
+    <ipAddressList id="bf09778f-b5ef-43a0-ba41-24ce30085deb">
+        <name>TestIPList_sub_2</name>
+        <description>Test web server IP addresses list</description>
+        <ipVersion>IPV4</ipVersion>
+        <ipAddress begin="190.1.1.0"/>
+        <ipAddress begin="190.1.1.3"/>
+        <ipAddress begin="190.1.1.10" end="190.1.1.20"/>
+        <ipAddress begin="190.1.2.0" prefixSize="24"/>
+        <childIpAddressList id="0291ef78-4059-4bc1-b433-3f6ad698dc41" name="TestIPList2"/>
+        <state>NORMAL</state>
+        <createTime>2016-09-01T01:20:56.000Z</createTime>
+    </ipAddressList>
+    <ipAddressList id="863847dd-046d-492d-9b84-ebea39c262c6">
+        <name>Test_IP_Address_List_2</name>
+        <description>Test Description</description>
+        <ipVersion>IPV4</ipVersion>
+        <ipAddress begin="190.2.2.100"/>
+        <childIpAddressList id="0291ef78-4059-4bc1-b433-3f6ad698dc41" name="TestIPList2"/>
+        <state>NORMAL</state>
+        <createTime>2016-09-05T05:37:56.000Z</createTime>
+    </ipAddressList>
+    <ipAddressList id="5e7c323f-c885-4e4b-9a27-94c44217dbd3">
+        <name>Test_IP_Address_List_3</name>
+        <description>Test Description</description>
+        <ipVersion>IPV4</ipVersion>
+        <ipAddress begin="190.2.2.0" prefixSize="24"/>
+        <ipAddress begin="190.2.2.100"/>
+        <ipAddress begin="190.2.2.106" end="190.2.2.108"/>
+        <childIpAddressList id="0291ef78-4059-4bc1-b433-3f6ad698dc41" name="TestIPList2"/>
+        <state>NORMAL</state>
+        <createTime>2016-09-05T05:57:53.000Z</createTime>
+    </ipAddressList>
+</ipAddressLists>

--- a/libcloud/test/compute/fixtures/dimensiondata/ip_address_lists_FILTERBYNAME.xml
+++ b/libcloud/test/compute/fixtures/dimensiondata/ip_address_lists_FILTERBYNAME.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ipAddressLists xmlns="urn:didata.com:api:cloud:types" pageNumber="1" pageCount="1" totalCount="1" pageSize="250">
+    <ipAddressList id="5e7c323f-c885-4e4b-9a27-94c44217dbd3">
+        <name>Test_IP_Address_List_3</name>
+        <description>Test Description</description>
+        <ipVersion>IPV4</ipVersion>
+        <ipAddress begin="190.2.2.0" prefixSize="24"/>
+        <ipAddress begin="190.2.2.100"/>
+        <ipAddress begin="190.2.2.106" end="190.2.2.108"/>
+        <childIpAddressList id="0291ef78-4059-4bc1-b433-3f6ad698dc41" name="TestIPList2"/>
+        <state>NORMAL</state>
+        <createTime>2016-09-05T05:57:53.000Z</createTime>
+    </ipAddressList>
+</ipAddressLists>

--- a/libcloud/test/compute/fixtures/dimensiondata/port_list_create.xml
+++ b/libcloud/test/compute/fixtures/dimensiondata/port_list_create.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<response
+        requestId="na9_20160321T074626030-0400_7e9fffe7-190b-46f2-9107- 9d52fe57d0ad"
+        xmlns="urn:didata.com:api:cloud:types">
+    <operation>CREATE_PORT_LIST</operation>
+    <responseCode>OK</responseCode>
+    <message>Port List 'MyPortList' has been created.</message>
+    <info name="portListId" value="9e6b496d-5261-4542-91aa-b50c7f569c54"/>
+</response>

--- a/libcloud/test/compute/fixtures/dimensiondata/port_list_delete.xml
+++ b/libcloud/test/compute/fixtures/dimensiondata/port_list_delete.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<response
+        requestId="na9_20160321T074626030-0400_7e9fffe7-190b-46f2-9107- 9d52fe57d0ad"
+        xmlns="urn:didata.com:api:cloud:types">
+    <operation>DELETE_PORT_LIST</operation>
+    <responseCode>OK</responseCode>
+    <message>Port List with Id 84e34850-595d-436e-a885-7cd37edb24a4 has been
+        deleted.
+    </message>
+</response>

--- a/libcloud/test/compute/fixtures/dimensiondata/port_list_edit.xml
+++ b/libcloud/test/compute/fixtures/dimensiondata/port_list_edit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<response
+        requestId="na9_20160321T074626030-0400_7e9fffe7-190b-46f2-9107- 9d52fe57d0ad"
+        xmlns="urn:didata.com:api:cloud:types">
+    <operation>EDIT_PORT_LIST</operation>
+    <responseCode>OK</responseCode>
+    <message>Port List 'MyPortList' has been edited successfully.</message>
+</response>

--- a/libcloud/test/compute/fixtures/dimensiondata/port_list_get.xml
+++ b/libcloud/test/compute/fixtures/dimensiondata/port_list_get.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<portList id="c8c92ea3-2da8-4d51-8153-f39bec794d69"
+          xmlns="urn:didata.com:api:cloud:types">
+    <name>MyPortList</name>
+    <description>Production Servers</description>
+    <port begin="8000" end="9600"/>
+    <port begin="25"/>
+    <port begin="443"/>
+    <childPortList id="c8c92ea3-2da8-4d51-8153-f39bec794d68"
+                   name="tomcatPorts"/>
+    <childPortList id="c8c92ea3-2da8-4d51-8153-f39bec794d67"
+                   name="mySqlPorts"/>
+    <state>NORMAL</state>
+    <createTime>2015-06-21T18:54:42.000Z</createTime>
+</portList>

--- a/libcloud/test/compute/fixtures/dimensiondata/port_list_lists.xml
+++ b/libcloud/test/compute/fixtures/dimensiondata/port_list_lists.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<portLists pageNumber="1" pageCount="1" totalCount="3" pageSize="3"
+           xmlns="urn:didata.com:api:cloud:types">
+    <!--Zero or more repetitions:-->
+    <portList id="c8c92ea3-2da8-4d51-8153-f39bec794d69"
+              xmlns="urn:didata.com:api:cloud:types">
+        <name>MyPortList</name>
+        <description>Production Servers</description>
+        <port begin="8000" end="9600"/>
+        <port begin="25"/>
+        <port begin="443"/>
+        <childPortList id="c8c92ea3-2da8-4d51-8153-f39bec794d68"
+                       name="tomcatPorts"/>
+        <childPortList id="c8c92ea3-2da8-4d51-8153-f39bec794d67"
+                       name="mySqlPorts"/>
+        <state>NORMAL</state>
+        <createTime>2015-06-21T18:54:42.000Z</createTime>
+    </portList>
+     <portList id="d52198b1-4a89-4d09-bc29-7b94fd9129dc">
+        <name>MyPortList2</name>
+        <description>Core functions</description>
+        <port begin="8080"/>
+        <port begin="8899" end="9023"/>
+        <port begin="9500"/>
+        <childPortList id="a9cd4984-6ff5-4f93-89ff-8618ab642bb9" name="MyPortList"/>
+        <state>NORMAL</state>
+        <createTime>2016-09-01T01:36:49.000Z</createTime>
+    </portList>
+    <portList id="b6557c5a-45fa-4138-89bd-8fe68392691b">
+        <name>Test_Port_List_1</name>
+        <description>Test Description</description>
+        <port begin="6000"/>
+        <port begin="6001" end="6010"/>
+        <childPortList id="a9cd4984-6ff5-4f93-89ff-8618ab642bb9" name="MyPortList"/>
+        <state>NORMAL</state>
+        <createTime>2016-09-06T02:32:29.000Z</createTime>
+    </portList>
+</portLists>

--- a/libcloud/test/compute/test_dimensiondata.py
+++ b/libcloud/test/compute/test_dimensiondata.py
@@ -1438,8 +1438,8 @@ class DimensionDataTests(unittest.TestCase, TestCaseMixin):
                                               end='190.2.2.108')
         ip_address_3 = DimensionDataIpAddress(begin='190.2.2.0',
                                               prefix_size='24')
-        ip_address_collection = {ip_address_1, ip_address_2,
-                                 ip_address_3}
+        ip_address_collection = [ip_address_1, ip_address_2,
+                                 ip_address_3]
 
         # Create IP Address List
         success = self.driver.ex_create_ip_address_list(
@@ -1461,8 +1461,8 @@ class DimensionDataTests(unittest.TestCase, TestCaseMixin):
                                               end='190.2.2.108')
         ip_address_3 = DimensionDataIpAddress(begin='190.2.2.0',
                                               prefix_size='24')
-        ip_address_collection = {ip_address_1, ip_address_2,
-                                 ip_address_3}
+        ip_address_collection = [ip_address_1, ip_address_2,
+                                 ip_address_3]
 
         # Create IP Address List
         success = self.driver.ex_create_ip_address_list(
@@ -1475,7 +1475,7 @@ class DimensionDataTests(unittest.TestCase, TestCaseMixin):
 
     def test_ex_edit_ip_address_list(self):
         ip_address_1 = DimensionDataIpAddress(begin='190.2.2.111')
-        ip_address_collection = {ip_address_1}
+        ip_address_collection = [ip_address_1]
 
         child_ip_address_list = DimensionDataChildIpAddressList(
             id='2221ef78-4059-4bc1-b433-3f6ad698dc41',
@@ -1502,7 +1502,7 @@ class DimensionDataTests(unittest.TestCase, TestCaseMixin):
 
     def test_ex_edit_ip_address_list_STR(self):
         ip_address_1 = DimensionDataIpAddress(begin='190.2.2.111')
-        ip_address_collection = {ip_address_1}
+        ip_address_collection = [ip_address_1]
 
         child_ip_address_list = DimensionDataChildIpAddressList(
             id='2221ef78-4059-4bc1-b433-3f6ad698dc41',
@@ -1615,7 +1615,7 @@ class DimensionDataTests(unittest.TestCase, TestCaseMixin):
         port_1 = DimensionDataPort(begin='8080')
         port_2 = DimensionDataIpAddress(begin='8899',
                                               end='9023')
-        port_collection = {port_1, port_2}
+        port_collection = [port_1, port_2]
 
         # Create IP Address List
         success = self.driver.ex_create_portlist(
@@ -1635,13 +1635,13 @@ class DimensionDataTests(unittest.TestCase, TestCaseMixin):
         port_1 = DimensionDataPort(begin='8080')
         port_2 = DimensionDataIpAddress(begin='8899',
                                               end='9023')
-        port_collection = {port_1, port_2}
+        port_collection = [port_1, port_2]
 
         child_port_1 = DimensionDataChildPortList(
             id="333174a2-ae74-4658-9e56-50fc90e086cf", name='test port 1')
         child_port_2 = DimensionDataChildPortList(
             id="311174a2-ae74-4658-9e56-50fc90e04444", name='test port 2')
-        child_ports = {child_port_1, child_port_2}
+        child_ports = [child_port_1, child_port_2]
 
         # Create IP Address List
         success = self.driver.ex_create_portlist(
@@ -1662,13 +1662,13 @@ class DimensionDataTests(unittest.TestCase, TestCaseMixin):
         port_1 = DimensionDataPort(begin='8080')
         port_2 = DimensionDataIpAddress(begin='8899',
                                               end='9023')
-        port_collection = {port_1, port_2}
+        port_collection = [port_1, port_2]
 
         child_port_1 = DimensionDataChildPortList(
             id="333174a2-ae74-4658-9e56-50fc90e086cf", name='test port 1')
         child_port_2 = DimensionDataChildPortList(
             id="311174a2-ae74-4658-9e56-50fc90e04444", name='test port 2')
-        child_ports_ids = {child_port_1.id, child_port_2.id}
+        child_ports_ids = [child_port_1.id, child_port_2.id]
 
         # Create IP Address List
         success = self.driver.ex_create_portlist(
@@ -1689,13 +1689,13 @@ class DimensionDataTests(unittest.TestCase, TestCaseMixin):
         port_1 = DimensionDataPort(begin='8080')
         port_2 = DimensionDataIpAddress(begin='8899',
                                         end='9023')
-        port_collection = {port_1, port_2}
+        port_collection = [port_1, port_2]
 
         child_port_1 = DimensionDataChildPortList(
             id="333174a2-ae74-4658-9e56-50fc90e086cf", name='test port 1')
         child_port_2 = DimensionDataChildPortList(
             id="311174a2-ae74-4658-9e56-50fc90e04444", name='test port 2')
-        child_ports = {child_port_1.id, child_port_2.id}
+        child_ports = [child_port_1.id, child_port_2.id]
 
         # Create IP Address List
         success = self.driver.ex_edit_portlist(
@@ -1713,13 +1713,13 @@ class DimensionDataTests(unittest.TestCase, TestCaseMixin):
         port_1 = DimensionDataPort(begin='8080')
         port_2 = DimensionDataIpAddress(begin='8899',
                                         end='9023')
-        port_collection = {port_1, port_2}
+        port_collection = [port_1, port_2]
 
         child_port_1 = DimensionDataChildPortList(
             id="333174a2-ae74-4658-9e56-50fc90e086cf", name='test port 1')
         child_port_2 = DimensionDataChildPortList(
             id="311174a2-ae74-4658-9e56-50fc90e04444", name='test port 2')
-        child_ports_ids = {child_port_1.id, child_port_2.id}
+        child_ports_ids = [child_port_1.id, child_port_2.id]
 
         # Create IP Address List
         success = self.driver.ex_edit_portlist(

--- a/libcloud/test/compute/test_dimensiondata.py
+++ b/libcloud/test/compute/test_dimensiondata.py
@@ -1541,56 +1541,56 @@ class DimensionDataTests(unittest.TestCase, TestCaseMixin):
             ex_ip_address_list='111ef78-4059-4bc1-b433-3f6ad698d111')
         self.assertTrue(success)
 
-    def test_ex_list_port_lists(self):
+    def test_ex_list_portlist(self):
         net_domain = self.driver.ex_list_network_domains()[0]
-        port_list = self.driver.ex_list_port_list(
+        portlist = self.driver.ex_list_portlist(
             ex_network_domain=net_domain)
-        self.assertTrue(isinstance(port_list, list))
-        self.assertEqual(len(port_list), 3)
-        self.assertTrue(isinstance(port_list[0].name, str))
-        self.assertTrue(isinstance(port_list[0].description, str))
-        self.assertTrue(isinstance(port_list[0].state, str))
-        self.assertTrue(isinstance(port_list[0].port_collection, list))
-        self.assertTrue(isinstance(port_list[0].port_collection[0].begin, str))
-        self.assertTrue(isinstance(port_list[0].port_collection[0].end, str))
-        self.assertTrue(isinstance(port_list[0].child_port_list_lists, list))
-        self.assertTrue(isinstance(port_list[0].child_port_list_lists[0].id,
+        self.assertTrue(isinstance(portlist, list))
+        self.assertEqual(len(portlist), 3)
+        self.assertTrue(isinstance(portlist[0].name, str))
+        self.assertTrue(isinstance(portlist[0].description, str))
+        self.assertTrue(isinstance(portlist[0].state, str))
+        self.assertTrue(isinstance(portlist[0].port_collection, list))
+        self.assertTrue(isinstance(portlist[0].port_collection[0].begin, str))
+        self.assertTrue(isinstance(portlist[0].port_collection[0].end, str))
+        self.assertTrue(isinstance(portlist[0].child_portlist_list, list))
+        self.assertTrue(isinstance(portlist[0].child_portlist_list[0].id,
                                    str))
-        self.assertTrue(isinstance(port_list[0].child_port_list_lists[0].name,
+        self.assertTrue(isinstance(portlist[0].child_portlist_list[0].name,
                                    str))
-        self.assertTrue(isinstance(port_list[0].create_time, str))
+        self.assertTrue(isinstance(portlist[0].create_time, str))
 
     def test_ex_get_port_list(self):
         net_domain = self.driver.ex_list_network_domains()[0]
 
-        port_list = self.driver.ex_list_port_list(
-            ex_network_domain=net_domain)[0]
+        portlist_id = self.driver.ex_list_portlist(
+            ex_network_domain=net_domain)[0].id
 
-        port_list = self.driver.ex_get_port_list(
-            ex_port_list=port_list)
-        self.assertTrue(isinstance(port_list, DimensionDataPortList))
+        portlist = self.driver.ex_get_portlist(
+            ex_portlist_id=portlist_id)
+        self.assertTrue(isinstance(portlist, DimensionDataPortList))
 
-        self.assertTrue(isinstance(port_list.name, str))
-        self.assertTrue(isinstance(port_list.description, str))
-        self.assertTrue(isinstance(port_list.state, str))
-        self.assertTrue(isinstance(port_list.port_collection, list))
-        self.assertTrue(isinstance(port_list.port_collection[0].begin, str))
-        self.assertTrue(isinstance(port_list.port_collection[0].end, str))
-        self.assertTrue(isinstance(port_list.child_port_list_lists, list))
-        self.assertTrue(isinstance(port_list.child_port_list_lists[0].id,
+        self.assertTrue(isinstance(portlist.name, str))
+        self.assertTrue(isinstance(portlist.description, str))
+        self.assertTrue(isinstance(portlist.state, str))
+        self.assertTrue(isinstance(portlist.port_collection, list))
+        self.assertTrue(isinstance(portlist.port_collection[0].begin, str))
+        self.assertTrue(isinstance(portlist.port_collection[0].end, str))
+        self.assertTrue(isinstance(portlist.child_portlist_list, list))
+        self.assertTrue(isinstance(portlist.child_portlist_list[0].id,
                                    str))
-        self.assertTrue(isinstance(port_list.child_port_list_lists[0].name,
+        self.assertTrue(isinstance(portlist.child_portlist_list[0].name,
                                    str))
-        self.assertTrue(isinstance(port_list.create_time, str))
+        self.assertTrue(isinstance(portlist.create_time, str))
 
-    def test_ex_get_port_list_STR(self):
+    def test_ex_get_portlist_STR(self):
         net_domain = self.driver.ex_list_network_domains()[0]
 
-        port_list = self.driver.ex_list_port_list(
+        portlist = self.driver.ex_list_portlist(
             ex_network_domain=net_domain)[0]
 
-        port_list = self.driver.ex_get_port_list(
-            ex_port_list=port_list.id)
+        port_list = self.driver.ex_get_portlist(
+            ex_portlist_id=portlist.id)
         self.assertTrue(isinstance(port_list, DimensionDataPortList))
 
         self.assertTrue(isinstance(port_list.name, str))
@@ -1599,14 +1599,14 @@ class DimensionDataTests(unittest.TestCase, TestCaseMixin):
         self.assertTrue(isinstance(port_list.port_collection, list))
         self.assertTrue(isinstance(port_list.port_collection[0].begin, str))
         self.assertTrue(isinstance(port_list.port_collection[0].end, str))
-        self.assertTrue(isinstance(port_list.child_port_list_lists, list))
-        self.assertTrue(isinstance(port_list.child_port_list_lists[0].id,
+        self.assertTrue(isinstance(port_list.child_portlist_list, list))
+        self.assertTrue(isinstance(port_list.child_portlist_list[0].id,
                                    str))
-        self.assertTrue(isinstance(port_list.child_port_list_lists[0].name,
+        self.assertTrue(isinstance(port_list.child_portlist_list[0].name,
                                    str))
         self.assertTrue(isinstance(port_list.create_time, str))
 
-    def test_ex_create_port_list_NOCHILDPORTLIST(self):
+    def test_ex_create_portlist_NOCHILDPORTLIST(self):
         name = "Test_Port_List"
         description = "Test Description"
 
@@ -1618,7 +1618,7 @@ class DimensionDataTests(unittest.TestCase, TestCaseMixin):
         port_collection = {port_1, port_2}
 
         # Create IP Address List
-        success = self.driver.ex_create_port_list(
+        success = self.driver.ex_create_portlist(
             ex_network_domain=net_domain, name=name,
             description=description,
             port_collection=port_collection
@@ -1626,7 +1626,7 @@ class DimensionDataTests(unittest.TestCase, TestCaseMixin):
 
         self.assertTrue(success)
 
-    def test_ex_create_port_list(self):
+    def test_ex_create_portlist(self):
         name = "Test_Port_List"
         description = "Test Description"
 
@@ -1644,16 +1644,16 @@ class DimensionDataTests(unittest.TestCase, TestCaseMixin):
         child_ports = {child_port_1, child_port_2}
 
         # Create IP Address List
-        success = self.driver.ex_create_port_list(
+        success = self.driver.ex_create_portlist(
             ex_network_domain=net_domain, name=name,
             description=description,
             port_collection=port_collection,
-            child_port_list_lists=child_ports
+            child_portlist_list=child_ports
         )
 
         self.assertTrue(success)
 
-    def test_ex_create_port_list_STR(self):
+    def test_ex_create_portlist_STR(self):
         name = "Test_Port_List"
         description = "Test Description"
 
@@ -1671,18 +1671,18 @@ class DimensionDataTests(unittest.TestCase, TestCaseMixin):
         child_ports_ids = {child_port_1.id, child_port_2.id}
 
         # Create IP Address List
-        success = self.driver.ex_create_port_list(
+        success = self.driver.ex_create_portlist(
             ex_network_domain=net_domain.id, name=name,
             description=description,
             port_collection=port_collection,
-            child_port_list_lists=child_ports_ids
+            child_portlist_list=child_ports_ids
         )
 
         self.assertTrue(success)
 
-    def test_ex_edit_port_list(self):
+    def test_ex_edit_portlist(self):
         net_domain = self.driver.ex_list_network_domains()[0]
-        port_list = self.driver.ex_list_port_list(net_domain)[0]
+        portlist = self.driver.ex_list_portlist(net_domain)[0]
 
         description = "Test Description"
 
@@ -1698,16 +1698,16 @@ class DimensionDataTests(unittest.TestCase, TestCaseMixin):
         child_ports = {child_port_1.id, child_port_2.id}
 
         # Create IP Address List
-        success = self.driver.ex_edit_port_list(
-            ex_port_list=port_list,
+        success = self.driver.ex_edit_portlist(
+            ex_portlist=portlist,
             description=description,
             port_collection=port_collection,
-            child_port_list_lists=child_ports
+            child_portlist_list=child_ports
         )
         self.assertTrue(success)
 
-    def test_ex_edit_port_list_STR(self):
-        port_list_id = "484174a2-ae74-4658-9e56-50fc90e086cf"
+    def test_ex_edit_portlist_STR(self):
+        portlist_id = "484174a2-ae74-4658-9e56-50fc90e086cf"
         description = "Test Description"
 
         port_1 = DimensionDataPort(begin='8080')
@@ -1722,28 +1722,28 @@ class DimensionDataTests(unittest.TestCase, TestCaseMixin):
         child_ports_ids = {child_port_1.id, child_port_2.id}
 
         # Create IP Address List
-        success = self.driver.ex_edit_port_list(
-            ex_port_list=port_list_id,
+        success = self.driver.ex_edit_portlist(
+            ex_portlist=portlist_id,
             description=description,
             port_collection=port_collection,
-            child_port_list_lists=child_ports_ids
+            child_portlist_list=child_ports_ids
         )
         self.assertTrue(success)
 
-    def test_ex_delete_port_list(self):
+    def test_ex_delete_portlist(self):
         net_domain = self.driver.ex_list_network_domains()[0]
-        port_list = self.driver.ex_list_port_list(net_domain)[0]
+        portlist = self.driver.ex_list_portlist(net_domain)[0]
 
-        success = self.driver.ex_delete_port_list(
-            ex_port_list=port_list)
+        success = self.driver.ex_delete_portlist(
+            ex_portlist=portlist)
         self.assertTrue(success)
 
-    def test_ex_delete_port_list_STR(self):
+    def test_ex_delete_portlist_STR(self):
         net_domain = self.driver.ex_list_network_domains()[0]
-        port_list = self.driver.ex_list_port_list(net_domain)[0]
+        portlist = self.driver.ex_list_portlist(net_domain)[0]
 
-        success = self.driver.ex_delete_port_list(
-            ex_port_list=port_list.id)
+        success = self.driver.ex_delete_portlist(
+            ex_portlist=portlist.id)
         self.assertTrue(success)
 
 


### PR DESCRIPTION
## Changes Title (replace this with a logical title for your changes)
### Description

Implemented a new feature to DD libcloud to Edit Firewall Rule. This feature didn't exists before but it is now made available. Firewall rule will also accept portlist and ipaddresslist. Code snippet provided in the comment section of each method.
### Status
- done, ready for review
### Checklist (tick everything that applies)
- [Y] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [Y] Documentation
- [Y] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
