### PR TITLE
Scrape prices for Australia region in GCE compute driver

### DIFF
--- a/contrib/update_google_prices.py
+++ b/contrib/update_google_prices.py
@@ -53,7 +53,9 @@ def main(argv):
         'eu': 'europe',  # alias for 'europe'
         'europe': 'europe',
         'apac': 'asia',  # alias for 'asia'
-        'asia': 'asia'
+        'asia': 'asia',
+        'au': 'australia',  # alias for 'australia'
+        'australia': 'australia'
     }
 
     # Initialize Google Cloud Platform regions.


### PR DESCRIPTION
## Scrape prices for Australia region in GCE compute driver

### Description

Update `contrib/update_google_prices.py` to scrape the price of GCE sizes in the Australia (Sydney) region.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)