### PR TITLE
Fix docker tls

### DIFF
--- a/libcloud/common/base.py
+++ b/libcloud/common/base.py
@@ -871,7 +871,7 @@ class KeyCertificateConnection(CertificateConnection):
     argument.
     """
 
-    key_file=None
+    key_file = None
 
     def __init__(self, key_file, cert_file, secure=True, host=None, port=None,
                  url=None, proxy_url=None, timeout=None, backoff=None,

--- a/libcloud/common/base.py
+++ b/libcloud/common/base.py
@@ -865,6 +865,33 @@ class CertificateConnection(Connection):
         self.cert_file = cert_file
 
 
+class KeyCertificateConnection(CertificateConnection):
+    """
+    Base connection class which accepts both ``key_file`` and ``cert_file``
+    argument.
+    """
+
+    key_file=None
+
+    def __init__(self, key_file, cert_file, secure=True, host=None, port=None,
+                 url=None, proxy_url=None, timeout=None, backoff=None,
+                 retry_delay=None):
+        """
+        Initialize `cert_file`; set `secure` to an ``int`` based on
+        passed value.
+        """
+        super(KeyCertificateConnection, self).__init__(cert_file,
+                                                       secure=secure,
+                                                       host=host,
+                                                       port=port, url=url,
+                                                       timeout=timeout,
+                                                       backoff=backoff,
+                                                       retry_delay=retry_delay,
+                                                       proxy_url=proxy_url)
+
+        self.key_file = key_file
+
+
 class ConnectionUserAndKey(ConnectionKey):
     """
     Base connection class which accepts a ``user_id`` and ``key`` argument.

--- a/libcloud/container/drivers/docker.py
+++ b/libcloud/container/drivers/docker.py
@@ -240,6 +240,9 @@ class DockerContainerDriver(ContainerDriver):
 
         if ca_cert:
             self.connection.connection.ca_cert = ca_cert
+        elif hasattr(self.connection.connection, 'ca_cert'):
+            # already set by libcloud.security.CA_CERTS_PATH
+            pass
         else:
             # do not verify SSL certificate
             self.connection.connection.ca_cert = False

--- a/libcloud/container/drivers/docker.py
+++ b/libcloud/container/drivers/docker.py
@@ -247,6 +247,8 @@ class DockerContainerDriver(ContainerDriver):
         self.connection.secure = secure
         self.connection.host = host
         self.connection.port = port
+        # set API version
+        self.version = self._get_api_version()
 
     def _ex_connection_class_kwargs(self):
         kwargs = {}

--- a/libcloud/container/drivers/docker.py
+++ b/libcloud/container/drivers/docker.py
@@ -141,7 +141,8 @@ class DockertlsConnection(KeyCertificateConnection):
             self.key_file = key_file
 
             certpath = os.path.expanduser(cert_file)
-            is_file_path = os.path.exists(certpath) and os.path.isfile(certpath)
+            is_file_path = os.path.exists(
+                certpath) and os.path.isfile(certpath)
             if not is_file_path:
                 raise InvalidCredsError(
                     'You need an certificate PEM file to authenticate with '

--- a/libcloud/container/drivers/docker.py
+++ b/libcloud/container/drivers/docker.py
@@ -180,7 +180,7 @@ class DockerContainerDriver(ContainerDriver):
     version = '1.24'
 
     def __init__(self, key='', secret='', secure=False, host='localhost',
-                 port=4243, key_file=None, cert_file=None):
+                 port=4243, key_file=None, cert_file=None, ca_cert=None):
         """
         :param    key: API key or username to used (required)
         :type     key: ``str``
@@ -237,11 +237,12 @@ class DockerContainerDriver(ContainerDriver):
                 raise Exception(
                     'Needs both private key file and '
                     'certificate file for tls authentication')
-            self.connection.key_file = key_file
-            self.connection.cert_file = cert_file
-            self.connection.secure = True
+
+        if ca_cert:
+            self.connection.connection.ca_cert = ca_cert
         else:
-            self.connection.secure = secure
+            # do not verify SSL certificate
+            self.connection.connection.ca_cert = False
 
         self.connection.secure = secure
         self.connection.host = host

--- a/libcloud/container/drivers/docker.py
+++ b/libcloud/container/drivers/docker.py
@@ -179,7 +179,7 @@ class DockerContainerDriver(ContainerDriver):
     supports_clusters = False
     version = '1.24'
 
-    def __init__(self, key=None, secret=None, secure=False, host='localhost',
+    def __init__(self, key='', secret='', secure=False, host='localhost',
                  port=4243, key_file=None, cert_file=None):
         """
         :param    key: API key or username to used (required)


### PR DESCRIPTION
## Fix Docker driver tls connection

### Description
I tried to connect a Docker daemon’s host machine with tls key_file & cert_file, 
through libcloud's docker driver and it fails under all circumstances.

I used this info for securing my Docker daemon’s host machine:
https://docs.docker.com/engine/security/https/

First scenario: tls with key_file and cert_file:

