### PR TITLE
Add support for selecting alternate cloud_environments

### DIFF
--- a/docs/compute/drivers/azure_arm.rst
+++ b/docs/compute/drivers/azure_arm.rst
@@ -49,8 +49,8 @@ You can select an alternate cloud environment using the "cloud_environment"
 parameter to AzureNodeDriver constructor.  Available alternate cloud
 environments are 'AzureChinaCloud', 'AzureUSGovernment' and 'AzureGermanCloud'.
 You can also supply explicit endpoints by providing a dict with the keys
-'resourceManagerEndpointUrl', 'activeDirectoryEndpointUrl' and
-'activeDirectoryResourceId'.
+'resourceManagerEndpointUrl', 'activeDirectoryEndpointUrl',
+'activeDirectoryResourceId' and 'storageEndpointSuffix'.
 
 API Docs
 --------

--- a/docs/compute/drivers/azure_arm.rst
+++ b/docs/compute/drivers/azure_arm.rst
@@ -42,6 +42,16 @@ password ("secret"), you can create an AzureNodeDriver:
 .. literalinclude:: /examples/compute/azure_arm/instantiate.py
    :language: python
 
+Alternate Cloud Environments
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can select an alternate cloud environment using the "cloud_environment"
+parameter to AzureNodeDriver constructor.  Available alternate cloud
+environments are 'AzureChinaCloud', 'AzureUSGovernment' and 'AzureGermanCloud'.
+You can also supply explicit endpoints by providing a dict with the keys
+'resourceManagerEndpointUrl', 'activeDirectoryEndpointUrl' and
+'activeDirectoryResourceId'.
+
 API Docs
 --------
 

--- a/libcloud/common/azure_arm.py
+++ b/libcloud/common/azure_arm.py
@@ -147,9 +147,17 @@ class AzureResourceManagementConnection(ConnectionUserAndKey):
         super(AzureResourceManagementConnection, self) \
             .__init__(key, secret, **kwargs)
         cloud_environment = kwargs.get("cloud_environment", "default")
-        self.host = urlparse(publicEnvironments[cloud_environment]['resourceManagerEndpointUrl']).hostname
-        self.login_host = urlparse(publicEnvironments[cloud_environment]['activeDirectoryEndpointUrl']).hostname
-        self.login_resource = publicEnvironments[cloud_environment]['activeDirectoryResourceId']
+        if isinstance(cloud_environment, basestring):
+            cloud_environment = publicEnvironments[cloud_environment]
+        if not isinstance(cloud_environment, dict):
+            raise Exception("cloud_environment must be one of '%s' or a dict "
+                            "containing keys 'resourceManagerEndpointUrl', "
+                            "'activeDirectoryEndpointUrl', "
+                            "'activeDirectoryResourceId'" % (
+                                "', '".join(publicEnvironments.keys())))
+        self.host = urlparse(cloud_environment['resourceManagerEndpointUrl']).hostname
+        self.login_host = urlparse(cloud_environment['activeDirectoryEndpointUrl']).hostname
+        self.login_resource = cloud_environment['activeDirectoryResourceId']
         self.tenant_id = tenant_id
         self.subscription_id = subscription_id
 

--- a/libcloud/common/azure_arm.py
+++ b/libcloud/common/azure_arm.py
@@ -153,11 +153,13 @@ class AzureResourceManagementConnection(ConnectionUserAndKey):
             raise Exception("cloud_environment must be one of '%s' or a dict "
                             "containing keys 'resourceManagerEndpointUrl', "
                             "'activeDirectoryEndpointUrl', "
-                            "'activeDirectoryResourceId'" % (
+                            "'activeDirectoryResourceId', "
+                            "'storageEndpointSuffix'" % (
                                 "', '".join(publicEnvironments.keys())))
         self.host = urlparse(cloud_environment['resourceManagerEndpointUrl']).hostname
         self.login_host = urlparse(cloud_environment['activeDirectoryEndpointUrl']).hostname
         self.login_resource = cloud_environment['activeDirectoryResourceId']
+        self.storage_suffix = cloud_environment['storageEndpointSuffix']
         self.tenant_id = tenant_id
         self.subscription_id = subscription_id
 

--- a/libcloud/common/azure_arm.py
+++ b/libcloud/common/azure_arm.py
@@ -143,10 +143,11 @@ class AzureResourceManagementConnection(ConnectionUserAndKey):
     rawResponseCls = RawResponse
 
     def __init__(self, key, secret, secure=True, tenant_id=None,
-                 subscription_id=None, **kwargs):
+                 subscription_id=None, cloud_environment=None, **kwargs):
         super(AzureResourceManagementConnection, self) \
             .__init__(key, secret, **kwargs)
