### PR TITLE
[LIBCLOUD-896] Added ENA support to images in EC2 compute driver.

### DIFF
--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -79,7 +79,7 @@ __all__ = [
     'IdempotentParamError'
 ]
 
-API_VERSION = '2013-10-15'
+API_VERSION = '2016-11-15'
 NAMESPACE = 'http://ec2.amazonaws.com/doc/%s/' % (API_VERSION)
 
 # Eucalyptus Constants
@@ -2092,6 +2092,10 @@ RESOURCE_EXTRA_ATTRIBUTES_MAP = {
         'ramdisk_id': {
             'xpath': 'ramdiskId',
             'transform_func': str
+        },
+        'ena_support': {
+            'xpath': 'enaSupport',
+            'transform_func': str
         }
     },
     'network': {
@@ -3625,7 +3629,8 @@ class BaseEC2NodeDriver(NodeDriver):
     def ex_register_image(self, name, description=None, architecture=None,
                           image_location=None, root_device_name=None,
                           block_device_mapping=None, kernel_id=None,
-                          ramdisk_id=None, virtualization_type=None):
+                          ramdisk_id=None, virtualization_type=None,
+                          ena_support=None):
         """
         Registers an Amazon Machine Image based off of an EBS-backed instance.
         Can also be used to create images from snapshots. More information
@@ -3665,6 +3670,10 @@ class BaseEC2NodeDriver(NodeDriver):
                                          or hvm (optional)
         :type       virtualization_type: ``str``
 
+        :param      ena_support: Enable enhanced networking with Elastic
+                                 Network Adapter for the AMI
+        :type       ena_support: ``bool``
+
         :rtype:     :class:`NodeImage`
         """
 
@@ -3695,6 +3704,9 @@ class BaseEC2NodeDriver(NodeDriver):
 
         if virtualization_type is not None:
             params['VirtualizationType'] = virtualization_type
