### PR TITLE
Fix number of ec2 t2.small cpus to 1

### DIFF
--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -713,7 +713,7 @@ INSTANCE_TYPES = {
         'disk': 0,  # EBS Only
         'bandwidth': None,
         'extra': {
-            'cpu': 11
+            'cpu': 1
         }
     },
     't2.medium': {


### PR DESCRIPTION
## Fix number of ec2 t2.small cpus to 1

### Description

Minor fix: libcloud was incorrectly stating that t2.small sizes of EC2 feature 11 vcpus. This PR fixes the number of cpus to 1.

### Status

- done, ready for review
