### PR TITLE
[LIBCLOUD-905] Added list images method for OnApp

### DIFF
--- a/docs/examples/compute/onapp/functionality.py
+++ b/docs/examples/compute/onapp/functionality.py
@@ -59,3 +59,9 @@ identifier = 'nodesidentifier'
 node, = [n for n in driver.list_nodes() if n.id == identifier]
 
 driver.destroy_node(node)
+
+#
+# List images
+#
+for image in driver.list_images():
+    print(image)

--- a/libcloud/compute/drivers/onapp.py
+++ b/libcloud/compute/drivers/onapp.py
@@ -322,7 +322,6 @@ class OnAppNodeDriver(NodeDriver):
         :rtype: ``list`` of :class:`NodeImage`
         """
         response = self.connection.request("/templates.json")
-        # return list(map(self._to_image, data['image_template']))
         templates = []
         for template in response.object:
             templates.append(self._to_image(template["image_template"]))

--- a/libcloud/test/compute/fixtures/onapp/list_images.json
+++ b/libcloud/test/compute/fixtures/onapp/list_images.json
@@ -1,0 +1,47 @@
+[
+  {
+    "image_template": {
+      "allow_resize_without_reboot": true,
+      "allowed_hot_migrate": true,
+      "allowed_swap": true,
+      "application_server": false,
+      "backup_server_id": "",
+      "baremetal_server": true,
+      "cdn": false,
+      "checksum": "f3ea0b39051d9c5fef3f7661c6318111",
+      "created_at": "2015-03-12T19:56:02+05:30",
+      "disk_target_device": "--- xen: sda kvm: hd ",
+      "draas": false,
+      "ext4": false,
+      "file_name": "centos-5.11-x64-1.1-xen.kvm.kvm_virtio.tar.gz",
+      "id": 123456,
+      "initial_password": "Password1",
+      "initial_username": "root",
+      "label": "CentOS 5.11 x64",
+      "manager_id": "",
+      "min_disk_size": 5,
+      "min_memory_size": 256,
+      "operating_system": "linux",
+      "operating_system_arch": "x64",
+      "operating_system_distro": "rhel",
+      "operating_system_edition": "",
+      "operating_system_tail": "",
+      "parent_template_id": "",
+      "properties": "",
+      "remote_id": "",
+      "resize_without_reboot_policy": {},
+      "smart_server": true,
+      "state": "active",
+      "template_size": 323924,
+      "updated_at": "",
+      "user_id": "",
+      "version": "1.1",
+      "virtualization": [
+        "xen",
+        "kvm",
+        "kvm_virtio"
+      ],
+      "type": "ImageTemplate"
+    }
+  }
+]

--- a/libcloud/test/compute/test_onapp.py
+++ b/libcloud/test/compute/test_onapp.py
@@ -69,6 +69,18 @@ class OnAppNodeTestCase(LibcloudTestCase):
         self.assertEqual(1, len(private_ips))
         self.assertEqual('192.168.15.72', private_ips[0])
 
+    def test_list_images(self):
+        images = self.driver.list_images()
+        extra = images[0].extra
+
+        self.assertEqual(1, len(images))
+        self.assertEqual('CentOS 5.11 x64', images[0].name)
+        self.assertEqual('123456', images[0].id)
+
+        self.assertEqual(True, extra['allowed_swap'])
+        self.assertEqual(256, extra['min_memory_size'])
+        self.assertEqual('rhel', extra['distribution'])
+
 
 class OnAppMockHttp(MockHttpTestCase):
     fixtures = ComputeFileFixtures('onapp')
@@ -87,6 +99,10 @@ class OnAppMockHttp(MockHttpTestCase):
             {},
             httplib.responses[httplib.NO_CONTENT]
         )
+
+    def _templates_json(self, method, url, body, headers):
+        body = self.fixtures.load('list_images.json')
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Added list images method for OnApp

### Description
- Implements methods for listing available images for OnApp driver
- Includes tests and documentation

JIRA ticket: https://issues.apache.org/jira/browse/LIBCLOUD-905
Provider API doc: https://docs.onapp.com/display/52API/Get+List+of+All+Templates

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes)
