### PR TITLE
Fix for LIBCLOUD-893

### DIFF
--- a/libcloud/security.py
+++ b/libcloud/security.py
@@ -55,7 +55,7 @@ else:
 
 if has_certifi and USE_CERTIFI:
     certifi_ca_bundle_path = certifi.where()
-    CA_CERTS_PATH.insert(0, certifi_ca_bundle_path)
+    CA_CERTS_PATH = certifi_ca_bundle_path
 
 # Allow user to explicitly specify which CA bundle to use, using an environment
 # variable


### PR DESCRIPTION
## Fix LIBCLOUD-893 NoneType error

### Description

This fixes a bug introduced into libcloud.security that caused a NoneType error to be throw if the certifi package was installed and set to be used (by default if it is installed it is automatically used)

### Status
done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