-        cloud_environment = kwargs.get("cloud_environment", "default")
+        if not cloud_environment:
+            cloud_environment = "default"
         if isinstance(cloud_environment, basestring):
             cloud_environment = publicEnvironments[cloud_environment]
         if not isinstance(cloud_environment, dict):

--- a/libcloud/common/azure_arm.py
+++ b/libcloud/common/azure_arm.py
@@ -57,7 +57,7 @@ class AzureAuthJsonResponse(JsonResponse):
             return str(b)
 
 # Based on https://github.com/Azure/azure-xplat-cli/blob/master/lib/util/profile/environment.js
-publicEnvironments = [
+publicEnvironments = {v['name']: v for v in [
   {
     'name': 'default',
     'portalUrl': 'http://go.microsoft.com/fwlink/?LinkId=254433',
@@ -129,7 +129,7 @@ publicEnvironments = [
     'keyVaultDnsSuffix': '.vault.microsoftazure.de',
     'azureDataLakeStoreFileSystemEndpointSuffix': 'N/A',
     'azureDataLakeAnalyticsCatalogAndJobEndpointSuffix': 'N/A'
-  }]
+  }]}
 
 class AzureResourceManagementConnection(ConnectionUserAndKey):
     """

--- a/libcloud/common/azure_arm.py
+++ b/libcloud/common/azure_arm.py
@@ -19,7 +19,7 @@ except ImportError:
     import json
 
 import time
-from urlparse import urlparse
+from libcloud.utils.py3 import urlparse
 
 from libcloud.common.base import (ConnectionUserAndKey,
                                   JsonResponse,
@@ -56,80 +56,95 @@ class AzureAuthJsonResponse(JsonResponse):
         else:
             return str(b)
 
-# Based on https://github.com/Azure/azure-xplat-cli/blob/master/lib/util/profile/environment.js
-publicEnvironments = {v['name']: v for v in [
-  {
-    'name': 'default',
-    'portalUrl': 'http://go.microsoft.com/fwlink/?LinkId=254433',
-    'publishingProfileUrl': 'http://go.microsoft.com/fwlink/?LinkId=254432',
-    'managementEndpointUrl': 'https://management.core.windows.net',
-    'resourceManagerEndpointUrl': 'https://management.azure.com/',
-    'sqlManagementEndpointUrl': 'https://management.core.windows.net:8443/',
-    'sqlServerHostnameSuffix': '.database.windows.net',
-    'galleryEndpointUrl': 'https://gallery.azure.com/',
-    'activeDirectoryEndpointUrl': 'https://login.microsoftonline.com',
-    'activeDirectoryResourceId': 'https://management.core.windows.net/',
-    'activeDirectoryGraphResourceId': 'https://graph.windows.net/',
-    'activeDirectoryGraphApiVersion': '2013-04-05',
-    'storageEndpointSuffix': '.core.windows.net',
-    'keyVaultDnsSuffix': '.vault.azure.net',
-    'azureDataLakeStoreFileSystemEndpointSuffix': 'azuredatalakestore.net',
-    'azureDataLakeAnalyticsCatalogAndJobEndpointSuffix': 'azuredatalakeanalytics.net'
-  },
-  {
-    'name': 'AzureChinaCloud',
-    'portalUrl': 'http://go.microsoft.com/fwlink/?LinkId=301902',
-    'publishingProfileUrl': 'http://go.microsoft.com/fwlink/?LinkID=301774',
-    'managementEndpointUrl': 'https://management.core.chinacloudapi.cn',
-    'resourceManagerEndpointUrl': 'https://management.chinacloudapi.cn',
-    'sqlManagementEndpointUrl': 'https://management.core.chinacloudapi.cn:8443/',
-    'sqlServerHostnameSuffix': '.database.chinacloudapi.cn',
-    'galleryEndpointUrl': 'https://gallery.chinacloudapi.cn/',
-    'activeDirectoryEndpointUrl': 'https://login.chinacloudapi.cn',
-    'activeDirectoryResourceId': 'https://management.core.chinacloudapi.cn/',
-    'activeDirectoryGraphResourceId': 'https://graph.chinacloudapi.cn/',
-    'activeDirectoryGraphApiVersion': '2013-04-05',
-    'storageEndpointSuffix': '.core.chinacloudapi.cn',
-    'keyVaultDnsSuffix': '.vault.azure.cn',
-    'azureDataLakeStoreFileSystemEndpointSuffix': 'N/A',
-    'azureDataLakeAnalyticsCatalogAndJobEndpointSuffix': 'N/A'
-  },
-  {
-    'name': 'AzureUSGovernment',
-    'portalUrl': 'https://manage.windowsazure.us',
-    'publishingProfileUrl': 'https://manage.windowsazure.us/publishsettings/index',
-    'managementEndpointUrl': 'https://management.core.usgovcloudapi.net',
-    'resourceManagerEndpointUrl': 'https://management.usgovcloudapi.net',
-    'sqlManagementEndpointUrl': 'https://management.core.usgovcloudapi.net:8443/',
-    'sqlServerHostnameSuffix': '.database.usgovcloudapi.net',
-    'galleryEndpointUrl': 'https://gallery.usgovcloudapi.net/',
-    'activeDirectoryEndpointUrl': 'https://login-us.microsoftonline.com',
-    'activeDirectoryResourceId': 'https://management.core.usgovcloudapi.net/',
-    'activeDirectoryGraphResourceId': 'https://graph.windows.net/',
-    'activeDirectoryGraphApiVersion': '2013-04-05',
-    'storageEndpointSuffix': '.core.usgovcloudapi.net',
-    'keyVaultDnsSuffix': '.vault.usgovcloudapi.net',
-    'azureDataLakeStoreFileSystemEndpointSuffix': 'N/A',
-    'azureDataLakeAnalyticsCatalogAndJobEndpointSuffix': 'N/A'
-  },
-  {
-    'name': 'AzureGermanCloud',
-    'portalUrl': 'http://portal.microsoftazure.de/',
-    'publishingProfileUrl': 'https://manage.microsoftazure.de/publishsettings/index',
-    'managementEndpointUrl': 'https://management.core.cloudapi.de',
-    'resourceManagerEndpointUrl': 'https://management.microsoftazure.de',
-    'sqlManagementEndpointUrl': 'https://management.core.cloudapi.de:8443/',
-    'sqlServerHostnameSuffix': '.database.cloudapi.de',
-    'galleryEndpointUrl': 'https://gallery.cloudapi.de/',
-    'activeDirectoryEndpointUrl': 'https://login.microsoftonline.de',
-    'activeDirectoryResourceId': 'https://management.core.cloudapi.de/',
-    'activeDirectoryGraphResourceId': 'https://graph.cloudapi.de/',
-    'activeDirectoryGraphApiVersion': '2013-04-05',
-    'storageEndpointSuffix': '.core.cloudapi.de',
-    'keyVaultDnsSuffix': '.vault.microsoftazure.de',
-    'azureDataLakeStoreFileSystemEndpointSuffix': 'N/A',
-    'azureDataLakeAnalyticsCatalogAndJobEndpointSuffix': 'N/A'
-  }]}
+# Based on
+# https://github.com/Azure/azure-xplat-cli/blob/master/lib/util/profile/environment.js
+publicEnvironments = {
+    "default": {
+        'name': 'default',
+        'portalUrl': 'http://go.microsoft.com/fwlink/?LinkId=254433',
+        'publishingProfileUrl':
+            'http://go.microsoft.com/fwlink/?LinkId=254432',
+        'managementEndpointUrl': 'https://management.core.windows.net',
+        'resourceManagerEndpointUrl':
+            'https://management.azure.com/',
+        'sqlManagementEndpointUrl':
+            'https://management.core.windows.net:8443/',
+        'sqlServerHostnameSuffix': '.database.windows.net',
+        'galleryEndpointUrl': 'https://gallery.azure.com/',
+        'activeDirectoryEndpointUrl': 'https://login.microsoftonline.com',
+        'activeDirectoryResourceId': 'https://management.core.windows.net/',
+        'activeDirectoryGraphResourceId': 'https://graph.windows.net/',
+        'activeDirectoryGraphApiVersion': '2013-04-05',
+        'storageEndpointSuffix': '.core.windows.net',
+        'keyVaultDnsSuffix': '.vault.azure.net',
+        'azureDataLakeStoreFileSystemEndpointSuffix': 'azuredatalakestore.net',
+        'azureDataLakeAnalyticsCatalogAndJobEndpointSuffix':
+            'azuredatalakeanalytics.net'
+    },
+    "AzureChinaCloud": {
+        'name': 'AzureChinaCloud',
+        'portalUrl': 'http://go.microsoft.com/fwlink/?LinkId=301902',
+        'publishingProfileUrl':
+            'http://go.microsoft.com/fwlink/?LinkID=301774',
+        'managementEndpointUrl': 'https://management.core.chinacloudapi.cn',
+        'resourceManagerEndpointUrl': 'https://management.chinacloudapi.cn',
+        'sqlManagementEndpointUrl':
+            'https://management.core.chinacloudapi.cn:8443/',
+        'sqlServerHostnameSuffix': '.database.chinacloudapi.cn',
+        'galleryEndpointUrl': 'https://gallery.chinacloudapi.cn/',
+        'activeDirectoryEndpointUrl': 'https://login.chinacloudapi.cn',
+        'activeDirectoryResourceId':
+            'https://management.core.chinacloudapi.cn/',
+        'activeDirectoryGraphResourceId': 'https://graph.chinacloudapi.cn/',
+        'activeDirectoryGraphApiVersion': '2013-04-05',
+        'storageEndpointSuffix': '.core.chinacloudapi.cn',
+        'keyVaultDnsSuffix': '.vault.azure.cn',
+        'azureDataLakeStoreFileSystemEndpointSuffix': 'N/A',
+        'azureDataLakeAnalyticsCatalogAndJobEndpointSuffix': 'N/A'
+    },
+    "AzureUSGovernment": {
+        'name': 'AzureUSGovernment',
+        'portalUrl': 'https://manage.windowsazure.us',
+        'publishingProfileUrl':
+            'https://manage.windowsazure.us/publishsettings/index',
+        'managementEndpointUrl': 'https://management.core.usgovcloudapi.net',
+        'resourceManagerEndpointUrl': 'https://management.usgovcloudapi.net',
+        'sqlManagementEndpointUrl':
+            'https://management.core.usgovcloudapi.net:8443/',
+        'sqlServerHostnameSuffix': '.database.usgovcloudapi.net',
+        'galleryEndpointUrl': 'https://gallery.usgovcloudapi.net/',
+        'activeDirectoryEndpointUrl': 'https://login-us.microsoftonline.com',
+        'activeDirectoryResourceId':
+            'https://management.core.usgovcloudapi.net/',
+        'activeDirectoryGraphResourceId': 'https://graph.windows.net/',
+        'activeDirectoryGraphApiVersion': '2013-04-05',
+        'storageEndpointSuffix': '.core.usgovcloudapi.net',
+        'keyVaultDnsSuffix': '.vault.usgovcloudapi.net',
+        'azureDataLakeStoreFileSystemEndpointSuffix': 'N/A',
+        'azureDataLakeAnalyticsCatalogAndJobEndpointSuffix': 'N/A'
+    },
+    "AzureGermanCloud": {
+        'name': 'AzureGermanCloud',
+        'portalUrl': 'http://portal.microsoftazure.de/',
+        'publishingProfileUrl':
+        'https://manage.microsoftazure.de/publishsettings/index',
+        'managementEndpointUrl': 'https://management.core.cloudapi.de',
+        'resourceManagerEndpointUrl': 'https://management.microsoftazure.de',
+        'sqlManagementEndpointUrl':
+            'https://management.core.cloudapi.de:8443/',
+        'sqlServerHostnameSuffix': '.database.cloudapi.de',
+        'galleryEndpointUrl': 'https://gallery.cloudapi.de/',
+        'activeDirectoryEndpointUrl': 'https://login.microsoftonline.de',
+        'activeDirectoryResourceId': 'https://management.core.cloudapi.de/',
+        'activeDirectoryGraphResourceId': 'https://graph.cloudapi.de/',
+        'activeDirectoryGraphApiVersion': '2013-04-05',
+        'storageEndpointSuffix': '.core.cloudapi.de',
+        'keyVaultDnsSuffix': '.vault.microsoftazure.de',
+        'azureDataLakeStoreFileSystemEndpointSuffix': 'N/A',
+        'azureDataLakeAnalyticsCatalogAndJobEndpointSuffix': 'N/A'
+    }
+}
+
 
 class AzureResourceManagementConnection(ConnectionUserAndKey):
     """
