### PR TITLE
NephoScale networking and Bare Metal servers

### DIFF
--- a/libcloud/compute/drivers/nephoscale.py
+++ b/libcloud/compute/drivers/nephoscale.py
@@ -248,7 +248,7 @@ class NephoscaleNodeDriver(NodeDriver):
         :rtype: ``list`` of :class:`Node`
         """
         if baremetal:
-        # show cloud servers and dedicated servers as well
+            # show cloud servers and dedicated servers as well
             result = self.connection.request('/server/').object
         else:
             result = self.connection.request('/server/cloud/').object
@@ -563,17 +563,17 @@ get all keys call with no arguments')
                 'console_key': console_key,
                 'zone': zone
                 }
-        #cloudlet or baremetal
+        # cloudlet or baremetal
         if baremetal:
             element_uri = 'dedicated'
-            #not required
+            # not required
             data.pop('console_key')
         else:
             element_uri = 'cloud'
-        #Comma delimited list of IP addresses to associate with the server
-        #eg "ips": "208.166.64.4, 10.128.0.4".
-        #If ips are set, NephoScale need to have the network specified as well
-        #eg  'networks': '59887,59889'
+        # Comma delimited list of IP addresses to associate with the server
+        # eg "ips": "208.166.64.4, 10.128.0.4".
+        # If ips are set, NephoScale need to have the network specified as well
+        # eg  'networks': '59887,59889'
 
         if ips:
             if type(ips) == list:
@@ -647,7 +647,7 @@ get all keys call with no arguments')
         }
 
         billable_type = data.get('service_type', {}).get('billable_type')
-        #1 for cloud servers, 2 for dedicated
+        # 1 for cloud servers, 2 for dedicated
         if billable_type == 1:
             extra['tags'] = {'type': 'Cloudlet'}
         elif billable_type == 2:

--- a/libcloud/compute/drivers/nephoscale.py
+++ b/libcloud/compute/drivers/nephoscale.py
@@ -69,6 +69,42 @@ class NodeKey(object):
                 (self.id, self.name))
 
 
+class NephoScaleNetwork(object):
+    """
+    A Virtual Network.
+    """
+
+    def __init__(self, id, name, subnets, is_default, zone, domain_type,
+                 driver, extra=None):
+        self.id = str(id)
+        self.name = name
+        self.subnets = subnets
+        self.is_default = is_default
+        self.zone = zone
+        self.domain_type = domain_type
+        self.driver = driver
+        self.extra = extra or {}
+
+    def __repr__(self):
+        return '<NephoScaleNetwork id="%s" name="%s">' % (self.id, self.name,)
+
+
+class NephoScaleDomain(object):
+    """
+    A Network Domain.
+    """
+
+    def __init__(self, id, name, cidr, driver, extra=None):
+        self.id = str(id)
+        self.name = name
+        self.cidr = cidr
+        self.driver = driver
+        self.extra = extra or {}
+
+    def __repr__(self):
+        return '<NephoScaleDomain id="%s">' % (self.id)
+
+
 class NephoscaleResponse(JsonResponse):
     """
     Nephoscale API Response
@@ -97,6 +133,9 @@ class NephoscaleConnection(ConnectionUserAndKey):
 
     allow_insecure = False
 
+    # increase timeout for NephoScale response
+    timeout = 180
+
     def add_default_headers(self, headers):
         """
         Add parameters that are necessary for every request
@@ -123,7 +162,7 @@ class NephoscaleNodeDriver(NodeDriver):
     connectionCls = NephoscaleConnection
     features = {'create_node': ['ssh_key']}
 
-    def list_locations(self):
+    def list_locations(self, active=True):
         """
         List available zones for deployment
 
@@ -136,16 +175,26 @@ class NephoscaleNodeDriver(NodeDriver):
                                     name=value.get('name'),
                                     country='US',
                                     driver=self)
-            locations.append(location)
+            if active:
+                # return only active locations
+                if value.get('activated', True) is True:
+                    locations.append(location)
+            else:
+                locations.append(location)
+
         return locations
 
-    def list_images(self):
+    def list_images(self, region=None):
         """
         List available images for deployment
 
         :rtype: ``list`` of :class:`NodeImage`
         """
