### PR TITLE
Fix issues with OpenStack auth raised in LIBCLOUD-912 and LIBCLOUD-904

### DIFF
--- a/libcloud/common/openstack.py
+++ b/libcloud/common/openstack.py
@@ -297,6 +297,7 @@ class OpenStackBaseConnection(ConnectionUserAndKey):
     def _set_up_connection_info(self, url):
         result = self._tuple_from_url(url)
         (self.host, self.port, self.secure, self.request_path) = result
+        self.connect()
 
     def _populate_hosts_and_request_paths(self):
         """

--- a/libcloud/test/common/test_openstack.py
+++ b/libcloud/test/common/test_openstack.py
@@ -17,7 +17,7 @@ import sys
 import unittest
 
 from mock import Mock
-
+from libcloud.common.base import LibcloudConnection
 from libcloud.common.openstack import OpenStackBaseConnection
 from libcloud.utils.py3 import PY25
 
@@ -31,6 +31,9 @@ class OpenStackBaseConnectionTest(unittest.TestCase):
                                                   ex_force_auth_url='https://127.0.0.1')
         self.connection.driver = Mock()
         self.connection.driver.name = 'OpenStackDriver'
+
+    def tearDown(self):
+        OpenStackBaseConnection.conn_class = LibcloudConnection
 
     def test_base_connection_timeout(self):
         self.connection.connect()

--- a/libcloud/test/common/test_openstack.py
+++ b/libcloud/test/common/test_openstack.py
@@ -37,7 +37,7 @@ class OpenStackBaseConnectionTest(unittest.TestCase):
         self.assertEqual(self.connection.timeout, self.timeout)
         if PY25:
             self.connection.conn_class.assert_called_with(host='127.0.0.1',
-                                                               port=443)
+                                                          port=443)
         else:
             self.connection.conn_class.assert_called_with(host='127.0.0.1',
                                                           secure=1,

--- a/libcloud/test/compute/fixtures/openstack/_v2_0__auth.json
+++ b/libcloud/test/compute/fixtures/openstack/_v2_0__auth.json
@@ -59,9 +59,9 @@
                     {
                         "region": "RegionOne",
                         "tenantId": "1337",
-                        "publicURL": "https://127.0.0.1/v2/1337",
-                        "versionInfo": "https://127.0.0.1/v2/",
-                        "versionList": "https://127.0.0.1/",
+                        "publicURL": "https://test_endpoint.com/v2/1337",
+                        "versionInfo": "https://test_endpoint.com/v2/",
+                        "versionList": "https://test_endpoint.com/",
                         "versionId": "2"
                     }
                 ],

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -63,19 +63,17 @@ class OpenStackAuthTests(unittest.TestCase):
     def test_auth_host_passed(self):
         forced_auth = 'http://x.y.z.y:5000'
         d = OpenStack_1_0_NodeDriver(
-            'user', 'correct_password', 
-            ex_force_auth_version='2.0_password', 
-            ex_force_auth_url='http://x.y.z.y:5000', 
+            'user', 'correct_password',
+            ex_force_auth_version='2.0_password',
+            ex_force_auth_url='http://x.y.z.y:5000',
             ex_tenant_name='admin')
         self.assertEqual(d._ex_force_auth_url, forced_auth)
         with requests_mock.Mocker() as mock:
-            body1 = "[]"
             body2 = ComputeFileFixtures('openstack').load('_v2_0__auth.json')
-            mock.register_uri('GET', 'https://test_endpoint.com/v2/1337/servers/detail', text=body1,
-                              headers={'content-type': 'application/json; charset=UTF-8'})
             mock.register_uri('POST', 'http://x.y.z.y:5000/v2.0/tokens', text=body2,
                               headers={'content-type': 'application/json; charset=UTF-8'})
-            d.list_nodes()
+            d.connection._populate_hosts_and_request_paths()
+            self.assertEqual(d.connection.host, 'test_endpoint.com')
 
 
 class OpenStack_1_0_Tests(TestCaseMixin):

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -69,15 +69,13 @@ class OpenStackAuthTests(unittest.TestCase):
             ex_force_auth_url='http://x.y.z.y:5000',
             ex_tenant_name='admin')
         self.assertEqual(d._ex_force_auth_url, forced_auth)
+        
         with requests_mock.Mocker() as mock:
-            body1 = ComputeFileFixtures('openstack').load('v1_slug_servers_ips.xml')
             body2 = ComputeFileFixtures('openstack').load('_v2_0__auth.json')
 
-            mock.register_uri('GET', 'https://test_endpoint.com/v2/1337/servers/test/ips', text=body1,
-                              headers={'content-type': 'application/xml; charset=UTF-8'})
             mock.register_uri('POST', 'http://x.y.z.y:5000/v2.0/tokens', text=body2,
                               headers={'content-type': 'application/json; charset=UTF-8'})
-            d.ex_list_ip_addresses('test')
+            d.connection._populate_hosts_and_request_paths()
             self.assertEqual(d.connection.host, 'test_endpoint.com')
 
 

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -33,6 +33,7 @@ from libcloud.utils.py3 import httplib
 from libcloud.utils.py3 import method_type
 from libcloud.utils.py3 import u
 
+from libcloud.common.base import LibcloudConnection
 from libcloud.common.types import InvalidCredsError, MalformedResponseError, \
     LibcloudError
 from libcloud.compute.types import Provider, KeyPairDoesNotExistError, StorageVolumeState, \
@@ -60,6 +61,7 @@ BASE_DIR = os.path.abspath(os.path.split(__file__)[0])
 class OpenStackAuthTests(unittest.TestCase):
     def setUp(self):
         OpenStack_1_0_NodeDriver.connectionCls = OpenStack_1_0_Connection
+        OpenStack_1_0_NodeDriver.connectionCls.conn_class = LibcloudConnection
 
     def test_auth_host_passed(self):
         forced_auth = 'http://x.y.z.y:5000'

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -27,6 +27,7 @@ except ImportError:
     import json
 
 from mock import Mock, patch
+import requests_mock
 
 from libcloud.utils.py3 import httplib
 from libcloud.utils.py3 import method_type
@@ -53,6 +54,28 @@ from libcloud.test.compute import TestCaseMixin
 from libcloud.test.secrets import OPENSTACK_PARAMS
 
 BASE_DIR = os.path.abspath(os.path.split(__file__)[0])
+
+
+class OpenStackAuthTests(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_auth_host_passed(self):
+        forced_auth = 'http://x.y.z.y:5000'
+        d = OpenStack_1_0_NodeDriver(
+            'user', 'correct_password', 
+            ex_force_auth_version='2.0_password', 
+            ex_force_auth_url='http://x.y.z.y:5000', 
+            ex_tenant_name='admin')
+        self.assertEqual(d._ex_force_auth_url, forced_auth)
+        with requests_mock.Mocker() as mock:
+            body1 = "[]"
+            body2 = ComputeFileFixtures('openstack').load('_v2_0__auth.json')
+            mock.register_uri('GET', 'https://test_endpoint.com/v2/1337/servers/detail', text=body1,
+                              headers={'content-type': 'application/json; charset=UTF-8'})
+            mock.register_uri('POST', 'http://x.y.z.y:5000/v2.0/tokens', text=body2,
+                              headers={'content-type': 'application/json; charset=UTF-8'})
+            d.list_nodes()
 
 
 class OpenStack_1_0_Tests(TestCaseMixin):

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -69,7 +69,7 @@ class OpenStackAuthTests(unittest.TestCase):
             ex_force_auth_url='http://x.y.z.y:5000',
             ex_tenant_name='admin')
         self.assertEqual(d._ex_force_auth_url, forced_auth)
-        
+
         with requests_mock.Mocker() as mock:
             body2 = ComputeFileFixtures('openstack').load('_v2_0__auth.json')
 

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -69,10 +69,14 @@ class OpenStackAuthTests(unittest.TestCase):
             ex_tenant_name='admin')
         self.assertEqual(d._ex_force_auth_url, forced_auth)
         with requests_mock.Mocker() as mock:
+            body1 = ComputeFileFixtures('openstack').load('v1_slug_servers_ips.xml')
             body2 = ComputeFileFixtures('openstack').load('_v2_0__auth.json')
+
+            mock.register_uri('GET', 'https://test_endpoint.com/v2/1337/servers/test/ips', text=body1,
+                              headers={'content-type': 'application/xml; charset=UTF-8'})
             mock.register_uri('POST', 'http://x.y.z.y:5000/v2.0/tokens', text=body2,
                               headers={'content-type': 'application/json; charset=UTF-8'})
-            d.connection._populate_hosts_and_request_paths()
+            d.ex_list_ip_addresses('test')
             self.assertEqual(d.connection.host, 'test_endpoint.com')
 
 

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -42,7 +42,8 @@ from libcloud.compute.drivers.openstack import (
     OpenStack_1_0_NodeDriver,
     OpenStack_1_1_NodeDriver, OpenStackSecurityGroup,
     OpenStackSecurityGroupRule, OpenStack_1_1_FloatingIpPool,
-    OpenStack_1_1_FloatingIpAddress, OpenStackKeyPair
+    OpenStack_1_1_FloatingIpAddress, OpenStackKeyPair,
+    OpenStack_1_0_Connection
 )
 from libcloud.compute.base import Node, NodeImage, NodeSize
 from libcloud.pricing import set_pricing, clear_pricing_data
@@ -58,7 +59,7 @@ BASE_DIR = os.path.abspath(os.path.split(__file__)[0])
 
 class OpenStackAuthTests(unittest.TestCase):
     def setUp(self):
-        pass
+        OpenStack_1_0_NodeDriver.connectionCls = OpenStack_1_0_Connection
 
     def test_auth_host_passed(self):
         forced_auth = 'http://x.y.z.y:5000'


### PR DESCRIPTION
Noticed so far:

The existing test fixture returns the host as 127.0.0.1 which also happens to be the default host for a connection class. 

The test I just added fails to demonstrate the issue with

requests_mock.exceptions.NoMockAddress: No mock address: GET https://127.0.0.1/v2/1337/servers/detail

