### PR TITLE
Refactoring LibcloudConnection and Connection classes from feedback

### DIFF
--- a/libcloud/common/base.py
+++ b/libcloud/common/base.py
@@ -674,9 +674,7 @@ class Connection(object):
         return response
 
     def morph_action_hook(self, action):
-        if not action.startswith("/"):
-            action = "/" + action
-        return self.request_path + action
+        return urlparse.urljoin(self.request_path, action)
 
     def add_default_params(self, params):
         """

--- a/libcloud/common/base.py
+++ b/libcloud/common/base.py
@@ -674,7 +674,12 @@ class Connection(object):
         return response
 
     def morph_action_hook(self, action):
-        return urlparse.urljoin(self.request_path, action)
+        url = urlparse.urljoin(self.request_path.lstrip('/').rstrip('/') +
+                               '/', action.lstrip('/'))
+        if not url.startswith('/'):
+            return '/' + url
+        else:
+            return url
 
     def add_default_params(self, params):
         """

--- a/libcloud/compute/drivers/profitbricks.py
+++ b/libcloud/compute/drivers/profitbricks.py
@@ -127,7 +127,7 @@ class ProfitBricksConnection(ConnectionUserAndKey):
         host and protocol components.
         '''
         if not with_full_url or with_full_url is False:
-            action = self.api_prefix + action
+            action = self.api_prefix + action.lstrip('/')
         else:
             action = action.replace(
                 'https://{host}'.format(host=self.host),

--- a/libcloud/httplib_ssl.py
+++ b/libcloud/httplib_ssl.py
@@ -19,7 +19,6 @@ verification, depending on libcloud.security settings.
 """
 
 import os
-import socket
 import warnings
 import requests
 

--- a/libcloud/httplib_ssl.py
+++ b/libcloud/httplib_ssl.py
@@ -182,16 +182,24 @@ class LibcloudConnection(LibcloudBaseConnection):
             self.set_http_proxy(proxy_url=proxy_url)
         self.session.timeout = kwargs.get('timeout', 60)
 
+    @property
+    def verification(self):
+        """
+        The option for SSL verification given to underlying requests
+        """
+        return self.ca_cert if self.ca_cert is not None else self.verify
+
     def request(self, method, url, body=None, headers=None, raw=False,
                 stream=False):
+        url = urlparse.urljoin(self.host, url)
         self.response = self.session.request(
             method=method.lower(),
-            url=''.join([self.host, url]),
+            url=url,
             data=body,
             headers=headers,
             allow_redirects=1,
             stream=stream,
-            verify=self.ca_cert if self.ca_cert is not None else self.verify
+            verify=self.verification
         )
 
     def prepared_request(self, method, url, body=None,

--- a/libcloud/httplib_ssl.py
+++ b/libcloud/httplib_ssl.py
@@ -36,24 +36,6 @@ ALLOW_REDIRECTS = 1
 
 HTTP_PROXY_ENV_VARIABLE_NAME = 'http_proxy'
 
-# Error message which is thrown when establishing SSL / TLS connection fails
-UNSUPPORTED_TLS_VERSION_ERROR_MSG = """
-Failed to establish SSL / TLS connection (%s). It is possible that the server \
-doesn't support requested SSL / TLS version (%s).
-For information on how to work around this issue, please see \
-https://libcloud.readthedocs.org/en/latest/other/\
-ssl-certificate-validation.html#changing-used-ssl-tls-version
-""".strip()
-
-# Maps ssl.PROTOCOL_* constant to the actual SSL / TLS version name
-SSL_CONSTANT_TO_TLS_VERSION_MAP = {
-    0: 'SSL v2',
-    2: 'SSLv3, TLS v1.0, TLS v1.1, TLS v1.2',
-    3: 'TLS v1.0',
-    4: 'TLS v1.1',
-    5: 'TLS v1.2'
-}
-
 
 class LibcloudBaseConnection(object):
     """
@@ -290,33 +272,3 @@ class HttpLibResponseProxy(object):
     def version(self):
         # requests doesn't expose this
         return '11'
-
-
-def get_socket_error_exception(ssl_version, exc):
-    """
-    Function which intercepts socket.error exceptions and re-throws an
-    exception with a more user-friendly message in case server doesn't support
-    requested SSL version.
-    """
-    exc_msg = str(exc)
-
-    # Re-throw an exception with a more friendly error message
-    if 'connection reset by peer' in exc_msg.lower():
-        ssl_version_name = SSL_CONSTANT_TO_TLS_VERSION_MAP[ssl_version]
-        msg = (UNSUPPORTED_TLS_VERSION_ERROR_MSG %
-               (exc_msg, ssl_version_name))
-
-        # Note: In some cases arguments are (errno, message) and in
-        # other it's just (message,)
-        exc_args = getattr(exc, 'args', [])
-
-        if len(exc_args) == 2:
-            new_exc_args = [exc.args[0], msg]
-        else:
-            new_exc_args = [msg]
-
-        new_exc = socket.error(*new_exc_args)
-        new_exc.original_exc = exc
-        return new_exc
-    else:
-        return exc

--- a/libcloud/httplib_ssl.py
+++ b/libcloud/httplib_ssl.py
@@ -32,6 +32,8 @@ __all__ = [
     'LibcloudConnection'
 ]
 
+ALLOW_REDIRECTS = 1
+
 HTTP_PROXY_ENV_VARIABLE_NAME = 'http_proxy'
 
 # Error message which is thrown when establishing SSL / TLS connection fails
@@ -197,7 +199,7 @@ class LibcloudConnection(LibcloudBaseConnection):
             url=url,
             data=body,
             headers=headers,
-            allow_redirects=1,
+            allow_redirects=ALLOW_REDIRECTS,
             stream=stream,
             verify=self.verification
         )

--- a/libcloud/storage/base.py
+++ b/libcloud/storage/base.py
@@ -650,20 +650,14 @@ class StorageDriver(BaseDriver):
             return (hasher.hexdigest(), total_len)
         if not hasattr(stream, '__exit__'):
             for s in stream:
-                if isinstance(s, str):
-                    hasher.update(s)
-                else:
-                    hasher.update(s)
+                hasher.update(s)
                 total_len = total_len + len(s)
             return (hasher.hexdigest(), total_len)
         with stream:
             buf = stream.read(blocksize)
             while len(buf) > 0:
                 total_len = total_len + len(buf)
-                if isinstance(buf, str):
-                    hasher.update(buf)
-                else:
-                    hasher.update(buf)
+                hasher.update(buf)
                 buf = stream.read(blocksize)
         return (hasher.hexdigest(), total_len)
 

--- a/libcloud/test/compute/test_profitbricks.py
+++ b/libcloud/test/compute/test_profitbricks.py
@@ -4962,7 +4962,7 @@ class ProfitBricksMockHttp(MockHttp):
 
     GET     - fetch a list of snapshots
     '''
