### PR TITLE
add new region 'waw' for CloudSigma

### DIFF
--- a/libcloud/common/cloudsigma.py
+++ b/libcloud/common/cloudsigma.py
@@ -70,6 +70,11 @@ API_ENDPOINTS_2_0 = {
         'name': 'Manila, Philippines',
         'country': 'Philippines',
         'host': 'mnl.cloudsigma.com'
+    },
+    'waw': {
+        'name': 'Warsaw, Poland',
+        'country': 'Poland',
+        'host': 'waw.cloudsigma.com'
     }
 }
 


### PR DESCRIPTION
## Add new region 'waw' for CloudSigma

### Description

CloudSIgma supports added new Warsaw region.

https://www.cloudsigma.com/cloudsigma-launches-poland-cloud-atman/

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)

