### PR TITLE
fix AliyunXmlResponse MalformedResponseError for SLB

### DIFF
--- a/libcloud/common/aliyun.py
+++ b/libcloud/common/aliyun.py
@@ -64,7 +64,10 @@ class AliyunXmlResponse(XmlResponse):
                 parser = ET.XMLParser(encoding='utf-8')
                 body = ET.XML(self.body.encode('utf-8'), parser=parser)
             else:
-                body = ET.XML(self.body.encode('utf-8'))
+                try:
+                    body = ET.XML(self.body)
+                except:
+                    body = ET.XML(self.body.encode('utf-8'))
         except:
             raise MalformedResponseError('Failed to parse XML',
                                          body=self.body,

--- a/libcloud/common/aliyun.py
+++ b/libcloud/common/aliyun.py
@@ -64,7 +64,7 @@ class AliyunXmlResponse(XmlResponse):
                 parser = ET.XMLParser(encoding='utf-8')
                 body = ET.XML(self.body.encode('utf-8'), parser=parser)
             else:
-                body = ET.XML(self.body)
+                body = ET.XML(self.body.encode('utf-8'))
         except:
             raise MalformedResponseError('Failed to parse XML',
                                          body=self.body,


### PR DESCRIPTION
## fix AliyunXmlResponse MalformedResponseError for SLB
### Description

When I run the example_loadbalancer.py, it encounters an malformedResponseError for Aliyun CreateLoadBalancer response. But when you login in Aliyun SLB, you would found that the instance has been created .    

-------------------------------

cls = get_driver(Provider.ALIYUN_SLB)
    driver = cls('username', 'api key', region='ord')
    # creating a balancer which balances traffic across two
    # nodes: 192.168.86.1:80 and 192.168.86.2:8080. Balancer
    # itself listens on port 80/tcp
    new_balancer_name = 'testlb' + os.urandom(4).encode('hex')
    members = (Member(None, '192.168.86.1', 80), Member(None, '192.168.86.2', 8080))
    new_balancer = driver.create_balancer(name=new_balancer_name, algorithm=Algorithm.ROUND_ROBIN, port=80, protocol='http', members=members)

---------------------------------------------------------------------------------------

### Status

Replace this: describe the PR status. Examples:

- work in progress
- done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