@@ -157,8 +172,10 @@ class AzureResourceManagementConnection(ConnectionUserAndKey):
                             "'activeDirectoryResourceId', "
                             "'storageEndpointSuffix'" % (
                                 "', '".join(publicEnvironments.keys())))
-        self.host = urlparse(cloud_environment['resourceManagerEndpointUrl']).hostname
-        self.login_host = urlparse(cloud_environment['activeDirectoryEndpointUrl']).hostname
+        self.host = urlparse.urlparse(
+            cloud_environment['resourceManagerEndpointUrl']).hostname
+        self.login_host = urlparse.urlparse(
+            cloud_environment['activeDirectoryEndpointUrl']).hostname
         self.login_resource = cloud_environment['activeDirectoryResourceId']
         self.storage_suffix = cloud_environment['storageEndpointSuffix']
         self.tenant_id = tenant_id

--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -1340,7 +1340,7 @@ class AzureNodeDriver(NodeDriver):
                                                     storageAccount)
             blobdriver = AzureBlobsStorageDriver(storageAccount,
                                                  keys["key1"],
-                                                 host="blob%s" % (self.connection.storage_suffix))
+                                                 host="%s.blob%s" % (storageAccount, self.connection.storage_suffix))
             blobdriver.delete_object(blobdriver.get_object(blobContainer,
                                                            blob))
             return True

