### PR TITLE
Added snapshot management to OVH compute 

### DIFF
--- a/libcloud/test/compute/fixtures/ovh/volume_snapshot_get.json
+++ b/libcloud/test/compute/fixtures/ovh/volume_snapshot_get.json
@@ -1,0 +1,22 @@
+[
+  {
+      "volumeId": "foo",
+      "status": "available",
+      "region": "GRA1",
+      "name": "",
+      "description": "",
+      "size": 10,
+      "creationDate": "2016-10-10T17:33:02Z",
+      "id": "foo-snap"
+  },
+  {
+      "volumeId": "bar",
+      "status": "available",
+      "region": "GRA1",
+      "name": "",
+      "description": "",
+      "size": 10,
+      "creationDate": "2016-10-09T17:33:02Z",
+      "id": "bar-snap"
+    }
+]

--- a/libcloud/test/compute/fixtures/ovh/volume_snapshot_get_details.json
+++ b/libcloud/test/compute/fixtures/ovh/volume_snapshot_get_details.json
@@ -1,0 +1,10 @@
+{
+    "volumeId": "foo",
+    "status": "available",
+    "region": "GRA1",
+    "name": "",
+    "description": "",
+    "size": 10,
+    "creationDate": "2016-10-10T17:33:02Z",
+    "id": "foo-snap"
+}

--- a/libcloud/test/compute/test_ovh.py
+++ b/libcloud/test/compute/test_ovh.py
@@ -107,6 +107,25 @@ class OvhMockHttp(BaseOvhMockHttp):
         body = self.fixtures.load('volume_get_detail.json')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
+    def _json_1_0_cloud_project_project_id_volume_snapshot_region_SBG_1_get(self, method, url, body, headers):
+        body = self.fixtures.load('volume_snapshot_get.json')
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+
+    def _json_1_0_cloud_project_project_id_volume_snapshot_get(self, method, url, body, headers):
+        body = self.fixtures.load('volume_snapshot_get.json')
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+
+    def _json_1_0_cloud_project_project_id_volume_snapshot_foo_get(self, method, url, body, headers):
+        body = self.fixtures.load('volume_snapshot_get_details.json')
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+
+    def _json_1_0_cloud_project_project_id_volume_snapshot_foo_snap_delete(self, method, url, body, headers):
+        return (httplib.OK, None, {}, httplib.responses[httplib.OK])
+
+    def _json_1_0_cloud_project_project_id_volume_foo_snapshot__post(self, method, url, body, headers):
+        body = self.fixtures.load('volume_snapshot_get_details.json')
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+
 
 @patch('libcloud.common.ovh.OvhConnection._timedelta', 42)
 class OvhTests(unittest.TestCase):
@@ -200,6 +219,25 @@ class OvhTests(unittest.TestCase):
         volume = self.driver.ex_get_volume('foo')
         response = self.driver.detach_volume(ex_node=node, volume=volume)
         self.assertTrue(response)
+
+    def test_ex_list_snapshots(self):
+        self.driver.ex_list_snapshots()
+
+    def test_ex_get_volume_snapshot(self):
+        self.driver.ex_get_volume_snapshot('foo')
+
+    def test_list_volume_snapshots(self):
+        volume = self.driver.ex_get_volume('foo')
+        self.driver.list_volume_snapshots(volume)
+
+    def test_create_volume_snapshot(self):
+        volume = self.driver.ex_get_volume('foo')
+        self.driver.create_volume_snapshot(volume)
+
+    def test_destroy_volume_snapshot(self):
+        snapshot = self.driver.ex_get_volume_snapshot('foo')
+        result = self.driver.destroy_volume_snapshot(snapshot)
+        self.assertTrue(result)
 
 if __name__ == '__main__':
     sys.exit(unittest.main())


### PR DESCRIPTION
## Added snapshot management to OVH compute
### Description

Added:
- `ex_list_snapshots`
- `ex_get_volume_snapshot`
- `list_volume_snapshots`
- `create_volume_snapshot`
- `destroy_volume_snapshot`

I also improved docstrings, sort argument base on `BaseNodeDriver` and add the prefix `ex_` to custom argument.
### Status

WIP, missing docstring and arguments checking.
### Checklist (tick everything that applies)
- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
