### PR TITLE
Added Import Snapshot and Describe Import Snapshot to EC2 compute driver

### DIFF
--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -22,6 +22,7 @@ import sys
 import base64
 import copy
 import warnings
+import time
 
 try:
     from lxml import etree as ET
@@ -67,6 +68,7 @@ __all__ = [
     'EC2NodeLocation',
     'EC2ReservedNode',
     'EC2SecurityGroup',
+    'EC2ImportSnapshotTask',
     'EC2PlacementGroup',
     'EC2Network',
     'EC2NetworkSubnet',
@@ -2872,6 +2874,22 @@ class EC2SecurityGroup(object):
                 % (self.id, self.name))
 
 
+class EC2ImportSnapshotTask(object):
+    """
+    Represents information about a describe_import_snapshot_task.
+
+    Note: This class is EC2 specific.
+    """
+
+    def __init__(self, status, snapshotId):
+        self.status = status
+        self.snapshotId = snapshotId
+
+    def __repr__(self):
+        return (('<EC2SecurityGroup: status=%s, snapshotId=%s')
+                % (self.status, self.snapshotId))
+
+
 class EC2PlacementGroup(object):
     """
     Represents information about a Placement Grous
@@ -3905,6 +3923,138 @@ class BaseEC2NodeDriver(NodeDriver):
                   'GroupName': name}
         response = self.connection.request(self.path, params=params).object
         return self._get_boolean(response)
+
+    def ex_import_snapshot(self, client_data=None,
+                           client_token=None, description=None,
+                           disk_container=None, dry_run=None, role_name=None):
+        """
+        Imports a disk into an EBS snapshot. More information can be found
+        at https://goo.gl/sbXkYA.
+
+        :param  client_data: Describes the client specific data (optional)
+        :type   client_data: ``dict``
+
+        :param  client_token: The token to enable idempotency for VM
+                import requests.(optional)
+        :type   client_token: ``str``
+
+        :param  description: The description string for the
+                             import snapshot task.(optional)
+        :type   description: ``str``
+
+        :param  disk_container:The disk container object for the
+                              import snapshot request.
+        :type   disk_container:``dict``
+
+        :param  dry_run: Checks whether you have the permission for
+                        the action, without actually making the request,
+                        and provides an error response.(optional)
+        :type   dry_run: ``bool``
+
+        :param  role_name: The name of the role to use when not using the
+                          default role, 'vmimport'.(optional)
+        :type   role_name: ``str``
+
+        :rtype: :class: ``VolumeSnapshot``
+        """
+
+        params = {'Action': 'ImportSnapshot'}
+
+        if client_data is not None:
+            params.update(self._get_client_date_params(client_data))
+
+        if client_token is not None:
+            params['ClientToken'] = client_token
+
+        if description is not None:
+            params['Description'] = description
+
+        if disk_container is not None:
+            params.update(self._get_disk_container_params(disk_container))
+
+        if dry_run is not None:
+            params['DryRun'] = dry_run
+
+        if role_name is not None:
+            params['RoleName'] = role_name
+
+        importSnapshot = self.connection.request(self.path,
+                                                 params=params).object
+
+        importTaskId = findtext(element=importSnapshot,
+                                xpath='importTaskId',
+                                namespace=NAMESPACE)
+
+        volumeSnapshot = self._wait_for_import_snapshot_completion(
+            import_task_id=importTaskId, timeout=1800, interval=15)
+
+        return volumeSnapshot
+
+    def _wait_for_import_snapshot_completion(self,
+                                             import_task_id,
+                                             timeout=1800,
+                                             interval=15):
+        """
+        It waits for import snapshot to be completed
+
+        :param import_task_id: Import task Id for the
+                               current Import Snapshot Task
+        :type import_task_id: ``str``
+
+        :param timeout: Timeout value for snapshot generation
+        :type timeout: ``float``
+
+        :param interval: Time interval for repetative describe
+                         import snapshot tasks requests
+        :type interval: ``float``
+
+        :rtype: :class:``VolumeSnapshot``
+        """
+        start_time = time.time()
+        snapshotId = None
+        while snapshotId is None:
+            if (time.time() - start_time >= timeout):
+                raise Exception('Timeout while waiting '
+                                'for import task Id %s'
+                                % import_task_id)
+            res = self.ex_describe_import_snapshot_tasks(import_task_id)
+            snapshotId = res.snapshotId
+
+            if snapshotId is None:
+                time.sleep(interval)
+
+        volumeSnapshot = VolumeSnapshot(snapshotId, driver=self)
+        return volumeSnapshot
+
+    def ex_describe_import_snapshot_tasks(self, import_task_id, dry_run=None):
+        """
+        Describes your import snapshot tasks. More information can be found
+        at https://goo.gl/CI0MdS.
+
+        :param import_task_id: Import task Id for the current
+                               Import Snapshot Task
+        :type import_task_id: ``str``
+
+        :param  dry_run: Checks whether you have the permission for
+                        the action, without actually making the request,
+                        and provides an error response.(optional)
+        :type   dry_run: ``bool``
+
+        :rtype: :class:``DescribeImportSnapshotTasks Object``
+
+        """
+        params = {'Action': 'DescribeImportSnapshotTasks'}
+
+        if dry_run is not None:
+            params['DryRun'] = dry_run
+
+        # This can be extended for multiple import snapshot tasks
+        params['ImportTaskId.1'] = import_task_id
+
+        res = self._to_import_snapshot_task(
+            self.connection.request(self.path, params=params).object
+        )
+        return res
 
     def ex_list_placement_groups(self, names=None):
         """
