### PR TITLE
Temporarily disable sphinx warnings as errors

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ deps = sphinx
        backports.ssl_match_hostname
 changedir = docs
 commands = python ../contrib/generate_provider_feature_matrix_table.py
-           sphinx-build -W -b html -d {envtmpdir}/doctrees . _build/html
+           sphinx-build -b html -d {envtmpdir}/doctrees . _build/html
 
 [testenv:scrape-ec2-prices]
 deps = requests


### PR DESCRIPTION
## Temporarily disable sphinx warnings as errors

### Description

Doc generation is currently broken in the build pipeline, thus blocking other PRs from passing tests.

This PR temporarily removes `-W` flag from the call to `sphinx-build` so that warnings are not treated as errors. Ideally we should get rid of such warnings.

### Status

- work in progress

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)