My environment:
- server side
root@cloudLining:~# ps aux | grep docker
root      4330  0.2  4.9 350520 24996 ?        Sl   Jun01   1:45 dockerd --tls --tlscert=server-cert.pem --tlskey=server-key.pem -H=tcp://0.0.0.0:4243 -D
root      4333  0.1  1.0 209380  5188 ?        Ssl  Jun01   1:04 docker-containerd -l unix:///var/run/docker/libcontainerd/docker-containerd.sock --metrics-interval=0 --start-timeout 2m --state-dir /var/run/doc$
root      5755  0.0  0.4  12000  2100 pts/0    S+   08:32   0:00 grep --color=auto docker

- client side
root@cloudLining:~# docker --tls --tlscacert=ca.pem --tlscert=server-cert.pem --tlskey=server-key.pem -H=tcp://127.0.0.1:4243 images
REPOSITORY           TAG                 IMAGE ID            CREATED             SIZE
tomcat               latest              d71978506e58        5 weeks ago         367 MB
ubuntu               latest              6a2f32de169d        7 weeks ago         117 MB
ubuntu               12.04               5b117edd0b76        7 weeks ago         104 MB
debian               7.11                69e388a5985c        2 months ago        85.3 MB

According to libcloud's docs: 
conn = driver(host='https://198.61.239.128', port=4243, key_file='key.pem', cert_file='cert.pem')

```  In [20]: from libcloud.container.providers import get_driver
    ...: from libcloud import security
    ...: security.VERIFY_SSL_CERT=False
    ...: driver = get_driver('docker')
    ...: key = '/home/johnny/Documents/kleidia/key.pem'
    ...: cert = '/home/johnny/Documents/kleidia/cert.pem'
    ...: d = driver(host='199.226.146.250', port=4243, key_file=key, cert_file=cert,secure=True)
    ...: d.list_images()

 ----> 1 d.list_images()

/home/johnny/Documents/mylibcloud/libcloudfine/fork_libcloud/libcloud/libcloud/container/drivers/docker.py in list_images(self)
    250         """
    251         result = self.connection.request('/v%s/images/json' %
--> 252                                          (self.version)).object
    253         images = []
    254         for image in result:

/home/johnny/Documents/mylibcloud/libcloudfine/fork_libcloud/libcloud/libcloud/common/base.pyc in request(self, action, params, data, headers, method, raw, stream)
    601                 else:
    602                     self.connection.request(method=method, url=url, body=data,
--> 603                                             headers=headers, stream=stream)
    604         except socket.gaierror:
    605             e = sys.exc_info()[1]

/home/johnny/Documents/mylibcloud/libcloudfine/fork_libcloud/libcloud/libcloud/http.pyc in request(self, method, url, body, headers, raw, stream)
    208         import ipdb
    209         ipdb.set_trace()
--> 210         self.response = self.session.request(
    211             method=method.lower(),
    212             url=url,

/home/johnny/Documents/mylibcloud/libcloudfine/fork_libcloud/local/lib/python2.7/site-packages/requests/sessions.pyc in request(self, method, url, params, data, headers, cookies, files, auth, timeout, allow_red$
    486         }
    487         send_kwargs.update(settings)
--> 488         resp = self.send(prep, **send_kwargs)
    489
    490         return resp

/home/johnny/Documents/mylibcloud/libcloudfine/fork_libcloud/local/lib/python2.7/site-packages/requests/sessions.pyc in send(self, request, **kwargs)
    607
    608         # Send the request
--> 609         r = adapter.send(request, **kwargs)
    610
    611         # Total elapsed time of the request (approximately)

/home/johnny/Documents/mylibcloud/libcloudfine/fork_libcloud/local/lib/python2.7/site-packages/requests/adapters.pyc in send(self, request, stream, timeout, verify, cert, proxies)
    485                 raise ProxyError(e, request=request)
    486
--> 487             raise ConnectionError(e, request=request)
    488
    489         except ClosedPoolError as e:

ConnectionError: HTTPSConnectionPool(host='4243', port=443): Max retries exceeded with url: /v1.24/images/json (Caused by NewConnectionError('<requests.packages.urllib3.connection.VerifiedHTTPSConnection object$
```
It's obvious at this point that variables are messed up!

I attached a more extensive debugging explanation here:
[docker_tls.txt](https://github.com/apache/libcloud/files/1047835/docker_tls.txt)

* With this pr I propose to add a new class DockertlsConnection in DockerContainerDriver, which
   handles the tls connection and is a subclass of class KeyCertificateConnection (added in 
   libcloud/common/base.py). 
 
* I replaced key,secret default values with empty strings( previous None)
  otherwise it's not possible to call 
  driver(host='https://198.61.239.128', port=4243, key_file='key.pem', cert_file='cert.pem')

* I added ca_cert variable in DockerContainerDriver, in case of a user doesn't want to change
  the environment's variables through libcloud.security.CA_CERTS_PATH
  commit d5af021a92ef04ff42439f0e5ff7bd007de05015
  commit e15e4a8346a121eb437c45b9f9c3c8812afd5ce5

* I passed the real version and not a default one

I have done seperated commits if you want to exclude anything.

I tested this pr against all scenarios:
- http 
- http basic authentication 
- tls
- tls key_file & cert_file
- tls verified key_file, cert_file, ca_cert

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [X] Documentation
- [X] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
