### PR TITLE
Fix secure propagation to connection class

### DIFF
--- a/libcloud/common/base.py
+++ b/libcloud/common/base.py
@@ -459,6 +459,9 @@ class Connection(object):
         if not hasattr(kwargs, 'port'):
             kwargs.update({'port': port})
 
+        if not hasattr(kwargs, 'secure'):
+            kwargs.update({'secure': self.secure})
+
         if not hasattr(kwargs, 'key_file') and hasattr(self, 'key_file'):
             kwargs.update({'key_file': getattr(self, 'key_file')})
 

--- a/libcloud/httplib_ssl.py
+++ b/libcloud/httplib_ssl.py
@@ -162,9 +162,10 @@ class LibcloudConnection(LibcloudBaseConnection):
     host = None
     response = None
 
-    def __init__(self, host, port, **kwargs):
+    def __init__(self, host, port, secure=None, **kwargs):
+        scheme = 'https' if secure is not None and secure else 'http'
         self.host = '{0}://{1}{2}'.format(
-            'https' if port == 443 else 'http',
+            'https' if port == 443 else scheme,
             host,
             ":{0}".format(port) if port not in (80, 443) else ""
         )

--- a/libcloud/test/common/test_openstack.py
+++ b/libcloud/test/common/test_openstack.py
@@ -40,8 +40,9 @@ class OpenStackBaseConnectionTest(unittest.TestCase):
                                                                port=443)
         else:
             self.connection.conn_class.assert_called_with(host='127.0.0.1',
-                                                               port=443,
-                                                               timeout=10)
+                                                          secure=1,
+                                                          port=443,
+                                                          timeout=10)
 
 
 if __name__ == '__main__':

--- a/libcloud/test/test_connection.py
+++ b/libcloud/test/test_connection.py
@@ -109,6 +109,24 @@ class BaseConnectionClassTestCase(unittest.TestCase):
         conn = LibcloudConnection(host='localhost', port=80)
         self.assertEqual(conn.host, 'http://localhost')
 
+    def test_secure_connection_unusual_port(self):
+        conn = Connection(secure=True, host='localhost', port=8081)
+        conn.connect()
+        self.assertEqual(conn.connection.host, 'https://localhost:8081')
+
+        conn2 = Connection(url='https://localhost:8081')
+        conn2.connect()
+        self.assertEqual(conn2.connection.host, 'https://localhost:8081')
+
+    def test_insecure_connection_unusual_port(self):
+        conn = Connection(secure=False, host='localhost', port=8081)
+        conn.connect()
+        self.assertEqual(conn.connection.host, 'http://localhost:8081')
+
+        conn2 = Connection(url='http://localhost:8081')
+        conn2.connect()
+        self.assertEqual(conn2.connection.host, 'http://localhost:8081')
+
 
 class ConnectionClassTestCase(unittest.TestCase):
     def setUp(self):

--- a/libcloud/test/test_connection.py
+++ b/libcloud/test/test_connection.py
@@ -110,6 +110,10 @@ class BaseConnectionClassTestCase(unittest.TestCase):
         self.assertEqual(conn.host, 'http://localhost')
 
     def test_secure_connection_unusual_port(self):
+        """
+        Test that the connection class will default to secure (https) even
+        when the port is an unusual (non 443, 80) number
+        """
         conn = Connection(secure=True, host='localhost', port=8081)
         conn.connect()
         self.assertEqual(conn.connection.host, 'https://localhost:8081')
@@ -118,7 +122,32 @@ class BaseConnectionClassTestCase(unittest.TestCase):
         conn2.connect()
         self.assertEqual(conn2.connection.host, 'https://localhost:8081')
 
+    def test_secure_by_default(self):
+        """
+        Test that the connection class will default to secure (https)
+        """
+        conn = Connection(host='localhost', port=8081)
+        conn.connect()
+        self.assertEqual(conn.connection.host, 'https://localhost:8081')
+
+    def test_implicit_port(self):
+        """
+        Test that the port is not included in the URL if the protocol implies
+        the port, e.g. http implies 80
+        """
+        conn = Connection(secure=True, host='localhost', port=443)
+        conn.connect()
+        self.assertEqual(conn.connection.host, 'https://localhost')
+
+        conn2 = Connection(secure=False, host='localhost', port=80)
+        conn2.connect()
+        self.assertEqual(conn2.connection.host, 'http://localhost')
+
     def test_insecure_connection_unusual_port(self):
+        """
+        Test that the connection will allow unusual ports and insecure
+        schemes
+        """
         conn = Connection(secure=False, host='localhost', port=8081)
         conn.connect()
         self.assertEqual(conn.connection.host, 'http://localhost:8081')


### PR DESCRIPTION
Since there is no longer a secure/insecure connection class, they are one and the same.

This change adds new tests to check that

- When a connection is defined as secure, the connection class will use the https scheme.
- When a connection scheme implies a port, the port is not included in the URL
- When a connection defines secure and an unusual port, the scheme is propagated

It uncovered 1 issue with secure connections not being explicit for unusual ports.