### PR TITLE
[LIBCLOUD-881] Fix error in GCE driver in ex_create_multiple_nodes fu…

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -6626,7 +6626,8 @@ class GCENodeDriver(NodeDriver):
         :return:  A DiskType object for the name
         :rtype:   :class:`GCEDiskType`
         """
-        zone = self._set_zone(zone)
+        zone = self._set_zone(zone) or self._find_zone_or_region(
+            name, 'diskTypes', region=False, res_name='DiskType')
         request = '/zones/%s/diskTypes/%s' % (zone.name, name)
         response = self.connection.request(request, method='GET').object
         return self._to_disktype(response)


### PR DESCRIPTION
### Description

I've encountered an error when I tried to create multiple nodes with GCE driver. Here is a traceback:
```
File "/usr/local/lib/python2.7/dist-packages/libcloud/compute/drivers/gce.py", line 4644, in ex_create_multiple_nodes
self._multi_create_node(status, node_attrs)
File "/usr/local/lib/python2.7/dist-packages/libcloud/compute/drivers/gce.py", line 7633, in _multi_create_node
ex_automatic_restart=node_attrs['ex_automatic_restart'])
File "/usr/local/lib/python2.7/dist-packages/libcloud/compute/drivers/gce.py", line 7533, in _create_node_req
nic_gce_struct=ex_nic_gce_struct, use_selflinks=use_selflinks)
File "/usr/local/lib/python2.7/dist-packages/libcloud/compute/drivers/gce.py", line 4058, in _create_instance_properties
is_boot=True, use_selflinks=use_selflinks)]
File "/usr/local/lib/python2.7/dist-packages/libcloud/compute/drivers/gce.py", line 4198, in _build_disk_gce_struct
obj=disk_type, get_selflinks=use_selflinks, objname='disktype')
File "/usr/local/lib/python2.7/dist-packages/libcloud/compute/drivers/gce.py", line 4241, in _get_selflink_or_name
obj = getobj(obj)
File "/usr/local/lib/python2.7/dist-packages/libcloud/compute/drivers/gce.py", line 6517, in ex_get_disktype
request = '/zones/%s/diskTypes/%s' % (zone.name, name)
```
### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
