### PR TITLE
Add missing test_requirement "requests_mock" to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ SUPPORTED_VERSIONS = ['2.6', '2.7', 'PyPy', '3.x']
 TEST_REQUIREMENTS = [
     'mock',
     'requests',
+    'requests_mock',
     'pytest',
     'pytest-runner'
 ]


### PR DESCRIPTION
## Add missing test_requirement "requests_mock" to setup.py

### Description

requests_mock is needed and defined in test_requirements.txt, but is missing from setup.py. Let's keep them consistent.

### Status
done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
