### PR TITLE
fix issue where port is not propagated down to connection URL

### DIFF
--- a/libcloud/httplib_ssl.py
+++ b/libcloud/httplib_ssl.py
@@ -163,9 +163,10 @@ class LibcloudConnection(LibcloudBaseConnection):
     response = None
 
     def __init__(self, host, port, **kwargs):
-        self.host = '{0}://{1}'.format(
+        self.host = '{0}://{1}{2}'.format(
             'https' if port == 443 else 'http',
-            host
+            host,
+            ":{0}".format(port) if port not in (80, 443) else ""
         )
         # Support for HTTP proxy
         proxy_url_env = os.environ.get(HTTP_PROXY_ENV_VARIABLE_NAME, None)

--- a/libcloud/test/test_connection.py
+++ b/libcloud/test/test_connection.py
@@ -99,6 +99,16 @@ class BaseConnectionClassTestCase(unittest.TestCase):
         self.assertEqual(conn.proxy_host, '127.0.0.5')
         self.assertEqual(conn.proxy_port, 3128)
 
+    def test_connection_to_unusual_port(self):
+        conn = LibcloudConnection(host='localhost', port=8080)
+        self.assertEqual(conn.proxy_scheme, None)
+        self.assertEqual(conn.proxy_host, None)
+        self.assertEqual(conn.proxy_port, None)
+        self.assertEqual(conn.host, 'http://localhost:8080')
+
+        conn = LibcloudConnection(host='localhost', port=80)
+        self.assertEqual(conn.host, 'http://localhost')
+
 
 class ConnectionClassTestCase(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Noticed that a custom port does not roll down properly to the connection class.

Also, there is still an outstanding issue that unless the port is 443, the connection will be assumed as plain HTTP.

E.g. setting port as 9999 but Secure=True will still issue a plain HTTP connection