### PR TITLE
[LIBCLOUD-867] Add st1 and sc1 volume types to valid types

### DIFF
--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -3179,7 +3179,7 @@ class BaseEC2NodeDriver(NodeDriver):
         :return: The newly created volume.
         :rtype: :class:`StorageVolume`
         """
-        valid_volume_types = ['standard', 'io1', 'gp2']
+        valid_volume_types = ['standard', 'io1', 'gp2', 'st1', 'sc1']
 
         params = {
             'Action': 'CreateVolume',


### PR DESCRIPTION
## Add additional supported storage types to create_volume
### Description

EC2 supports additional storage types geared toward throughput and cold storage. We have a need for the cold storage volume type but libcloud currently doesn't support it. It seemed a good idea to just put up a pull request for this instead of asking for the change since it's so small.

We didn't feel there was a need to create a test for this change, nor additional documentation examples. If this is not the case we can add them.
### Status
- done, ready for review
### Checklist (tick everything that applies)
- [*] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
