### PR TITLE
Add method to modify snapshot attribute for EC2

### DIFF
--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -4782,6 +4782,30 @@ class BaseEC2NodeDriver(NodeDriver):
 
         return self._get_boolean(res)
 
+    def ex_modify_snapshot_attribute(self, snapshot, attributes):
+        """
+        Modify Snapshot attributes.
+
+        :param      snapshot: VolumeSnapshot instance
+        :type       snanpshot: :class:`VolumeSnapshot`
+
+        :param      attributes: Dictionary with snapshot attributes
+        :type       attributes: ``dict``
+
+        :return: True on success, False otherwise.
+        :rtype: ``bool``
+        """
+        attributes = attributes or {}
+        attributes.update({'SnapshotId': snapshot.id})
+
+        params = {'Action': 'ModifySnapshotAttribute'}
+        params.update(attributes)
+
+        res = self.connection.request(self.path,
+                                      params=params.copy()).object
+
+        return self._get_boolean(res)
+
     def ex_modify_image_attribute(self, image, attributes):
         """
         Modify image attributes.

--- a/libcloud/test/compute/fixtures/ec2/modify_snapshot_attribute.xml
+++ b/libcloud/test/compute/fixtures/ec2/modify_snapshot_attribute.xml
@@ -1,0 +1,4 @@
+<ModifySnapshotAttributeResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+  <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
+  <return>true</return>
+</ModifySnapshotAttributeResponse>

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -933,6 +933,14 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
         resp = self.driver.ex_modify_image_attribute(image, data)
         self.assertTrue(resp)
 
+    def test_ex_modify_snapshot_attribute(self):
+        snap = VolumeSnapshot(id='snap-1234567890abcdef0',
+                              size=10, driver=self.driver)
+
+        data = {'CreateVolumePermission.Add.1.Group': 'all'}
+        resp = self.driver.ex_modify_snapshot_attribute(snap, data)
+        self.assertTrue(resp)
+
     def test_create_node_ex_security_groups(self):
         EC2MockHttp.type = 'ex_security_groups'
 
@@ -1399,6 +1407,10 @@ class EC2MockHttp(MockHttpTestCase):
 
     def _ModifyInstanceAttribute(self, method, url, body, headers):
         body = self.fixtures.load('modify_instance_attribute.xml')
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+
+    def _ModifySnapshotAttribute(self, method, url, body, headers):
+        body = self.fixtures.load('modify_snapshot_attribute.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
     def _idempotent_CreateTags(self, method, url, body, headers):


### PR DESCRIPTION
Signed-off-by: Sayan Chowdhury <sayan.chowdhury2012@gmail.com>

## Add method to modify snapshot attribute for EC2

### Description

It's right now not possible to modify the snapshot attribute for EC2. This PR adds code, tests for modifying the snapshot attribute.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [X] Documentation
- [X] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
