### PR TITLE
[LIBCLOUD-936] fixed AWS ALB/ELB driver init method to instantiate ne…

### DIFF
--- a/libcloud/loadbalancer/drivers/alb.py
+++ b/libcloud/loadbalancer/drivers/alb.py
@@ -53,12 +53,11 @@ class ApplicationLBDriver(Driver):
 
     def __init__(self, access_id, secret, region, token=None):
         self.token = token
-        super(ApplicationLBDriver, self).__init__(
-            access_id, secret, token=token
-        )
         self.region = region
         self.region_name = region
-        self.connection.host = HOST % (region)
+        super(ApplicationLBDriver, self).__init__(
+            access_id, secret, token=token, host=HOST % region, region=region
+        )
 
     def list_protocols(self):
         return ['http', 'https']

--- a/libcloud/loadbalancer/drivers/elb.py
+++ b/libcloud/loadbalancer/drivers/elb.py
@@ -55,10 +55,11 @@ class ElasticLBDriver(Driver):
 
     def __init__(self, access_id, secret, region, token=None):
         self.token = token
-        super(ElasticLBDriver, self).__init__(access_id, secret, token=token)
         self.region = region
         self.region_name = region
-        self.connection.host = HOST % (region)
+        super(ElasticLBDriver, self).__init__(
+            access_id, secret, token=token, host=HOST % region, region=region
+        )
 
     def list_protocols(self):
         return ['tcp', 'ssl', 'http', 'https']


### PR DESCRIPTION
## Fixed AWS ALB/ELB driver init method to instantiate nested connection object properly

### Description

AWS ELB/ALB Driver connection object initialization is broken. 

Error:
`/Users/irvan/py27venv/bin/python test_token.py
Traceback (most recent call last):
  File "test_token.py", line 33, in <module>
    data = driver.list_balancers()
  File "/Users/irvan/Repos/GIT/github/libcloud/libcloud/loadbalancer/drivers/elb.py", line 68, in list_balancers
    data = self.connection.request(ROOT, params=params).object
  File "/Users/irvan/Repos/GIT/github/libcloud/libcloud/common/base.py", line 603, in request
    headers=headers, stream=stream)
  File "/Users/irvan/Repos/GIT/github/libcloud/libcloud/http.py", line 215, in request
    verify=self.verification
  File "/Users/irvan/py27venv/lib/python2.7/site-packages/requests/sessions.py", line 518, in request
    resp = self.send(prep, **send_kwargs)
  File "/Users/irvan/py27venv/lib/python2.7/site-packages/requests/sessions.py", line 639, in send
    r = adapter.send(request, **kwargs)
  File "/Users/irvan/py27venv/lib/python2.7/site-packages/requests/adapters.py", line 502, in send
    raise ConnectionError(e, request=request)
requests.exceptions.ConnectionError: HTTPSConnectionPool(host='elasticloadbalancing.%s.amazonaws.com', port=443): Max retries exceeded with url: /2012-06-01/?Action=DescribeLoadBalancers&Version=2012-06-01 (Caused by NewConnectionError('<requests.packages.urllib3.connection.VerifiedHTTPSConnection object at 0x10760f4d0>: Failed to establish a new connection: [Errno 8] nodename nor servname provided, or not known',))`

Issue:
https://issues.apache.org/jira/browse/LIBCLOUD-936

### Status

done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
