### PR TITLE
Fix access to httplib.HTTPResponse class from RawResponses

### DIFF
--- a/libcloud/common/base.py
+++ b/libcloud/common/base.py
@@ -46,7 +46,7 @@ from libcloud.utils.compression import decompress_data
 
 from libcloud.common.exceptions import exception_from_message
 from libcloud.common.types import LibcloudError, MalformedResponseError
-from libcloud.httplib_ssl import LibcloudConnection
+from libcloud.httplib_ssl import LibcloudConnection, HttpLibResponseProxy
 
 __all__ = [
     'RETRY_FAILED_HTTP_REQUESTS',
@@ -271,7 +271,6 @@ class XmlResponse(Response):
 
 
 class RawResponse(Response):
-
     def __init__(self, connection, response=None):
         """
         :param connection: Parent connection object.
@@ -308,7 +307,8 @@ class RawResponse(Response):
     def response(self):
         if not self._response:
             response = self.connection.connection.getresponse()
-            self._response, self.body = response, response.text
+            self._response = HttpLibResponseProxy(response)
+            self.body = response.text
             if not self.success():
                 self.parse_error()
         return self._response

--- a/libcloud/httplib_ssl.py
+++ b/libcloud/httplib_ssl.py
@@ -24,7 +24,7 @@ import warnings
 import requests
 
 import libcloud.security
-from libcloud.utils.py3 import urlparse
+from libcloud.utils.py3 import urlparse, PY3
 
 
 __all__ = [
@@ -236,6 +236,50 @@ class LibcloudConnection(LibcloudBaseConnection):
     def close(self):  # pragma: no cover
         # return connection back to pool
         self.response.close()
+
+
+class HttpLibResponseProxy(object):
+    """
+    Provides a proxy pattern around the :class:`requests.Reponse`
+    object to a :class:`httplib.HTTPResponse` object
+    """
+    def __init__(self, response):
+        self._response = response
+
+    def read(self, amt=None):
+        return self._response.text
+
+    def getheader(self, name, default=None):
+        """
+        Get the contents of the header name, or default
+        if there is no matching header.
+        """
+        if name in self._response.headers.keys():
+            return self._response.headers[name]
+        else:
+            return default
+
+    def getheaders(self):
+        """
+        Return a list of (header, value) tuples.
+        """
+        if PY3:
+            return list(self._response.headers.items())
+        else:
+            return self._response.headers.items()
+
+    @property
+    def status(self):
+        return self._response.status_code
+
+    @property
+    def reason(self):
+        return self._response.reason
+
+    @property
+    def version(self):
+        # requests doesn't expose this
+        return '11'
 
 
 def get_socket_error_exception(ssl_version, exc):

--- a/libcloud/storage/base.py
+++ b/libcloud/storage/base.py
@@ -25,7 +25,6 @@ import hashlib
 from os.path import join as pjoin
 
 from libcloud.utils.py3 import httplib
-from libcloud.utils.py3 import next
 from libcloud.utils.py3 import b
 
 import libcloud.utils.files
@@ -557,25 +556,12 @@ class StorageDriver(BaseDriver):
                 'overwrite_existing=False',
                 driver=self)
 
-        stream = response.iter_content(chunk_size)
-
-        try:
-            data_read = next(stream)
-        except StopIteration:
-            # Empty response?
-            return False
-
         bytes_transferred = 0
 
         with open(file_path, 'wb') as file_handle:
-            while len(data_read) > 0:
-                file_handle.write(b(data_read))
-                bytes_transferred += len(data_read)
-
-                try:
-                    data_read = next(stream)
-                except StopIteration:
-                    data_read = ''
+            for chunk in response._response.iter_content(chunk_size):
+                file_handle.write(b(chunk))
+                bytes_transferred += len(chunk)
 
         if int(obj.size) != int(bytes_transferred):
             # Transfer failed, support retry?

--- a/libcloud/storage/drivers/s3.py
+++ b/libcloud/storage/drivers/s3.py
@@ -419,7 +419,7 @@ class BaseS3StorageDriver(StorageDriver):
         return self._get_object(
             obj=obj, callback=read_in_chunks,
             response=response,
-            callback_kwargs={'iterator': response.iter_content(),
+            callback_kwargs={'iterator': response.iter_content(CHUNK_SIZE),
                              'chunk_size': chunk_size},
             success_status_code=httplib.OK)
 

--- a/libcloud/storage/drivers/s3.py
+++ b/libcloud/storage/drivers/s3.py
@@ -419,7 +419,7 @@ class BaseS3StorageDriver(StorageDriver):
         return self._get_object(
             obj=obj, callback=read_in_chunks,
             response=response,
-            callback_kwargs={'iterator': response.iter_content,
+            callback_kwargs={'iterator': response.iter_content(),
                              'chunk_size': chunk_size},
             success_status_code=httplib.OK)
 

--- a/libcloud/test/storage/test_s3.py
+++ b/libcloud/test/storage/test_s3.py
@@ -17,7 +17,7 @@ import base64
 import hmac
 import os
 import sys
-import unittest
+
 from io import BytesIO
 
 from hashlib import sha1
@@ -50,6 +50,7 @@ from libcloud.utils.py3 import b
 
 from libcloud.test import StorageMockHttp, MockRawResponse, MockResponse  # pylint: disable-msg=E0611
 from libcloud.test import MockHttpTestCase  # pylint: disable-msg=E0611
+from libcloud.test import unittest
 from libcloud.test.file_fixtures import StorageFileFixtures  # pylint: disable-msg=E0611
 from libcloud.test.secrets import STORAGE_S3_PARAMS
 

--- a/libcloud/test/test_response_classes.py
+++ b/libcloud/test/test_response_classes.py
@@ -19,7 +19,7 @@ import unittest
 import requests
 import requests_mock
 
-from libcloud.common.base import XmlResponse, JsonResponse, RawResponse, Connection
+from libcloud.common.base import XmlResponse, JsonResponse, Connection
 from libcloud.common.types import MalformedResponseError
 from libcloud.httplib_ssl import LibcloudConnection
 
@@ -95,17 +95,30 @@ class ResponseClassesTests(unittest.TestCase):
         self.assertEqual(parsed, '')
 
     def test_RawResponse_class_read_method(self):
+        """
+        Test that the RawResponse class includes a response
+        property which exhibits the same properties and methods
+        as httplib.HTTPResponse for backward compat <1.5.0
+        """
         TEST_DATA = '1234abcd'
-        
+
         conn = Connection(host='mock.com', port=80, secure=False)
         conn.connect()
-        adapter = requests_mock.Adapter()
-        conn.connection.session.mount('mock', adapter)
-        adapter.register_uri('GET', 'http://test.com/raw_data', text=TEST_DATA)
-        
-        response = conn.request('/raw_data', raw=True)
+
+        with requests_mock.Mocker() as m:
+            m.register_uri('GET', 'http://mock.com/raw_data', text=TEST_DATA,
+                           headers={'test': 'value'})
+            response = conn.request('/raw_data', raw=True)
         data = response.response.read()
         self.assertEqual(data, TEST_DATA)
+
+        header_value = response.response.getheader('test')
+        self.assertEqual(header_value, 'value')
+
+        headers = response.response.getheaders()
+        self.assertEqual(headers, [('test', 'value')])
+
+        self.assertEqual(response.response.status, 200)
 
 if __name__ == '__main__':
     sys.exit(unittest.main())

--- a/libcloud/test/test_response_classes.py
+++ b/libcloud/test/test_response_classes.py
@@ -19,7 +19,7 @@ import unittest
 import requests
 import requests_mock
 
-from libcloud.common.base import XmlResponse, JsonResponse
+from libcloud.common.base import XmlResponse, JsonResponse, RawResponse, Connection
 from libcloud.common.types import MalformedResponseError
 from libcloud.httplib_ssl import LibcloudConnection
 
@@ -94,6 +94,18 @@ class ResponseClassesTests(unittest.TestCase):
         parsed = response.parse_body()
         self.assertEqual(parsed, '')
 
+    def test_RawResponse_class_read_method(self):
+        TEST_DATA = '1234abcd'
+        
+        conn = Connection(host='mock.com', port=80, secure=False)
+        conn.connect()
+        adapter = requests_mock.Adapter()
+        conn.connection.session.mount('mock', adapter)
+        adapter.register_uri('GET', 'http://test.com/raw_data', text=TEST_DATA)
+        
+        response = conn.request('/raw_data', raw=True)
+        data = response.response.read()
+        self.assertEqual(data, TEST_DATA)
 
 if __name__ == '__main__':
     sys.exit(unittest.main())

--- a/libcloud/utils/loggingconnection.py
+++ b/libcloud/utils/loggingconnection.py
@@ -27,7 +27,8 @@ import sys
 import os
 
 from libcloud.common.base import (LibcloudConnection,
-                                  HTTPResponse)
+                                  HTTPResponse,
+                                  HttpLibResponseProxy)
 from libcloud.utils.py3 import httplib
 from libcloud.utils.py3 import PY3
 from libcloud.utils.py3 import StringIO
@@ -172,7 +173,7 @@ class LoggingConnection(LibcloudConnection):
         return " ".join(cmd)
 
     def getresponse(self):
-        r = LibcloudConnection.getresponse(self)
+        r = HttpLibResponseProxy(LibcloudConnection.getresponse(self))
         if self.log is not None:
             r, rv = self._log_response(r)
             self.log.write(rv + "\n")


### PR DESCRIPTION
I've noticed that some drivers rely on access to a `httplib.HTTPResponse` object as a property of `RawResponse`. This was updated in #728 to the requests response class, which would, in turn, break a few implementations.

To avoid backward compatibility issues, this introduces a proxy class with `HTTPResponse` methods and properties and tests to validate access.

None of the existing unit tests would have caught this behaviour since the response classes are mocked. This issue was caught in #970 