### PR TITLE
Fix CertificateConnection in >2.0Rc1

### DIFF
--- a/libcloud/common/base.py
+++ b/libcloud/common/base.py
@@ -468,8 +468,6 @@ class Connection(object):
         if not hasattr(kwargs, 'cert_file') and hasattr(self, 'cert_file'):
             kwargs.update({'cert_file': getattr(self, 'cert_file')})
 
-        #  kwargs = {'host': host, 'port': int(port)}
-
         # Timeout is only supported in Python 2.6 and later
         # http://docs.python.org/library/httplib.html#httplib.HTTPConnection
         if self.timeout and not PY25:

--- a/libcloud/httplib_ssl.py
+++ b/libcloud/httplib_ssl.py
@@ -22,7 +22,7 @@ import os
 import warnings
 import requests
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.ssl_ import create_urllib3_context
+from requests.packages.urllib3.poolmanager import PoolManager
 
 import libcloud.security
 from libcloud.utils.py3 import urlparse, PY3
@@ -38,57 +38,18 @@ ALLOW_REDIRECTS = 1
 HTTP_PROXY_ENV_VARIABLE_NAME = 'http_proxy'
 
 
-class SignedX509Adapter(HTTPAdapter):
-    def __init__(self, cert_file=None, key_file=None):
+class SignedHTTPSAdapter(HTTPAdapter):
+    def __init__(self, cert_file, key_file):
         self.cert_file = cert_file
         self.key_file = key_file
+        super(SignedX509Adapter, self).__init__()
 
-    def init_poolmanager(self, *args, **kwargs):
-        self.tls_context = create_urllib3_context()
-        kwargs['ssl_context'] = self.tls_context
-        
-        has_sni = getattr(ssl, 'HAS_SNI', False)
-
-        if has_sni:
-            self.tls_context.verify_mode = ssl.CERT_REQUIRED
-
-            if self.cert_file and self.key_file:
-                self.tls_context.load_cert_chain(
-                    certfile=self.cert_file,
-                    keyfile=self.key_file,
-                    password=None)
-
-            if self.ca_cert:
-                self.tls_context.load_verify_locations(cafile=self.ca_cert)
-
-            try:
-                self.sock = self.tls_context.wrap_socket(
-                    sock,
-                    server_hostname=self.host,
-                )
-            except:
-                exc = sys.exc_info()[1]
-                exc = get_socket_error_exception(ssl_version=ssl_version,
-                                                 exc=exc)
-                raise exc
-        else:
-            # SNI support not available
-            try:
-                self.sock = ssl.wrap_socket(
-                    sock,
-                    self.key_file,
-                    self.cert_file,
-                    cert_reqs=ssl.CERT_REQUIRED,
-                    ca_certs=self.ca_cert,
-                    ssl_version=ssl_version
-                )
-            except:
-                exc = sys.exc_info()[1]
-                exc = get_socket_error_exception(ssl_version=ssl_version,
-                                                 exc=exc)
-                raise exc
-        
-        return super(HTTPAdapter, self).init_poolmanager(*args, **kwargs)
+    def init_poolmanager(self, connections, maxsize, block=False):
+        self.poolmanager = PoolManager(
+            num_pools=connections, maxsize=maxsize,
+            block=block,
+            cert_file=self.cert_file,
+            key_file=self.key_file)
 
 
 class LibcloudBaseConnection(object):
@@ -199,7 +160,7 @@ class LibcloudBaseConnection(object):
         Setup request signing by mounting a signing
         adapter to the session
         """
-        self.session.mount("https", SignedX509Adapter(cert_file, key_file))
+        self.session.mount('https://', SignedHTTPSAdapter(cert_file, key_file))
 
 
 class LibcloudConnection(LibcloudBaseConnection):
@@ -220,11 +181,12 @@ class LibcloudConnection(LibcloudBaseConnection):
 
         self._setup_verify()
         self._setup_ca_cert()
-        
+
         LibcloudBaseConnection.__init__(self)
-        
+
         if 'cert_file' in kwargs or 'key_file' in kwargs:
             self._setup_signing(**kwargs)
+
         if proxy_url:
             self.set_http_proxy(proxy_url=proxy_url)
         self.session.timeout = kwargs.get('timeout', 60)

--- a/libcloud/httplib_ssl.py
+++ b/libcloud/httplib_ssl.py
@@ -42,7 +42,7 @@ class SignedHTTPSAdapter(HTTPAdapter):
     def __init__(self, cert_file, key_file):
         self.cert_file = cert_file
         self.key_file = key_file
-        super(SignedX509Adapter, self).__init__()
+        super(SignedHTTPSAdapter, self).__init__()
 
     def init_poolmanager(self, connections, maxsize, block=False):
         self.poolmanager = PoolManager(

--- a/libcloud/test/test_connection.py
+++ b/libcloud/test/test_connection.py
@@ -24,9 +24,10 @@ from mock import Mock, patch
 import requests_mock
 
 from libcloud.test import unittest
-from libcloud.common.base import Connection
+from libcloud.common.base import Connection, CertificateConnection
 from libcloud.httplib_ssl import LibcloudBaseConnection
 from libcloud.httplib_ssl import LibcloudConnection
+from libcloud.httplib_ssl import SignedHTTPSAdapter
 from libcloud.utils.misc import retry
 
 
@@ -362,6 +363,18 @@ class ConnectionClassTestCase(unittest.TestCase):
 
             self.assertGreater(mock_connect.call_count, 1,
                                'Retry logic failed')
+
+
+class CertificateConnectionClassTestCase(unittest.TestCase):
+    def setUp(self):
+        self.connection = CertificateConnection(cert_file='test.pem',
+                                                url='https://test.com/test')
+        self.connection.connect()
+
+    def test_adapter_internals(self):
+        adapter = self.connection.connection.session.adapters['https://']
+        self.assertTrue(isinstance(adapter, SignedHTTPSAdapter))
+        self.assertEqual(adapter.cert_file, 'test.pem')
 
 if __name__ == '__main__':
     sys.exit(unittest.main())


### PR DESCRIPTION
## Reimplement the CertificateConnection class using urllib3 and requests

### Description

In 2.0, the httplib module was used as a low-level module for making requests to the APIs, some drivers used a `CertificateConnection` class in `libcloud.common.base`, which accepted an x509 certificate to be used for encoding the requests.

Those drivers are : 
- Azure (classic)
- Docker (with TLS)
- OpenStack

This PR will reimplement the CertificateConnection class inside `libcloud.httplib_ssl` by mounting a `HTTPAdapter` to the requests session, detecting TLS and signing requests for the cert file.

We also need a test for this issue.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
