### PR TITLE
[LIBCLOUD-879] Add support of node without public IP in LB

### DIFF
--- a/libcloud/loadbalancer/drivers/gce.py
+++ b/libcloud/loadbalancer/drivers/gce.py
@@ -338,9 +338,12 @@ class GCELBDriver(Driver):
         # would be found if it was there.
         if hasattr(node, 'name'):
             member_id = node.name
-            member_ip = node.public_ips[0]
         else:
             member_id = node
+
+        if hasattr(node, 'public_ips') and len(node.public_ips) > 0:
+            member_ip = node.public_ips[0]
+        else:
             member_ip = None
 
         extra = {'node': node}

--- a/libcloud/test/compute/fixtures/gce/zones_us-central1-b_instances_libcloud-lb-nopubip-001.json
+++ b/libcloud/test/compute/fixtures/gce/zones_us-central1-b_instances_libcloud-lb-nopubip-001.json
@@ -1,0 +1,49 @@
+{
+  "canIpForward": false,
+  "creationTimestamp": "2013-12-13T10:51:25.165-08:00",
+  "disks": [
+    {
+      "boot": true,
+      "deviceName": "libcloud-lb-demo-www-001",
+      "index": 0,
+      "kind": "compute#attachedDisk",
+      "mode": "READ_WRITE",
+      "source": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-b/disks/libcloud-lb-demo-www-001",
+      "type": "PERSISTENT"
+    }
+  ],
+  "id": "11523404878663997348",
+  "kind": "compute#instance",
+  "machineType": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-b/machineTypes/n1-standard-1",
+  "metadata": {
+    "fingerprint": "09vSzO6KXcw=",
+    "items": [
+      {
+        "key": "startup-script",
+        "value": "apt-get -y update && apt-get -y install apache2 && hostname > /var/www/index.html"
+      }
+    ],
+    "kind": "compute#metadata"
+  },
+  "name": "libcloud-lb-nopubip-001",
+  "networkInterfaces": [
+    {
+      "name": "nic0",
+      "network": "https://www.googleapis.com/compute/v1/projects/project_name/global/networks/default",
+      "networkIP": "10.240.94.66"
+    }
+  ],
+  "scheduling": {
+    "automaticRestart": true,
+    "onHostMaintenance": "MIGRATE"
+  },
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-b/instances/libcloud-lb-nopubip-001",
+  "status": "RUNNING",
+  "tags": {
+    "fingerprint": "XI0he92M8l8=",
+    "items": [
+      "libcloud-lb-demo-www"
+    ]
+  },
+  "zone": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-b"
+}

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -3160,6 +3160,12 @@ class GCEMockHttp(MockHttpTestCase):
                 'zones_us-central1-a_instances_lcnode-001.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
+    def _zones_us_central1_b_instances_libcloud_lb_nopubip_001(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'zones_us-central1-b_instances_libcloud-lb-nopubip-001.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
     def _zones_us_central1_b_instances_libcloud_lb_demo_www_000(
             self, method, url, body, headers):
         body = self.fixtures.load(

--- a/libcloud/test/loadbalancer/test_gce.py
+++ b/libcloud/test/loadbalancer/test_gce.py
@@ -189,6 +189,13 @@ class GCELoadBalancerTest(GoogleTestCase):
         self.assertEqual(member.id, node.name)
         self.assertEqual(member.port, balancer.port)
 
+    def test_node_to_member_no_pub_ip(self):
+        node = self.driver.gce.ex_get_node('libcloud-lb-nopubip-001',
+                                           'us-central1-b')
+        balancer = self.driver.get_balancer('lcforwardingrule')
+        member = self.driver._node_to_member(node, balancer)
+        self.assertIsNone(member.ip)
+
     def test_forwarding_rule_to_loadbalancer(self):
         fwr = self.driver.gce.ex_get_forwarding_rule('lcforwardingrule')
         balancer = self.driver._forwarding_rule_to_loadbalancer(fwr)


### PR DESCRIPTION
## Add support of Node without public IP in GCP load balancer

### Description

Link to jira ticket 879 
https://issues.apache.org/jira/browse/LIBCLOUD-879

I had a condition to only try to grab the publicIP of a node if it had one since publicIP is not mandatory.

### Status

This PR is ready to be review. I run the test (tox) before and after the change and no impact.

### Checklist (tick everything that applies)

- [X] [Code linting] I tried to followed the guidline
- [X] [Documentation] No change require
- [X] [Tests] Added 1 test case to cover the new behavior
- [X] [ICLA] Minor change so I skip it

