### PR TITLE
Add aliyun ecs instance join leave security group

### DIFF
--- a/libcloud/compute/drivers/ecs.py
+++ b/libcloud/compute/drivers/ecs.py
@@ -889,18 +889,13 @@ class ECSDriver(NodeDriver):
         if group_id is None:
             raise AttributeError('group_id is required')
 
-        nodes = self.list_nodes(ex_node_ids=[node.id])
-        if len(nodes) != 1 and node.id != nodes[0].id:
-            raise LibcloudError('could not find the node with id %s.'
-                                % node.id)
-        current = nodes[0]
-        if (current.state != NodeState.RUNNING) and \
-           (current.state != NodeState.STOPPED):
+        if (node.state != NodeState.RUNNING) and \
+           (node.state != NodeState.STOPPED):
             raise LibcloudError('The node state with id % s need\
                                 be running or stopped .' % node.id)
 
         params = {'Action': 'JoinSecurityGroup',
-                  'InstanceId': current.id,
+                  'InstanceId': node.id,
                   'SecurityGroupId': group_id}
         resp = self.connection.request(self.path, params)
         return resp.success()
@@ -919,15 +914,12 @@ class ECSDriver(NodeDriver):
         :return: leave operation result.
         :rtype: ``bool``
         """
-
-        nodes = self.list_nodes(ex_node_ids=[node.id])
-        if len(nodes) != 1 and node.id != nodes[0].id:
-            raise LibcloudError('could not find the node with id %s.'
-                                % node.id)
-        current = nodes[0]
-        if (current.state != NodeState.RUNNING) and \
-           (current.state != NodeState.STOPPED):
-            raise LibcloudError('The node state with id %s need \
+        if group_id is None:
+            raise AttributeError('group_id is required')
+        
+        if (node.state != NodeState.RUNNING) and \
+           (node.state != NodeState.STOPPED):
+            raise LibcloudError('The node state with id % s need\
                                 be running or stopped .' % node.id)
 
         params = {'Action': 'LeaveSecurityGroup',

--- a/libcloud/compute/drivers/ecs.py
+++ b/libcloud/compute/drivers/ecs.py
@@ -889,8 +889,8 @@ class ECSDriver(NodeDriver):
         if group_id is None:
             raise AttributeError('group_id is required')
 
-        if (node.state != NodeState.RUNNING) and \
-           (node.state != NodeState.STOPPED):
+        if node.state != NodeState.RUNNING and \
+           node.state != NodeState.STOPPED:
             raise LibcloudError('The node state with id % s need\
                                 be running or stopped .' % node.id)
 
@@ -917,8 +917,8 @@ class ECSDriver(NodeDriver):
         if group_id is None:
             raise AttributeError('group_id is required')
 
-        if (node.state != NodeState.RUNNING) and \
-           (node.state != NodeState.STOPPED):
+        if node.state != NodeState.RUNNING and \
+           node.state != NodeState.STOPPED:
             raise LibcloudError('The node state with id % s need\
                                 be running or stopped .' % node.id)
 

--- a/libcloud/compute/drivers/ecs.py
+++ b/libcloud/compute/drivers/ecs.py
@@ -880,7 +880,7 @@ class ECSDriver(NodeDriver):
         :type node: :class:`Node`
 
         :param group_id: security group id.
-        :type ex_filters: ``str``
+        :type group_id: ``str``
 
 
         :return: join operation result.

--- a/libcloud/compute/drivers/ecs.py
+++ b/libcloud/compute/drivers/ecs.py
@@ -879,7 +879,7 @@ class ECSDriver(NodeDriver):
         :param node: The node to join security group
         :type node: :class:`Node`
 
-        :keyword group_id: security group id.
+        :param group_id: security group id.
         :type ex_filters: ``str``
 
 
@@ -894,8 +894,10 @@ class ECSDriver(NodeDriver):
             raise LibcloudError('could not find the node with id %s.'
                                 % node.id)
         current = nodes[0]
-        if current.state != NodeState.RUNNING and current.state != NodeState.STOPPED:
-            raise LibcloudError('The node state with id %s need be running or stopped .' % node.id)
+        if (current.state != NodeState.RUNNING) and \
+           (current.state != NodeState.STOPPED):
+            raise LibcloudError('The node state with id % s need\
+                                be running or stopped .' % node.id)
 
         params = {'Action': 'JoinSecurityGroup',
                   'InstanceId': current.id,
@@ -910,7 +912,7 @@ class ECSDriver(NodeDriver):
         :param node: The node to leave security group
         :type node: :class:`Node`
 
-        :keyword group_id: security group id.
+        :param group_id: security group id.
         :type ex_filters: ``str``
 
 
@@ -923,9 +925,10 @@ class ECSDriver(NodeDriver):
             raise LibcloudError('could not find the node with id %s.'
                                 % node.id)
         current = nodes[0]
-        if current.state != NodeState.RUNNING and current.state != NodeState.STOPPED:
-            raise LibcloudError('The node with id %s could not join security group, node need be running or stopped .'
-                                % node.id)
+        if (current.state != NodeState.RUNNING) and \
+           (current.state != NodeState.STOPPED):
+            raise LibcloudError('The node state with id %s need \
+                                be running or stopped .' % node.id)
 
         params = {'Action': 'LeaveSecurityGroup',
                   'InstanceId': node.id,
@@ -952,7 +955,7 @@ class ECSDriver(NodeDriver):
         zone_elements = findall(resp_body, 'Zones/Zone',
                                 namespace=self.namespace)
         zones = [self._to_zone(el) for el in zone_elements]
-        return zones    
+        return zones
     ##
     # Volume and snapshot management methods
     ##

--- a/libcloud/compute/drivers/ecs.py
+++ b/libcloud/compute/drivers/ecs.py
@@ -916,7 +916,7 @@ class ECSDriver(NodeDriver):
         """
         if group_id is None:
             raise AttributeError('group_id is required')
