### PR TITLE
Fix Node.extra having incomplete block_device_mapping on EC2

### DIFF
--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -2513,7 +2513,7 @@ RESOURCE_EXTRA_ATTRIBUTES_MAP = {
             'xpath': 'ebs/attachTime',
             'transform_func': parse_date
         },
-        'delete_on_termination': {
+        'delete': {
             'xpath': 'ebs/deleteOnTermination',
             'transform_func': str
         },

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -2508,6 +2508,24 @@ OUTSCALE_INC_REGION_DETAILS = {
 Define the extra dictionary for specific resources
 """
 RESOURCE_EXTRA_ATTRIBUTES_MAP = {
+    'ebs_instance_block_device': {
+        'attach_time': {
+            'xpath': 'ebs/attachTime',
+            'transform_func': parse_date
+        },
+        'delete_on_termination': {
+            'xpath': 'ebs/deleteOnTermination',
+            'transform_func': str
+        },
+        'status': {
+            'xpath': 'ebs/status',
+            'transform_func': str
+        },
+        'volume_id': {
+            'xpath': 'ebs/volumeId',
+            'transform_func': str
+        }
+    },
     'ebs_volume': {
         'snapshot_id': {
             'xpath': 'ebs/snapshotId',
@@ -6462,7 +6480,8 @@ class BaseEC2NodeDriver(NodeDriver):
             element, RESOURCE_EXTRA_ATTRIBUTES_MAP['node'])
 
         # Add additional properties to our extra dictionary
-        extra['block_device_mapping'] = self._to_device_mappings(element)
+        extra['block_device_mapping'] = self._to_instance_device_mappings(
+            element)
         extra['groups'] = self._get_security_groups(element)
         extra['network_interfaces'] = self._to_interfaces(element)
         extra['product_codes'] = product_codes
@@ -6988,6 +7007,29 @@ class BaseEC2NodeDriver(NodeDriver):
         if mapping['virtual_name'] is None:
             mapping['ebs'] = self._get_extra_dict(
                 element, RESOURCE_EXTRA_ATTRIBUTES_MAP['ebs_volume'])
+
+        return mapping
+
+    def _to_instance_device_mappings(self, object):
+        return [self._to_instance_device_mapping(el) for el in object.findall(
+            fixxpath(xpath='blockDeviceMapping/item', namespace=NAMESPACE))
+        ]
+
+    def _to_instance_device_mapping(self, element):
+        """
+        Parse the XML element and return a dictionary of device properties.
+        Additional information can be found at https://goo.gl/OGK88a.
+
+        :rtype:     ``dict``
+        """
+        mapping = {}
+
+        mapping['device_name'] = findattr(element=element,
+                                          xpath='deviceName',
+                                          namespace=NAMESPACE)
+        mapping['ebs'] = self._get_extra_dict(
+            element,
+            RESOURCE_EXTRA_ATTRIBUTES_MAP['ebs_instance_block_device'])
 
         return mapping
 

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -237,7 +237,9 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
         self.assertEqual(node.extra['block_device_mapping'][0]['device_name'], '/dev/sda1')
         self.assertEqual(node.extra['block_device_mapping'][0]['ebs']['volume_id'], 'vol-5e312311')
         self.assertTrue(node.extra['block_device_mapping'][0]['ebs']['delete'])
-
+        self.assertEqual(node.extra['block_device_mapping'][0]['ebs']['status'], 'attached')
+        self.assertEqual(node.extra['block_device_mapping'][0]['ebs']['attach_time'],
+                         datetime(2013, 4, 9, 18, 1, 1, tzinfo=UTC))
         self.assertEqual(public_ips[0], '1.2.3.4')
 
         nodes = self.driver.list_nodes(ex_node_ids=['i-4382922a',


### PR DESCRIPTION
##  Fix `Node.extra` having incomplete `block_device_mapping` on EC2

### Description

Fix node's Block Device Mapping was parsed from incorrect mapping.
[EbsInstanceBlockDevice](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_EbsInstanceBlockDevice.html) is different from  [EbsBlockDevice](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_EbsBlockDevice.html).

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
