### PR TITLE
Fix impossible location condition

### DIFF
--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -756,10 +756,11 @@ class AzureNodeDriver(NodeDriver):
         :rtype: ``list``
         """
 
-        if location is None and self.default_location:
-            location = self.default_location
-        else:
-            raise ValueError("location is required.")
+        if location is None:
+            if self.default_location:
+                location = self.default_location
+            else:
+                raise ValueError("location is required.")
 
         action = "/subscriptions/%s/providers/Microsoft.Compute/" \
                  "locations/%s/publishers" \


### PR DESCRIPTION
## Changes Title: Fix impossible location condition

### Description
When requesting a list of publishers from other parts of the code (such as when listing images), a condition can be encountered where the `location` has been passed in (and therefore is not `None`), but  `self.default_location` is also set. The `location` that is passed in should be used, but the condition doesn't allow it to be.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
