### PR TITLE
Add SR-IOV net support to images in EC2 compute driver

### DIFF
--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -2392,6 +2392,10 @@ RESOURCE_EXTRA_ATTRIBUTES_MAP = {
         'ena_support': {
             'xpath': 'enaSupport',
             'transform_func': str
+        },
+        'sriov_net_support': {
+            'xpath': 'sriovNetSupport',
+            'transform_func': str
         }
     },
     'network': {
@@ -3928,7 +3932,7 @@ class BaseEC2NodeDriver(NodeDriver):
                           image_location=None, root_device_name=None,
                           block_device_mapping=None, kernel_id=None,
                           ramdisk_id=None, virtualization_type=None,
-                          ena_support=None):
+                          ena_support=None, sriov_net_support=None):
         """
         Registers an Amazon Machine Image based off of an EBS-backed instance.
         Can also be used to create images from snapshots. More information
@@ -3972,6 +3976,11 @@ class BaseEC2NodeDriver(NodeDriver):
                                  Network Adapter for the AMI
         :type       ena_support: ``bool``
 
+        :param      sriov_net_support: Set to "simple" to enable enhanced
+                                       networking with the Intel 82599 Virtual
+                                       Function interface
+        :type       sriov_net_support: ``str``
+
         :rtype:     :class:`NodeImage`
         """
 
@@ -4005,6 +4014,9 @@ class BaseEC2NodeDriver(NodeDriver):
 
         if ena_support is not None:
             params['EnaSupport'] = ena_support
+
+        if sriov_net_support is not None:
+            params['SriovNetSupport'] = sriov_net_support
 
         image = self._to_image(
             self.connection.request(self.path, params=params).object

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -559,7 +559,8 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
                                               description='My Image',
                                               architecture='x86_64',
                                               block_device_mapping=mapping,
-                                              ena_support=True)
+                                              ena_support=True,
+                                              sriov_net_support='simple')
         self.assertEqual(image.id, 'ami-57c2fb3e')
 
     def test_ex_list_availability_zones(self):


### PR DESCRIPTION
## Add SR-IOV net support to images in EC2 compute driver

### Description

This change adds a missing configuration option while registering images. More documentation about this option here: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RegisterImage.html

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
