### PR TITLE
Bug fix for deletion against asynchronous Google subnetwork API

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -6900,7 +6900,7 @@ class GCENodeDriver(NodeDriver):
                 region_name = region.name
 
         request = '/regions/%s/subnetworks/%s' % (region_name, subnet_name)
-        self.connection.request(request, method='DELETE').object
+        self.connection.async_request(request, method='DELETE').object
         return True
 
     def ex_get_subnetwork(self, name, region=None):

--- a/libcloud/test/compute/fixtures/gce/regions_us-central1_subnetworks_cf_972cf02e6ad49112.json
+++ b/libcloud/test/compute/fixtures/gce/regions_us-central1_subnetworks_cf_972cf02e6ad49112.json
@@ -1,4 +1,5 @@
 {
+ "status": "DONE",
  "kind": "compute#subnetwork",
  "id": "4297043163355844284",
  "creationTimestamp": "2016-03-25T05:34:27.209-07:00",


### PR DESCRIPTION
## Bug fix for `ex_destroy_subnetwork`

### Description
libcloud assumes that the Google subnetwork API is synchronous which does not appear to be the case. This causes breakage in ansible where the libcloud API for `ex_destroy_subnetwork` reports that is has successfully destroyed the subnetwork. Immediate calls to `ex_destroy_network` seem to indicate that the subnetwork has not been destroyed as the network is reported to still be in use by the subnetwork. This bug fix is also verified to fix this race condition that causes ansible to fail when sequentially executing the code in PR ansible/ansible-modules-core#3773 first for subnetwork deletion and then for network deletion.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