--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -61,9 +61,10 @@ class AzureVhdImage(NodeImage):
     """Represents a VHD node image that an Azure VM can boot from."""
 
     def __init__(self, storage_account, blob_container, name, driver):
-        urn = "https://%s.blob.core.windows.net/%s/%s" % (storage_account,
-                                                          blob_container,
-                                                          name)
+        urn = "https://%s.blob%s/%s/%s" % (storage_account,
+                                           driver.connection.storage_suffix,
+                                           blob_container,
+                                           name)
         super(AzureVhdImage, self).__init__(urn, name, driver)
 
     def __repr__(self):
@@ -511,9 +512,10 @@ class AzureNodeDriver(NodeDriver):
         n = 0
         while True:
             try:
-                instance_vhd = "https://%s.blob.core.windows.net" \
+                instance_vhd = "https://%s.blob%s" \
                                "/%s/%s-os_%i.vhd" \
                                % (ex_storage_account,
+                                  self.connection.storage_suffix,
                                   ex_blob_container,
                                   name,
                                   n)
@@ -1337,7 +1339,8 @@ class AzureNodeDriver(NodeDriver):
             keys = self.ex_get_storage_account_keys(resource_group,
                                                     storageAccount)
             blobdriver = AzureBlobsStorageDriver(storageAccount,
-                                                 keys["key1"])
+                                                 keys["key1"],
+                                                 host="blob%s" % (self.connection.storage_suffix))
             blobdriver.delete_object(blobdriver.get_object(blobContainer,
                                                            blob))
             return True

