### PR TITLE
google: Prevent GCE auth to hide S3 auth

### DIFF
--- a/libcloud/common/google.py
+++ b/libcloud/common/google.py
@@ -583,10 +583,10 @@ class GoogleAuthType(object):
     def guess_type(cls, user_id):
         if cls._is_sa(user_id):
             return cls.SA
-        elif cls._is_gce():
-            return cls.GCE
         elif cls._is_gcs_s3(user_id):
             return cls.GCS_S3
+        elif cls._is_gce():
+            return cls.GCE
         else:
             return cls.IA
 

--- a/libcloud/test/common/test_google.py
+++ b/libcloud/test/common/test_google.py
@@ -223,16 +223,19 @@ class GoogleInstalledAppAuthConnectionTest(GoogleTestCase):
 class GoogleAuthTypeTest(GoogleTestCase):
 
     def test_guess(self):
-        self.assertEqual(GoogleAuthType.guess_type(GCE_PARAMS[0]),
-                         GoogleAuthType.SA)
         self.assertEqual(GoogleAuthType.guess_type(GCE_PARAMS_IA[0]),
                          GoogleAuthType.IA)
         with mock.patch.object(GoogleAuthType, '_is_gce', return_value=True):
+            # Since _is_gce currently depends on the environment, not on
+            # parameters, other auths should override GCE. It does not make
+            # sense for IA auth to happen on GCE, which is why it's left out.
+            self.assertEqual(GoogleAuthType.guess_type(GCE_PARAMS[0]),
+                             GoogleAuthType.SA)
+            self.assertEqual(
+                GoogleAuthType.guess_type(GCS_S3_PARAMS[0]),
+                GoogleAuthType.GCS_S3)
             self.assertEqual(GoogleAuthType.guess_type(GCE_PARAMS_GCE[0]),
                              GoogleAuthType.GCE)
-        self.assertEqual(
-            GoogleAuthType.guess_type(GCS_S3_PARAMS[0]),
-            GoogleAuthType.GCS_S3)
 
 
 class GoogleOAuth2CredentialTest(GoogleTestCase):


### PR DESCRIPTION
## Prevent GCE auth to hide S3 auth
### Description

We currently authenticate to Google Cloud Storage using Amazon S3 compatibility auth. Our code runs in Kubernetes on Google Container Engine. We tried to upgrade libcloud recently but 3849f65 from @crunk1 prevented us to authenticate. (Interestingly, it's also the commit that made us want to upgrade, since we eventually want to use service accounts.)

The issue happened for two reasons:
- `GoogleAuthType._is_gce()` always returns True when the code is run on the Google Container Engine, regardless of the authentication provided (which makes the issue impossible to reproduce in a local Docker environment)
- `GoogleAuthType._is_gcs_s3()` is always checked _after_ `_is_gce()`, so it could not be used on Google Container Engine

This pull request simply changes the order to give S3 higher priority. Note that Installed Applications auth has lower priority still, because it's the default auth when everything else fails. That's OK because I guess it's not possible on GCE. Still, I think the documentation should recommend to always specify the auth type, because explicit is better than implicit and it helps to avoid unclear errors.
### done, ready for review
### Checklist (tick everything that applies)
- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
