### PR TITLE
[LIBCLOUD-918] Add an option to create a static public IP address.

### DIFF
--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -1609,7 +1609,8 @@ class AzureNodeDriver(NodeDriver):
                                     params={"api-version": "2015-06-15"})
         return [self._to_ip_address(net) for net in r.object["value"]]
 
-    def ex_create_public_ip(self, name, resource_group, location=None):
+    def ex_create_public_ip(self, name, resource_group, location=None,
+                            publicIPAllocationMethod=None):
         """
         Create a public IP resources.
 
@@ -1622,6 +1623,11 @@ class AzureNodeDriver(NodeDriver):
         :param location: The location at which to create the public IP
         (if None, use default location specified as 'region' in __init__)
         :type location: :class:`.NodeLocation`
+
+        :param publicIPAllocationMethod: Call ex_create_public_ip with
+        publicIPAllocationMethod="Static" to create a static public
+        IP address
+        :type publicIPAllocationMethod: ``str``
 
         :return: The newly created public ip object
         :rtype: :class:`.AzureIPAddress`
@@ -1642,6 +1648,10 @@ class AzureNodeDriver(NodeDriver):
                 "publicIPAllocationMethod": "Dynamic"
             }
         }
+
+        if publicIPAllocationMethod == "Static":
+            data['properties']['publicIPAllocationMethod'] = "Static"
+
         r = self.connection.request(target,
                                     params={"api-version": "2015-06-15"},
                                     data=data,

--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -1610,7 +1610,7 @@ class AzureNodeDriver(NodeDriver):
         return [self._to_ip_address(net) for net in r.object["value"]]
 
     def ex_create_public_ip(self, name, resource_group, location=None,
-                            publicIPAllocationMethod=None):
+                            public_ip_allocation_method=None):
         """
         Create a public IP resources.
 
@@ -1624,10 +1624,10 @@ class AzureNodeDriver(NodeDriver):
         (if None, use default location specified as 'region' in __init__)
         :type location: :class:`.NodeLocation`
 
-        :param publicIPAllocationMethod: Call ex_create_public_ip with
-        publicIPAllocationMethod="Static" to create a static public
+        :param public_ip_allocation_method: Call ex_create_public_ip with
+        public_ip_allocation_method="Static" to create a static public
         IP address
-        :type publicIPAllocationMethod: ``str``
+        :type public_ip_allocation_method: ``str``
 
         :return: The newly created public ip object
         :rtype: :class:`.AzureIPAddress`
@@ -1649,7 +1649,7 @@ class AzureNodeDriver(NodeDriver):
             }
         }
 
-        if publicIPAllocationMethod == "Static":
+        if public_ip_allocation_method == "Static":
             data['properties']['publicIPAllocationMethod'] = "Static"
 
         r = self.connection.request(target,


### PR DESCRIPTION
### Title

Add an option to create a static public IP address.

### Description

Azure ARM driver's ex_create_public_ip only has the option to create a dynamic 
public IP address. This change adds the option to create a static public IP address.

https://docs.microsoft.com/en-us/azure/virtual-network/virtual-network-ip-addresses-overview-arm

### Status

done, ready for review

### Checklist (tick everything that applies)

- [X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [X] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
