### PR TITLE
Better Error Message on Fieldnames; Add start_container

### DIFF
--- a/libcloud/container/drivers/rancher.py
+++ b/libcloud/container/drivers/rancher.py
@@ -39,7 +39,12 @@ class RancherResponse(JsonResponse):
 
     def parse_error(self):
         parsed = super(RancherResponse, self).parse_error()
-        return "%s - %s" % (parsed['message'], parsed['detail'])
+        if 'fieldName' in parsed:
+            return "Field %s is %s: %s - %s" % (parsed['fieldName'], parsed['code'],
+                                          parsed['message'], parsed['detail'])
+        else:
+            return "%%s - %s" % (parsed['message'],
+                                    parsed['detail'])
 
     def success(self):
         return self.status in VALID_RESPONSE_CODES

--- a/libcloud/container/drivers/rancher.py
+++ b/libcloud/container/drivers/rancher.py
@@ -45,8 +45,7 @@ class RancherResponse(JsonResponse):
                                                 parsed['message'],
                                                 parsed['detail'])
         else:
-            return "%%s - %s" % (parsed['message'],
-                                 parsed['detail'])
+            return "%s - %s" % (parsed['message'], parsed['detail'])
 
     def success(self):
         return self.status in VALID_RESPONSE_CODES

--- a/libcloud/container/drivers/rancher.py
+++ b/libcloud/container/drivers/rancher.py
@@ -40,11 +40,13 @@ class RancherResponse(JsonResponse):
     def parse_error(self):
         parsed = super(RancherResponse, self).parse_error()
         if 'fieldName' in parsed:
-            return "Field %s is %s: %s - %s" % (parsed['fieldName'], parsed['code'],
-                                          parsed['message'], parsed['detail'])
+            return "Field %s is %s: %s - %s" % (parsed['fieldName'],
+                                                parsed['code'],
+                                                parsed['message'],
+                                                parsed['detail'])
         else:
             return "%%s - %s" % (parsed['message'],
-                                    parsed['detail'])
+                                 parsed['detail'])
 
     def success(self):
         return self.status in VALID_RESPONSE_CODES
@@ -563,6 +565,24 @@ class RancherContainerDriver(ContainerDriver):
                                          (self.baseuri, con_id)).object
 
         return self._to_container(result)
