### PR TITLE
Fix grammatical error in compute/index.rst

### DIFF
--- a/docs/compute/index.rst
+++ b/docs/compute/index.rst
@@ -13,7 +13,7 @@ configuration management tool (such as Puppet, Chef, or cfengine) on it.
 Besides managing cloud and virtual servers, compute component also allows you
 to manage cloud block storage (not to be confused with cloud object storage)
 for providers which support it.
-Block storage management is lives under compute API, because it is in most cases
+Block storage management lives under compute API, because it is in most cases
 tightly coupled with compute resources.
 
 Terminology


### PR DESCRIPTION
## Fix grammatical error in compute/index.rst
### Description

Two 3rd person present tense verbs were used together.
Fixed it by removing one of the verbs.
### Status
- done, ready for review

Fix grammatical error
