### PR TITLE
LIBCLOUD-861: Implement Volume Snapshot Operations for Digital Ocean

### DIFF
--- a/libcloud/compute/drivers/digitalocean.py
+++ b/libcloud/compute/drivers/digitalocean.py
@@ -27,7 +27,7 @@ from libcloud.common.types import InvalidCredsError
 from libcloud.compute.types import Provider, NodeState
 from libcloud.compute.base import NodeImage, NodeSize, NodeLocation, KeyPair
 from libcloud.compute.base import Node, NodeDriver
-from libcloud.compute.base import StorageVolume
+from libcloud.compute.base import StorageVolume, VolumeSnapshot
 
 __all__ = [
     'DigitalOceanNodeDriver',
@@ -398,6 +398,49 @@ class DigitalOcean_v2_NodeDriver(DigitalOcean_v2_BaseDriver,
 
         return all([r.status == httplib.ACCEPTED for r in responses])
 
+    def create_volume_snapshot(self, volume, name):
+        """
+        Create a new volume snapshot.
+
+        :param volume: Volume to create a snapshot for
+        :type volume: class:`StorageVolume`
+
+        :return: The newly created volume snapshot.
+        :rtype: :class:`VolumeSnapshot`
+        """
+        attr = {'name': name}
+        res = self.connection.request('/v2/volumes/%s/snapshots' % (
+            volume.id), data=json.dumps(attr), method='POST')
+        data = res.object['snapshot']
+        return self._to_volume_snapshot(data=data)
+
+    def list_volume_snapshots(self, volume):
+        """
+        List snapshots for a volume.
+
+        :param volume: Volume to list snapshots for
+        :type volume: class:`StorageVolume`
+
+        :return: List of volume snapshots.
+        :rtype: ``list`` of :class: `StorageVolume`
+        """
+        data = self._paginated_request('/v2/volumes/%s/snapshots' %
+                                       (volume.id), 'snapshots')
+        return list(map(self._to_volume_snapshot, data))
+
+    def delete_volume_snapshot(self, snapshot):
+        """
+        Delete a volume snapshot
+
+        :param snapshot: volume snapshot to delete
+        :type snapshot: class:`VolumeSnapshot`
+
+        :rtype: ``bool``
+        """
+        res = self.connection.request('v2/snapshots/%s' % (snapshot.id),
+                                      method='DELETE')
+        return res.status == httplib.NO_CONTENT
+
     def _to_node(self, data):
         extra_keys = ['memory', 'vcpus', 'disk', 'region', 'image',
                       'size_slug', 'locked', 'created_at', 'networks',
@@ -467,3 +510,12 @@ class DigitalOcean_v2_NodeDriver(DigitalOcean_v2_BaseDriver,
                        private_key=None,
                        driver=self,
                        extra=extra)
+
+    def _to_volume_snapshot(self, data):
+        extra = {'created_at': data['created_at'],
+                 'resource_id': data['resource_id'],
+                 'regions': data['regions'],
+                 'min_disk_size': data['min_disk_size']}
+        return VolumeSnapshot(id=data['id'], name=data['name'],
+                              size=data['size_gigabytes'],
+                              driver=self, extra=extra)

--- a/libcloud/test/compute/fixtures/digitalocean_v2/create_volume_snapshot.json
+++ b/libcloud/test/compute/fixtures/digitalocean_v2/create_volume_snapshot.json
@@ -1,0 +1,14 @@
+{
+  "snapshot": {
+    "id": "c0def940-9324-11e6-9a56-000f533176b1",
+    "name": "test-snapshot",
+    "regions": [
+      "nyc1"
+    ],
+    "created_at": "2016-10-15T22:14:34Z",
+    "resource_id": "8371d4fe-92b0-11e6-9a56-000f533176b1",
+    "resource_type": "volume",
+    "min_disk_size": 1,
+    "size_gigabytes": 0
+  }
+}

--- a/libcloud/test/compute/fixtures/digitalocean_v2/list_volume_snapshots.json
+++ b/libcloud/test/compute/fixtures/digitalocean_v2/list_volume_snapshots.json
@@ -1,0 +1,44 @@
+{
+  "snapshots": [
+    {
+      "id": "c0def940-9324-11e6-9a56-000f533176b1",
+      "name": "test-snapshot",
+      "regions": [
+        "nyc1"
+      ],
+      "created_at": "2016-10-15T22:14:34Z",
+      "resource_id": "8371d4fe-92b0-11e6-9a56-000f533176b1",
+      "resource_type": "volume",
+      "min_disk_size": 1,
+      "size_gigabytes": 0
+    },
+    {
+      "id": "c2036724-9343-11e6-aef4-000f53315a41",
+      "name": "test-snapshot-2",
+      "regions": [
+        "nyc1"
+      ],
+      "created_at": "2016-10-16T01:56:30Z",
+      "resource_id": "8371d4fe-92b0-11e6-9a56-000f533176b1",
+      "resource_type": "volume",
+      "min_disk_size": 1,
+      "size_gigabytes": 0
+    },
+    {
+      "id": "d347e033-9343-11e6-9a56-000f533176b1",
+      "name": "test-snapshot-3",
+      "regions": [
+        "nyc1"
+      ],
+      "created_at": "2016-10-16T01:56:59Z",
+      "resource_id": "8371d4fe-92b0-11e6-9a56-000f533176b1",
+      "resource_type": "volume",
+      "min_disk_size": 1,
+      "size_gigabytes": 0
+    }
+  ],
+  "links": {},
+  "meta": {
+    "total": 3
+  }
+}


### PR DESCRIPTION
## LIBCLOUD-861: Implement Volume Snapshot Operations for Digital Ocean
### Description

This pull request adds the necessary changes to implement volume snapshot operations, i.e. creating, listing and deleting volume snapshots, for the Digital Ocean driver, along with the corresponding tests and fixtures.

JIRA Ticket: https://issues.apache.org/jira/browse/LIBCLOUD-861
### Status
- done, ready for review
### Checklist (tick everything that applies)
- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
