### PR TITLE
Add price_monthly in extra dict to digitalocean sizes

### DIFF
--- a/libcloud/compute/drivers/digitalocean.py
+++ b/libcloud/compute/drivers/digitalocean.py
@@ -509,7 +509,8 @@ class DigitalOcean_v2_NodeDriver(DigitalOcean_v2_BaseDriver,
 
     def _to_size(self, data):
         extra = {'vcpus': data['vcpus'],
-                 'regions': data['regions']}
+                 'regions': data['regions'],
+                 'price_monthly': data['price_monthly']}
         return NodeSize(id=data['slug'], name=data['slug'], ram=data['memory'],
                         disk=data['disk'], bandwidth=data['transfer'],
                         price=data['price_hourly'], driver=self, extra=extra)


### PR DESCRIPTION
## Add price_monthly extra param to digitalocean sizes

### Description

DigitalOcean sizes are commonly referred to by their monthly price. This PR makes libcloud expose such information within the extra dictionary of Size. This new field is named 'price_monthly', as in the DigitalOcean API.

### Status

- done, ready for review
