### PR TITLE
Fix Linode DNS records to have 'priority' in extra

### DIFF
--- a/libcloud/dns/drivers/linode.py
+++ b/libcloud/dns/drivers/linode.py
@@ -265,7 +265,8 @@ class LinodeDNSDriver(DNSDriver):
         Build a Record object from the item dictionary.
         """
         extra = {'protocol': item['PROTOCOL'], 'ttl_sec': item['TTL_SEC'],
-                 'port': item['PORT'], 'weight': item['WEIGHT']}
+                 'port': item['PORT'], 'weight': item['WEIGHT'],
+                 'priority': item['PRIORITY']}
         type = self._string_to_record_type(item['TYPE'])
         record = Record(id=item['RESOURCEID'], name=item['NAME'], type=type,
                         data=item['TARGET'], zone=zone, driver=self,

--- a/libcloud/test/dns/test_linode.py
+++ b/libcloud/test/dns/test_linode.py
@@ -68,6 +68,15 @@ class LinodeTests(unittest.TestCase):
         self.assertHasKeys(arecord.extra, ['protocol', 'ttl_sec', 'port',
                                            'weight'])
 
+        srvrecord = records[1]
+        self.assertEquals(srvrecord.id, '3585141')
+        self.assertEquals(srvrecord.name, '_minecraft._udp')
+        self.assertEquals(srvrecord.type, RecordType.SRV)
+        self.assertEquals(srvrecord.data, 'mc.linode.com')
+        self.assertHasKeys(srvrecord.extra, ['protocol', 'ttl_sec', 'port',
+                                             'priority', 'weight'])
+
+
     def test_list_records_zone_does_not_exist(self):
         zone = self.driver.list_zones()[0]
 


### PR DESCRIPTION
## Fix Linode DNS records to have 'priority' in extra field

### Description

Linode DNS Record does not expose 'priority' value on its `extra` field, which is used in `DNSDriver._get_bind_record_line()`. It's required for MX/SRV records to be exported with `DNSDriver.export_to_bind_format()`.

Linode DNS resources already have 'PRIORITY' field (see https://www.linode.com/api/dns/domain.resource.list and https://github.com/apache/libcloud/blob/trunk/libcloud/test/dns/fixtures/linode/resource_list.json), we can just copy it into the `extra` field.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
