### PR TITLE
Add Python 3.6 to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
     - 3.3
     - 3.4
     - 3.5
+    - 3.6
     - pypy
     - pypy3
 os:

--- a/libcloud/test/test_utils.py
+++ b/libcloud/test/test_utils.py
@@ -53,7 +53,7 @@ if PY3:
     from io import FileIO as file
 
 
-def show_warning(msg, cat, fname, lno, line=None):
+def show_warning(msg, cat, fname, lno, file=None, line=None):
     WARNINGS_BUFFER.append((msg, cat, fname, lno))
 
 original_func = warnings.showwarning

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{2.5,2.6,2.7,pypy,pypy3,3.2,3.3,3.4,3.5},lint,pylint
+envlist = py{2.5,2.6,2.7,pypy,pypy3,3.2,3.3,3.4,3.5,3.6},lint,pylint
 
 [testenv]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
@@ -24,11 +24,12 @@ basepython =
     py3.3: python3.3
     py3.4: python3.4
     py3.5: python3.5
+    py3.6: python3.6
 whitelist_externals = cp
 
 # Explicitly spell out all environments to test with builtin xml and lxml,
 # as it seems I can't use the following:
-# [testenv:py{2.5,2.6,2.7,pypy,pypy3,3.2,3.3,3.4,3.5}-lxml]
+# [testenv:py{2.5,2.6,2.7,pypy,pypy3,3.2,3.3,3.4,3.5,3.6}-lxml]
 [testenv:py2.5-lxml]
 deps = -r{toxinidir}/requirements-tests.txt
        unittest2
@@ -60,7 +61,9 @@ deps = -r{toxinidir}/requirements-tests.txt
 [testenv:py3.5-lxml]
 deps = -r{toxinidir}/requirements-tests.txt
        lxml
-
+[testenv:py3.6-lxml]
+deps = -r{toxinidir}/requirements-tests.txt
+       lxml
 [testenv:docs]
 deps = sphinx
        pysphere


### PR DESCRIPTION
Add Python 3.6 line to the `.travis.yml` file to check our compatibility with 3.6