### PR TITLE
Add p2 instances

### DIFF
--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -324,6 +324,27 @@ INSTANCE_TYPES = {
             'cpu': 32
         }
     },
+    'p2.xlarge': {
+        'id': 'p2.xlarge',
+        'name': 'Cluster GPU P2 Large Instance',
+        'ram': GiB(61),
+        'disk' : 4,
+        'bandwidth': None
+    },
+    'p2.8xlarge': {
+        'id': 'p2.8xlarge',
+        'name': 'Cluster GPU P2 Large Instance',
+        'ram': GiB(488),
+        'disk': 32,
+        'bandwidth': None
+    },
+    'p2.16xlarge': {
+        'id': 'p2.16xlarge',
+        'name': 'Cluster GPU P2 Large Instance',
+        'ram': GiB(732),
+        'disk': 64,
+        'bandwidth': None
+    },
     'cc1.4xlarge': {
         'id': 'cc1.4xlarge',
         'name': 'Cluster Compute Quadruple Extra Large Instance',
@@ -881,6 +902,9 @@ REGION_DETAILS = {
             'c1.xlarge',
             'g2.2xlarge',
             'g2.8xlarge',
+            'p2.xlarge',
+            'p2.8xlarge',
+            'p2.16xlarge',
             'c3.large',
             'c3.xlarge',
             'c3.2xlarge',
@@ -1784,6 +1808,9 @@ OUTSCALE_SAS_REGION_DETAILS = {
             'cc2.8xlarge',
             'm3.xlarge',
             'm3.2xlarge',
+            'p2.xlarge',
+            'p2.8xlarge',
+            'p2.16xlarge',
             'cr1.8xlarge',
             'os1.8xlarge'
         ]
@@ -1861,6 +1888,9 @@ OUTSCALE_INC_REGION_DETAILS = {
             'm2.xlarge',
             'm2.2xlarge',
             'm2.4xlarge',
+            'p2.xlarge',
+            'p2.8xlarge',
+            'p2.16xlarge',
             'nv1.small',
             'nv1.medium',
             'nv1.large',

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -437,7 +437,7 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
             elif region_name == 'us-west-1':
                 self.assertEqual(len(sizes), 46)
             if region_name == 'us-west-2':
-                self.assertEqual(len(sizes), 53)
+                self.assertEqual(len(sizes), 56)
             elif region_name == 'ap-southeast-1':
                 self.assertEqual(len(sizes), 45)
             elif region_name == 'ap-southeast-2':


### PR DESCRIPTION
## Add P2 GPU instances to EC2 driver

### Description

P2 instances feature a K80 GPU I need but don't currently appear in ec2 driver list_sizes(). All regions that have p2 should appear in list_sizes

### Status

Done

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)

