### PR TITLE
Ensure that request_path is restored on exception 

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -250,13 +250,19 @@ class GCELicense(UuidMixin, LazyObject):
         # connection thread-safe? Saving, modifying, and restoring
         # driver.connection.request_path is really hacky and thread-unsafe.
         saved_request_path = self.driver.connection.request_path
-        new_request_path = saved_request_path.replace(self.driver.project,
-                                                      self.project)
-        self.driver.connection.request_path = new_request_path
+        try:
+            new_request_path = saved_request_path.replace(self.driver.project,
+                                                          self.project)
+            self.driver.connection.request_path = new_request_path
 
-        request = '/global/licenses/%s' % self.name
-        response = self.driver.connection.request(request, method='GET').object
-        self.driver.connection.request_path = saved_request_path
+            request = '/global/licenses/%s' % self.name
+            response = self.driver.connection.request(request,
+                                                      method='GET').object
+        except:
+            raise
+        finally:
+            # Restore the connection request_path
+            self.driver.connection.request_path = saved_request_path
 
         self.extra = {
             'selfLink': response.get('selfLink'),


### PR DESCRIPTION
## Ensure that request_path is restored on exception 

### Description

When requesting a GCE license, restore the request_path in a finally block.  Uses same pattern as used in other parts of the driver.

### Status

Ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
