### PR TITLE
Fix checking for "location is None" in several functions

### DIFF
--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -910,10 +910,11 @@ class AzureNodeDriver(NodeDriver):
         :type location: :class:`.NodeLocation`
         """
 
-        if location is None and self.default_location:
-            location = self.default_location
-        else:
-            raise ValueError("location is required.")
+        if location is None:
+            if self.default_location:
+                location = self.default_location
+            else:
+                raise ValueError("location is required.")
 
         target = "/subscriptions/%s/resourceGroups/%s/" \
                  "providers/Microsoft.Network/networkSecurityGroups/%s" \
@@ -943,10 +944,11 @@ class AzureNodeDriver(NodeDriver):
         :type location: :class:`.NodeLocation`
         """
 
-        if location is None and self.default_location:
-            location = self.default_location
-        else:
-            raise ValueError("location is required.")
+        if location is None:
+            if self.default_location:
+                location = self.default_location
+            else:
+                raise ValueError("location is required.")
 
         target = "/subscriptions/%s/resourceGroups/%s/" \
                  "providers/Microsoft.Network/networkSecurityGroups/%s" \
@@ -1076,10 +1078,11 @@ class AzureNodeDriver(NodeDriver):
         :rtype: :class:`.AzureIPAddress`
         """
 
-        if location is None and self.default_location:
-            location = self.default_location
-        else:
-            raise ValueError("location is required.")
+        if location is None:
+            if self.default_location:
+                location = self.default_location
+            else:
+                raise ValueError("location is required.")
 
         target = "/subscriptions/%s/resourceGroups/%s/" \
                  "providers/Microsoft.Network/publicIPAddresses/%s" \

--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -595,7 +595,7 @@ class AzureNodeDriver(NodeDriver):
 
         if isinstance(auth, NodeAuthSSHKey):
             data["properties"]["osProfile"]["adminPassword"] = \
-                binascii.hexlify(os.urandom(20))
+                binascii.hexlify(os.urandom(20)).decode("utf-8")
             data["properties"]["osProfile"]["linuxConfiguration"] = {
                 "disablePasswordAuthentication": "true",
                 "ssh": {


### PR DESCRIPTION
This suggested update fixes the condition that checks for parameter "location" being None. If the parameter is not None, the original code would still exit and raise ValueError exception.

## Changes Title (LIBCLOUD-926 - [BUG Azure_ARM] in ex_create_public_ip function among other)

### Description

This suggested update fixes the condition that checks for parameter "location" being None. If the parameter is not None, the original code would still exit and raise ValueError exception.

In the file libcloud/compute/drivers/azure_arm.py.
There are some functions as ex_create_public_ip function that it needs a location parameter, when this parameter is send, a error happen: "Location is required".
Looking at the code I found with the following:

```
       if location is None and self.default_location:
            location = self.default_location
        else:
            raise ValueError("location is required.")
```
This does not evaluate a possible parameter, only if the value is None.

I suggested the following change:

```
        if location is None:
            if self.default_location:
                location = self.default_location
            else:
                raise ValueError("location is required.")
```

The affected methods are:
```
   ex_create_network_security_group
   ex_delete_network_security_group
   ex_create_public_ip
```
The same code has been used in several other places.

### Status

OPEN

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