+
+    def start_container(self, container):
+        """
+        Start a container
+
+        :param container: The container to be started
+        :type  container: :class:`libcloud.container.base.Container`
+
+        :return: The container refreshed with current data
+        :rtype: :class:`libcloud.container.base.Container`
+        """
+        result = self.connection.request('%s/containers/%s?action=start' %
+                                         (self.baseuri, container.id),
+                                         method='POST')
+        if result.status in VALID_RESPONSE_CODES:
+            return self.get_container(container.id)
+        else:
+            raise RancherException(result.status, 'failed to start container')
 
     def stop_container(self, container):
         """

--- a/libcloud/test/container/test_rancher.py
+++ b/libcloud/test/container/test_rancher.py
@@ -157,6 +157,10 @@ class RancherContainerDriverTestCase(unittest.TestCase):
         self.assertEqual(container.extra['environment'],
                          {'STORAGE_TYPE': 'file'})
 
+    def test_start_container(self):
+        container = self.driver.get_container("1i31")
+        container.start()
+
     def test_stop_container(self):
         container = self.driver.get_container("1i31")
         container.stop()

--- a/libcloud/test/container/test_rancher.py
+++ b/libcloud/test/container/test_rancher.py
@@ -160,10 +160,14 @@ class RancherContainerDriverTestCase(unittest.TestCase):
     def test_start_container(self):
         container = self.driver.get_container("1i31")
         container.start()
+        self.assertEqual(container.id, "1i31")
+        self.assertEqual(container.name, "newcontainer")
 
     def test_stop_container(self):
         container = self.driver.get_container("1i31")
         container.stop()
+        self.assertEqual(container.id, "1i31")
+        self.assertEqual(container.name, "newcontainer")
 
     def test_ex_search_containers(self):
         containers = self.driver.ex_search_containers({"state": "running"})
@@ -172,6 +176,8 @@ class RancherContainerDriverTestCase(unittest.TestCase):
     def test_destroy_container(self):
         container = self.driver.get_container("1i31")
         container.destroy()
+        self.assertEqual(container.id, "1i31")
+        self.assertEqual(container.name, "newcontainer")
 
 
 class RancherMockHttp(MockHttp):

--- a/libcloud/test/container/test_rancher.py
+++ b/libcloud/test/container/test_rancher.py
@@ -159,15 +159,15 @@ class RancherContainerDriverTestCase(unittest.TestCase):
 
     def test_start_container(self):
         container = self.driver.get_container("1i31")
-        container.start()
-        self.assertEqual(container.id, "1i31")
-        self.assertEqual(container.name, "newcontainer")
+        started = container.start()
+        self.assertEqual(started.id, "1i31")
+        self.assertEqual(started.name, "newcontainer")
 
     def test_stop_container(self):
         container = self.driver.get_container("1i31")
-        container.stop()
-        self.assertEqual(container.id, "1i31")
-        self.assertEqual(container.name, "newcontainer")
+        stopped = container.stop()
+        self.assertEqual(stopped.id, "1i31")
+        self.assertEqual(stopped.name, "newcontainer")
 
     def test_ex_search_containers(self):
         containers = self.driver.ex_search_containers({"state": "running"})
@@ -175,9 +175,9 @@ class RancherContainerDriverTestCase(unittest.TestCase):
 
     def test_destroy_container(self):
         container = self.driver.get_container("1i31")
-        container.destroy()
-        self.assertEqual(container.id, "1i31")
-        self.assertEqual(container.name, "newcontainer")
+        destroyed = container.destroy()
+        self.assertEqual(destroyed.id, "1i31")
+        self.assertEqual(destroyed.name, "newcontainer")
 
 
 class RancherMockHttp(MockHttp):


### PR DESCRIPTION
## Better Error Handling and `start_container`
### Description

This PR extends the Rancher Driver to add `start_container` support. It follows the base class so providing a container object is necessary (and you get one back as expected).

Additionally, I ran into an a scenario where fields which caused errors would return something like:

```
In [12]: driver.ex_deploy_service(name='empty_test', image=image, environment_id="", service_description="testing", environment={"ohnoes":"maybe"})
---------------------------------------------------------------------------
BaseHTTPError                             Traceback (most recent call last)
<ipython-input-12-e9850d5a4dbf> in <module>()
----> 1 driver.ex_deploy_service(name='empty_test', image=image, environment_id="", service_description="testing", environment={"ohnoes":"maybe"})
/home/mloria/arrovenv/libcloud/libcloud/container/drivers/rancher.py in ex_deploy_service(self, name, image, environment_id, start, assign_service_ip_address, service_description, external_i
d, metadata, retain_ip, scale, scale_policy, secondary_launch_configs, selector_container, selector_link, vip, **launch_conf)
    394         data = json.dumps(dict((k, v) for (k, v) in service_payload.items()
    395                                if v is not None))
--> 396         result = self.connection.request('%s/services' % self.baseuri,
    397                                          data=data, method='POST').object
    398
/home/mloria/arrovenv/libcloud/libcloud/common/base.py in request(self, action, params, data, headers, method, raw)
    860
    861         try:
--> 862             response = responseCls(**kwargs)
    863         finally:
    864             # Always reset the context after the request has completed
/home/mloria/arrovenv/libcloud/libcloud/common/base.py in __init__(self, response, connection)
    177             raise exception_from_message(code=self.status,
    178                                          message=self.parse_error(),
--> 179                                          headers=self.headers)
    180
    181         self.object = self.parse_body()

BaseHTTPError: None - None
```

So I edited `parse_error` to check for this and print something a bit nicer:

```
BaseHTTPError: name is NotUnique: None - None
```
### Status
- done, ready for review
### Checklist (tick everything that applies)
- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
