### PR TITLE
Add ability to update multi-value records in multi-value format in Route 53

### DIFF
--- a/libcloud/dns/drivers/route53.py
+++ b/libcloud/dns/drivers/route53.py
@@ -352,8 +352,13 @@ class Route53DNSDriver(DNSDriver):
 
         rrecs = ET.SubElement(rrs, 'ResourceRecords')
 
-        rrec = ET.SubElement(rrecs, 'ResourceRecord')
-        ET.SubElement(rrec, 'Value').text = data
+        # Value can be provided as a multi line string
+        values = [value.strip() for value in data.split('\n') if
+                  value.strip()]
+
+        for value in values:
+            rrec = ET.SubElement(rrecs, 'ResourceRecord')
+            ET.SubElement(rrec, 'Value').text = value
 
         for other_record in other_records:
             rrec = ET.SubElement(rrecs, 'ResourceRecord')


### PR DESCRIPTION
## Ability to update multi-value records in multi-value format in Route 53

### Description

This fix allows updating multi-value records with syntax accepted by multi-value record's value, i.e. new-line separated IP-addresses, effectively allowing extension of existing multi-value record.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