-        result = self.connection.request('/image/server/').object
+        if region:
+            result = self.connection.request('/image/server/?region=%s' %
+                                             region).object
+        else:
+            result = self.connection.request('/image/server/').object
         images = []
         for value in result.get('data', []):
             extra = {'architecture': value.get('architecture'),
@@ -163,68 +212,208 @@ class NephoscaleNodeDriver(NodeDriver):
             images.append(image)
         return images
 
-    def list_sizes(self):
+    def list_sizes(self, baremetal=False):
         """
         List available sizes containing prices
 
         :rtype: ``list`` of :class:`NodeSize`
         """
-        result = self.connection.request('/server/type/cloud/').object
+        # cloudlet or baremetal
+        if baremetal:
+            element_uri = 'dedicated'
+        else:
+            element_uri = 'cloud'
+
+        result = self.connection.request('/server/type/%s/?sort=ram'
+                                         % element_uri).object
         sizes = []
         for value in result.get('data', []):
             value_id = value.get('id')
+            name = "%s - %s" % (value.get('sku').get('name'),
+                   value.get('sku').get('description'))
             size = NodeSize(id=value_id,
-                            name=value.get('friendly_name'),
+                            name=name,
                             ram=value.get('ram'),
                             disk=value.get('storage'),
                             bandwidth=None,
                             price=self._get_size_price(size_id=str(value_id)),
                             driver=self)
             sizes.append(size)
-
         return sorted(sizes, key=lambda k: k.price)
 
-    def list_nodes(self):
+    def list_nodes(self, baremetal=True):
         """
         List available nodes
 
         :rtype: ``list`` of :class:`Node`
         """
-        result = self.connection.request('/server/cloud/').object
+        if baremetal:
+        # show cloud servers and dedicated servers as well
+            result = self.connection.request('/server/').object
+        else:
+            result = self.connection.request('/server/cloud/').object
         nodes = [self._to_node(value) for value in result.get('data', [])]
         return nodes
 
-    def rename_node(self, node, name, hostname=None):
+    def ex_list_networks(self):
+        """
+        List available networks
+
+        """
+        networks = self.connection.request('/network/domain/').object
+
+        subnets = self.connection.request('/network/cidr/ipv4/').object
+        ret = []
+        for value in networks.get('data', []):
+            network_subnets = []
+            # Skip duplicate results
+            if value.get('id') in [n.get('id') for n in network_subnets]:
+                continue
+            for s1 in value.get('cidr', []):
+                for s2 in subnets.get('data', []):
+                    if s1.get('id') == s2.get('id'):
+                        s1['ipaddress_list_status'] = \
+                            s2['ipaddress_list_status']
+                        s1['name'] = s1['cidr_str']
+                        network_subnets.append(s1)
+
+            network = NephoScaleNetwork(id=value.get('id'),
+                                        name=value.get('name'),
+                                        subnets=network_subnets,
+                                        is_default=value.get('is_default',
+                                                             False),
+                                        zone=value.get('zone'),
+                                        domain_type=value.get('domain_type'),
+                                        driver=self,
+                                        )
+
+            # Nephoscale's response might contain duplicate
+            # network information
+            if network.id not in [net.id for net in ret]:
+                ret.append(network)
+        return ret
+
+    def ex_list_domains(self):
+        """
+        List available domains
+
+        """
+        result = self.connection.request('/network/domain/').object
+        domains = []
+        for value in result.get('data', []):
+            extra = {}
+            cidr = value.get('cidr')
+            domain = NephoScaleDomain(id=value.get('id'),
+                                      name=value.get('id'),
+                                      driver=self,
+                                      extra=extra,
+                                      cidr=cidr)
+            domains.append(domain)
+        return domains
+
+    def ex_list_unassigned_ips(self, public=True):
+        """List available unassigned ipv4 addresses
+
+        If public = False, return ipv4 private addresses
+
+        """
+        if public:
+            ip_type = 0
+        else:
+            ip_type = 1
+        url = '/network/cidr/ipv4/?ip_type=%s&fields=' \
+              'ipaddress_list_unassigned' % ip_type
+        result = self.connection.request(url).object
+        ips = []
+        for value in result.get('data', []):
+            ips.extend(value.get('ipaddress_list_unassigned', []))
+        return ips
+
+    def ex_associate_ip(self, ip, server=None, assign=True):
+        """Assign and unassign an ip address
+
+        Server is optional, if specified the ip address is assigned there
+        Otherwise the ip address is just reserverd
+
+
+        Examples:
+            associate ip address with server:
+                c.ex_associate_ip('69.50.244.8', server=c.list_nodes()[2])
+            associate an ip address (mark it as assigned):
+                c.ex_associate_ip('10.132.63.227')
+            unassign ip address (mark it as unassigned):
+                c.ex_associate_ip('10.132.63.227', assign=False)
+
+
+        """
+        # first get the id of the subnet the ip address belongs to
+        subnet_id = None
+        networks = self.ex_list_networks()
+
+        for network in networks:
+            for subnet in network.subnets:
+                if ip in subnet.get('ipaddress_list'):
+                    subnet_id = subnet.get('id')
+                    break
+            if subnet_id:
+                break
+
+        if not subnet_id:
+            raise Exception("The ip address %s cannot "
+                            "be found on any of the available subnets" % ip)
+        url = '/network/cidr/ipv4/%s/' % subnet_id
+
+        payload = '_method=PUT&ipaddress=%s&reserved=%s' % \
+                  (ip, str(assign).lower())
+
+        if server:
+            payload += '&server=%s' % server
+
+        try:
+            result = self.connection.request(url,
+                                             data=payload,
+                                             method='POST').object
+        except Exception:
+            e = sys.exc_info()[1]
+            raise Exception("Failed to associate ip: %s" % e)
+        return result.get('response') in VALID_RESPONSE_CODES
+
+    def ex_rename_node(self, node, name, hostname=None):
         """rename a cloud server, optionally specify hostname too"""
         data = {'name': name}
         if hostname:
             data['hostname'] = hostname
         params = urlencode(data)
-        result = self.connection.request('/server/cloud/%s/' % node.id,
+        result = self.connection.request('/server/cloud/%s/'
+                                         % node.extra.get('id'),
                                          data=params, method='PUT').object
         return result.get('response') in VALID_RESPONSE_CODES
 
     def reboot_node(self, node):
         """reboot a running node"""
         result = self.connection.request('/server/cloud/%s/initiator/restart/'
-                                         % node.id, method='POST').object
+                                         % node.extra.get('id'),
+                                         method='POST').object
         return result.get('response') in VALID_RESPONSE_CODES
 
     def ex_start_node(self, node):
         """start a stopped node"""
         result = self.connection.request('/server/cloud/%s/initiator/start/'
-                                         % node.id, method='POST').object
+                                         % node.extra.get('id'),
+                                         method='POST').object
         return result.get('response') in VALID_RESPONSE_CODES
 
     def ex_stop_node(self, node):
         """stop a running node"""
         result = self.connection.request('/server/cloud/%s/initiator/stop/'
-                                         % node.id, method='POST').object
+                                         % node.extra.get('id'),
+                                         method='POST').object
         return result.get('response') in VALID_RESPONSE_CODES
 
     def destroy_node(self, node):
         """destroy a node"""
