### PR TITLE
Add loadBalancingScheme parameter for ex_create_forwarding_rule method in GCE driver.

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -3126,7 +3126,8 @@ class GCENodeDriver(NodeDriver):
     def ex_create_forwarding_rule(self, name, target=None, region=None,
                                   protocol='tcp', port_range=None,
                                   address=None, description=None,
-                                  global_rule=False, targetpool=None):
+                                  global_rule=False, targetpool=None,
+                                  lb_scheme=None):
         """
         Create a forwarding rule.
 
@@ -3168,6 +3169,10 @@ class GCENodeDriver(NodeDriver):
                               Use target instead.
         :type     targetpool: ``str`` or :class:`GCETargetPool`
 
+        :keyword  lb_scheme: Load balancing scheme, can be 'EXTERNAL' or
+                             'INTERNAL'. Defaults to 'EXTERNAL'.
+        :type     lb_scheme: ``str`` or ``None``
+
         :return:  Forwarding Rule object
         :rtype:   :class:`GCEForwardingRule`
         """
@@ -3197,6 +3202,9 @@ class GCENodeDriver(NodeDriver):
             forwarding_rule_data['portRange'] = port_range
         if description:
             forwarding_rule_data['description'] = description
+
+        if lb_scheme:
+            forwarding_rule_data['loadBalancingScheme'] = lb_scheme
 
         if global_rule:
             request = '/global/forwardingRules'


### PR DESCRIPTION
loadBalancingScheme parameter exists in ForwardingRules resource: https://cloud.google.com/compute/docs/reference/latest/forwardingRules
However, we do not have it in ex_create_forwarding_rule method in GCE driver.