### PR TITLE
Fix bug in Dimension Data driver

### DIFF
--- a/libcloud/compute/drivers/dimensiondata.py
+++ b/libcloud/compute/drivers/dimensiondata.py
@@ -2504,7 +2504,7 @@ class DimensionDataNodeDriver(NodeDriver):
         :rtype: ``list`` of ``list``
         """
         result = self.connection.raw_request_with_orgId_api_1(
-            'report/usageSoftwareUnits?startDate=%s&endDate=%s' % (
+            'report/auditlog?startDate=%s&endDate=%s' % (
                 start_date, end_date))
         return self._format_csv(result.response)
 


### PR DESCRIPTION
The code for ex_audit_log calls the wrong URL. this updates fixes that.