-        
+
         if (node.state != NodeState.RUNNING) and \
            (node.state != NodeState.STOPPED):
             raise LibcloudError('The node state with id % s need\

--- a/libcloud/compute/drivers/ecs.py
+++ b/libcloud/compute/drivers/ecs.py
@@ -851,7 +851,7 @@ class ECSDriver(NodeDriver):
         List security group attributes in the current region.
 
         :keyword group_id: security group id.
-        :type ex_filters: ``str``
+        :type group_id: ``str``
 
         :keyword nic_type: internet|intranet.
         :type nic_type: ``str``
@@ -908,7 +908,7 @@ class ECSDriver(NodeDriver):
         :type node: :class:`Node`
 
         :param group_id: security group id.
-        :type ex_filters: ``str``
+        :type group_id: ``str``
 
 
         :return: leave operation result.

--- a/libcloud/test/compute/fixtures/ecs/join_security_group_by_id.xml
+++ b/libcloud/test/compute/fixtures/ecs/join_security_group_by_id.xml
@@ -1,0 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<JoinSecurityGroupResponse>
+	<RequestId>473469C7-AA6F-4DC5-B3DB-A3DC0DE3C83E</RequestId>
+</JoinSecurityGroupResponse>

--- a/libcloud/test/compute/fixtures/ecs/leave_security_group_by_id.xml
+++ b/libcloud/test/compute/fixtures/ecs/leave_security_group_by_id.xml
@@ -1,0 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<LeaveSecurityGroupResponse>
+	<RequestId>473469C7-AA6F-4DC5-B3DB-A3DC0DE3C83E</RequestId>
+</LeaveSecurityGroupResponse>

--- a/libcloud/test/compute/test_ecs.py
+++ b/libcloud/test/compute/test_ecs.py
@@ -531,15 +531,15 @@ class ECSDriverTestCase(LibcloudTestCase):
     def test_ex_join_security_group(self):
         ex_security_group_id_value = 'sg-28ou0f3xa'
         result = self.driver.ex_join_security_group(
-             self.fake_node,
-             group_id=ex_security_group_id_value)
+              self.fake_node,
+              group_id=ex_security_group_id_value)
         self.assertTrue(result)
 
     def test_ex_leave_security_group(self):
         ex_security_group_id_value = 'sg-28ou0f3xa'
         result = self.driver.ex_leave_security_group(
-             self.fake_node,
-             group_id=ex_security_group_id_value)
+               self.fake_node,
+               group_id=ex_security_group_id_value)
         self.assertTrue(result)
 
     def test_ex_list_security_groups_with_ex_filters(self):

--- a/libcloud/test/compute/test_ecs.py
+++ b/libcloud/test/compute/test_ecs.py
@@ -530,12 +530,12 @@ class ECSDriverTestCase(LibcloudTestCase):
 
     def test_ex_join_security_group(self):
         ex_security_group_id_value='F876FF7BA984'
