### PR TITLE
[LIBCLOUD-909] Added methods for managing SSH key pairs for OnApp

### DIFF
--- a/docs/examples/compute/onapp/functionality.py
+++ b/docs/examples/compute/onapp/functionality.py
@@ -65,3 +65,34 @@ driver.destroy_node(node)
 #
 for image in driver.list_images():
     print(image)
+
+#
+# List key pairs
+#
+for key_pair in driver.list_key_pairs():
+    print(key_pair)
+
+#
+# Get key pair
+#
+id = 2  # ID of key pair
+key_pair = driver.get_key_pair(id)
+print(key_pair)
+
+#
+# Import key pair from string
+#
+name = 'example'  # this param is unused
+key = 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC8uuUq...'
+key_pair = driver.import_key_pair_from_string(name, key)
+
+#
+# Import key pair from file
+#
+driver.import_key_pair_from_file('example', '~/.ssh/id_rsa.pub')
+
+#
+# Delete key pair
+#
+key_pair = driver.list_key_pairs()[0]
+driver.delete_key_pair(key_pair)

--- a/libcloud/compute/drivers/onapp.py
+++ b/libcloud/compute/drivers/onapp.py
@@ -1,8 +1,10 @@
 import json
 
-from libcloud.compute.base import Node, NodeDriver, NodeImage
-from libcloud.common.onapp import OnAppConnection
+from libcloud.utils.py3 import httplib
 from libcloud.utils.networking import is_private_subnet
+
+from libcloud.common.onapp import OnAppConnection
+from libcloud.compute.base import Node, NodeDriver, NodeImage, KeyPair
 from libcloud.compute.providers import Provider
 
 
@@ -327,9 +329,84 @@ class OnAppNodeDriver(NodeDriver):
             templates.append(self._to_image(template["image_template"]))
         return templates
 
+    def list_key_pairs(self):
+        """
+        List all the available key pair objects.
+
+        :rtype: ``list`` of :class:`.KeyPair` objects
+        """
+        user_id = self.connection.request('/profile.json').object['user']['id']
+        response = self.connection.request('/users/%s/ssh_keys.json' % user_id)
+        ssh_keys = []
+        for ssh_key in response.object:
+            ssh_keys.append(self._to_key_pair(ssh_key['ssh_key']))
+        return ssh_keys
+
+    def get_key_pair(self, name):
+        """
+        Retrieve a single key pair.
+
+        :param name: ID of the key pair to retrieve.
+        :type name: ``str``
+
+        :rtype: :class:`.KeyPair` object
+        """
+        user_id = self.connection.request('/profile.json').object['user']['id']
+        response = self.connection.request(
+            '/users/%s/ssh_keys/%s.json' % (user_id, name))
+        return self._to_key_pair(response.object['ssh_key'])
+
+    def import_key_pair_from_string(self, name, key_material):
+        """
+        Import a new public key from string.
+
+        :param name: Key pair name (unused).
+        :type name: ``str``
+
+        :param key_material: Public key material.
+        :type key_material: ``str``
+
+        :rtype: :class:`.KeyPair` object
+        """
+        data = json.dumps({'key': key_material})
+        user_id = self.connection.request('/profile.json').object['user']['id']
+        response = self.connection.request(
+            '/users/%s/ssh_keys.json' % user_id,
+            data=data,
+            headers={
+                "Content-type": "application/json"},
+            method="POST")
+        return self._to_key_pair(response.object['ssh_key'])
+
+    def delete_key_pair(self, key):
+        """
+        Delete an existing key pair.
+
+        :param key_pair: Key pair object.
+        :type key_pair: :class:`.KeyPair`
+
+        :return: True on success
+        :rtype: ``bool``
+        """
+        key_id = key.name
+        response = self.connection.request(
+            '/settings/ssh_keys/%s.json' % key_id,
+            method='DELETE')
+        return response.status == httplib.NO_CONTENT
+
     #
     # Helper methods
     #
