### PR TITLE
[LIBCLOUD-834] Reintroduce S3 multipart upload support with signature v4

### DIFF
--- a/libcloud/common/aws.py
+++ b/libcloud/common/aws.py
@@ -322,9 +322,11 @@ class AWSRequestSignerAlgorithmV4(AWSRequestSigner):
     def _get_payload_hash(self, method, data=None):
         if method in ('POST', 'PUT'):
             if data:
+                if hasattr(data, 'next') or hasattr(data, '__next__'):
+                    # File upload; don't try to read the entire payload
+                    return UNSIGNED_PAYLOAD
                 return _hash(data)
             else:
-                # When upload file, we can't know payload here even if given
                 return UNSIGNED_PAYLOAD
         else:
             return _hash('')


### PR DESCRIPTION
## Reintroduce S3 multipart upload support with signature v4

### Description

All S3 regions now support signature V4. Rather than try to implement multipart
uploads with both V2 and V4, all region drivers have been converted to use
the latter. All multipart changes are based on code which existed in v1.5.0.

Some minor adjustments were made to the use of requests made throughout
the BaseS3StorageDriver class. The practice of constructing request paths with
parameters included needed to be removed. It causes issues during the
signature calculation. The solution is to use the params argument instead.
In addition, a fix was necessary in the signature calculation to not compute a
payload hash in the event of file uploads. It seems this was already taken into
consideration but failed to account for the scenario where an iterator is
passed to the data argument.

I have tested these changes against S3 using each of the following methods and with each regional driver.

get_container
create_container
delete_container
list_container_objects
get_object
delete_object
upload_object
upload_object_via_stream
download_object
download_object_via_stream
ex_iterate_multipart_uploads
ex_cleanup_all_multipart_uploads

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