-        result = self.connection.request('/server/cloud/%s/' % node.id,
+        result = self.connection.request('/server/cloud/%s/'
+                                         % node.extra.get('id'),
                                          method='DELETE').object
         return result.get('response') in VALID_RESPONSE_CODES
 
@@ -311,10 +500,11 @@ get all keys call with no arguments')
         return result.get('response') in VALID_RESPONSE_CODES
 
     def create_node(self, name, size, image, server_key=None,
-                    console_key=None, zone=None, **kwargs):
+                    console_key=None, zone=None, baremetal=False,
+                    ips=None, **kwargs):
         """Creates the node, and sets the ssh key, console key
         NephoScale will respond with a 200-200 response after sending a valid
-        request. If nowait=True is specified in the args, we then ask a few
+        request. If ex_wait=True is specified in the args, we then ask a few
         times until the server is created and assigned a public IP address,
         so that deploy_node can be run
 
@@ -351,13 +541,13 @@ get all keys call with no arguments')
         We can also specify the location
         >>> location = conn.list_locations()[0]
         >>> node = conn.create_node(name=name,
-        >>> ...                     size=size,
-        >>> ...                     image=image,
-        >>> ...                     console_key=console_key,
-        >>> ...                     server_key=server_key,
-        >>> ...                     connect_attempts=10,
-        >>> ...                     nowait=True,
-        >>> ...                     zone=location.id)
+            ...                     size=size,
+            ...                     image=image,
+            ...                     console_key=console_key,
+            ...                     server_key=server_key,
+            ...                     connect_attempts=10,
+            ...                     ex_wait=True,
+            ...                     zone=location.id)
         """
         hostname = kwargs.get('hostname', name)
         service_type = size.id
@@ -373,15 +563,40 @@ get all keys call with no arguments')
                 'console_key': console_key,
                 'zone': zone
                 }
