### PR TITLE
Add SSL URI support for LIBCLOUD-458

### DIFF
--- a/libcloud/storage/drivers/cloudfiles.py
+++ b/libcloud/storage/drivers/cloudfiles.py
@@ -318,7 +318,7 @@ class CloudFilesStorageDriver(StorageDriver, OpenStackDriverMixin):
                                            cdn_request=True)
 
         if response.status == httplib.NO_CONTENT:
-            if ssl_uri == True:
+            if ssl_uri:
                 cdn_url = response.headers['x-cdn-ssl-uri']
             else:
                 cdn_url = response.headers['x-cdn-uri']

--- a/libcloud/storage/drivers/cloudfiles.py
+++ b/libcloud/storage/drivers/cloudfiles.py
@@ -310,7 +310,7 @@ class CloudFilesStorageDriver(StorageDriver, OpenStackDriverMixin):
 
         raise LibcloudError('Unexpected status code: %s' % (response.status))
 
-    def get_container_cdn_url(self, container, ssl_uri=False):
+    def get_container_cdn_url(self, container, ex_ssl_uri=False):
         # pylint: disable=unexpected-keyword-arg
         container_name_encoded = self._encode_container_name(container.name)
         response = self.connection.request('/%s' % (container_name_encoded),
@@ -318,7 +318,7 @@ class CloudFilesStorageDriver(StorageDriver, OpenStackDriverMixin):
                                            cdn_request=True)
 
         if response.status == httplib.NO_CONTENT:
-            if ssl_uri:
+            if ex_ssl_uri:
                 cdn_url = response.headers['x-cdn-ssl-uri']
             else:
                 cdn_url = response.headers['x-cdn-uri']

--- a/libcloud/storage/drivers/cloudfiles.py
+++ b/libcloud/storage/drivers/cloudfiles.py
@@ -310,7 +310,7 @@ class CloudFilesStorageDriver(StorageDriver, OpenStackDriverMixin):
 
         raise LibcloudError('Unexpected status code: %s' % (response.status))
 
-    def get_container_cdn_url(self, container):
+    def get_container_cdn_url(self, container, ssl_uri=False):
         # pylint: disable=unexpected-keyword-arg
         container_name_encoded = self._encode_container_name(container.name)
         response = self.connection.request('/%s' % (container_name_encoded),
@@ -318,7 +318,10 @@ class CloudFilesStorageDriver(StorageDriver, OpenStackDriverMixin):
                                            cdn_request=True)
 
         if response.status == httplib.NO_CONTENT:
-            cdn_url = response.headers['x-cdn-uri']
+            if ssl_uri == True:
+                cdn_url = response.headers['x-cdn-ssl-uri']
+            else:
+                cdn_url = response.headers['x-cdn-uri']
             return cdn_url
         elif response.status == httplib.NOT_FOUND:
             raise ContainerDoesNotExistError(value='',


### PR DESCRIPTION
Add an optional argument to retrieve the x-cdn-ssl-uri of a Cloud Files container.

Done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
