### PR TITLE
Fix error in GCE ex_get_disktype

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ addons:
   apt:
     packages:
       - graphviz
-      - libvirt
+      - libvirt-bin
 
 matrix:
   fast_finish: true
@@ -62,7 +62,7 @@ matrix:
           packages:
             - graphviz
             - gcc
-            - libvirt
+            - libvirt-bin
   # For now allow failures of all the builds which use lxml
   allow_failures:
     - env: ENV=2.6-lxml

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -6519,7 +6519,10 @@ class GCENodeDriver(NodeDriver):
         :rtype:   :class:`GCEDiskType`
         """
         zone = self._set_zone(zone)
-        request = '/zones/%s/diskTypes/%s' % (zone.name, name)
+        if zone is None:
+            request = '/aggregated/diskTypes/%s' % name
+        else:
+            request = '/zones/%s/diskTypes/%s' % (zone.name, name)
         response = self.connection.request(request, method='GET').object
         return self._to_disktype(response)
 


### PR DESCRIPTION
## Fix error in GCE ex_get_disktype

### Description

Fix error in GCE ex_get_disktype in case the zone parameter is None.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
