### PR TITLE
Openstack updates for Keystone 3 and Nova 2.x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ Changes in current version of Apache Libcloud
 Common
 ~~~~~~
 
+- Use PyTest as the unit testing runner
+  (Anthony Shaw)
+
 - Use of LXML is now disabled by defalt, use libcloud.utils.py3.DEFAULT_LXML = True to reenable. LXML has compatibility 
   issues with a number of drivers and etree is a standard package
   [GITHUB-1038]
@@ -14,6 +17,10 @@ Common
 
 Compute
 ~~~~~~~
+
+- [EC2] Add i3 instance types for AWS
+  [GITHUB-1038]
+  (Stephen Mullins)
 
 - [VULTR] Extend extra dict of Vultr sizes to include additional fields (plan_type and available_locations)
   [GITHUB-1044]

--- a/demos/example_openstack.py
+++ b/demos/example_openstack.py
@@ -1,0 +1,17 @@
+from pprint import pprint
+
+from libcloud.compute.providers import get_driver
+from libcloud.compute.types import Provider
+
+Openstack = get_driver(Provider.OPENSTACK)
+
+con = Openstack(
+    'admin', 'password',
+    ex_force_auth_url='http://23.12.198.36/identity/v3/auth/tokens',
+    ex_force_base_url='http://23.12.198.36:8774/v2.1',
+    api_version='2.0',
+    ex_tenant_name='demo')
+
+pprint(con.list_locations())
+pprint(con.list_images())
+pprint(con.list_nodes())

--- a/docs/compute/drivers/openstack.rst
+++ b/docs/compute/drivers/openstack.rst
@@ -13,6 +13,32 @@ Among many other private clouds, it also powers Rackspace's Public Cloud.
 
 .. _connecting-to-openstack-installation:
 
+Selecting the Nova API version
+------------------------------
+
+Along with your connection criteria, you can specify the Nova version with `api_version`, 
+currently supported versions of Nova are:
+
+- 1.0
+- 1.1
+- 2.0
+- 2.1 (v12)
+- 2.2 (v13)
+
+.. code-block:: python
+
+  from libcloud.compute.providers import get_driver
+  from libcloud.compute.types import Provider
+
+  Openstack = get_driver(Provider.OPENSTACK)
+
+  con = Openstack(
+      'admin', 'password',
+      ex_force_base_url='http://23.12.198.36:8774/v2.1',
+      api_version='2.0',
+      ex_tenant_name='demo')
+
+
 Connecting to the OpenStack installation
 ----------------------------------------
 

--- a/docs/compute/drivers/openstack.rst
+++ b/docs/compute/drivers/openstack.rst
@@ -45,6 +45,10 @@ Available arguments:
     and API key
   * ``2.0_password`` - authenticate against keystone with a username and
     password
+  * ``2.0_voms`` - 2.0 VOMS key
+  * ``3.x_password`` - 3.x keystone password
+  * ``3.x_oidc_access_token`` - OIDC access token
+
 
   Unless you are working with a very old version of OpenStack you will either
   want to use ``2.0_apikey`` or ``2.0_password``.

--- a/libcloud/common/openstack_identity.py
+++ b/libcloud/common/openstack_identity.py
@@ -1062,8 +1062,10 @@ class OpenStackIdentity_3_0_Connection(OpenStackIdentityConnection):
             body = 'code: %s body:%s' % (response.status, response.body)
         elif response.status == 300:
             # ambiguous version request