-        result = self.driver.ex_join_security_group(self.fake_node, ex_security_group_id=ex_security_group_id_value)
+        result = self.driver.ex_join_security_group(self.fake_node, group_id=ex_security_group_id_value)
         self.assertTrue(result)
 
     def test_ex_leave_security_group(self):
         ex_security_group_id_value='F876FF7BA984'
-        result = self.driver.ex_leave_security_group(self.fake_node, ex_security_group_id=ex_security_group_id_value)
+        result = self.driver.ex_leave_security_group(self.fake_node, group_id=ex_security_group_id_value)
         self.assertTrue(result)
 
     def test_ex_list_security_groups_with_ex_filters(self):

--- a/libcloud/test/compute/test_ecs.py
+++ b/libcloud/test/compute/test_ecs.py
@@ -912,6 +912,14 @@ class ECSMockHttp(MockHttpTestCase):
         self.assertUrlContainsQueryParams(url, params)
         resp_body = self.fixtures.load('describe_security_groups.xml')
         return (httplib.OK, resp_body, {}, httplib.responses[httplib.OK])
+    
+    def _JoinSecurityGroup(self, method, url, body, headers):
+        body = self.fixtures.load('join_security_group_by_id.xml')
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+    
+    def _LeaveSecurityGroup(self, method, url, body, headers):
+        body = self.fixtures.load('leave_security_group_by_id.xml')
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
     def _list_sgs_filters_DescribeSecurityGroups(self, method, url, body,
                                                  headers):

--- a/libcloud/test/compute/test_ecs.py
+++ b/libcloud/test/compute/test_ecs.py
@@ -528,6 +528,14 @@ class ECSDriverTestCase(LibcloudTestCase):
         self.assertEqual('', sg.vpc_id)
         self.assertEqual('2015-06-26T08:35:30Z', sg.creation_time)
 
+    def test_ex_join_security_group(self):
+        result = self.driver.ex_join_security_group(self.fake_node, ex_security_group_id='F876FF7BA984')
+        self.assertTrue(result)
+
+    def test_ex_leave_security_group(self):
+        result = self.driver.ex_leave_security_group(self.fake_node, ex_security_group_id='F876FF7BA984')
+        self.assertTrue(result)
+
     def test_ex_list_security_groups_with_ex_filters(self):
         ECSMockHttp.type = 'list_sgs_filters'
         self.vpc_id = 'vpc1'

--- a/libcloud/test/compute/test_ecs.py
+++ b/libcloud/test/compute/test_ecs.py
@@ -529,12 +529,12 @@ class ECSDriverTestCase(LibcloudTestCase):
         self.assertEqual('2015-06-26T08:35:30Z', sg.creation_time)
 
     def test_ex_join_security_group(self):
-        ex_security_group_id_value='F876FF7BA984'
+        ex_security_group_id_value='sg-28ou0f3xa'
         result = self.driver.ex_join_security_group(self.fake_node, group_id=ex_security_group_id_value)
         self.assertTrue(result)
 
     def test_ex_leave_security_group(self):
-        ex_security_group_id_value='F876FF7BA984'
+        ex_security_group_id_value='sg-28ou0f3xa'
         result = self.driver.ex_leave_security_group(self.fake_node, group_id=ex_security_group_id_value)
         self.assertTrue(result)
 

--- a/libcloud/test/compute/test_ecs.py
+++ b/libcloud/test/compute/test_ecs.py
@@ -529,11 +529,13 @@ class ECSDriverTestCase(LibcloudTestCase):
         self.assertEqual('2015-06-26T08:35:30Z', sg.creation_time)
 
     def test_ex_join_security_group(self):
-        result = self.driver.ex_join_security_group(self.fake_node, ex_security_group_id='F876FF7BA984')
+        ex_security_group_id_value='F876FF7BA984'
+        result = self.driver.ex_join_security_group(self.fake_node, ex_security_group_id=ex_security_group_id_value)
         self.assertTrue(result)
 
     def test_ex_leave_security_group(self):
-        result = self.driver.ex_leave_security_group(self.fake_node, ex_security_group_id='F876FF7BA984')
+        ex_security_group_id_value='F876FF7BA984'
+        result = self.driver.ex_leave_security_group(self.fake_node, ex_security_group_id=ex_security_group_id_value)
         self.assertTrue(result)
 
     def test_ex_list_security_groups_with_ex_filters(self):

