### PR TITLE
Restore RawResponse speed

### DIFF
--- a/libcloud/common/base.py
+++ b/libcloud/common/base.py
@@ -278,7 +278,7 @@ class RawResponse(Response):
         if not self._response:
             response = self.connection.connection.getresponse()
             self._response = HttpLibResponseProxy(response)
-            self.body = response.text
+            self.body = response.content
             if not self.success():
                 self.parse_error()
         return self._response


### PR DESCRIPTION
RawResponse uses response.body from requests, which is pathologically
slow due to chardet (requests#2359). Since we're only interested in the
bytes, using response.content is faster. On a 3Mib file, this makes
a download_object() go from 40s to 4s.

## Restore RawResponse speed

### Description

RawResponse uses response.body from requests, which is pathologically
slow due to chardet (requests#2359). Since we're only interested in the
bytes, using response.content is faster. On a 3Mib file, this makes
a download_object() go from 40s to 4s.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
