### PR TITLE
[LIBCLOUD-914] Fix raise in s3.upload_object_via_stream

### DIFF
--- a/libcloud/storage/base.py
+++ b/libcloud/storage/base.py
@@ -631,8 +631,7 @@ class StorageDriver(BaseDriver):
                     self._get_hash_function())
 
         if not response.success():
-            raise LibcloudError(
-                value='Object upload failed, Perhaps a timeout?', driver=self)
+            response.parse_error()
 
         if upload_func:
             upload_func(**upload_func_kwargs)

--- a/libcloud/storage/drivers/oss.py
+++ b/libcloud/storage/drivers/oss.py
@@ -610,10 +610,6 @@ class OSSStorageDriver(StorageDriver):
         if query_args:
             request_path = '?'.join((request_path, query_args))
 
-        # TODO: Let the underlying exceptions bubble up and capture the SIGPIPE
-        # here.
-        # SIGPIPE is thrown if the provided container does not exist or the
-        # user does not have correct permission
         result_dict = self._upload_object(
             object_name=object_name, content_type=content_type,
             request_path=request_path, request_method=method,

--- a/libcloud/storage/drivers/s3.py
+++ b/libcloud/storage/drivers/s3.py
@@ -805,10 +805,6 @@ class BaseS3StorageDriver(StorageDriver):
         if query_args:
             request_path = '?'.join((request_path, query_args))
 
-        # TODO: Let the underlying exceptions bubble up and capture the SIGPIPE
-        # here.
-        # SIGPIPE is thrown if the provided container does not exist or the
-        # user does not have correct permission
         result_dict = self._upload_object(
             object_name=object_name, content_type=content_type,
             request_path=request_path, request_method=method,


### PR DESCRIPTION
## [LIBCLOUD-914] Fix raise in s3.upload_object_via_stream

### Description

Since libcloud 2.0, s3.upload_object_via_stream as used in Google Storage was raising a generic
libcloud.common.types.LibcloudError on all exceptions, but we now raise
the correct exception. This also removes a comment that is probably
outdated.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
