### PR TITLE
libcloud-921: aligning the function arguments with the signature

### DIFF
--- a/libcloud/common/base.py
+++ b/libcloud/common/base.py
@@ -928,7 +928,7 @@ class BaseDriver(object):
 
         try:
             if secret is not None or \
-            issubclass(self.connectionCls, ConnectionUserAndKey):
+               issubclass(self.connectionCls, ConnectionUserAndKey):
                 args.append(self.secret)
         except TypeError:
             if secret is not None:

--- a/libcloud/common/base.py
+++ b/libcloud/common/base.py
@@ -926,8 +926,13 @@ class BaseDriver(object):
         self.secure = secure
         args = [self.key]
 
-        if self.secret is not None:
-            args.append(self.secret)
+        try:
+            if secret is not None or \
+            issubclass(self.connectionCls, ConnectionUserAndKey):
+                args.append(self.secret)
+        except TypeError:
+            if secret is not None:
+                args.append(self.secret)
 
         args.append(secure)
 


### PR DESCRIPTION
#LIBCLOUD-921 

Docker Container Driver uses ConnectionUserAndKey as the ConnectionCls. However, on using the insecure Docker Engine, username passed is None. This results in mis-alignment of the function signature and the arguments being passed.

try/catch statement is required to handle the MockHttp class during the tests.