### PR TITLE
Add test to check that can list sizes for all valid ec2 regions

### DIFF
--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -27,7 +27,7 @@ from libcloud.compute.drivers.ec2 import EC2PlacementGroup
 from libcloud.compute.drivers.ec2 import NimbusNodeDriver, EucNodeDriver
 from libcloud.compute.drivers.ec2 import OutscaleSASNodeDriver
 from libcloud.compute.drivers.ec2 import IdempotentParamError
-from libcloud.compute.drivers.ec2 import REGION_DETAILS
+from libcloud.compute.drivers.ec2 import REGION_DETAILS, VALID_EC2_REGIONS
 from libcloud.compute.drivers.ec2 import ExEC2AvailabilityZone
 from libcloud.compute.drivers.ec2 import EC2NetworkSubnet
 from libcloud.compute.base import Node, NodeImage, NodeSize, NodeLocation
@@ -70,6 +70,19 @@ class BaseEC2Tests(LibcloudTestCase):
                 pass
             else:
                 self.fail('Invalid region, but exception was not thrown')
+
+    def test_list_sizes_valid_regions(self):
+        unsupported_regions = list()
+
+        for region in VALID_EC2_REGIONS:
+            driver = EC2NodeDriver(*EC2_PARAMS, **{'region': region})
+            try:
+                driver.list_sizes()
+            except:
+                unsupported_regions.append(region)
+
+        if unsupported_regions:
+            self.fail('Cannot list sizes from ec2 regions: %s' % unsupported_regions)
 
 
 class EC2Tests(LibcloudTestCase, TestCaseMixin):


### PR DESCRIPTION
## Add test to check that can list sizes for all valid ec2 regions

### Description

EC2 compute driver fails to list sizes in some regions. The reason is that pricing hasn't been updated in such cases.

This PR adds a test to force the build fail if not all supported regions are working properly. I'd like to start a discussion about how to avoid this failure from happening again in the future (what about scraping prices as part of the build process?).

### Status

- start discussion

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)