### PR TITLE
[LIBCLOUD-888] TypeError occurred when calling ex_list_nics in Azure ARM Driver

### DIFF
--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -868,8 +868,8 @@ class AzureNodeDriver(NodeDriver):
         :rtype: ``list`` of :class:`.AzureNic`
         """
 
-        action = "/subscriptions/%s/providers/Microsoft.Network" \
-                 "/networkInterfaces" % \
+        action = "/subscriptions/%s/resourceGroups/%s" \
+                 "/providers/Microsoft.Network/networkInterfaces" % \
                  (self.subscription_id, resource_group)
         r = self.connection.request(action,
                                     params={"api-version": "2015-06-15"})


### PR DESCRIPTION
## TypeError occurred when calling ex_list_nics in Azure ARM Driver

### Description

In Azure ARM mode, 'TypeError: not all arguments converted during string formatting' occurs when calling ex_list_nics() method.
According to https://msdn.microsoft.com/en-us/library/mt163627.aspx, The request URI form requires two parameters subscription-id and resource-group-name. ex_list_nics() has resource-group-name as a parameter, but it is not presented in the arguments list to format.

### Status

done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
