### PR TITLE
Fix #LIBCLOUD-925

### DIFF
--- a/libcloud/common/google.py
+++ b/libcloud/common/google.py
@@ -220,7 +220,9 @@ class GoogleResponse(JsonResponse):
             code = err.get('code')
             message = err.get('message')
         else:
-            code = err.get('reason', None)
+            code = None
+            if 'reason' in err:
+                code = err.get('reason')
             message = body.get('error_description', err)
 
         return (code, message)


### PR DESCRIPTION
## Fixex an error in _get_error function in GCE driver.

### Description
Fixes an error in _get_error function in common/google.py file that assumes that the body['error'] value is a dict, but in some cases it contains an string (unicode).
So it tries to do a err.get and it failts.

### Status
done, ready for review

### Checklist (tick everything that applies)

- [X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