+
+    def _to_key_pair(self, data):
+        extra = {'created_at': data['created_at'],
+                 'updated_at': data['updated_at']}
+        return KeyPair(name=data['id'],
+                       fingerprint=None,
+                       public_key=data['key'],
+                       private_key=None,
+                       driver=self,
+                       extra=extra)
 
     def _to_image(self, template):
         extra = {'distribution': template['operating_system_distro'],

--- a/libcloud/test/compute/fixtures/onapp/get_key_pair.json
+++ b/libcloud/test/compute/fixtures/onapp/get_key_pair.json
@@ -1,0 +1,9 @@
+{
+  "ssh_key": {
+    "id": 1,
+    "user_id": 123,
+    "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC8uuUqh0cXhx5s9AxlQHCWzQoS9w0qy/WN/I/CZuy4p+mQYhOYSqBi/aqf4/wySyOtzez785IGBriX24zk6vMcfSuB7wgHzCGZ433zAkdZu39nPPpCo3WWZmJ3GKYjEN+yNJNG8kR3OW3N0mRSId3ebFZoLUafli8sSt6XeXHgeLPfEvbpiEdKxHskRsZHP8JoM2tQD9Ms5/9KPbbhg4geeu9FO28kozacBdyQMS1db+45b9xz0L9GPYO0NasESq9cC4BvlhPvAFHDT1kio6DjjhZ5kUK7OcmRK+8/Jk+9cTSj9MzVMCwRni3HyA37/Mu4qBpDkR9sPwgJ9G/UY7ZP John@Johns-MacBook-Pro",
+    "created_at": "2017-03-22T19:11:32.000+05:30",
+    "updated_at": "2017-03-22T19:11:32.000+05:30"
+  }
+}

--- a/libcloud/test/compute/fixtures/onapp/import_key_pair.json
+++ b/libcloud/test/compute/fixtures/onapp/import_key_pair.json
@@ -1,0 +1,9 @@
+{
+  "ssh_key": {
+    "id": 3,
+    "user_id": 123,
+    "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC8uuUq",
+    "created_at": "2017-03-22T19:11:32.000+05:30",
+    "updated_at": "2017-03-22T19:11:32.000+05:30"
+  }
+}

--- a/libcloud/test/compute/fixtures/onapp/list_key_pairs.json
+++ b/libcloud/test/compute/fixtures/onapp/list_key_pairs.json
@@ -1,0 +1,20 @@
+[
+  {
+    "ssh_key": {
+      "id": 1,
+      "user_id": 123,
+      "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC8uuUqh0cXhx5s9AxlQHCWzQoS9w0qy/WN/I/CZuy4p+mQYhOYSqBi/aqf4/wySyOtzez785IGBriX24zk6vMcfSuB7wgHzCGZ433zAkdZu39nPPpCo3WWZmJ3GKYjEN+yNJNG8kR3OW3N0mRSId3ebFZoLUafli8sSt6XeXHgeLPfEvbpiEdKxHskRsZHP8JoM2tQD9Ms5/9KPbbhg4geeu9FO28kozacBdyQMS1db+45b9xz0L9GPYO0NasESq9cC4BvlhPvAFHDT1kio6DjjhZ5kUK7OcmRK+8/Jk+9cTSj9MzVMCwRni3HyA37/Mu4qBpDkR9sPwgJ9G/UY7ZP John@Johns-MacBook-Pro",
+      "created_at": "2017-03-22T19:11:32.000+05:30",
+      "updated_at": "2017-03-22T19:11:32.000+05:30"
+    }
+  },
+  {
+    "ssh_key": {
+      "id": 2,
+      "user_id": 123,
+      "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCx/N6Mm/8BapBlTPhjnrj06yyAKYDTfBgIOzhPzdq1rco6FS7JVUot3zY4pX3ZUkLJh5JDsNz9FyqyGpXBzO3G7QpDhGggjqfYxpsR9VQBDNC8YKpQdaa6j2s1yJsI0cb+/sQl9SC/9WyBCceK3mzPt5AsSzdY0hA2+jPYuCzvTT/S0qfsk2WyvA+fK7ue7yWD/8KSNQx2/xsP3GU+/Ck5D7w+8ck1oUVXAFoO/WUIEwbx5u9wurv73GsK6Pqgt1tjtNznS50JsyHmayeZzrX1hr33PE9IarlUzWAUj4zvpdDTpCm/u2f2UnmSJJ0cT45NUUG085WTyhy2ZHBz3jOT John@Johns-iMac",
+      "created_at": "2017-03-24T14:31:24.000+05:30",
+      "updated_at": "2017-03-24T14:31:24.000+05:30"
+    }
+  }
+]

--- a/libcloud/test/compute/fixtures/onapp/profile.json
+++ b/libcloud/test/compute/fixtures/onapp/profile.json
@@ -1,0 +1,12 @@
+{
+  "user": {
+    "id": 123,
+    "identifier": "abcdef123345",
+    "email": "abc@example.com",
+    "first_name": "John",
+    "last_name": "Smith",
+    "status": "active",
+    "created_at": "2017-03-22T20:39:36.000+07:00",
+    "updated_at": "2017-03-22T20:39:36.000+07:00"
+  }
+}

--- a/libcloud/test/compute/test_onapp.py
+++ b/libcloud/test/compute/test_onapp.py
@@ -81,6 +81,32 @@ class OnAppNodeTestCase(LibcloudTestCase):
         self.assertEqual(256, extra['min_memory_size'])
         self.assertEqual('rhel', extra['distribution'])
 
+    def test_list_key_pairs(self):
+        keys = self.driver.list_key_pairs()
+        self.assertEqual(2, len(keys))
+        self.assertEqual(1, keys[0].name)
+        self.assertIsNotNone(keys[0].public_key)
+        self.assertIsNotNone(keys[1].public_key)
+
+    def test_get_key_pair(self):
+        key = self.driver.get_key_pair(1)
+        self.assertEqual(1, key.name)
+        self.assertIsNotNone(key.public_key)
+
+    def test_import_key_pair_from_string(self):
+        key = self.driver.import_key_pair_from_string(
+            'name',
+            'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC8uuUq')
+        self.assertEqual(3, key.name)
+        self.assertEqual(
+            'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC8uuUq',
+            key.public_key)
+
+    def test_delete_key_pair(self):
+        key = self.driver.get_key_pair(1)
+        response = self.driver.delete_key_pair(key)
+        self.assertTrue(response)
+
 
 class OnAppMockHttp(MockHttpTestCase):
     fixtures = ComputeFileFixtures('onapp')
@@ -103,6 +129,25 @@ class OnAppMockHttp(MockHttpTestCase):
     def _templates_json(self, method, url, body, headers):
         body = self.fixtures.load('list_images.json')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+
+    def _profile_json(self, method, url, body, headers):
+        body = self.fixtures.load('profile.json')
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+
+    def _users_123_ssh_keys_json(self, method, url, body, headers):
+        if method == 'GET':
+            body = self.fixtures.load('list_key_pairs.json')
+        else:
+            body = self.fixtures.load('import_key_pair.json')
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+
+    def _users_123_ssh_keys_1_json(self, method, url, body, headers):
+        body = self.fixtures.load('get_key_pair.json')
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+
+    def _settings_ssh_keys_1_json(self, method, url, body, headers):
+        return (httplib.NO_CONTENT, '', {},
+                httplib.responses[httplib.NO_CONTENT])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Added methods for managing SSH key pairs for OnApp

### Description
- Implements methods for managing SSH key pairs for OnApp driver
- Includes tests and documentation

JIRA ticket: https://issues.apache.org/jira/browse/LIBCLOUD-909
Provider API doc: https://docs.onapp.com/display/53API/SSH+keys

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes)
