### PR TITLE
LIBCLOUD-901 Correctly wrap requests library Responses with 4xx/5xx status codes

### DIFF
--- a/libcloud/common/base.py
+++ b/libcloud/common/base.py
@@ -282,7 +282,7 @@ class RawResponse(Response):
         self._error = None
         self._reason = None
         self.connection = connection
-        if response:
+        if response is not None:
             self.headers = lowercase_keys(dict(response.headers))
             self.error = response.reason
             self.status = response.status_code


### PR DESCRIPTION
## Correctly wrap requests library Responses with 4xx/5xx status codes

### Description

This fixes the constructor of `RawResponse` to explicitly check if `response is not None`. This is necessary because the requests library overloads the `__nonzero__`/`__bool__` methods on the `Response` object to return False if a 4xx or 5xx status code is returned. This [has been fixed](https://github.com/kennethreitz/requests/pull/2587) in the 3.0 branch of requests, but that version hasn't been released yet.

### Status
done, ready for review

### Checklist (tick everything that applies)
I haven't checked any of these because all I did was make a 10 character change.

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
