### PR TITLE
Fix GCENodeDriver.ex_get_volume() when zone param is of class GCEZone or NodeLocation

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -7098,7 +7098,8 @@ class GCENodeDriver(NodeDriver):
             self._ex_populate_volume_dict()
 
         try:
-            zone = zone.name  # if zone is of class GCEZone or NodeLocation, get name instead
+            # if zone is of class GCEZone or NodeLocation, get name instead
+            zone = zone.name
         except AttributeError:
             pass
 

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -7097,6 +7097,11 @@ class GCENodeDriver(NodeDriver):
             # Make the API call and build volume dictionary
             self._ex_populate_volume_dict()
 
+        try:
+            zone = zone.name  # if zone is of class GCEZone or NodeLocation, get name instead
+        except AttributeError:
+            pass
+
         return self._ex_lookup_volume(name, zone)
 
     def ex_get_region(self, name):

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -89,6 +89,13 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         region2 = self.driver._get_region_from_zone(zone2)
         self.assertEqual(region2.name, expected_region2)
 
+    def test_get_volume(self):
+        volume_name = 'lcdisk'
+        location = self.driver.zone
+        volume = self.driver.ex_get_volume(volume_name, zone=location)
+        self.assertTrue(isinstance(volume, StorageVolume))
+        self.assertEqual(volume.name, volume_name)
+
     def test_find_zone_or_region(self):
         zone1 = self.driver._find_zone_or_region('libcloud-demo-np-node',
                                                  'instances')

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -91,8 +91,21 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
 
     def test_get_volume(self):
         volume_name = 'lcdisk'
+        volume = self.driver.ex_get_volume(volume_name)
+        self.assertTrue(isinstance(volume, StorageVolume))
+        self.assertEqual(volume.name, volume_name)
+
+    def test_get_volume_location(self):
+        volume_name = 'lcdisk'
         location = self.driver.zone
         volume = self.driver.ex_get_volume(volume_name, zone=location)
+        self.assertTrue(isinstance(volume, StorageVolume))
+        self.assertEqual(volume.name, volume_name)
+
+    def test_get_volume_location_name(self):
+        volume_name = 'lcdisk'
+        location = self.driver.zone
+        volume = self.driver.ex_get_volume(volume_name, zone=location.name)
         self.assertTrue(isinstance(volume, StorageVolume))
         self.assertEqual(volume.name, volume_name)
 


### PR DESCRIPTION
## Fix GCENodeDriver.ex_get_volume() when zone param is of class GCEZone or NodeLocation

### Description

Use the zone name (not a zone object) when looking up a volume in the GCE compute driver. This PR makes the method compliant with its documentation.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)