### PR TITLE
Add Cloudscale Host Keys And Documentation Improvements

### DIFF
--- a/docs/compute/_supported_providers.rst
+++ b/docs/compute/_supported_providers.rst
@@ -11,7 +11,7 @@ Provider                              Documentation                             
 `Bluebox Blocks`_                                                                       BLUEBOX             single region driver                                                                                                                                                      :mod:`libcloud.compute.drivers.bluebox`           :class:`BlueboxNodeDriver`          
 `Brightbox`_                                                                            BRIGHTBOX           single region driver                                                                                                                                                      :mod:`libcloud.compute.drivers.brightbox`         :class:`BrightboxNodeDriver`        
 `BSNL`_                               :doc:`Click </compute/drivers/bsnl>`              BSNL                single region driver                                                                                                                                                      :mod:`libcloud.compute.drivers.bsnl`              :class:`BSNLNodeDriver`             
-`Cloudscale`_                         :doc:`Click </compute/drivers/cloudscale>`        CLOUDSCALE          single region driver                                                                                                                                                      :mod:`libcloud.compute.drivers.cloudscale`        :class:`CloudscaleNodeDriver`       
+`cloudscale.ch`_                      :doc:`Click </compute/drivers/cloudscale>`        CLOUDSCALE          single region driver                                                                                                                                                      :mod:`libcloud.compute.drivers.cloudscale`        :class:`CloudscaleNodeDriver`       
 `CloudSigma (API v2.0)`_              :doc:`Click </compute/drivers/cloudsigma>`        CLOUDSIGMA          single region driver                                                                                                                                                      :mod:`libcloud.compute.drivers.cloudsigma`        :class:`CloudSigmaNodeDriver`       
 `CloudStack`_                         :doc:`Click </compute/drivers/cloudstack>`        CLOUDSTACK          single region driver                                                                                                                                                      :mod:`libcloud.compute.drivers.cloudstack`        :class:`CloudStackNodeDriver`       
 `Cloudwatt`_                          :doc:`Click </compute/drivers/cloudwatt>`         CLOUDWATT           single region driver                                                                                                                                                      :mod:`libcloud.compute.drivers.cloudwatt`         :class:`CloudwattNodeDriver`        
@@ -69,7 +69,7 @@ Provider                              Documentation                             
 .. _`Bluebox Blocks`: http://bluebox.net
 .. _`Brightbox`: http://www.brightbox.co.uk/
 .. _`BSNL`: http://www.bsnlcloud.com/
-.. _`Cloudscale`: https://www.cloudscale.ch
+.. _`cloudscale.ch`: https://www.cloudscale.ch
 .. _`CloudSigma (API v2.0)`: http://www.cloudsigma.com/
 .. _`CloudStack`: http://cloudstack.org/
 .. _`Cloudwatt`: https://www.cloudwatt.com/

--- a/docs/compute/drivers/cloudscale.rst
+++ b/docs/compute/drivers/cloudscale.rst
@@ -1,5 +1,5 @@
-Cloudscale Compute Driver Documentation
-=======================================
+cloudscale.ch Compute Driver Documentation
+==========================================
 
 `cloudscale.ch`_ is a public cloud provider based in Switzerland.
 

--- a/libcloud/compute/drivers/cloudscale.py
+++ b/libcloud/compute/drivers/cloudscale.py
@@ -203,11 +203,11 @@ class CloudscaleNodeDriver(NodeDriver):
 
     def _to_node(self, data):
         state = self.NODE_STATE_MAP.get(data['status'], NodeState.UNKNOWN)
-        extra_keys = ['volumes', 'interfaces', 'anti_affinity_with']
+        extra_keys_exclude = ['uuid', 'name', 'status', 'flavor', 'image']
         extra = {}
-        for key in extra_keys:
-            if key in data:
-                extra[key] = data[key]
+        for k, v in data.items():
+            if k not in extra_keys_exclude:
+                extra[k] = v
 
         public_ips = []
         private_ips = []


### PR DESCRIPTION
## Add Cloudscale Host Keys And Documentation Improvements

### Description

This is a pretty small set of changes.

It only includes two things: 

- We have had some issues where we added stuff like host keys to our API. This should be reflected in Libcloud. Basically the default behavior is to store all keys in the `extra` field that are not already part of the server object.
- cloudscale.ch's name was never cloudscale. It's always written as the full URL.

### Status

Done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
