### PR TITLE
[LIBCLOUD-917] Gandi compute driver should use a unique location name

### DIFF
--- a/docs/examples/compute/gandi/create_node.py
+++ b/docs/examples/compute/gandi/create_node.py
@@ -6,7 +6,7 @@ driver = Gandi('api_key')
 
 image = [i for i in driver.list_images() if 'Debian 8 64' in i.name][0]
 size = [s for s in driver.list_sizes() if s.name == 'Medium instance'][0]
-location = [l for l in driver.list_locations() if l.name == 'Equinix Paris'][0]
+location = [l for l in driver.list_locations() if l.name == 'FR-SD2'][0]
 
 node = driver.create_node(name='yournode', size=size, image=image,
                           location=location, login="youruser", password="pass")

--- a/libcloud/compute/drivers/gandi.py
+++ b/libcloud/compute/drivers/gandi.py
@@ -436,7 +436,7 @@ class GandiNodeDriver(BaseGandiDriver, NodeDriver):
     def _to_loc(self, loc):
         return NodeLocation(
             id=loc['id'],
-            name=loc['name'],
+            name=loc['dc_code'],
             country=loc['country'],
             driver=self
         )

--- a/libcloud/test/compute/fixtures/gandi/datacenter_list.xml
+++ b/libcloud/test/compute/fixtures/gandi/datacenter_list.xml
@@ -20,6 +20,10 @@
                                     <value><int>1</int></value>
                                 </member>
                                 <member>
+                                    <name>dc_code</name>
+                                    <value><string>FR-SD2</string></value>
+                                </member>
+                                <member>
                                     <name>name</name>
                                     <value><string>Equinix Paris</string></value>
                                 </member>
@@ -34,6 +38,10 @@
                                 <member>
                                     <name>iso</name>
                                     <value><string>US</string></value>
+                                </member>
+                                <member>
+                                    <name>dc_code</name>
+                                    <value><string>US-BA1</string></value>
                                 </member>
                                 <member>
                                     <name>id</name>


### PR DESCRIPTION
### Description

Gandi compute driver uses a non unique field value as name for locations

See JIRA ticket https://issues.apache.org/jira/browse/LIBCLOUD-917

### Status
- done, ready for review

### Checklist (tick everything that applies)

- [X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [X] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