+        #cloudlet or baremetal
+        if baremetal:
+            element_uri = 'dedicated'
+            #not required
+            data.pop('console_key')
+        else:
+            element_uri = 'cloud'
+        #Comma delimited list of IP addresses to associate with the server
+        #eg "ips": "208.166.64.4, 10.128.0.4".
+        #If ips are set, NephoScale need to have the network specified as well
+        #eg  'networks': '59887,59889'
+
+        if ips:
+            if type(ips) == list:
+                ips = ','.join(ips)
+            data['ips'] = ips
+
+            networks = []
+            domains = self.ex_list_domains()
+            for ip in ips.split(','):
+                ip = ip.replace(' ', '')
+                network = self.get_network_domain_from_ip(domains, ip)
+                networks.append(network)
+            data['networks'] = ','.join(networks)
 
         params = urlencode(data)
         try:
-            node = self.connection.request('/server/cloud/', data=params,
+            node = self.connection.request('/server/%s/'
+                                           % element_uri, data=params,
                                            method='POST')
         except Exception:
             e = sys.exc_info()[1]
             raise Exception("Failed to create node %s" % e)
-        node = Node(id='', name=name, state=NodeState.UNKNOWN, public_ips=[],
+        node = Node(id=name, name=name, state=NodeState.UNKNOWN, public_ips=[],
                     private_ips=[], driver=self)
 
         nowait = kwargs.get('ex_wait', False)
@@ -420,6 +635,7 @@ get all keys call with no arguments')
                 else:
                     public_ips.append(ip)
         extra = {
+            'id': data.get('id'),
             'zone_data': data.get('zone'),
             'zone': data.get('zone', {}).get('name'),
             'image': data.get('image', {}).get('friendly_name'),
@@ -430,7 +646,14 @@ get all keys call with no arguments')
             'hostname': data.get('hostname')
         }
 
-        node = Node(id=data.get('id'), name=data.get('name'), state=state,
+        billable_type = data.get('service_type', {}).get('billable_type')
+        #1 for cloud servers, 2 for dedicated
+        if billable_type == 1:
+            extra['tags'] = {'type': 'Cloudlet'}
+        elif billable_type == 2:
+            extra['tags'] = {'type': 'BareMetal'}
+
+        node = Node(id=data.get('name'), name=data.get('name'), state=state,
                     public_ips=public_ips, private_ips=private_ips,
                     driver=self, extra=extra)
         return node
@@ -441,6 +664,17 @@ get all keys call with no arguments')
                        password=data.get('password'),
                        key_group=data.get('key_group'),
                        public_key=data.get('public_key'))
+
+    def get_network_domain_from_ip(self, domains, ip):
+        """Returns the network domain id an ip belongs to
+        Used in create_node, if ips are specified
+        """
+        network_domain = ''
+        for domain in domains:
+            for cidr in domain.cidr:
+                if ip in cidr.get('ipaddress_list', []):
+                    network_domain = domain.id
+        return network_domain
 
     def random_password(self, size=8):
         value = os.urandom(size)

--- a/libcloud/test/compute/test_nephoscale.py
+++ b/libcloud/test/compute/test_nephoscale.py
@@ -97,7 +97,7 @@ class NephoScaleTest(unittest.TestCase, TestCaseMixin):
 
     def test_rename_node(self):
         node = self.driver.list_nodes()[0]
-        result = self.driver.rename_node(node, 'new-name')
+        result = self.driver.ex_rename_node(node, 'new-name')
         self.assertTrue(result)
 
     def test_create_node(self):
@@ -130,11 +130,12 @@ class NephoscaleMockHttp(MockHttp):
         body = self.fixtures.load('list_sizes.json')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
+    def _server(self, method, url, body, headers):
+        body = self.fixtures.load('list_nodes.json')
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+
     def _server_cloud(self, method, url, body, headers):
-        if method == 'POST':
-            body = self.fixtures.load('success_action.json')
-        else:
-            body = self.fixtures.load('list_nodes.json')
+        body = self.fixtures.load('success_action.json')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
     def _image_server(self, method, url, body, headers):


### PR DESCRIPTION
## support NephoScale networking and Bare Metal servers


### Description

- add networking support (new functions ex_list_networks, ex_list_domains, ex_list_unassigned_ips, ex_associate_ip: work via new NephoScaleNetwork and NephoScaleDomain objects)
- support bare metal servers, show on list_nodes, allow to create new ones
- add ex_rename_node function
- smaller optimizations (list_locations active switch, list_images per region, list_sizes for baremetal servers)

### Status

done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
