### PR TITLE
Fixies for docker

### DIFF
--- a/libcloud/container/drivers/docker.py
+++ b/libcloud/container/drivers/docker.py
@@ -386,10 +386,16 @@ class DockerContainerDriver(ContainerDriver):
 
         data = json.dumps(payload)
         if start:
-            result = self.connection.request(
-                '/v%s/containers/%s/start' %
-                (self.version, id_), data=data,
-                method='POST')
+            if float(self._get_api_version()) > 1.22:
+                result = self.connection.request(
+                    '/v%s/containers/%s/start' %
+                    (self.version, id_),
+                    method='POST')
+            else:
+                result = self.connection.request(
+                    '/v%s/containers/%s/start' %
+                    (self.version, id_), data=data,
+                    method='POST')
 
         return self.get_container(id_)
 
@@ -417,15 +423,22 @@ class DockerContainerDriver(ContainerDriver):
         :return: The container refreshed with current data
         :rtype: :class:`libcloud.container.base.Container`
         """
-        payload = {
-            'Binds': [],
-            'PublishAllPorts': True,
-        }
-        data = json.dumps(payload)
-        result = self.connection.request(
-            '/v%s/containers/%s/start' %
-            (self.version, container.id),
-            method='POST', data=data)
+        if float(self._get_api_version()) > 1.22:
+            result = self.connection.request(
+                '/v%s/containers/%s/start' %
+                (self.version, container.id),
+                method='POST')
+        else:
+            payload = {
+                'Binds': [],
+                'PublishAllPorts': True,
+            }
+            data = json.dumps(payload)
+            result = self.connection.request(
+                '/v%s/containers/%s/start' %
+                (self.version, container.id),
+                method='POST', data=data)
+
         if result.status in VALID_RESPONSE_CODES:
             return self.get_container(container.id)
         else:

--- a/libcloud/container/drivers/docker.py
+++ b/libcloud/container/drivers/docker.py
@@ -642,6 +642,8 @@ class DockerContainerDriver(ContainerDriver):
             state = ContainerState.STOPPED
         elif status.startswith('Up '):
             state = ContainerState.RUNNING
+        elif 'running' in status:
+            state = ContainerState.RUNNING
         else:
             state = ContainerState.STOPPED
         image = data.get('Image')

--- a/libcloud/test/container/fixtures/docker/linux_124/container_a68.json
+++ b/libcloud/test/container/fixtures/docker/linux_124/container_a68.json
@@ -6,7 +6,7 @@
     "None"
   ],
   "State": {
-    "Status": "exited",
+    "Status": "running",
     "Running": false,
     "Paused": false,
     "Restarting": false,

--- a/libcloud/test/container/test_docker.py
+++ b/libcloud/test/container/test_docker.py
@@ -78,6 +78,7 @@ class DockerContainerDriverTestCase(unittest.TestCase):
             container = driver.get_container('a68c1872c74630522c7aa74b85558b06824c5e672cee334296c50fb209825303')
             self.assertEqual(container.id, 'a68c1872c74630522c7aa74b85558b06824c5e672cee334296c50fb209825303')
             self.assertEqual(container.name, 'gigantic_goldberg')
+            self.assertEqual(container.state, 'running')
 
     def test_start_container(self):
         for driver in self.drivers:


### PR DESCRIPTION
## Fixies for docker

### Description

Docker remote has change its call for start a container. As we can check here:
https://docs.docker.com/engine/api/version-history/#v124-api-changes
The previous implementation doesn't work and throws the following error:
```
/home/johnny/Documents/mylibcloud/libcloudfine/fork_libcloud/libcloud/libcloud/common/base.pyc in __init__(self, response, connection)
    159         if not self.success():
    160             raise exception_from_message(code=self.status,
--> 161                                          message=self.parse_error())
    162
    163         self.object = self.parse_body()

BaseHTTPError: {"message":"starting container with non-empty request body was deprecated since v1.10 and removed in v1.12"}
(where v refers to docker version)
```
So i changed the implementation to work like:
```POST /containers/(id or name)/start``` without data

Also, i add one more line which checks container status, because
this changed also, ```status=(created	restarting	running	paused	exited	dead)```
in API v 1.24 ```https://docs.docker.com/engine/api/v1.24/```

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)

