### PR TITLE
Fix bug with GCE instance_templates disk_type selection

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -3999,7 +3999,7 @@ class GCENodeDriver(NodeDriver):
 
         properties = self._create_instance_properties(
             name, node_size=size, source=source, image=image,
-            disk_type='pd-standard', disk_auto_delete=True,
+            disk_type=disk_type, disk_auto_delete=True,
             external_ip=external_ip, network=network, subnetwork=subnetwork,
             can_ip_forward=can_ip_forward, service_accounts=service_accounts,
             on_host_maintenance=on_host_maintenance,


### PR DESCRIPTION
## Fix bug with GCE instance_templates disk_type selection

### Description

Using instance templates it always used pd-standard as disk type, not allowing you to choose between pd-ssd or pd-standard. It always chose pd-standard.

### Status
done, ready for review

