### PR TITLE
Fix docker's list_containers function

### DIFF
--- a/libcloud/container/drivers/docker.py
+++ b/libcloud/container/drivers/docker.py
@@ -55,7 +55,7 @@ class DockerResponse(JsonResponse):
             content_type = self.headers.get('content-type', 'application/json')
             if content_type == 'application/json' or content_type == '':
                 if self.headers.get('transfer-encoding') == 'chunked' and \
-                        'create?fromImage' in self.request.url:
+                        'fromImage' in self.request.url:
                     body = [json.loads(chunk) for chunk in
                             self.body.strip().replace('\r', '').split('\n')]
                 else:

--- a/libcloud/container/drivers/docker.py
+++ b/libcloud/container/drivers/docker.py
@@ -54,7 +54,8 @@ class DockerResponse(JsonResponse):
             # an error, but response status could still be 200
             content_type = self.headers.get('content-type', 'application/json')
             if content_type == 'application/json' or content_type == '':
-                if self.headers.get('transfer-encoding') == 'chunked':
+                if self.headers.get('transfer-encoding') == 'chunked' and \
+                        'create?fromImage' in self.request.url:
                     body = [json.loads(chunk) for chunk in
                             self.body.strip().replace('\r', '').split('\n')]
                 else:


### PR DESCRIPTION
add an extra check otherwise list_containers breaks with AttributeError

## Fix function list_containers for docker

### Description
I tested locally docker's list_containers(), which was expected to return a list of containers.
But i ended up with this 
```AttributeError                          Traceback (most recent call last)
<ipython-input-5-34990fe7ad41> in <module>()
----> 1 con.list_containers()

/home/johnny/Documents/mylibcloud/env/src/fork_libcloud/libcloud/libcloud/container/drivers/docker.py in list_containers(self, image, all)
    301             raise
    302 
--> 303         containers = [self._to_container(value) for value in result]
    304         return containers
    305 

/home/johnny/Documents/mylibcloud/env/src/fork_libcloud/libcloud/libcloud/container/drivers/docker.py in _to_container(self, data)
    622                 name = data.get('Names')[0].strip('/')
    623             except:
--> 624                 name = data.get('Id')
    625         state = data.get('State')
    626         if isinstance(state, dict):

AttributeError: 'list' object has no attribute 'get'
```
I investigated more and i fixed this previous commit 
https://github.com/apache/libcloud/pull/918/commits/2f9c3a3aa1b6654ede67a2a6e63dd3e59437c6de

I extended the previous check with ``` 'fromImage' in self.request.url```, so to restrict that check which
refers to install_image and only. Because ```self.headers.get('transfer-encoding') == 'chunked'```  is valid in other cases too. This way everything seems to work fine!

### done

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