@@ -6040,6 +6190,19 @@ class BaseEC2NodeDriver(NodeDriver):
                               state=state,
                               name=name)
 
+    def _to_import_snapshot_task(self, element):
+        status = findtext(element=element, xpath='importSnapshotTaskSet/item/'
+                          'snapshotTaskDetail/status', namespace=NAMESPACE)
+
+        if status != 'completed':
+            snapshotId = None
+        else:
+            xpath = 'importSnapshotTaskSet/item/snapshotTaskDetail/snapshotId'
+            snapshotId = findtext(element=element, xpath=xpath,
+                                  namespace=NAMESPACE)
+
+        return EC2ImportSnapshotTask(status, snapshotId=snapshotId)
+
     def _to_key_pairs(self, elems):
         key_pairs = [self._to_key_pair(elem=elem) for elem in elems]
         return key_pairs
@@ -6694,6 +6857,71 @@ class BaseEC2NodeDriver(NodeDriver):
                     for key, value in v.items():
                         params['BlockDeviceMapping.%d.%s.%s'
                                % (idx, k, key)] = str(value)
+        return params
+
+    def _get_disk_container_params(self, disk_container):
+        """
+        Return a list of dictionaries with query parameters for
+        a valid disk container.
+
+        :param      disk_container: List of dictionaries with
+                                    disk_container details
+        :type       disk_container: ``list`` or ``dict``
+
+        :return:    Dictionary representation of the disk_container
+        :rtype:     ``dict``
+        """
+
+        if not isinstance(disk_container, (list, tuple)):
+            raise AttributeError('disk_container not list or tuple')
+
+        params = {}
+
+        for idx, content in enumerate(disk_container):
+            idx += 1  # We want 1-based indexes
+            if not isinstance(content, dict):
+                raise AttributeError(
+                    'content %s in disk_container not a dict' % content)
+
+            for k, v in content.items():
+                if not isinstance(v, dict):
+                    params['DiskContainer.%s' % (k)] = str(v)
+
+                else:
+                    for key, value in v.items():
+                        params['DiskContainer.%s.%s'
+                               % (k, key)] = str(value)
+
+        return params
+
+    def _get_client_data_params(self, client_data):
+        """
+        Return a dictionary with query parameters for
+        a valid client data.
+
+        :param      client_data: List of dictionaries with the disk
+                                 upload details
+        :type       client_data: ``dict``
+
+        :return:    Dictionary representation of the client data
+        :rtype:     ``dict``
+        """
+
+        if not isinstance(client_data, (list, tuple)):
+            raise AttributeError('client_data not list or tuple')
+
+        params = {}
+
+        for idx, content in enumerate(client_data):
+            idx += 1  # We want 1-based indexes
+            if not isinstance(content, dict):
+                raise AttributeError(
+                    'content %s in client_data'
+                    'not a dict' % content)
+
+            for k, v in content.items():
+                params['ClientData.%s' % (k)] = str(v)
+
         return params
 
     def _get_common_security_group_params(self, group_id, protocol,

--- a/libcloud/test/compute/fixtures/ec2/describe_import_snapshot_tasks.xml
+++ b/libcloud/test/compute/fixtures/ec2/describe_import_snapshot_tasks.xml
@@ -1,0 +1,18 @@
+<DescribeImportSnapshotTasksResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+    <requestId>a8c44ac4-8e63-46e9-b8b2-8c72ce3d9b18</requestId>
+    <importSnapshotTaskSet>
+        <item>
+            <importTaskId>import-snap-fh7y6i6w</importTaskId>
+            <snapshotTaskDetail>
+                <snapshotId>snap-0ea83e8a87e138f39</snapshotId>
+                <format>RAW</format>
+                <diskImageSize>1.073741824E10</diskImageSize>
+                <userBucket>
+                    <s3Bucket>dummy-bucket</s3Bucket>
+                    <s3Key>dummy-key</s3Key>
+                </userBucket>
+                <status>completed</status>
+            </snapshotTaskDetail>
+        </item>
+    </importSnapshotTaskSet>
+</DescribeImportSnapshotTasksResponse>

--- a/libcloud/test/compute/fixtures/ec2/describe_import_snapshot_tasks_active.xml
+++ b/libcloud/test/compute/fixtures/ec2/describe_import_snapshot_tasks_active.xml
@@ -1,0 +1,17 @@
+<DescribeImportSnapshotTasksResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+    <requestId>a8c44ac4-8e63-46e9-b8b2-8c72ce3d9b18</requestId>
+    <importSnapshotTaskSet>
+        <item>
+            <importTaskId>import-snap-fh7y6i6w</importTaskId>
+            <snapshotTaskDetail>
+                <format>RAW</format>
+                <diskImageSize>1.073741824E10</diskImageSize>
+                <userBucket>
+                    <s3Bucket>dummy-bucket</s3Bucket>
+                    <s3Key>dummy-key</s3Key>
+                </userBucket>
+                <status>active</status>
+            </snapshotTaskDetail>
+        </item>
+    </importSnapshotTaskSet>
+</DescribeImportSnapshotTasksResponse>

--- a/libcloud/test/compute/fixtures/ec2/import_snapshot.xml
+++ b/libcloud/test/compute/fixtures/ec2/import_snapshot.xml
@@ -1,0 +1,16 @@
+<ImportSnapshotResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+    <requestId>0d490bf6-19cf-4456-9c71-31d097faf46d</requestId>
+    <importTaskId>import-snap-fgsddbhv</importTaskId>
+        <snapshotTaskDetail>
+        <format>RAW</format>
+        <progress>3</progress>
+        <diskImageSize>0.0</diskImageSize>
+        <statusMessage>pending</statusMessage>
+        <userBucket>
+            <s3Bucket>dummy-bucket</s3Bucket>
+            <s3Key>dummy-key</s3Key>
+        </userBucket>
+        <status>active</status>
+    </snapshotTaskDetail>
+</ImportSnapshotResponse>
+


### PR DESCRIPTION
## Added Import Snapshot and Describe Import Snapshot to EC2 compute driver

### Description

On Importing Snapshot in aws, it returns the import snapshot task which needs to be monitored by describe import snapshot task until it is ready. Hence, added a wait block method. Finally, it returns a volume snapshot.  

### Status
- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
