### PR TITLE
Allow multiple preemptible instances to be created

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -4446,7 +4446,8 @@ class GCENodeDriver(NodeDriver):
             ex_service_accounts=None, timeout=DEFAULT_TASK_COMPLETION_TIMEOUT,
             description=None, ex_can_ip_forward=None, ex_disks_gce_struct=None,
             ex_nic_gce_struct=None, ex_on_host_maintenance=None,
-            ex_automatic_restart=None, ex_image_family=None):
+            ex_automatic_restart=None, ex_image_family=None,
+            ex_preemptible=None):
         """
         Create multiple nodes and return a list of Node objects.
 
@@ -4579,6 +4580,12 @@ class GCENodeDriver(NodeDriver):
 
         :return:  A list of Node objects for the new nodes.
         :rtype:   ``list`` of :class:`Node`
+
+        :keyword  ex_preemptible: Defines whether the instance is preemptible.
+                                        (If not supplied, the instance will
+                                         not be preemptible)
+        :type     ex_preemptible: ``bool`` or ``None``
+
         """
         if image and ex_disks_gce_struct:
             raise ValueError("Cannot specify both 'image' and "
@@ -4625,7 +4632,8 @@ class GCENodeDriver(NodeDriver):
                       'ex_disks_gce_struct': ex_disks_gce_struct,
                       'ex_nic_gce_struct': ex_nic_gce_struct,
                       'ex_on_host_maintenance': ex_on_host_maintenance,
-                      'ex_automatic_restart': ex_automatic_restart}
+                      'ex_automatic_restart': ex_automatic_restart,
+                      'ex_preemptible': ex_preemptible}
         # List for holding the status information for disk/node creation.
         status_list = []
 
@@ -7636,7 +7644,8 @@ class GCENodeDriver(NodeDriver):
             ex_nic_gce_struct=node_attrs['ex_nic_gce_struct'],
             ex_on_host_maintenance=node_attrs['ex_on_host_maintenance'],
             ex_automatic_restart=node_attrs['ex_automatic_restart'],
-            ex_subnetwork=node_attrs['subnetwork'])
+            ex_subnetwork=node_attrs['subnetwork'],
+            ex_preemptible=node_attrs['ex_preemptible'])
 
         try:
             node_res = self.connection.request(request, method='POST',

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -4537,6 +4537,11 @@ class GCENodeDriver(NodeDriver):
                                   send/receive non-matching src/dst packets.
         :type     ex_can_ip_forward: ``bool`` or ``None``
 
+        :keyword  ex_preemptible: Defines whether the instance is preemptible.
+                                        (If not supplied, the instance will
+                                         not be preemptible)
+        :type     ex_preemptible: ``bool`` or ``None``
+
         :keyword  ex_disks_gce_struct: Support for passing in the GCE-specific
                                        formatted disks[] structure. No attempt
                                        is made to ensure proper formatting of
@@ -4580,11 +4585,6 @@ class GCENodeDriver(NodeDriver):
 
         :return:  A list of Node objects for the new nodes.
         :rtype:   ``list`` of :class:`Node`
-
-        :keyword  ex_preemptible: Defines whether the instance is preemptible.
-                                        (If not supplied, the instance will
-                                         not be preemptible)
-        :type     ex_preemptible: ``bool`` or ``None``
 
         """
         if image and ex_disks_gce_struct:

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -4534,12 +4534,12 @@ class GCENodeDriver(NodeDriver):
         :type     description: ``str`` or ``None``
 
         :keyword  ex_can_ip_forward: Set to ``True`` to allow this node to
-                                  send/receive non-matching src/dst packets.
+                                     send/receive non-matching src/dst packets.
         :type     ex_can_ip_forward: ``bool`` or ``None``
 
         :keyword  ex_preemptible: Defines whether the instance is preemptible.
-                                        (If not supplied, the instance will
-                                         not be preemptible)
+                                  (If not supplied, the instance will
+                                  not be preemptible)
         :type     ex_preemptible: ``bool`` or ``None``
 
         :keyword  ex_disks_gce_struct: Support for passing in the GCE-specific


### PR DESCRIPTION
## Allow multiple preemptible instances to be created with `ex_create_multiple_nodes`

### Description

This change enables multiple nodes to be created as preemptible on Google Cloud through the `ex_create_multiple_nodes` function call. Currently, this parameter is supported in the underlying functions in libcloud called by `ex_create_multiple_nodes` such as `_create_node_req` but the function itself does not expose this parameter at the top level. This patch enables a cluster of preemptible instances to be provisioned in parallel.

### Status

- ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [X] Documentation
- [X] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)

\cc @supertom @erjohnso 

