### PR TITLE
add ex_start_node for the openstack driver

### DIFF
--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -2419,6 +2419,9 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
     def ex_stop_node(self, node):
         return self._post_simple_node_action(node, 'os-stop')
 
+    def ex_start_node(self, node):
+        return self._post_simple_node_action(node, 'os-start')
+
     def ex_suspend_node(self, node):
         return self._post_simple_node_action(node, 'suspend')
 

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -1445,6 +1445,14 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
         ret = self.driver.ex_stop_node(node)
         self.assertTrue(ret is True)
 
+    def test_ex_start_node(self):
+        node = Node(
+            id='12063', name=None, state=None,
+            public_ips=None, private_ips=None, driver=self.driver,
+        )
+        ret = self.driver.ex_start_node(node)
+        self.assertTrue(ret is True)
+
     def test_ex_suspend_node(self):
         node = Node(
             id='12063', name=None, state=None,


### PR DESCRIPTION
### add ex_start_node for the openstack driver
#### Currently only ex_resume_node is implemented, but it does not start stopped instances.

http://developer.openstack.org/api-ref-compute-v2.1.html

```
BaseHTTPError: 409 Conflict Cannot 'resume' instance 39ec1234-1234-1234-ba28-123412349d9c while it is in vm_state stopped
```
