### PR TITLE
Handle Vultr API rate-limit

### DIFF
--- a/libcloud/common/types.py
+++ b/libcloud/common/types.py
@@ -100,6 +100,17 @@ class InvalidCredsError(ProviderError):
 InvalidCredsException = InvalidCredsError
 
 
+class ServiceUnavailableError(ProviderError):
+    """Exception used when a provider returns 503 Service Unavailable."""
+
+    def __init__(self, value='Service unavailable at provider', driver=None):
+        super(ServiceUnavailableError, self).__init__(
+            value,
+            http_code=httplib.SERVICE_UNAVAILABLE,
+            driver=driver
+        )
+
+
 class LazyList(object):
 
     def __init__(self, get_more, value_dict=None):

--- a/libcloud/compute/drivers/vultr.py
+++ b/libcloud/compute/drivers/vultr.py
@@ -17,15 +17,56 @@ Vultr Driver
 """
 
 import time
+from functools import update_wrapper
 
 from libcloud.utils.py3 import httplib
 from libcloud.utils.py3 import urlencode
 
 from libcloud.common.base import ConnectionKey, JsonResponse
 from libcloud.compute.types import Provider, NodeState
-from libcloud.common.types import LibcloudError, InvalidCredsError
+from libcloud.common.types import InvalidCredsError
+from libcloud.common.types import LibcloudError
+from libcloud.common.types import ServiceUnavailableError
 from libcloud.compute.base import NodeDriver
 from libcloud.compute.base import Node, NodeImage, NodeSize, NodeLocation
+
+
+class rate_limited:
+    """
+    Decorator for retrying Vultr calls that are rate-limited.
+
+    :param int sleep: Seconds to sleep after being rate-limited.
+    :param int retries: Number of retries.
+    """
+
+    def __init__(self, sleep=1, retries=1):
+        self.sleep = sleep
+        self.retries = retries
+
+    def __call__(self, call):
+        """
+        Run ``call`` method until it's not rate-limited.
+
+        The method is invoked while it returns 503 Service Unavailable or the
+        allowed number of retries is reached.
+
+        :param callable call: Method to be decorated.
+        """
+
+        def wrapper(*args, **kwargs):
+            last_exception = None
+
+            for i in range(self.retries + 1):
+                try:
+                    return call(*args, **kwargs)
+                except ServiceUnavailableError as e:
+                    last_exception = e
+                    time.sleep(self.sleep)  # hit by rate limit, let's sleep
+
+            raise last_exception
+
+        update_wrapper(wrapper, call)
+        return wrapper
 
 
 class VultrResponse(JsonResponse):
@@ -35,6 +76,8 @@ class VultrResponse(JsonResponse):
             return body
         elif self.status == httplib.FORBIDDEN:
             raise InvalidCredsError(self.body)
+        elif self.status == httplib.SERVICE_UNAVAILABLE:
+            raise ServiceUnavailableError(self.body)
         else:
             raise LibcloudError(self.body)
 
@@ -57,7 +100,7 @@ class VultrConnection(ConnectionKey):
 
     host = 'api.vultr.com'
     responseCls = VultrResponse
-    unauthenticated_endpoints = {  # {path: actions}
+    unauthenticated_endpoints = {  # {action: methods}
         '/v1/app/list': ['GET'],
         '/v1/os/list': ['GET'],
         '/v1/plans/list': ['GET'],
@@ -82,9 +125,11 @@ class VultrConnection(ConnectionKey):
     def encode_data(self, data):
         return urlencode(data)
 
+    @rate_limited()
     def get(self, url):
         return self.request(url)
 
+    @rate_limited()
     def post(self, url, data):
         headers = {'Content-Type': 'application/x-www-form-urlencoded'}
         return self.request(url, data=data, headers=headers, method='POST')
@@ -99,7 +144,7 @@ class VultrConnection(ConnectionKey):
 
         try:
             return self.method \
-                   not in self.unauthenticated_endpoints[self.action]
+                not in self.unauthenticated_endpoints[self.action]
         except KeyError:
             return True
 

--- a/libcloud/compute/drivers/vultr.py
+++ b/libcloud/compute/drivers/vultr.py
@@ -58,15 +58,16 @@ class VultrConnection(ConnectionKey):
     host = 'api.vultr.com'
     responseCls = VultrResponse
 
-    def add_default_params(self, params):
+    def add_default_headers(self, headers):
         """
-        Add parameters that are necessary for every request
+        Adds ``API-Key`` default header.
 
-        This method add ``api_key`` to
-        the request.
+        :return: Updated headers.
+        :rtype: dict
         """
-        params['api_key'] = self.key
-        return params
+
+        headers.update({'API-Key': self.key})
+        return headers
 
     def encode_data(self, data):
         return urlencode(data)

--- a/libcloud/test/compute/fixtures/vultr/error_rate_limit.txt
+++ b/libcloud/test/compute/fixtures/vultr/error_rate_limit.txt
@@ -1,0 +1,1 @@
+Rate limit reached - please try your request again later.  Current rate limit: 2 requests/sec

--- a/libcloud/test/compute/test_vultr.py
+++ b/libcloud/test/compute/test_vultr.py
@@ -37,6 +37,10 @@ class VultrTests(LibcloudTestCase):
         VultrMockHttp.type = None
         self.driver = VultrNodeDriver(*VULTR_PARAMS)
 
+    def test_list_images_dont_require_api_key(self):
+        self.driver.list_images()
+        self.assertFalse(self.driver.connection.require_api_key())
+
     def test_list_images_success(self):
         images = self.driver.list_images()
         self.assertTrue(len(images) >= 1)
@@ -66,6 +70,10 @@ class VultrTests(LibcloudTestCase):
         location = locations[0]
         self.assertEqual(location.id, '1')
         self.assertEqual(location.name, 'New Jersey')
+
+    def test_list_nodes_require_api_key(self):
+        self.driver.list_nodes()
+        self.assertTrue(self.driver.connection.require_api_key())
 
     def test_list_nodes_success(self):
         nodes = self.driver.list_nodes()


### PR DESCRIPTION
## Handle Vultr API rate-limit

### Description

Vultr API imposes a rate limit of 2 requests/sec (actually they provide some leeway, but let's stick with the official documentation). A typical workflow for a libcloud's client that wants to launch a Vultr node could involve something like the following:

1. driver.list_locations()
2. driver.list_sizes()
3. driver.list_images()
4. driver.list_key_pairs()
5. driver.create_key_pair(name, key)
6. driver.create_node(...)

A client could easily exceed the rate limit in certain circumstances.

This PR makes Vultr compute driver handle rate-limiting in two ways:

1. Minimize the likelihood of being rate-limited by not authenticating requests that don't require an api key. Such requests aren't rate-limited.
2. If hit by the rate limit, retry the request. A `rate_limited` decorator is in charge of automatically retrying the request after a sleep period when a 503 Service Unavailable response is received.

In order to implement (1), this PR first updates the way the driver authenticates with Vultr. Now it uses an HTTP header (as described in current api docs: https://www.vultr.com/api/) instead of a query parameter.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)