### PR TITLE
add ex_hard_reboot in DigitalOcean_v2 driver

### DIFF
--- a/libcloud/compute/drivers/digitalocean.py
+++ b/libcloud/compute/drivers/digitalocean.py
@@ -256,6 +256,12 @@ class DigitalOcean_v2_NodeDriver(DigitalOcean_v2_BaseDriver,
                                       data=json.dumps(attr), method='POST')
         return res.status == httplib.CREATED
 
+    def ex_hard_reboot(self, node):
+        attr = {'type': 'power_cycle'}
+        res = self.connection.request('/v2/droplets/%s/actions' % (node.id),
+                                      data=json.dumps(attr), method='POST')
+        return res.status == httplib.CREATED
+
     def ex_power_on_node(self, node):
         attr = {'type': 'power_on'}
         res = self.connection.request('/v2/droplets/%s/actions' % (node.id),

--- a/libcloud/test/compute/fixtures/digitalocean/ex_hard_reboot.json
+++ b/libcloud/test/compute/fixtures/digitalocean/ex_hard_reboot.json
@@ -1,0 +1,12 @@
+{
+  "action": {
+    "id": 36077294,
+    "status": "in-progress",
+    "type": "power_cycle",
+    "started_at": "2014-11-04T17:08:03Z",
+    "completed_at": null,
+    "resource_id": 3067651,
+    "resource_type": "droplet",
+    "region": "ams3"
+  }
+}

--- a/libcloud/test/compute/fixtures/digitalocean_v2/ex_hard_reboot.json
+++ b/libcloud/test/compute/fixtures/digitalocean_v2/ex_hard_reboot.json
@@ -1,0 +1,12 @@
+{
+  "action": {
+    "id": 36077294,
+    "status": "in-progress",
+    "type": "power_cycle",
+    "started_at": "2014-11-04T17:08:03Z",
+    "completed_at": null,
+    "resource_id": 3067651,
+    "resource_type": "droplet",
+    "region": "ams3"
+  }
+}

--- a/libcloud/test/compute/test_digitalocean_v2.py
+++ b/libcloud/test/compute/test_digitalocean_v2.py
@@ -148,6 +148,12 @@ class DigitalOcean_v2_Tests(LibcloudTestCase):
         result = self.driver.ex_shutdown_node(node)
         self.assertTrue(result)
 
+    def test_ex_hard_reboot_success(self):
+        node = self.driver.list_nodes()[0]
+        DigitalOceanMockHttp.type = 'POWERCYCLE'
+        result = self.driver.ex_hard_reboot(node)
+        self.assertTrue(result)
+
     def test_destroy_node_success(self):
         node = self.driver.list_nodes()[0]
         DigitalOceanMockHttp.type = 'DESTROY'
@@ -302,6 +308,12 @@ class DigitalOceanMockHttp(MockHttpTestCase):
         # ex_shutdown_node
         body = self.fixtures.load('ex_shutdown_node.json')
         return (httplib.CREATED, body, {}, httplib.responses[httplib.CREATED])
+
+    def _v2_droplets_3164444_actions_POWERCYCLE(self, method, url,
+                                                body, headers):
+        # ex_hard_reboot
+        body = self.fixtures.load('ex_hard_reboot.json')
+        return (httplib.CREATED, body, {}, httplib.responses[httplib.OK])
 
     def _v2_account_keys(self, method, url, body, headers):
         body = self.fixtures.load('list_key_pairs.json')


### PR DESCRIPTION
### add ex_hard_reboot in DigitalOcean_v2 driver
#### Currently only reboot_node is implemented, power_cycle is slightly different

> A reboot action is an attempt to reboot the Droplet in a graceful way, similar to using the reboot command from the console.
> 
> A powercycle action is similar to pushing the reset button on a physical machine, it's similar to booting from scratch.

https://developers.digitalocean.com/documentation/v2/
