### PR TITLE
a few optimizations on DigitalOcean compute driver

### DIFF
--- a/libcloud/compute/base.py
+++ b/libcloud/compute/base.py
@@ -394,7 +394,7 @@ class NodeLocation(object):
     'US'
     """
 
-    def __init__(self, id, name, country, driver):
+    def __init__(self, id, name, country, driver, extra=None):
         """
         :param id: Location ID.
         :type id: ``str``
@@ -407,11 +407,16 @@ class NodeLocation(object):
 
         :param driver: Driver this location belongs to.
         :type driver: :class:`.NodeDriver`
+
+        :param extra: Optional provided specific attributes associated with
+                      this location.
+        :type extra: ``dict``
         """
         self.id = str(id)
         self.name = name
         self.country = country
         self.driver = driver
+        self.extra = extra or {}
 
     def __repr__(self):
         return (('<NodeLocation: id=%s, name=%s, country=%s, driver=%s>')

--- a/libcloud/compute/drivers/digitalocean.py
+++ b/libcloud/compute/drivers/digitalocean.py
@@ -111,9 +111,21 @@ class DigitalOcean_v2_NodeDriver(DigitalOcean_v2_BaseDriver,
         data = self._paginated_request('/v2/account/keys', 'ssh_keys')
         return list(map(self._to_key_pair, data))
 
-    def list_locations(self):
+    def list_locations(self, available=True):
+        """
+        List locations
+
+        If available is True, show only locations which are available
+        """
+        locations = []
         data = self._paginated_request('/v2/regions', 'regions')
-        return list(map(self._to_location, data))
+        for location in data:
+            if available:
+                if location.get('available'):
+                    locations.append(self._to_location(location))
+            else:
+                locations.append(self._to_location(location))
+        return locations
 
     def list_nodes(self):
         data = self._paginated_request('/v2/droplets', 'droplets')
@@ -184,6 +196,12 @@ class DigitalOcean_v2_NodeDriver(DigitalOcean_v2_BaseDriver,
             raise ValueError('Failed to create node: %s' % (error_message))
 
         return self._to_node(data=data)
+
+    def ex_start_node(self, node):
+        params = {"type": "power_on"}
+        res = self.connection.request('/v2/droplets/%s/actions/' % node.id,
+                                      params=params, method='POST')
+        return res.status in [httplib.OK, httplib.CREATED, httplib.ACCEPTED]
 
     def destroy_node(self, node):
         res = self.connection.request('/v2/droplets/%s' % (node.id),
@@ -453,8 +471,19 @@ class DigitalOcean_v2_NodeDriver(DigitalOcean_v2_BaseDriver,
                                       method='DELETE')
         return res.status == httplib.NO_CONTENT
 
+    def ex_resize_node(self, node, size):
+        """Resizes a Droplet from one plan to another
+
+        Droplet needs to be down
+
+        """
+        params = {"type": "resize", "size": size}
+        res = self.connection.request('/v2/droplets/%s/actions/' % node.id,
+                                      params=params, method='POST')
+        return res.status in [httplib.OK, httplib.CREATED, httplib.ACCEPTED]
+
     def _to_node(self, data):
-        extra_keys = ['memory', 'vcpus', 'disk', 'region', 'image',
+        extra_keys = ['memory', 'vcpus', 'disk', 'image', 'size',
                       'size_slug', 'locked', 'created_at', 'networks',
                       'kernel', 'backup_ids', 'snapshot_ids', 'features']
         if 'status' in data:
@@ -477,7 +506,7 @@ class DigitalOcean_v2_NodeDriver(DigitalOcean_v2_BaseDriver,
         for key in extra_keys:
             if key in data:
                 extra[key] = data[key]
-
+        extra['region'] = data.get('region', {}).get('name')
         node = Node(id=data['id'], name=data['name'], state=state,
                     public_ips=public_ips, private_ips=private_ips,
                     created_at=created, driver=self, extra=extra)
@@ -490,7 +519,8 @@ class DigitalOcean_v2_NodeDriver(DigitalOcean_v2_BaseDriver,
                  'regions': data['regions'],
                  'min_disk_size': data['min_disk_size'],
                  'created_at': data['created_at']}
-        return NodeImage(id=data['id'], name=data['name'], driver=self,
+        name = "%s %s" % (data.get('distribution'), data.get('name'))
+        return NodeImage(id=data['id'], name=name, driver=self,
                          extra=extra)
 
     def _to_volume(self, data):
@@ -504,8 +534,9 @@ class DigitalOcean_v2_NodeDriver(DigitalOcean_v2_BaseDriver,
                              extra=extra)
 
     def _to_location(self, data):
+        extra = data.get('features', [])
         return NodeLocation(id=data['slug'], name=data['name'], country=None,
-                            driver=self)
+                            extra=extra, driver=self)
 
     def _to_size(self, data):
         extra = {'vcpus': data['vcpus'],


### PR DESCRIPTION
## a few optimizations on DigitalOcean compute driver

### Description

- add ex_start_node and ex_resize_node functions
- add available switch on list_locations (show only active locations)
- add size missing from the node metadata (contains info as hourly/monthly pricing). Removed regions which is redundant IMHO
- better naming on list_images results (before: "6.7 x32", now "CentOS 6.7 x32")
### Status

done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
