### PR TITLE
fix 1 lgtm.com alert

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -7915,8 +7915,6 @@ class GCENodeDriver(NodeDriver):
             error = e.value
             code = e.code
             response = {'status': 'DONE'}
-        except ResourceNotFoundError:
-            return
         if response['status'] == 'DONE':
             status['node_response'] = None
             if error:


### PR DESCRIPTION
Fix 1 lgtm.com alert

### Description

Hi,
Just wanted to quickly fix this alert that is flagged up on lgtm.com.

`ResourceNotFoundError` is a subclass of `GoogleBaseError` so the ordering of the except blocks would have never allowed to reach it.

Assuming the previous behaviour was satisfactory the `ResourceNotFoundError` block should be deleted.

Hope this helps!

A total of 162 alerts have been flagged up by lgtm.com, you can enable pull request integration for fully automated PR reviews that will flag these in the future so that they don't get past code review.
https://lgtm.com/projects/g/apache/libcloud/alerts/

### Status
 done, ready for review

### Checklist (tick everything that applies)

- [ X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
