### PR TITLE
LIBCLOUD-858: Fix Listing Libvirt Nodes with Python 3

### DIFF
--- a/libcloud/compute/drivers/libvirt_driver.py
+++ b/libcloud/compute/drivers/libvirt_driver.py
@@ -33,6 +33,7 @@ from libcloud.compute.base import NodeDriver, Node
 from libcloud.compute.base import NodeState
 from libcloud.compute.types import Provider
 from libcloud.utils.networking import is_public_subnet
+from libcloud.utils.py3 import ensure_string
 
 try:
     import libvirt
@@ -428,7 +429,7 @@ class LibvirtNodeDriver(NodeDriver):
         :return: Dictionary which maps mac address to IP address.
         :rtype: ``dict``
         """
-        lines = cmd_output.split('\n')
+        lines = ensure_string(cmd_output).split('\n')
 
         arp_table = defaultdict(list)
         for line in lines:

--- a/libcloud/test/compute/test_libvirt_driver.py
+++ b/libcloud/test/compute/test_libvirt_driver.py
@@ -19,6 +19,7 @@ import mock
 
 from libcloud.compute.drivers.libvirt_driver import LibvirtNodeDriver
 from libcloud.compute.drivers.libvirt_driver import have_libvirt
+from libcloud.utils.py3 import PY3
 
 from libcloud.test import unittest
 
@@ -42,6 +43,11 @@ class LibvirtNodeDriverTestCase(unittest.TestCase):
 1.2.10.33 dev br0 lladdr 52:54:00:04:89:51 REACHABLE
 1.2.10.97 dev br0 lladdr
 1.2.10.40 dev br0 lladdr 52:54:00:77:1c:83 STALE"""
+    if PY3:
+        from libcloud.utils.py3 import b
+        arp_output_str = b(arp_output_str)
+        ip_output_str = b(ip_output_str)
+        bad_output_str = b(bad_output_str)
 
     def _assert_arp_table(self, arp_table):
         self.assertIn('52:54:00:bc:f9:6c', arp_table)


### PR DESCRIPTION
## Fix Listing Libvirt Nodes with Python 3
### Description

Listing nodes with the `Libvirt` provider fails on Python 3 because of a `split` operation on a `bytes` object where the delimiter is not a `bytes` object.

Use the `ensure_string` function from the `py3` module to ensure that the output of a `subprocess.Popen` call is always a string for Python 2 and 3. Also add a test to convert the mock command output results to `bytes` objects if the active Python version is 3.
### Status
- done, ready for review
### Checklist (tick everything that applies)
- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
