### PR TITLE
Fix "Failed to parse XML" error when XML contains wrong encoding declaration

### DIFF
--- a/libcloud/common/aws.py
+++ b/libcloud/common/aws.py
@@ -27,7 +27,7 @@ except ImportError:
 
 from libcloud.common.base import ConnectionUserAndKey, XmlResponse, BaseDriver
 from libcloud.common.base import JsonResponse
-from libcloud.common.types import InvalidCredsError, MalformedResponseError
+from libcloud.common.types import InvalidCredsError
 from libcloud.utils.py3 import b, httplib, urlquote
 from libcloud.utils.xml import findtext, findall
 

--- a/libcloud/common/aws.py
+++ b/libcloud/common/aws.py
@@ -25,7 +25,6 @@ try:
 except ImportError:
     import json
 
-from libcloud.utils.py3 import ET
 from libcloud.common.base import ConnectionUserAndKey, XmlResponse, BaseDriver
 from libcloud.common.base import JsonResponse
 from libcloud.common.types import InvalidCredsError, MalformedResponseError
@@ -94,12 +93,7 @@ class AWSGenericResponse(AWSBaseResponse):
             else:
                 raise InvalidCredsError(self.body)
 
-        try:
-            body = self.parse_body()
-        except Exception:
-            raise MalformedResponseError('Failed to parse XML',
-                                         body=self.body,
-                                         driver=self.connection.driver)
+        body = self.parse_body()
 
         if self.xpath:
             errs = findall(element=body, xpath=self.xpath,

--- a/libcloud/common/aws.py
+++ b/libcloud/common/aws.py
@@ -95,7 +95,7 @@ class AWSGenericResponse(AWSBaseResponse):
                 raise InvalidCredsError(self.body)
 
         try:
-            body = ET.XML(self.body)
+            body = self.parse_body()
         except Exception:
             raise MalformedResponseError('Failed to parse XML',
                                          body=self.body,

--- a/libcloud/common/openstack.py
+++ b/libcloud/common/openstack.py
@@ -358,7 +358,11 @@ class OpenStackResponse(Response):
 
         if self.has_content_type('application/xml'):
             try:
-                return ET.XML(self.body)
+                try:
+                    return ET.XML(self.body)
+                except ValueError:
+                    # lxml wants a bytes and tests are basically hard-coded to str
+                    return ET.XML(self.body.encode('utf-8'))
             except:
                 raise MalformedResponseError(
                     'Failed to parse XML',

--- a/libcloud/common/openstack.py
+++ b/libcloud/common/openstack.py
@@ -361,7 +361,7 @@ class OpenStackResponse(Response):
                 try:
                     return ET.XML(self.body)
                 except ValueError:
-                    # lxml wants a bytes and tests are basically hard-coded to str
+                    # lxml wants bytes
                     return ET.XML(self.body.encode('utf-8'))
             except:
                 raise MalformedResponseError(

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -24,7 +24,6 @@ import copy
 import warnings
 import time
 
-from libcloud.utils.py3 import ET
 from libcloud.utils.py3 import b, basestring, ensure_string
 
 from libcloud.utils.xml import fixxpath, findtext, findattr, findall
@@ -33,8 +32,7 @@ from libcloud.utils.publickey import get_pubkey_comment
 from libcloud.utils.iso8601 import parse_date
 from libcloud.common.aws import AWSBaseResponse, SignedAWSConnection
 from libcloud.common.aws import DEFAULT_SIGNATURE_VERSION
-from libcloud.common.types import (InvalidCredsError, MalformedResponseError,
-                                   LibcloudError)
+from libcloud.common.types import (InvalidCredsError, LibcloudError)
 from libcloud.compute.providers import Provider
 from libcloud.compute.base import Node, NodeDriver, NodeLocation, NodeSize
 from libcloud.compute.base import NodeImage, StorageVolume, VolumeSnapshot

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -3053,11 +3053,7 @@ class EC2Response(AWSBaseResponse):
         if self.status == 403 and self.body[:len(msg)] == msg:
             raise InvalidCredsError(msg)
 
-        try:
-            body = self.parse_body()
-        except:
-            raise MalformedResponseError("Failed to parse XML",
-                                         body=self.body, driver=EC2NodeDriver)
+        body = self.parse_body()
 
         for err in body.findall('Errors/Error'):
             code, message = err.getchildren()

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -3054,7 +3054,7 @@ class EC2Response(AWSBaseResponse):
             raise InvalidCredsError(msg)
 
         try:
-            body = ET.XML(self.body)
+            body = self.parse_body()
         except:
             raise MalformedResponseError("Failed to parse XML",
                                          body=self.body, driver=EC2NodeDriver)


### PR DESCRIPTION
## Fix "Failed to parse XML" error when XML contains wrong encoding declaration

### Description

`lxml` fails to parse XML unicode string if latter contains encoding declaration. It raises `ValueError: Unicode strings with encoding declaration are not supported. Please use bytes input or XML fragments without declaration.` which was completely obstructed by reraise of `MalformedResponseError`.

This was already partially fixed in `libcloud.common.base.XmlResponse.parse_body()`, however some subclasses had this method overwritten, or were not using it.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