+
+        if ena_support is not None:
+            params['EnaSupport'] = ena_support
 
         image = self._to_image(
             self.connection.request(self.path, params=params).object

--- a/libcloud/test/compute/fixtures/ec2/allocate_address.xml
+++ b/libcloud/test/compute/fixtures/ec2/allocate_address.xml
@@ -1,4 +1,4 @@
-<AllocateAddressResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<AllocateAddressResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>56926e0e-5fa3-41f3-927c-17212def59df</requestId>
     <publicIp>192.0.2.1</publicIp>
     <domain>standard</domain>

--- a/libcloud/test/compute/fixtures/ec2/allocate_vpc_address.xml
+++ b/libcloud/test/compute/fixtures/ec2/allocate_vpc_address.xml
@@ -1,4 +1,4 @@
-<AllocateAddressResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<AllocateAddressResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>eb920193-37a9-401a-8fff-089783b2c153</requestId>
     <publicIp>192.0.2.2</publicIp>
     <domain>vpc</domain>

--- a/libcloud/test/compute/fixtures/ec2/associate_address.xml
+++ b/libcloud/test/compute/fixtures/ec2/associate_address.xml
@@ -1,4 +1,4 @@
-<AssociateAddressResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<AssociateAddressResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>1a470be4-b44d-4423-a80c-44ef2070b8be</requestId>
     <return>true</return>
 </AssociateAddressResponse>

--- a/libcloud/test/compute/fixtures/ec2/associate_vpc_address.xml
+++ b/libcloud/test/compute/fixtures/ec2/associate_vpc_address.xml
@@ -1,4 +1,4 @@
-<AssociateAddressResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<AssociateAddressResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>s132fsz2-6cdg-4ox3-a148-lpqnvdc98c2a</requestId>
     <return>true</return>
     <associationId>eipassoc-167a8073</associationId>

--- a/libcloud/test/compute/fixtures/ec2/attach_internet_gateway.xml
+++ b/libcloud/test/compute/fixtures/ec2/attach_internet_gateway.xml
@@ -1,4 +1,4 @@
-<AttachInternetGatewayResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<AttachInternetGatewayResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>1eb45fd7-d4f6-4b63-a52f-54fc0c82617e</requestId>
     <return>true</return>
 </AttachInternetGatewayResponse>

--- a/libcloud/test/compute/fixtures/ec2/attach_network_interface.xml
+++ b/libcloud/test/compute/fixtures/ec2/attach_network_interface.xml
@@ -1,4 +1,4 @@
-<AttachNetworkInterfaceResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<AttachNetworkInterfaceResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>e46c7abc-8b14-4315-99cb-773a0f95d833</requestId>
     <attachmentId>eni-attach-2b588b47</attachmentId>
 </AttachNetworkInterfaceResponse>

--- a/libcloud/test/compute/fixtures/ec2/attach_volume.xml
+++ b/libcloud/test/compute/fixtures/ec2/attach_volume.xml
@@ -1,4 +1,4 @@
-<AttachVolumeResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<AttachVolumeResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
   <volumeId>vol-4d826724</volumeId>
   <instanceId>i-6058a509</instanceId>

--- a/libcloud/test/compute/fixtures/ec2/authorize_security_group_egress.xml
+++ b/libcloud/test/compute/fixtures/ec2/authorize_security_group_egress.xml
@@ -1,4 +1,4 @@
-<AuthorizeSecurityGroupEgressResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<AuthorizeSecurityGroupEgressResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
   <return>true</return>
 </AuthorizeSecurityGroupEgressResponse>

--- a/libcloud/test/compute/fixtures/ec2/authorize_security_group_ingress.xml
+++ b/libcloud/test/compute/fixtures/ec2/authorize_security_group_ingress.xml
@@ -1,4 +1,4 @@
-<AuthorizeSecurityGroupIngressResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<AuthorizeSecurityGroupIngressResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
   <return>true</return>
 </AuthorizeSecurityGroupIngressResponse>

--- a/libcloud/test/compute/fixtures/ec2/copy_image.xml
+++ b/libcloud/test/compute/fixtures/ec2/copy_image.xml
@@ -1,4 +1,4 @@
-<CopyImageResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<CopyImageResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>7b7d87d5-c045-4c2c-a2c4-b538debe14b2</requestId>
     <imageId>ami-4db38224</imageId>
 </CopyImageResponse>

--- a/libcloud/test/compute/fixtures/ec2/create_image.xml
+++ b/libcloud/test/compute/fixtures/ec2/create_image.xml
@@ -1,4 +1,4 @@
-<CreateImageResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<CreateImageResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>3629ec66-c1f8-4b66-aac5-a8ad1cdf6c15</requestId>
     <imageId>ami-e9b38280</imageId>
 </CreateImageResponse>

--- a/libcloud/test/compute/fixtures/ec2/create_internet_gateway.xml
+++ b/libcloud/test/compute/fixtures/ec2/create_internet_gateway.xml
@@ -1,4 +1,4 @@
-<CreateInternetGatewayResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<CreateInternetGatewayResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>437b9824-8143-4583-98f7-0937d53aea83</requestId>
     <internetGateway>
         <internetGatewayId>igw-13ac2b36</internetGatewayId>

--- a/libcloud/test/compute/fixtures/ec2/create_key_pair.xml
+++ b/libcloud/test/compute/fixtures/ec2/create_key_pair.xml
@@ -1,4 +1,4 @@
-<CreateKeyPairResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<CreateKeyPairResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
   <keyName>my-key-pair</keyName>
   <keyFingerprint>
      1f:51:ae:28:bf:89:e9:d8:1f:25:5d:37:2d:7d:b8:ca:9f:f5:f1:6f

--- a/libcloud/test/compute/fixtures/ec2/create_network_interface.xml
+++ b/libcloud/test/compute/fixtures/ec2/create_network_interface.xml
@@ -1,4 +1,4 @@
-<CreateNetworkInterfaceResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<CreateNetworkInterfaceResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>ca764ebe-8abc-4d37-9995-b9e88c086fa8</requestId>
     <networkInterface>
         <networkInterfaceId>eni-2b36086d</networkInterfaceId>

--- a/libcloud/test/compute/fixtures/ec2/create_placement_groups.xml
+++ b/libcloud/test/compute/fixtures/ec2/create_placement_groups.xml
@@ -1,4 +1,4 @@
-<CreatePlacementGroupResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<CreatePlacementGroupResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
    <requestId>d4904fd9-82c2-4ea5-adfe-a9cc3EXAMPLE</requestId>
    <return>true</return>
 </CreatePlacementGroupResponse>

--- a/libcloud/test/compute/fixtures/ec2/create_security_group.xml
+++ b/libcloud/test/compute/fixtures/ec2/create_security_group.xml
@@ -1,4 +1,4 @@
-<CreateSecurityGroupResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<CreateSecurityGroupResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
   <return>true</return>
   <groupId>sg-52e2f530</groupId>

--- a/libcloud/test/compute/fixtures/ec2/create_snapshot.xml
+++ b/libcloud/test/compute/fixtures/ec2/create_snapshot.xml
@@ -1,4 +1,4 @@
-<CreateSnapshotResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<CreateSnapshotResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
   <requestId>59dbff89-35bd-4eac-99ed-be587</requestId>
   <snapshotId>snap-a7cb2hd9</snapshotId>
   <volumeId>vol-4282672b</volumeId>

--- a/libcloud/test/compute/fixtures/ec2/create_subnet.xml
+++ b/libcloud/test/compute/fixtures/ec2/create_subnet.xml
@@ -1,4 +1,4 @@
-<CreateSubnetResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<CreateSubnetResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>e94b315e-6424-4536-b48d-0dfb47732c72</requestId>
     <subnet>
         <subnetId>subnet-ce0e7ce6</subnetId>

--- a/libcloud/test/compute/fixtures/ec2/create_tags.xml
+++ b/libcloud/test/compute/fixtures/ec2/create_tags.xml
@@ -1,4 +1,4 @@
-<CreateTagsResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<CreateTagsResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>b001068a-ca0d-4f05-b622-28fe984f44be</requestId>
     <return>true</return>
 </CreateTagsResponse>

--- a/libcloud/test/compute/fixtures/ec2/create_volume.xml
+++ b/libcloud/test/compute/fixtures/ec2/create_volume.xml
@@ -1,4 +1,4 @@
-<CreateVolumeResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<CreateVolumeResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId> 
   <volumeId>vol-4d826724</volumeId>
   <size>10</size>

--- a/libcloud/test/compute/fixtures/ec2/create_vpc.xml
+++ b/libcloud/test/compute/fixtures/ec2/create_vpc.xml
@@ -1,4 +1,4 @@
-<CreateVpcResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<CreateVpcResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>7a662fe5-1f34-4e17-9ee9-69a28a8ac0be</requestId>
     <vpc>
         <vpcId>vpc-ad3527cf</vpcId>

--- a/libcloud/test/compute/fixtures/ec2/delete_internet_gateway.xml
+++ b/libcloud/test/compute/fixtures/ec2/delete_internet_gateway.xml
@@ -1,4 +1,4 @@
-<DeleteInternetGatewayResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DeleteInternetGatewayResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>b1a5c8c9-91c7-43f3-8234-c162db89a2df</requestId>
     <return>true</return>
 </DeleteInternetGatewayResponse>

--- a/libcloud/test/compute/fixtures/ec2/delete_key_pair.xml
+++ b/libcloud/test/compute/fixtures/ec2/delete_key_pair.xml
@@ -1,4 +1,4 @@
-<DeleteKeyPairResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DeleteKeyPairResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>59dbff89-35bd-4eac-99ed-be587</requestId>
     <return>true</return>
 </DeleteKeyPairResponse>

--- a/libcloud/test/compute/fixtures/ec2/delete_network_interface.xml
+++ b/libcloud/test/compute/fixtures/ec2/delete_network_interface.xml
@@ -1,4 +1,4 @@
-<DeleteNetworkInterfaceResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DeleteNetworkInterfaceResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>c0bc0036-e328-47c6-bd6d-318b007f66ee</requestId>
     <return>true</return>
 </DeleteNetworkInterfaceResponse>

--- a/libcloud/test/compute/fixtures/ec2/delete_placement_groups.xml
+++ b/libcloud/test/compute/fixtures/ec2/delete_placement_groups.xml
@@ -1,4 +1,4 @@
-<DeletePlacementGroupResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DeletePlacementGroupResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
    <requestId>d4904fd9-82c2-4ea5-adfe-a9cc3EXAMPLE</requestId>
    <return>true</return>
 </DeletePlacementGroupResponse>

--- a/libcloud/test/compute/fixtures/ec2/delete_security_group.xml
+++ b/libcloud/test/compute/fixtures/ec2/delete_security_group.xml
@@ -1,4 +1,4 @@
-<DeleteSecurityGroupResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DeleteSecurityGroupResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId> 
   <return>true</return>
 </DeleteSecurityGroupResponse>

--- a/libcloud/test/compute/fixtures/ec2/delete_snapshot.xml
+++ b/libcloud/test/compute/fixtures/ec2/delete_snapshot.xml
@@ -1,4 +1,4 @@
-<DeleteSnapshotResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DeleteSnapshotResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
   <requestId>5cd6fa89-35bd-4aac-99ed-na8af7</requestId>
   <return>true</return>
 </DeleteSnapshotResponse>

--- a/libcloud/test/compute/fixtures/ec2/delete_subnet.xml
+++ b/libcloud/test/compute/fixtures/ec2/delete_subnet.xml
@@ -1,4 +1,4 @@
-<DeleteSubnetResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DeleteSubnetResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>5cd6fa89-35bd-4aac-99ed-na8af7</requestId>
     <return>true</return>
 </DeleteSubnetResponse>

--- a/libcloud/test/compute/fixtures/ec2/delete_tags.xml
+++ b/libcloud/test/compute/fixtures/ec2/delete_tags.xml
@@ -1,4 +1,4 @@
-<DeleteTagsResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DeleteTagsResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>7a297da7-3ecb-4156-8bcb-3be73896cc14</requestId>
     <return>true</return>
 </DeleteTagsResponse>

--- a/libcloud/test/compute/fixtures/ec2/delete_volume.xml
+++ b/libcloud/test/compute/fixtures/ec2/delete_volume.xml
@@ -1,4 +1,4 @@
-<DeleteVolumeResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DeleteVolumeResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId> 
   <return>true</return>
 </DeleteVolumeResponse>

--- a/libcloud/test/compute/fixtures/ec2/delete_vpc.xml
+++ b/libcloud/test/compute/fixtures/ec2/delete_vpc.xml
@@ -1,4 +1,4 @@
-<DeleteVpcResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DeleteVpcResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>85793fa6-2ece-480c-855f-0f82c3257e50</requestId>
     <return>true</return>
 </DeleteVpcResponse>

--- a/libcloud/test/compute/fixtures/ec2/deregister_image.xml
+++ b/libcloud/test/compute/fixtures/ec2/deregister_image.xml
@@ -1,4 +1,4 @@
-<DeregisterImageResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DeregisterImageResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
   <requestId>d06f248d-444e-475d-a8f8-1ebb4ac39842</requestId>
   <return>true</return>
 </DeregisterImageResponse>

--- a/libcloud/test/compute/fixtures/ec2/describe_account_attributes.xml
+++ b/libcloud/test/compute/fixtures/ec2/describe_account_attributes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<DescribeAccountAttributesResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DescribeAccountAttributesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>a00adaf6-f86c-48eb-85f8-7ac470ae993d</requestId>
     <accountAttributeSet>
         <item>

--- a/libcloud/test/compute/fixtures/ec2/describe_addresses.xml
+++ b/libcloud/test/compute/fixtures/ec2/describe_addresses.xml
@@ -1,4 +1,4 @@
-<DescribeAddressesResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DescribeAddressesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
   <addressesSet>
      <item>

--- a/libcloud/test/compute/fixtures/ec2/describe_addresses_all.xml
+++ b/libcloud/test/compute/fixtures/ec2/describe_addresses_all.xml
@@ -1,4 +1,4 @@
-<DescribeAddressesResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DescribeAddressesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
     <addressesSet>
         <item>

--- a/libcloud/test/compute/fixtures/ec2/describe_addresses_multi.xml
+++ b/libcloud/test/compute/fixtures/ec2/describe_addresses_multi.xml
@@ -1,4 +1,4 @@
-<DescribeAddressesResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DescribeAddressesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
   <addressesSet>
      <item>

--- a/libcloud/test/compute/fixtures/ec2/describe_addresses_single.xml
+++ b/libcloud/test/compute/fixtures/ec2/describe_addresses_single.xml
@@ -1,4 +1,4 @@
-<DescribeAddressesResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DescribeAddressesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
   <addressesSet>
      <item>

--- a/libcloud/test/compute/fixtures/ec2/describe_availability_zones.xml
+++ b/libcloud/test/compute/fixtures/ec2/describe_availability_zones.xml
@@ -1,4 +1,4 @@
-<DescribeAvailabilityZonesResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DescribeAvailabilityZonesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>cc0dfb29-efef-451c-974f-341b3edfb28f</requestId>
     <availabilityZoneInfo>
         <item>

--- a/libcloud/test/compute/fixtures/ec2/describe_images.xml
+++ b/libcloud/test/compute/fixtures/ec2/describe_images.xml
@@ -1,4 +1,4 @@
-<DescribeImagesResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DescribeImagesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>73fac9c5-f6d2-4b45-846f-47adf1e82d6c</requestId>
     <imagesSet>
         <item>

--- a/libcloud/test/compute/fixtures/ec2/describe_images_ex_imageids.xml
+++ b/libcloud/test/compute/fixtures/ec2/describe_images_ex_imageids.xml
@@ -1,4 +1,4 @@
-<DescribeImagesResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DescribeImagesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>73fac9c5-f6d2-4b45-846f-47adf1e82d6c</requestId>
     <imagesSet>
         <item>

--- a/libcloud/test/compute/fixtures/ec2/describe_instances.xml
+++ b/libcloud/test/compute/fixtures/ec2/describe_instances.xml
@@ -1,4 +1,4 @@
-<DescribeInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DescribeInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>ec0d2a7d-5080-4f4b-9b02-cb0d5d2d4274</requestId>
     <reservationSet>
         <item>

--- a/libcloud/test/compute/fixtures/ec2/describe_internet_gateways.xml
+++ b/libcloud/test/compute/fixtures/ec2/describe_internet_gateways.xml
@@ -1,4 +1,4 @@
-<DescribeInternetGatewaysResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DescribeInternetGatewaysResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>843ff26c-f1ac-48f5-93a6-fa28f8abd9dd</requestId>
     <internetGatewaySet>
         <item>

--- a/libcloud/test/compute/fixtures/ec2/describe_key_pairs.xml
+++ b/libcloud/test/compute/fixtures/ec2/describe_key_pairs.xml
@@ -1,4 +1,4 @@
-<DescribeKeyPairsResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DescribeKeyPairsResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
     <keySet>
       <item>

--- a/libcloud/test/compute/fixtures/ec2/describe_network_interfaces.xml
+++ b/libcloud/test/compute/fixtures/ec2/describe_network_interfaces.xml
@@ -1,4 +1,4 @@
-<DescribeNetworkInterfacesResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DescribeNetworkInterfacesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>e8fc6c0b-d6f8-4b85-aa29-e6a097eb4631</requestId>
     <networkInterfaceSet>
         <item>

--- a/libcloud/test/compute/fixtures/ec2/describe_placement_groups.xml
+++ b/libcloud/test/compute/fixtures/ec2/describe_placement_groups.xml
@@ -1,4 +1,4 @@
-<DescribePlacementGroupsResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DescribePlacementGroupsResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestID>d4904fd9-82c2-4ea5-adfe-a9cc3EXAMPLE</requestID>
     <placementGroupSet>
         <item>

--- a/libcloud/test/compute/fixtures/ec2/describe_reserved_instances.xml
+++ b/libcloud/test/compute/fixtures/ec2/describe_reserved_instances.xml
@@ -1,4 +1,4 @@
-<DescribeReservedInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DescribeReservedInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
   <requestId>56d0fffa-8819-4658-bdd7-548f143a86d2</requestId>
     <reservedInstancesSet>
         <item>

--- a/libcloud/test/compute/fixtures/ec2/describe_security_groups.xml
+++ b/libcloud/test/compute/fixtures/ec2/describe_security_groups.xml
@@ -1,4 +1,4 @@
-<DescribeSecurityGroupsResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DescribeSecurityGroupsResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
    <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
    <securityGroupInfo>
       <item>

--- a/libcloud/test/compute/fixtures/ec2/describe_snapshots.xml
+++ b/libcloud/test/compute/fixtures/ec2/describe_snapshots.xml
@@ -1,4 +1,4 @@
-<DescribeSnapshotsResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DescribeSnapshotsResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
    <requestId>and4xcasi-35bd-4e3c-89ab-cb183</requestId>
    <snapshotSet>
       <item>

--- a/libcloud/test/compute/fixtures/ec2/describe_subnets.xml
+++ b/libcloud/test/compute/fixtures/ec2/describe_subnets.xml
@@ -1,4 +1,4 @@
-<DescribeSubnetsResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DescribeSubnetsResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>67bba371-8044-45a7-b4a3-d72fef8b96d8</requestId>
     <subnetSet>
         <item>

--- a/libcloud/test/compute/fixtures/ec2/describe_tags.xml
+++ b/libcloud/test/compute/fixtures/ec2/describe_tags.xml
@@ -1,4 +1,4 @@
-<DescribeTagsResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DescribeTagsResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>fa7e0e44-df5e-49a0-98d7-5d4d19a29f95</requestId>
     <tagSet>
         <item>

--- a/libcloud/test/compute/fixtures/ec2/describe_volumes.xml
+++ b/libcloud/test/compute/fixtures/ec2/describe_volumes.xml
@@ -1,4 +1,4 @@
-<DescribeVolumesResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DescribeVolumesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>766b978a-f574-4c8d-a974-57547a8c304e</requestId>
     <volumeSet>
         <item>

--- a/libcloud/test/compute/fixtures/ec2/describe_vpcs.xml
+++ b/libcloud/test/compute/fixtures/ec2/describe_vpcs.xml
@@ -1,4 +1,4 @@
-<DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>be8cfa34-0710-4895-941f-961c5738f8f8</requestId>
     <vpcSet>
         <item>

--- a/libcloud/test/compute/fixtures/ec2/detach_internet_gateway.xml
+++ b/libcloud/test/compute/fixtures/ec2/detach_internet_gateway.xml
@@ -1,4 +1,4 @@
-<DetachInternetGatewayResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DetachInternetGatewayResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>7098cc6d-a984-4d34-a5ed-6ae1a645c0b6</requestId>
     <return>true</return>
 </DetachInternetGatewayResponse>

--- a/libcloud/test/compute/fixtures/ec2/detach_network_interface.xml
+++ b/libcloud/test/compute/fixtures/ec2/detach_network_interface.xml
@@ -1,4 +1,4 @@
-<DetachNetworkInterfaceResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DetachNetworkInterfaceResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>1a683cd6-58ea-4b93-a6e9-a23b56afddf0</requestId>
     <return>true</return>
 </DetachNetworkInterfaceResponse>

--- a/libcloud/test/compute/fixtures/ec2/detach_volume.xml
+++ b/libcloud/test/compute/fixtures/ec2/detach_volume.xml
@@ -1,4 +1,4 @@
-<DetachVolumeResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DetachVolumeResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId> 
   <volumeId>vol-4d826724</volumeId>
   <instanceId>i-6058a509</instanceId>

--- a/libcloud/test/compute/fixtures/ec2/disassociate_address.xml
+++ b/libcloud/test/compute/fixtures/ec2/disassociate_address.xml
@@ -1,4 +1,4 @@
-<DisassociateAddressResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<DisassociateAddressResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>dfb841f8-cc26-4f45-a3ac-dc08589eec1d</requestId>
     <return>true</return>
 </DisassociateAddressResponse>

--- a/libcloud/test/compute/fixtures/ec2/get_console_output.xml
+++ b/libcloud/test/compute/fixtures/ec2/get_console_output.xml
@@ -1,4 +1,4 @@
-<GetConsoleOutputResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<GetConsoleOutputResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>f0ffb5ce-8d62-4ab9-add7-67a0f99c9811</requestId>
     <instanceId>i-40128925</instanceId>
     <timestamp>2013-12-02T12:31:38.000Z</timestamp>

--- a/libcloud/test/compute/fixtures/ec2/import_key_pair.xml
+++ b/libcloud/test/compute/fixtures/ec2/import_key_pair.xml
@@ -1,4 +1,4 @@
-<ImportKeyPairResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<ImportKeyPairResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</requestId>
     <keyName>keypair</keyName>
     <keyFingerprint>00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00</keyFingerprint>

--- a/libcloud/test/compute/fixtures/ec2/modify_image_attribute.xml
+++ b/libcloud/test/compute/fixtures/ec2/modify_image_attribute.xml
@@ -1,3 +1,3 @@
-<ModifyImageAttributeResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<ModifyImageAttributeResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <return>true</return>
 </ModifyImageAttributeResponse>

--- a/libcloud/test/compute/fixtures/ec2/modify_instance_attribute.xml
+++ b/libcloud/test/compute/fixtures/ec2/modify_instance_attribute.xml
@@ -1,4 +1,4 @@
-<ModifyInstanceAttributeResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<ModifyInstanceAttributeResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId> 
   <return>true</return>
 </ModifyInstanceAttributeResponse>

--- a/libcloud/test/compute/fixtures/ec2/reboot_instances.xml
+++ b/libcloud/test/compute/fixtures/ec2/reboot_instances.xml
@@ -1,4 +1,4 @@
-<RebootInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<RebootInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
   <requestId>76dabb7a-fb39-4ed1-b5e0-31a4a0fdf5c0</requestId>
   <return>true</return>
 </RebootInstancesResponse>

--- a/libcloud/test/compute/fixtures/ec2/register_image.xml
+++ b/libcloud/test/compute/fixtures/ec2/register_image.xml
@@ -1,4 +1,4 @@
-<RegisterImageResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<RegisterImageResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>6d858ea7-053e-4751-9fae-b891019fc8d2</requestId>
     <imageId>ami-57c2fb3e</imageId>
 </RegisterImageResponse>

--- a/libcloud/test/compute/fixtures/ec2/release_address.xml
+++ b/libcloud/test/compute/fixtures/ec2/release_address.xml
@@ -1,4 +1,4 @@
-<ReleaseAddressResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<ReleaseAddressResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>23ec1390-8c1d-4a3e-8042-b1ad84933f57</requestId>
     <return>true</return>
 </ReleaseAddressResponse>

--- a/libcloud/test/compute/fixtures/ec2/revoke_security_group_egress.xml
+++ b/libcloud/test/compute/fixtures/ec2/revoke_security_group_egress.xml
@@ -1,4 +1,4 @@
-<RevokeSecurityGroupEgressResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<RevokeSecurityGroupEgressResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
   <return>true</return>
 </RevokeSecurityGroupEgressResponse>

--- a/libcloud/test/compute/fixtures/ec2/revoke_security_group_ingress.xml
+++ b/libcloud/test/compute/fixtures/ec2/revoke_security_group_ingress.xml
@@ -1,4 +1,4 @@
-<RevokeSecurityGroupIngressResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<RevokeSecurityGroupIngressResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
   <return>true</return>
 </RevokeSecurityGroupIngressResponse>

--- a/libcloud/test/compute/fixtures/ec2/run_instances.xml
+++ b/libcloud/test/compute/fixtures/ec2/run_instances.xml
@@ -1,4 +1,4 @@
-<RunInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<RunInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
   <reservationId>r-47a5402e</reservationId>
   <ownerId>AIDADH4IGTRXXKCD</ownerId>
   <groupSet>

--- a/libcloud/test/compute/fixtures/ec2/run_instances_iam_profile.xml
+++ b/libcloud/test/compute/fixtures/ec2/run_instances_iam_profile.xml
@@ -1,4 +1,4 @@
-<RunInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<RunInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
   <reservationId>r-47a5403e</reservationId>
   <ownerId>AIDADH4IGTRXXKCD</ownerId>
   <groupSet>

--- a/libcloud/test/compute/fixtures/ec2/run_instances_idem.xml
+++ b/libcloud/test/compute/fixtures/ec2/run_instances_idem.xml
@@ -1,4 +1,4 @@
-<RunInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<RunInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
   <reservationId>r-47a5402e</reservationId>
   <ownerId>AIDADH4IGTRXXKCD</ownerId>
   <groupSet>

--- a/libcloud/test/compute/fixtures/ec2/run_instances_with_subnet_and_security_group.xml
+++ b/libcloud/test/compute/fixtures/ec2/run_instances_with_subnet_and_security_group.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<RunInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<RunInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>ebfcb9e2-fe5f-4afd-ac91-6a9946305e32</requestId>
     <reservationId>r-11111111</reservationId>
     <ownerId>111111111111</ownerId>

--- a/libcloud/test/compute/fixtures/ec2/start_instances.xml
+++ b/libcloud/test/compute/fixtures/ec2/start_instances.xml
@@ -1,4 +1,4 @@
-<StartInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<StartInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>322f78ee-967b-40c9-aecd-8d442022da20</requestId>
     <instancesSet>
         <item>

--- a/libcloud/test/compute/fixtures/ec2/stop_instances.xml
+++ b/libcloud/test/compute/fixtures/ec2/stop_instances.xml
@@ -1,4 +1,4 @@
-<StopInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<StopInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>4ace6850-c876-4971-af0b-67a4278c36a1</requestId>
     <instancesSet>
         <item>

--- a/libcloud/test/compute/fixtures/ec2/terminate_instances.xml
+++ b/libcloud/test/compute/fixtures/ec2/terminate_instances.xml
@@ -1,4 +1,4 @@
-<TerminateInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+<TerminateInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
   <requestId>fa63083d-e0f7-4933-b31a-f266643bdee8</requestId>
   <instancesSet>
     <item>

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -558,7 +558,8 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
                                               root_device_name='/dev/sda1',
                                               description='My Image',
                                               architecture='x86_64',
-                                              block_device_mapping=mapping)
+                                              block_device_mapping=mapping,
+                                              ena_support=True)
         self.assertEqual(image.id, 'ami-57c2fb3e')
 
     def test_ex_list_availability_zones(self):


### PR DESCRIPTION
## Added ENA support to images in EC2 compute driver.

### Description

Please refer to: https://issues.apache.org/jira/browse/LIBCLOUD-896

Bumping the EC2 API version was necessary to support the new ENA options. I performed some spot checking of the test fixtures against the API reference docs and didn't notice any breaking changes. If there are some comprehensive functional tests to prove this I am willing to run them.

### Status

done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
