### PR TITLE
add ex_change_kernel in DigitalOcean_v2 driver

### DIFF
--- a/libcloud/compute/drivers/digitalocean.py
+++ b/libcloud/compute/drivers/digitalocean.py
@@ -244,6 +244,12 @@ class DigitalOcean_v2_NodeDriver(DigitalOcean_v2_BaseDriver,
         data = self._paginated_request('/v2/images/%s' % (image_id), 'image')
         return self._to_image(data)
 
+    def ex_change_kernel(self, node, kernel_id):
+        attr = {'type': 'change_kernel', 'kernel': kernel_id}
+        res = self.connection.request('/v2/droplets/%s/actions' % (node.id),
+                                      data=json.dumps(attr), method='POST')
+        return res.status == httplib.CREATED
+
     def ex_rename_node(self, node, name):
         attr = {'type': 'rename', 'name': name}
         res = self.connection.request('/v2/droplets/%s/actions' % (node.id),

--- a/libcloud/test/compute/fixtures/digitalocean/ex_change_kernel.json
+++ b/libcloud/test/compute/fixtures/digitalocean/ex_change_kernel.json
@@ -1,0 +1,12 @@
+{
+  "action": {
+    "id": 36077295,
+    "status": "in-progress",
+    "type": "kernel_change",
+    "started_at": "2014-11-04T17:08:03Z",
+    "completed_at": null,
+    "resource_id": 3067650,
+    "resource_type": "droplet",
+    "region": "ams2"
+  }
+}

--- a/libcloud/test/compute/fixtures/digitalocean_v2/ex_change_kernel.json
+++ b/libcloud/test/compute/fixtures/digitalocean_v2/ex_change_kernel.json
@@ -1,0 +1,12 @@
+{
+  "action": {
+    "id": 36077295,
+    "status": "in-progress",
+    "type": "kernel_change",
+    "started_at": "2014-11-04T17:08:03Z",
+    "completed_at": null,
+    "resource_id": 3067650,
+    "resource_type": "droplet",
+    "region": "ams2"
+  }
+}

--- a/libcloud/test/compute/test_digitalocean_v2.py
+++ b/libcloud/test/compute/test_digitalocean_v2.py
@@ -154,6 +154,12 @@ class DigitalOcean_v2_Tests(LibcloudTestCase):
         result = self.driver.destroy_node(node)
         self.assertTrue(result)
 
+    def test_ex_change_kernel_success(self):
+        node = self.driver.list_nodes()[0]
+        DigitalOceanMockHttp.type = 'KERNELCHANGE'
+        result = self.driver.ex_change_kernel(node, 7515)
+        self.assertTrue(result)
+
     def test_ex_rename_node_success(self):
         node = self.driver.list_nodes()[0]
         DigitalOceanMockHttp.type = 'RENAME'
@@ -270,6 +276,11 @@ class DigitalOceanMockHttp(MockHttpTestCase):
         # destroy_node
         return (httplib.NO_CONTENT, body, {},
                 httplib.responses[httplib.NO_CONTENT])
+
+    def _v2_droplets_3164444_actions_KERNELCHANGE(self, method, url, body, headers):
+        # change_kernel
+        body = self.fixtures.load('ex_change_kernel.json')
+        return (httplib.CREATED, body, {}, httplib.responses[httplib.CREATED])
 
     def _v2_droplets_3164444_actions_RENAME(self, method, url, body, headers):
         # rename_node


### PR DESCRIPTION
### add ex_change_kernel in DigitalOcean_v2 driver
#### So the kernel can be managed using the API

> To change the kernel of a Droplet, send a POST request to
> /v2/droplets/$DROPLET_ID/actions. Set the "type" attribute to
> change_kernel and the "kernel" attribute to the new kernel's ID.

https://developers.digitalocean.com/documentation/v2/#change-the-kernel

The `DigitalOcean GrubLoader` can also be set with this allowing for [Internal Kernel Management](https://www.digitalocean.com/community/tutorials/how-to-update-a-digitalocean-server-s-kernel) in a Droplet.
