### PR TITLE
Support "Force Detach" of AWS EBS Volumes

### DIFF
--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -3322,11 +3322,13 @@ class BaseEC2NodeDriver(NodeDriver):
         self.connection.request(self.path, params=params)
         return True
 
-    def detach_volume(self, volume):
+    def detach_volume(self, volume, ex_force=False):
         params = {
             'Action': 'DetachVolume',
             'VolumeId': volume.id}
 
+        if ex_force:
+            params['Force'] = 1
         self.connection.request(self.path, params=params)
         return True
 


### PR DESCRIPTION
##  Support "Force Detach" of AWS EBS Volumes

### Description

Added kw parameter `ex_force` to `BaseEC2NodeDriver.detach_volume `

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
