### PR TITLE
[LIBCLOUD-906] Fix Public IP not assigned when creating NIC on Azure ARM

### DIFF
--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -1013,7 +1013,8 @@ class AzureNodeDriver(NodeDriver):
         }
 
         if public_ip:
-            data["properties"]["ipConfigurations"][0]["publicIPAddress"] = {
+            ip_config = data["properties"]["ipConfigurations"][0]
+            ip_config["properties"]["publicIPAddress"] = {
                 "id": public_ip.id
             }
 


### PR DESCRIPTION
## Fix Public IP not assigned when creating NIC on Azure ARM

### Description

This fixes the wrong use of `public_ip` in `ex_create_network_interface` in `AzureNodeDriver`. The problem was the wrong access to the `data` dictionary when inserting the request for a public ip to be assigned to the NIC that is going to be created

### Status
done, ready for review

### Checklist (tick everything that applies)

(just a line of code changes)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