--- a/libcloud/test/compute/test_ecs.py
+++ b/libcloud/test/compute/test_ecs.py
@@ -531,17 +531,15 @@ class ECSDriverTestCase(LibcloudTestCase):
     def test_ex_join_security_group(self):
         ex_security_group_id_value = 'sg-28ou0f3xa'
         result = self.driver.ex_join_security_group(
-                                     self.fake_node,
-                                     group_id=ex_security_group_id_value
-                 )
+             self.fake_node,
+             group_id=ex_security_group_id_value)
         self.assertTrue(result)
 
     def test_ex_leave_security_group(self):
         ex_security_group_id_value = 'sg-28ou0f3xa'
         result = self.driver.ex_leave_security_group(
-                                     self.fake_node,
-                                     group_id=ex_security_group_id_value
-                 )
+             self.fake_node,
+             group_id=ex_security_group_id_value)
         self.assertTrue(result)
 
     def test_ex_list_security_groups_with_ex_filters(self):

--- a/libcloud/test/compute/test_ecs.py
+++ b/libcloud/test/compute/test_ecs.py
@@ -529,13 +529,19 @@ class ECSDriverTestCase(LibcloudTestCase):
         self.assertEqual('2015-06-26T08:35:30Z', sg.creation_time)
 
     def test_ex_join_security_group(self):
-        ex_security_group_id_value='sg-28ou0f3xa'
-        result = self.driver.ex_join_security_group(self.fake_node, group_id=ex_security_group_id_value)
+        ex_security_group_id_value = 'sg-28ou0f3xa'
+        result = self.driver.ex_join_security_group(
+                                     self.fake_node,
+                                     group_id=ex_security_group_id_value
+                 )
         self.assertTrue(result)
 
     def test_ex_leave_security_group(self):
-        ex_security_group_id_value='sg-28ou0f3xa'
-        result = self.driver.ex_leave_security_group(self.fake_node, group_id=ex_security_group_id_value)
+        ex_security_group_id_value = 'sg-28ou0f3xa'
+        result = self.driver.ex_leave_security_group(
+                                     self.fake_node,
+                                     group_id=ex_security_group_id_value
+                 )
         self.assertTrue(result)
 
     def test_ex_list_security_groups_with_ex_filters(self):
@@ -912,11 +918,11 @@ class ECSMockHttp(MockHttpTestCase):
         self.assertUrlContainsQueryParams(url, params)
         resp_body = self.fixtures.load('describe_security_groups.xml')
         return (httplib.OK, resp_body, {}, httplib.responses[httplib.OK])
-    
+
     def _JoinSecurityGroup(self, method, url, body, headers):
         body = self.fixtures.load('join_security_group_by_id.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
-    
+
     def _LeaveSecurityGroup(self, method, url, body, headers):
         body = self.fixtures.load('leave_security_group_by_id.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])

--- a/libcloud/test/compute/test_ecs.py
+++ b/libcloud/test/compute/test_ecs.py
@@ -530,16 +530,14 @@ class ECSDriverTestCase(LibcloudTestCase):
 
     def test_ex_join_security_group(self):
         ex_security_group_id_value = 'sg-28ou0f3xa'
-        result = self.driver.ex_join_security_group(
-              self.fake_node,
-              group_id=ex_security_group_id_value)
+        result = self.driver.ex_join_security_group(self.fake_node,
+                                                    group_id=ex_security_group_id_value)
         self.assertTrue(result)
 
     def test_ex_leave_security_group(self):
         ex_security_group_id_value = 'sg-28ou0f3xa'
-        result = self.driver.ex_leave_security_group(
-               self.fake_node,
-               group_id=ex_security_group_id_value)
+        result = self.driver.ex_leave_security_group(self.fake_node,
+                                                     group_id=ex_security_group_id_value)
         self.assertTrue(result)
 
     def test_ex_list_security_groups_with_ex_filters(self):


### PR DESCRIPTION
## Add aliyun ecs instance join leave security group

### Description

When I use libcloud in my project, I need use function about "Join/Leave Security Group" for Aliyun ECS instance. But I can not find it in libcloud. That's why I make this pull request.

Two functions are added: join_security_group/leave_security_group 

### Status


- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
