### PR TITLE
Fixed variable used in example

### DIFF
--- a/docs/examples/compute/onapp/functionality.py
+++ b/docs/examples/compute/onapp/functionality.py
@@ -34,7 +34,7 @@ rate_limit = None
 # set max port speed. If none set, the system sets port speed to unlimited
 
 node = driver.create_node(
-    ex_label=name,
+    name=name,
     ex_memory=memory,
     ex_cpus=cpus,
     ex_cpu_shares=cpu_shares,


### PR DESCRIPTION
## Fixed wrong argument used in example for OnApp driver

### Description

The example for OnApp driver is wrong, should be `name` instead of `ex_label`.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
