### PR TITLE
Add ability to delete multi-value records in Route 53

### DIFF
--- a/libcloud/dns/drivers/route53.py
+++ b/libcloud/dns/drivers/route53.py
@@ -271,6 +271,23 @@ class Route53DNSDriver(DNSDriver):
             rrec = ET.SubElement(rrecs, 'ResourceRecord')
             ET.SubElement(rrec, 'Value').text = other_record['data']
 
+        # Re-create old records. Since we are deleting a multi value record,
+        # only a single record is deleted and others are left as is.
+        change = ET.SubElement(changes, 'Change')
+        ET.SubElement(change, 'Action').text = 'CREATE'
+
+        rrs = ET.SubElement(change, 'ResourceRecordSet')
+
+        ET.SubElement(rrs, 'Name').text = record_name
+        ET.SubElement(rrs, 'Type').text = self.RECORD_TYPE_MAP[record.type]
+        ET.SubElement(rrs, 'TTL').text = str(record.extra.get('ttl', '0'))
+
+        rrecs = ET.SubElement(rrs, 'ResourceRecords')
+
+        for other_record in other_records:
+            rrec = ET.SubElement(rrecs, 'ResourceRecord')
+            ET.SubElement(rrec, 'Value').text = other_record['data']
+
         uri = API_ROOT + 'hostedzone/' + record.zone.id + '/rrset'
         data = ET.tostring(changeset)
         self.connection.set_context({'zone_id': record.zone.id})

--- a/libcloud/dns/drivers/route53.py
+++ b/libcloud/dns/drivers/route53.py
@@ -219,14 +219,64 @@ class Route53DNSDriver(DNSDriver):
                       driver=self, ttl=extra.get('ttl', None), extra=extra)
 
     def delete_record(self, record):
+        # Multiple value records need to be handled specially - we need to
+        # pass values for other records as well
+        multiple_value_record = record.extra.get('_multi_value', False)
+
+        if multiple_value_record:
+            self._delete_multi_value_record(record)
+        else:
+            self._delete_single_value_record(record)
+
+        return True
+
+    def _delete_single_value_record(self, record):
         try:
             r = record
             batch = [('DELETE', r.name, r.type, r.data, r.extra)]
-            self._post_changeset(record.zone, batch)
+
+            return self._post_changeset(record.zone, batch)
         except InvalidChangeBatch:
             raise RecordDoesNotExistError(value='', driver=self,
                                           record_id=r.id)
-        return True
+
+    def _delete_multi_value_record(self, record):
+        other_records = record.extra.get('_other_records', [])
+
+        attrs = {'xmlns': NAMESPACE}
+        changeset = ET.Element('ChangeResourceRecordSetsRequest', attrs)
+        batch = ET.SubElement(changeset, 'ChangeBatch')
+        changes = ET.SubElement(batch, 'Changes')
+
+        change = ET.SubElement(changes, 'Change')
+        ET.SubElement(change, 'Action').text = 'DELETE'
+
+        rrs = ET.SubElement(change, 'ResourceRecordSet')
+
+        if record.name:
+            record_name = record.name + '.' + record.zone.domain
+        else:
+            record_name = record.zone.domain
+
+        ET.SubElement(rrs, 'Name').text = record_name
+        ET.SubElement(rrs, 'Type').text = self.RECORD_TYPE_MAP[record.type]
+        ET.SubElement(rrs, 'TTL').text = str(record.extra.get('ttl', '0'))
+
+        rrecs = ET.SubElement(rrs, 'ResourceRecords')
+
+        rrec = ET.SubElement(rrecs, 'ResourceRecord')
+        ET.SubElement(rrec, 'Value').text = record.data
+
+        for other_record in other_records:
+            rrec = ET.SubElement(rrecs, 'ResourceRecord')
+            ET.SubElement(rrec, 'Value').text = other_record['data']
+
+        uri = API_ROOT + 'hostedzone/' + record.zone.id + '/rrset'
+        data = ET.tostring(changeset)
+        self.connection.set_context({'zone_id': record.zone.id})
+        response = self.connection.request(uri, method='POST', data=data)
+
+        return response.status == httplib.OK
 
     def ex_create_multi_value_record(self, name, zone, type, data, extra=None):
         """

--- a/libcloud/test/dns/test_route53.py
+++ b/libcloud/test/dns/test_route53.py
@@ -232,6 +232,12 @@ class Route53Tests(unittest.TestCase):
         status = self.driver.delete_record(record=record)
         self.assertTrue(status)
 
+    def test_delete_multi_value_record(self):
+        zone = self.driver.list_zones()[0]
+        record = self.driver.list_records(zone=zone)[3]
+        status = self.driver.delete_record(record=record)
+        self.assertTrue(status)
+
     def test_delete_record_does_not_exist(self):
         zone = self.driver.list_zones()[0]
         record = self.driver.list_records(zone=zone)[0]


### PR DESCRIPTION
## Ability to delete multi-value records in Route 53

### Description

Currently any `.delete()` operation on multi-value records results in `RecordDoesNotExistError`. This PR handles record deletion correctly regardless of its type.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