-    def _cloudapi_v3__snapshots(
+    def _cloudapi_v3_snapshots(
         self, method, url, body, headers
     ):
         if method == 'GET':

--- a/libcloud/test/test_connection.py
+++ b/libcloud/test/test_connection.py
@@ -123,6 +123,43 @@ class BaseConnectionClassTestCase(unittest.TestCase):
             response = conn.request('/test')
         self.assertEqual(response.body, 'data')
 
+    def test_morph_action_hook(self):
+        conn = Connection(url="http://test.com")
+
+        conn.request_path = ''
+        self.assertEqual(conn.morph_action_hook('/test'), '/test')
+        self.assertEqual(conn.morph_action_hook('test'), '/test')
+
+        conn.request_path = '/v1'
+        self.assertEqual(conn.morph_action_hook('/test'), '/v1/test')
+        self.assertEqual(conn.morph_action_hook('test'), '/v1/test')
+
+        conn.request_path = '/v1'
+        self.assertEqual(conn.morph_action_hook('/test'), '/v1/test')
+        self.assertEqual(conn.morph_action_hook('test'), '/v1/test')
+
+        conn.request_path = 'v1'
+        self.assertEqual(conn.morph_action_hook('/test'), '/v1/test')
+        self.assertEqual(conn.morph_action_hook('test'), '/v1/test')
+
+        conn.request_path = 'v1/'
+        self.assertEqual(conn.morph_action_hook('/test'), '/v1/test')
+        self.assertEqual(conn.morph_action_hook('test'), '/v1/test')
+
+    def test_connect_with_prefix(self):
+        """
+        Test that a connection with a base path (e.g. /v1/) will
+        add the base path to requests
+        """
+        conn = Connection(url='http://test.com/')
+        conn.connect()
+        conn.request_path = '/v1'
+        self.assertEqual(conn.connection.host, 'http://test.com')
+        with requests_mock.mock() as m:
+            m.get('http://test.com/v1/test', text='data')
+            response = conn.request('/test')
+        self.assertEqual(response.body, 'data')
+
     def test_secure_connection_unusual_port(self):
         """
         Test that the connection class will default to secure (https) even

--- a/libcloud/test/test_connection.py
+++ b/libcloud/test/test_connection.py
@@ -21,6 +21,8 @@ import ssl
 
 from mock import Mock, patch
 
+import requests_mock
+
 from libcloud.test import unittest
 from libcloud.common.base import Connection
 from libcloud.httplib_ssl import LibcloudBaseConnection
@@ -108,6 +110,18 @@ class BaseConnectionClassTestCase(unittest.TestCase):
 
         conn = LibcloudConnection(host='localhost', port=80)
         self.assertEqual(conn.host, 'http://localhost')
+
+    def test_connection_url_merging(self):
+        """
+        Test that the connection class will parse URLs correctly
+        """
+        conn = Connection(url='http://test.com/')
+        conn.connect()
+        self.assertEqual(conn.connection.host, 'http://test.com')
+        with requests_mock.mock() as m:
+            m.get('http://test.com/test', text='data')
+            response = conn.request('/test')
+        self.assertEqual(response.body, 'data')
 
     def test_secure_connection_unusual_port(self):
         """


### PR DESCRIPTION
Issues Raised:

- Use URLJoin instead of `''.join` : https://github.com/apache/libcloud/pull/923#discussion_r95320130 raised by @allardhoeve 
- Create a test to ensure creating Connection instances with a trailing / and then using request with a method with a leading / does not create malformed URL requests
- Make allow_redirects configurable  (but true by default?) https://github.com/apache/libcloud/pull/923#discussion_r95320171 @allardhoeve 
- Move verification logic into property in LibcloudConnection https://github.com/apache/libcloud/pull/923#discussion_r95319749
- Fix if/else in hash buffer code https://github.com/apache/libcloud/pull/923#discussion_r95324871
- Remove SSL/TLS error messages and custom socket.error handling code as it's no longer needed