### PR TITLE
Fix Linode for 2.0x 

### DIFF
--- a/libcloud/common/linode.py
+++ b/libcloud/common/linode.py
@@ -16,9 +16,6 @@
 from libcloud.common.base import ConnectionKey, JsonResponse
 from libcloud.common.types import InvalidCredsError
 
-from libcloud.utils.py3 import PY3
-from libcloud.utils.py3 import b
-
 __all__ = [
     'API_HOST',
     'API_ROOT',

--- a/libcloud/common/linode.py
+++ b/libcloud/common/linode.py
@@ -82,26 +82,8 @@ class LinodeResponse(JsonResponse):
 
         :keyword response: The raw response returned by urllib
         :return: parsed :class:`LinodeResponse`"""
-
-        self.connection = connection
-
-        self.headers = dict(response.getheaders())
-        self.error = response.reason
-        self.status = response.status
-
-        # This attribute is set when using LoggingConnection.
-        original_data = getattr(response, '_original_data', None)
-
-        if original_data:
-            # LoggingConnection already decompresses data so it can log it
-            # which means we don't need to decompress it here.
-            self.body = response._original_data
-        else:
-            self.body = self._decompress_response(body=response.read(),
-                                                  headers=self.headers)
-
-        if PY3:
-            self.body = b(self.body).decode('utf-8')
+        self.errors = []
+        super(LinodeResponse, self).__init__(response, connection)
 
         self.invalid = LinodeException(0xFF,
                                        "Invalid JSON received from server")


### PR DESCRIPTION
Changes in #1025 highlighted a problem with the Linode response class.

It has a lot of copy+paste from the Response `__init__` and no call to super. This looks related to some legacy code but its a common anti-pattern.

https://github.com/apache/libcloud/commit/fe72fc13a131b446e1f18cd22005f9c8fd03ce79

This changeset removes the duplicate (but now broken) code and calls `super` correctly.