### PR TITLE
Add OpenStackIdentity_2_0_Connection_VOMS class to manage auth with VOMS proxy files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ matrix:
           packages:
             - graphviz
             - gcc
-            - libvirt
+            - libvirt-bin
   # For now allow failures of all the builds which use lxml
   allow_failures:
     - env: ENV=2.6-lxml

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ addons:
   apt:
     packages:
       - graphviz
-      - libvirt
+      - libvirt-bin
 
 matrix:
   fast_finish: true

--- a/libcloud/common/openstack_identity.py
+++ b/libcloud/common/openstack_identity.py
@@ -24,7 +24,8 @@ import datetime
 from libcloud.utils.py3 import httplib
 from libcloud.utils.iso8601 import parse_date
 
-from libcloud.common.base import ConnectionUserAndKey, Response
+from libcloud.common.base import (ConnectionUserAndKey, Response,
+                                  CertificateConnection)
 from libcloud.compute.types import (LibcloudError, InvalidCredsError,
                                     MalformedResponseError)
 
@@ -41,6 +42,7 @@ AUTH_VERSIONS_WITH_EXPIRES = [
     '2.0',
     '2.0_apikey',
     '2.0_password',
+    '2.0_voms',
     '3.0',
     '3.x_password',
     '3.x_oidc_access_token'
@@ -69,6 +71,7 @@ __all__ = [
     'OpenStackIdentity_1_0_Connection',
     'OpenStackIdentity_1_1_Connection',
     'OpenStackIdentity_2_0_Connection',
+    'OpenStackIdentity_2_0_Connection_VOMS',
     'OpenStackIdentity_3_0_Connection',
     'OpenStackIdentity_3_0_Connection_OIDC_access_token',
 
@@ -1536,6 +1539,86 @@ class OpenStackIdentity_3_0_Connection_OIDC_access_token(
                                          driver=self.driver)
 
 
+class OpenStackIdentity_2_0_Connection_VOMS(OpenStackIdentityConnection,
+                                            CertificateConnection):
+    """
+    Connection class for Keystone API v2.0. with VOMS proxy support
+    In this case the key parameter will be the path of the VOMS proxy file.
+    """
+
+    responseCls = OpenStackAuthResponse
+    name = 'OpenStack Identity API v2.0 VOMS support'
+    auth_version = '2.0'
+
+    def __init__(self, auth_url, user_id, key, tenant_name=None,
+                 domain_name='Default',
+                 token_scope=OpenStackIdentityTokenScope.PROJECT,
+                 timeout=None, parent_conn=None):
+        CertificateConnection.__init__(self, cert_file=key,
+                                       url=auth_url,
+                                       timeout=timeout)
+
+        self.parent_conn = parent_conn
+
+        # enable tests to use the same mock connection classes.
+        if parent_conn:
+            self.conn_classes = parent_conn.conn_classes
+            self.driver = parent_conn.driver
+        else:
+            self.driver = None
+
+        self.auth_url = auth_url
+        self.tenant_name = tenant_name
+        self.domain_name = domain_name
+        self.token_scope = token_scope
+        self.timeout = timeout
+
+        self.urls = {}
+        self.auth_token = None
+        self.auth_token_expires = None
+        self.auth_user_info = None
+
+    def authenticate(self, force=False):
+        if not self._is_authentication_needed(force=force):
+            return self
+
+        data = {'auth': {"voms": True}}
+        if self.tenant_name:
+            data['auth']['tenantName'] = self.tenant_name
+        reqbody = json.dumps(data)
+        return self._authenticate_2_0_with_body(reqbody)
+
+    def _authenticate_2_0_with_body(self, reqbody):
+        resp = self.request('/v2.0/tokens', data=reqbody,
+                            headers={'Content-Type': 'application/json'},
+                            method='POST')
+
+        if resp.status == httplib.UNAUTHORIZED:
+            raise InvalidCredsError()
+        elif resp.status not in [httplib.OK,
+                                 httplib.NON_AUTHORITATIVE_INFORMATION]:
+            body = 'code: %s body: %s' % (resp.status, resp.body)
+            raise MalformedResponseError('Malformed response', body=body,
+                                         driver=self.driver)
+        else:
+            body = resp.object
+
+            try:
+                access = body['access']
+                expires = access['token']['expires']
+
+                self.auth_token = access['token']['id']
+                self.auth_token_expires = parse_date(expires)
+                self.urls = access['serviceCatalog']
+                self.auth_user_info = access.get('user', {})
+            except KeyError:
+                e = sys.exc_info()[1]
+                raise MalformedResponseError('Auth JSON response is \
+                                             missing required elements', e)
+
+        return self
+
+
 def get_class_for_auth_version(auth_version):
     """
     Retrieve class for the provided auth version.
@@ -1548,6 +1631,8 @@ def get_class_for_auth_version(auth_version):
         cls = OpenStackIdentity_2_0_Connection
     elif auth_version == '2.0_password':
         cls = OpenStackIdentity_2_0_Connection
+    elif auth_version == '2.0_voms':
+        cls = OpenStackIdentity_2_0_Connection_VOMS
     elif auth_version == '3.x_password':
         cls = OpenStackIdentity_3_0_Connection
     elif auth_version == '3.x_oidc_access_token':

--- a/libcloud/test/common/test_openstack_identity.py
+++ b/libcloud/test/common/test_openstack_identity.py
@@ -33,6 +33,7 @@ from libcloud.common.openstack_identity import OpenStackIdentity_3_0_Connection
 from libcloud.common.openstack_identity import OpenStackIdentity_3_0_Connection_OIDC_access_token
 from libcloud.common.openstack_identity import OpenStackIdentityUser
 from libcloud.compute.drivers.openstack import OpenStack_1_0_NodeDriver
+from libcloud.common.openstack_identity import OpenStackIdentity_2_0_Connection_VOMS
 
 from libcloud.test import unittest
 from libcloud.test import MockHttp
@@ -449,6 +450,27 @@ class OpenStackIdentity_3_0_Connection_OIDC_access_tokenTests(
         auth.authenticate()
 
 
+class OpenStackIdentity_2_0_Connection_VOMSTests(unittest.TestCase):
+    def setUp(self):
+        mock_cls = OpenStackIdentity_2_0_Connection_VOMSMockHttp
+        mock_cls.type = None
+        OpenStackIdentity_2_0_Connection_VOMS.conn_classes = (mock_cls, mock_cls)
+
+        self.auth_instance = OpenStackIdentity_2_0_Connection_VOMS(auth_url='http://none',
+                                                                                user_id=None,
+                                                                                key='/tmp/proxy.pem',
+                                                                                tenant_name='VO')
+        self.auth_instance.auth_token = 'mock'
+
+    def test_authenticate(self):
+        auth = OpenStackIdentity_2_0_Connection_VOMS(auth_url='http://none',
+                                                                  user_id=None,
+                                                                  key='/tmp/proxy.pem',
+                                                                  token_scope='test',
+                                                                  tenant_name="VO")
+        auth.authenticate()
+
+
 class OpenStackServiceCatalogTestCase(unittest.TestCase):
     fixtures = ComputeFileFixtures('openstack')
 
@@ -707,6 +729,25 @@ class OpenStackIdentity_3_0_MockHttp(MockHttp):
             # get user projects
             body = json.dumps({"projects": [{"id": "project_id"}]})
             return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
+        raise NotImplementedError()
+
+
+class OpenStackIdentity_2_0_Connection_VOMSMockHttp(MockHttp):
+    fixtures = ComputeFileFixtures('openstack_identity/v2')
+    json_content_headers = {'content-type': 'application/json; charset=UTF-8'}
+
+    def _v2_0_tokens(self, method, url, body, headers):
+        if method == 'POST':
+            status = httplib.UNAUTHORIZED
+            data = json.loads(body)
+            if 'voms' in data['auth'] and data['auth']['voms'] is True:
+                if 'tenantName' in data['auth'] and data['auth']['tenantName'] == 'VO':
+                    status = httplib.OK
+
+            body = ComputeFileFixtures('openstack').load('_v2_0__auth.json')
+            headers = self.json_content_headers.copy()
+            headers['x-subject-token'] = '00000000000000000000000000000000'
+            return (status, body, headers, httplib.responses[httplib.OK])
         raise NotImplementedError()
 
 if __name__ == '__main__':

--- a/libcloud/test/common/test_openstack_identity.py
+++ b/libcloud/test/common/test_openstack_identity.py
@@ -741,13 +741,19 @@ class OpenStackIdentity_2_0_Connection_VOMSMockHttp(MockHttp):
             status = httplib.UNAUTHORIZED
             data = json.loads(body)
             if 'voms' in data['auth'] and data['auth']['voms'] is True:
-                if 'tenantName' in data['auth'] and data['auth']['tenantName'] == 'VO':
-                    status = httplib.OK
+                status = httplib.OK
 
             body = ComputeFileFixtures('openstack').load('_v2_0__auth.json')
             headers = self.json_content_headers.copy()
             headers['x-subject-token'] = '00000000000000000000000000000000'
             return (status, body, headers, httplib.responses[httplib.OK])
+        raise NotImplementedError()
+
+    def _v2_0_tenants(self, method, url, body, headers):
+        if method == 'GET':
+            # get user projects
+            body = json.dumps({"tenant": [{"name": "tenant_name"}]})
+            return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
         raise NotImplementedError()
 
 if __name__ == '__main__':

--- a/libcloud/test/common/test_openstack_identity.py
+++ b/libcloud/test/common/test_openstack_identity.py
@@ -457,17 +457,17 @@ class OpenStackIdentity_2_0_Connection_VOMSTests(unittest.TestCase):
         OpenStackIdentity_2_0_Connection_VOMS.conn_classes = (mock_cls, mock_cls)
 
         self.auth_instance = OpenStackIdentity_2_0_Connection_VOMS(auth_url='http://none',
-                                                                                user_id=None,
-                                                                                key='/tmp/proxy.pem',
-                                                                                tenant_name='VO')
+                                                                   user_id=None,
+                                                                   key='/tmp/proxy.pem',
+                                                                   tenant_name='VO')
         self.auth_instance.auth_token = 'mock'
 
     def test_authenticate(self):
         auth = OpenStackIdentity_2_0_Connection_VOMS(auth_url='http://none',
-                                                                  user_id=None,
-                                                                  key='/tmp/proxy.pem',
-                                                                  token_scope='test',
-                                                                  tenant_name="VO")
+                                                     user_id=None,
+                                                     key='/tmp/proxy.pem',
+                                                     token_scope='test',
+                                                     tenant_name="VO")
         auth.authenticate()
 
 


### PR DESCRIPTION
## Add OpenStackIdentity_2_0_Connection_VOMS class to manage auth with VOMS proxy files
### Description

The class OpenStackIdentity_2_0_Connection_VOMS has been added to enable OpenStack driver to manage VOMS proxy files to get access to an OpenStack site.

https://keystone-voms.readthedocs.io/en/stable-mitaka/

### Status
- done, ready for review
### Checklist (tick everything that applies)
- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
