### PR TITLE
Add "MULTI_IP_SUBNET" guestOsFeatures option.

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -1645,7 +1645,8 @@ class GCENodeDriver(NodeDriver):
     }
 
     BACKEND_SERVICE_PROTOCOLS = ['HTTP', 'HTTPS', 'HTTP2', 'TCP', 'SSL']
-    GUEST_OS_FEATURES = ['VIRTIO_SCSI_MULTIQUEUE', 'WINDOWS']
+    GUEST_OS_FEATURES = ['VIRTIO_SCSI_MULTIQUEUE', 'WINDOWS',
+                         'MULTI_IP_SUBNET']
 
     def __init__(self, user_id, key=None, datacenter=None, project=None,
                  auth_type=None, scopes=None, credential_file=None, **kwargs):
@@ -3117,8 +3118,9 @@ class GCENodeDriver(NodeDriver):
 
         :keywork  guest_os_features: Features of the guest operating system,
                                      valid for bootable images only. Possible
-                                     values include \'VIRTIO_SCSI_MULTIQUEUE\'
-                                     and \'WINDOWS\' if specified.
+                                     values include \'VIRTIO_SCSI_MULTIQUEUE\',
+                                     \'WINDOWS\', \'MULTI_IP_SUBNET\' if
+                                     specified.
         :type     guest_os_features: ``list`` of ``str`` or ``None``
 
         :keyword  use_existing: If True and an image with the given name

--- a/libcloud/test/compute/fixtures/gce/projects_coreos-cloud_global_images.json
+++ b/libcloud/test/compute/fixtures/gce/projects_coreos-cloud_global_images.json
@@ -1333,6 +1333,9 @@
     },
     {
       "type": "WINDOWS"
+    },
+    {
+      "type": "MULTI_IP_SUBNET"
     }
    ],
    "sourceType": "RAW",

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -741,9 +741,11 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         description = 'CoreOS beta 522.3.0'
         name = 'coreos'
         family = 'coreos'
-        guest_os_features = ['VIRTIO_SCSI_MULTIQUEUE', 'WINDOWS']
+        guest_os_features = ['VIRTIO_SCSI_MULTIQUEUE', 'WINDOWS',
+                             'MULTI_IP_SUBNET']
         expected_features = [
-            {'type': 'VIRTIO_SCSI_MULTIQUEUE'}, {'type': 'WINDOWS'}
+            {'type': 'VIRTIO_SCSI_MULTIQUEUE'}, {'type': 'WINDOWS'},
+            {'type': 'MULTI_IP_SUBNET'},
         ]
         mock_request = mock.Mock()
         mock_request.side_effect = self.driver.connection.async_request
@@ -771,9 +773,11 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         url = 'gs://storage.core-os.net/coreos/amd64-generic/247.0.0/coreos_production_gce.tar.gz'
         description = 'CoreOS beta 522.3.0'
         family = 'coreos'
-        guest_os_features = ['VIRTIO_SCSI_MULTIQUEUE', 'WINDOWS']
+        guest_os_features = ['VIRTIO_SCSI_MULTIQUEUE', 'WINDOWS',
+                             'MULTI_IP_SUBNET']
         expected_features = [
-            {'type': 'VIRTIO_SCSI_MULTIQUEUE'}, {'type': 'WINDOWS'}
+            {'type': 'VIRTIO_SCSI_MULTIQUEUE'}, {'type': 'WINDOWS'},
+            {'type': 'MULTI_IP_SUBNET'},
         ]
         image = self.driver.ex_copy_image(name, url, description=description,
                                           family=family,


### PR DESCRIPTION
"MULTI_IP_SUBNET" is a valid guestOsFeatures option in the Compute Alpha API.

### Description

Adding a new option to a list of values accepted by the API.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)

