### PR TITLE
Fix missing return statement

### DIFF
--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -7295,6 +7295,8 @@ class BaseEC2NodeDriver(NodeDriver):
             idx += 1  # We want 1-based indexes
             params['BillingProduct.%d' % (idx)] = str(v)
 
+        return params
+
     def _get_disk_container_params(self, disk_container):
         """
         Return a list of dictionaries with query parameters for


### PR DESCRIPTION
## Fix missing return statement

### Description

This line was lost during a recent merge prior to v2.0.0.

For reference, here is the merge: https://github.com/apache/libcloud/commit/2f8189068f5d23bf04595468b4b7e4d76be5da63#diff-36825a12922cd525dde5f5dd9635f775R7151

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
