### PR TITLE
Fix error in travis test with libvirt package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ addons:
   apt:
     packages:
       - graphviz
-      - libvirt
+      - libvirt-bin
 
 matrix:
   fast_finish: true
@@ -62,7 +62,7 @@ matrix:
           packages:
             - graphviz
             - gcc
-            - libvirt
+            - libvirt-bin
   # For now allow failures of all the builds which use lxml
   allow_failures:
     - env: ENV=2.6-lxml


### PR DESCRIPTION
## Fix error in travis test with libvirt package

### Description

This pull request fix an error in travis tests that tries to install libvirt package that is not available, and all the tests fails.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