--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -1339,9 +1339,11 @@ class AzureNodeDriver(NodeDriver):
             (storageAccount, blobContainer, blob) = _split_blob_uri(uri)
             keys = self.ex_get_storage_account_keys(resource_group,
                                                     storageAccount)
-            blobdriver = AzureBlobsStorageDriver(storageAccount,
-                                                 keys["key1"],
-                                                 host="%s.blob%s" % (storageAccount, self.connection.storage_suffix))
+            blobdriver = AzureBlobsStorageDriver(
+                storageAccount,
+                keys["key1"],
+                host="%s.blob%s" % (storageAccount,
+                                    self.connection.storage_suffix))
             blobdriver.delete_object(blobdriver.get_object(blobContainer,
                                                            blob))
             return True

--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -191,6 +191,7 @@ class AzureNodeDriver(NodeDriver):
                  api_version=None, region=None, **kwargs):
         self.tenant_id = tenant_id
         self.subscription_id = subscription_id
+        self.cloud_environment = kwargs.get("cloud_environment")
         super(AzureNodeDriver, self).__init__(key=key, secret=secret,
                                               secure=secure,
                                               host=host, port=port,
@@ -1351,6 +1352,7 @@ class AzureNodeDriver(NodeDriver):
         kwargs = super(AzureNodeDriver, self)._ex_connection_class_kwargs()
         kwargs['tenant_id'] = self.tenant_id
         kwargs['subscription_id'] = self.subscription_id
+        kwargs["cloud_environment"] = self.cloud_environment
         return kwargs
 
     def _to_node(self, data, fetch_nic=True):


### PR DESCRIPTION
## Add support for selecting alternate cloud_environments

### Description

Add support for selecting alternate cloud_environments via "cloud_environments" keyword option when creating compute driver object. Supports default, AzureChinaCloud, AzureUSGovernment, and AzureGermanCloud.  Affects endpoints used by azure_arm compute driver.

### Status

- In testing

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