-            raise LibcloudError('Auth request returned ambiguous version error, try' 
-                                'using the version specific URL to connect, e.g. identity/v3/auth/tokens')
+            raise LibcloudError(
+                'Auth request returned ambiguous version error, try'
+                'using the version specific URL to connect,'
+                ' e.g. identity/v3/auth/tokens')
         else:
             body = 'code: %s body:%s' % (response.status, response.body)
             raise MalformedResponseError('Malformed response', body=body,

--- a/libcloud/common/openstack_identity.py
+++ b/libcloud/common/openstack_identity.py
@@ -1060,6 +1060,10 @@ class OpenStackIdentity_3_0_Connection(OpenStackIdentityConnection):
                 raise MalformedResponseError('Auth JSON response is \
                                              missing required elements', e)
             body = 'code: %s body:%s' % (response.status, response.body)
+        elif response.status == 300:
+            # ambiguous version request
+            raise LibcloudError('Auth request returned ambiguous version error, try' 
+                                'using the version specific URL to connect, e.g. identity/v3/auth/tokens')
         else:
             body = 'code: %s body:%s' % (response.status, response.body)
             raise MalformedResponseError('Malformed response', body=body,

--- a/libcloud/compute/drivers/hostvirtual.py
+++ b/libcloud/compute/drivers/hostvirtual.py
@@ -85,13 +85,14 @@ class HostVirtualNodeDriver(NodeDriver):
     def list_locations(self):
         result = self.connection.request(API_ROOT + '/cloud/locations/').object
         locations = []
-        for dc in result:
+        for k in result:
+            dc = result[k]
             locations.append(NodeLocation(
                 dc["id"],
                 dc["name"],
                 dc["name"].split(',')[1].replace(" ", ""),  # country
                 self))
-        return locations
+        return sorted(locations, key=lambda x: int(x.id))
 
     def list_sizes(self, location=None):
         params = {}

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -134,6 +134,8 @@ class OpenStackNodeDriver(NodeDriver, OpenStackDriverMixin):
                 cls = OpenStack_1_0_NodeDriver
             elif api_version == '1.1':
                 cls = OpenStack_1_1_NodeDriver
+            elif api_version in ['2.0', '2.1', '2.2']:
+                cls = OpenStack_2_NodeDriver
             else:
                 raise NotImplementedError(
                     "No OpenStackNodeDriver found for API version %s" %
@@ -2433,6 +2435,33 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
         uri = '/servers/{node_id}/action'.format(node_id=node.id)
         resp = self.connection.request(uri, method='POST', data={action: None})
         return resp.status == httplib.ACCEPTED
+
+
+class OpenStack_2_Connection(OpenStackComputeConnection):
+    responseCls = OpenStack_1_1_Response
+    accept_format = 'application/json'
+    default_content_type = 'application/json; charset=UTF-8'
+
+    def encode_data(self, data):
+        return json.dumps(data)
+
+
+class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
+    """
+    OpenStack node driver.
+    """
+    connectionCls = OpenStack_2_Connection
+    type = Provider.OPENSTACK
+
+    features = {"create_node": ["generates_password"]}
+    _networks_url_prefix = '/os-networks'
+
+    def __init__(self, *args, **kwargs):
+        self._ex_force_api_version = str(kwargs.pop('ex_force_api_version',
+                                                    None))
+        if 'ex_force_auth_version' not in kwargs:
+            kwargs['ex_force_auth_version'] = '3.x_password'
+        super(OpenStack_2_NodeDriver, self).__init__(*args, **kwargs)
 
 
 class OpenStack_1_1_FloatingIpPool(object):

--- a/libcloud/test/compute/fixtures/hostvirtual/list_locations.json
+++ b/libcloud/test/compute/fixtures/hostvirtual/list_locations.json
@@ -1,46 +1,106 @@
-[
-  {
-    "id": "3",
-    "name": "SJC - San Jose, CA"
+{
+  "SJC - San Jose, CA": {
+    "name": "SJC - San Jose, CA",
+    "id": "3"
   },
-  {
-    "id": "13",
-    "name": "IAD2- Reston, VA"
+  "IAD - Reston, VA": {
+    "name": "IAD - Reston, VA",
+    "id": "13"
   },
-  {
-    "id": "21",
-    "name": "LAX3 - Los Angeles, CA"
+  "LAX - Los Angeles, CA": {
+    "name": "LAX - Los Angeles, CA",
+    "id": "21"
   },
-  {
-    "id": "31",
-    "name": "CHI - Chicago, IL"
+  "CHI - Chicago, IL": {
+    "name": "CHI - Chicago, IL",
+    "id": "31"
   },
-  {
-    "id": "41",
-    "name": "NYC - New York, NY"
+  "LGA - New York, NY": {
+    "name": "LGA - New York, NY",
+    "id": "41"
   },
-  {
-    "id": "61",
-    "name": "MAA - Chennai (Madras), India"
+  "MAA - Chennai (Madras), India": {
+    "name": "MAA - Chennai (Madras), India",
+    "id": "61"
   },
-  {
-    "id": "71",
-    "name": "LON - London, United Kingdom"
+  "LHR - London, United Kingdom": {
+    "name": "LHR - London, United Kingdom",
+    "id": "71"
   },
-  {
-    "id": "72",
-    "name": "AMS2 - Amsterdam, NL"
+  "AMS - Amsterdam, NL": {
+    "name": "AMS - Amsterdam, NL",
+    "id": "72"
   },
-  {
-    "id": "82",
-    "name": "FRA - Paris, France"
+  "CDG - Paris, France": {
+    "name": "CDG - Paris, France",
+    "id": "82"
   },
-  {
-    "id": "83",
-    "name": "HK - Hong Kong, HK"
+  "HKG - Hong Kong, HK": {
+    "name": "HKG - Hong Kong, HK",
+    "id": "83"
   },
-  {
-    "id": "101",
-    "name": "DFW - Dallas, TX"
+  "DFW - Dallas, TX": {
+    "name": "DFW - Dallas, TX",
+    "id": "101"
+  },
+  "SVM - StrongVM, DDoS Protected": {
+    "name": "SVM - StrongVM, DDoS Protected",
+    "id": "121"
+  },
+  "DEN - Denver, CO": {
+    "name": "DEN - Denver, CO",
+    "id": "122"
+  },
+  "MIA - Miami, FL": {
+    "name": "MIA - Miami, FL",
+    "id": "123"
+  },
+  "SEA - Seattle, WA": {
+    "name": "SEA - Seattle, WA",
+    "id": "124"
+  },
+  "TOR - Toronto, CA": {
+    "name": "TOR - Toronto, CA",
+    "id": "127"
+  },
+  "SYD - Sydney, AU": {
+    "name": "SYD - Sydney, AU",
+    "id": "137"
+  },
+  "OTP - Bucharest, RO": {
+    "name": "OTP - Bucharest, RO",
+    "id": "146"
+  },
+  "FRA - Frankfurt, DE": {
+    "name": "FRA - Frankfurt, DE",
+    "id": "164"
+  },
+  "SIN - Singapore, SG": {
+    "name": "SIN - Singapore, SG",
+    "id": "173"
+  },
+  "GRU - Sao Paulo, Brazil": {
+    "name": "GRU - Sao Paulo, Brazil",
+    "id": "182"
+  },
+  "SJC2 - San Jose, CA": {
+    "name": "SJC2 - San Jose, CA",
+    "id": "227"
+  },
+  "RDU - Raleigh, NC": {
+    "name": "RDU - Raleigh, NC",
+    "id": "236"
+  },
+  "IAD3 - Ashburn, VA": {
+    "name": "IAD3 - Ashburn, VA",
+    "id": "245"
+  },
+  "DFW2 - Dallas, TX": {
+    "name": "DFW2 - Dallas, TX",
+    "id": "281"
+  },
+  "PHX - Phoenix, AZ": {
+    "name": "PHX - Phoenix, AZ",
+    "id": "290"
   }
-]
+}

--- a/libcloud/test/compute/test_hostvirtual.py
+++ b/libcloud/test/compute/test_hostvirtual.py
@@ -64,7 +64,7 @@ class HostVirtualTest(unittest.TestCase):
         self.assertEqual(locations[0].id, '3')
         self.assertEqual(locations[0].name, 'SJC - San Jose, CA')
         self.assertEqual(locations[1].id, '13')
-        self.assertEqual(locations[1].name, 'IAD2- Reston, VA')
+        self.assertEqual(locations[1].name, 'IAD - Reston, VA')
 
     def test_reboot_node(self):
         node = self.driver.list_nodes()[0]

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -510,7 +510,7 @@ class OpenStackMockHttp(MockHttp, unittest.TestCase):
             raise NotImplementedError()
         # this is currently used for deletion of an image
         # as such it should not accept GET/POST
-        return(httplib.NO_CONTENT, "", "", httplib.responses[httplib.NO_CONTENT])
+        return(httplib.NO_CONTENT, "", {}, httplib.responses[httplib.NO_CONTENT])
 
     def _v1_0_slug_images(self, method, url, body, headers):
         if method != "POST":

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -19,6 +19,7 @@ import os
 import sys
 import unittest
 import datetime
+import pytest
 from libcloud.utils.iso8601 import UTC
 
 try:
@@ -44,7 +45,8 @@ from libcloud.compute.drivers.openstack import (
     OpenStack_1_1_NodeDriver, OpenStackSecurityGroup,
     OpenStackSecurityGroupRule, OpenStack_1_1_FloatingIpPool,
     OpenStack_1_1_FloatingIpAddress, OpenStackKeyPair,
-    OpenStack_1_0_Connection
+    OpenStack_1_0_Connection,
+    OpenStackNodeDriver
 )
 from libcloud.compute.base import Node, NodeImage, NodeSize
 from libcloud.pricing import set_pricing, clear_pricing_data
@@ -56,6 +58,17 @@ from libcloud.test.compute import TestCaseMixin
 from libcloud.test.secrets import OPENSTACK_PARAMS
 
 BASE_DIR = os.path.abspath(os.path.split(__file__)[0])
+
+
+def test_driver_instantiation_invalid_auth():
+    forced_auth = 'http://x.y.z.y:5000'
+    with pytest.raises(LibcloudError):
+        d = OpenStackNodeDriver(
+            'user', 'correct_password',
+            ex_force_auth_version='5.0',
+            ex_force_auth_url='http://x.y.z.y:5000',
+            ex_tenant_name='admin')
+        d.list_nodes()
 
 
 class OpenStackAuthTests(unittest.TestCase):

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -61,7 +61,6 @@ BASE_DIR = os.path.abspath(os.path.split(__file__)[0])
 
 
 def test_driver_instantiation_invalid_auth():
-    forced_auth = 'http://x.y.z.y:5000'
     with pytest.raises(LibcloudError):
         d = OpenStackNodeDriver(
             'user', 'correct_password',

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -81,7 +81,7 @@ class OpenStackAuthTests(unittest.TestCase):
             self.assertEqual(d.connection.host, 'test_endpoint.com')
 
 
-class OpenStack_1_0_Tests(TestCaseMixin):
+class OpenStack_1_0_Tests(TestCaseMixin, unittest.TestCase):
     should_list_locations = False
     should_list_volumes = False
 


### PR DESCRIPTION
## Openstack updates for Keystone 3 and Nova 2.x

This is a test for version 12 of OpenStack

* Testing Nova 2.1 API
* Adding 2.0, 2.1 and 2.2 as a valid `api_version`
* Giving a better error for the identity HTTP : 300 response that you'll receive

cc @allardhoeve 
