### PR TITLE
DimensionData - Add support to specify api version and add new api endpoint for QA env

### DIFF
--- a/libcloud/common/dimensiondata.py
+++ b/libcloud/common/dimensiondata.py
@@ -83,6 +83,11 @@ API_ENDPOINTS = {
         'host': 'api-canada.dimensiondata.com',
         'vendor': 'DimensionData'
     },
+    'dd-qa': {
+        'name': 'Test (QA)',
+        'host': 'apiqa1geo1.itaas.dimensiondata.com',
+        'vendor': 'DimensionData'
+    },
     'is-na': {
         'name': 'North America (NA)',
         'host': 'usapi.cloud.is.co.za',
@@ -382,7 +387,8 @@ class DimensionDataConnection(ConnectionUserAndKey):
     allow_insecure = False
 
     def __init__(self, user_id, key, secure=True, host=None, port=None,
-                 url=None, timeout=None, proxy_url=None, **conn_kwargs):
+                 url=None, timeout=None, proxy_url=None,
+                 api_version=None, **conn_kwargs):
         super(DimensionDataConnection, self).__init__(
             user_id=user_id,
             key=key,
@@ -393,6 +399,10 @@ class DimensionDataConnection(ConnectionUserAndKey):
 
         if conn_kwargs['region']:
             self.host = conn_kwargs['region']['host']
+
+        if api_version:
+            if api_version.startswith('2'):
+                self.api_version_2 = api_version
 
     def add_default_headers(self, headers):
         headers['Authorization'] = \

--- a/libcloud/compute/drivers/dimensiondata.py
+++ b/libcloud/compute/drivers/dimensiondata.py
@@ -114,6 +114,9 @@ class DimensionDataNodeDriver(NodeDriver):
         if region is not None:
             self.selected_region = API_ENDPOINTS[region]
 
+        if api_version is not None:
+            self.api_version = api_version
+
         super(DimensionDataNodeDriver, self).__init__(key=key, secret=secret,
                                                       secure=secure, host=host,
                                                       port=port,
@@ -129,6 +132,7 @@ class DimensionDataNodeDriver(NodeDriver):
         kwargs = super(DimensionDataNodeDriver,
                        self)._ex_connection_class_kwargs()
         kwargs['region'] = self.selected_region
+        kwargs['api_version'] = self.api_version
         return kwargs
 
     def _create_node_mcp1(self, name, image, auth, ex_description,


### PR DESCRIPTION
## Changes Title (replace this with a logical title for your changes)

### Description
Enhance DD driver to use api version specified. For example, one could choose to use version 2.3 instead of 2.4. 

-Added QA environment for beta features. 
-Added support for api version. Default will be used if no api_version provided. 
   E.g. driver = cls('username', 'userpassword', region='dd-qa', api_version='2.4')

### Status
- done, ready for review

### Checklist (tick everything that applies)

- [X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)

