### PR TITLE
Bug fix for ex_create_multiple_nodes Google Cloud disk auto delete

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -7632,6 +7632,7 @@ class GCENodeDriver(NodeDriver):
             ex_service_accounts=node_attrs['ex_service_accounts'],
             description=node_attrs['description'],
             ex_can_ip_forward=node_attrs['ex_can_ip_forward'],
+            ex_disk_auto_delete=node_attrs['ex_disk_auto_delete'],
             ex_disks_gce_struct=node_attrs['ex_disks_gce_struct'],
             ex_nic_gce_struct=node_attrs['ex_nic_gce_struct'],
             ex_on_host_maintenance=node_attrs['ex_on_host_maintenance'],


### PR DESCRIPTION
## Bug fix for `ex_create_multiple_nodes` Google Cloud disk auto delete parameter

### Description

There seems to be a small bug in `ex_create_multiple_nodes` that will cause the function to create disks that are auto delete regardless of the parameter passed in. This patch should fix this behavior.

### Status

- ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [X] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)