### PR TITLE
LIBCLOUD-875 fix route 53 DNS quote encapsulation

### DIFF
--- a/libcloud/dns/drivers/route53.py
+++ b/libcloud/dns/drivers/route53.py
@@ -188,6 +188,8 @@ class Route53DNSDriver(DNSDriver):
         return response.status in [httplib.OK]
 
     def create_record(self, name, zone, type, data, extra=None):
+        if type in (RecordType.TXT, RecordType.SPF):
+            data = self._quote_data(data)
         extra = extra or {}
         batch = [('CREATE', name, type, data, extra)]
         self._post_changeset(zone, batch)
@@ -555,3 +557,8 @@ class Route53DNSDriver(DNSDriver):
         kwargs = super(Route53DNSDriver, self)._ex_connection_class_kwargs()
         kwargs['token'] = self.token
         return kwargs
+
+    def _quote_data(self, data):
+        if data[0] == '"' and data[-1] == '"':
+            return data
+        return '"{0}"'.format(data)

--- a/libcloud/dns/drivers/route53.py
+++ b/libcloud/dns/drivers/route53.py
@@ -561,4 +561,4 @@ class Route53DNSDriver(DNSDriver):
     def _quote_data(self, data):
         if data[0] == '"' and data[-1] == '"':
             return data
-        return '"{0}"'.format(data)
+        return '"{0}"'.format(data.replace('"', '\"'))

--- a/libcloud/test/dns/test_route53.py
+++ b/libcloud/test/dns/test_route53.py
@@ -228,6 +228,21 @@ class Route53Tests(unittest.TestCase):
         self.assertEqual(record.type, RecordType.SPF)
         self.assertEqual(record.data, '"test"')
 
+    def test_create_TXT_record_escaped(self):
+        """
+        Check that TXT record with quotes inside are escaped correctly
+        """
+        zone = self.driver.list_zones()[0]
+        record = self.driver.create_record(
+            name='', zone=zone,
+            type=RecordType.TXT, data='test "with"'
+        )
+        self.assertEqual(record.id, 'TXT:')
+        self.assertEqual(record.name, '')
+        self.assertEqual(record.zone, zone)
+        self.assertEqual(record.type, RecordType.TXT)
+        self.assertEqual(record.data, '"test \"with\""')
+
     def test_create_multi_value_record(self):
         zone = self.driver.list_zones()[0]
         records = self.driver.ex_create_multi_value_record(

--- a/libcloud/test/dns/test_route53.py
+++ b/libcloud/test/dns/test_route53.py
@@ -168,6 +168,66 @@ class Route53Tests(unittest.TestCase):
         self.assertEqual(record.type, RecordType.A)
         self.assertEqual(record.data, '127.0.0.1')
 
+    def test_create_TXT_record(self):
+        """
+        Check that TXT records are created in quotes
+        """
+        zone = self.driver.list_zones()[0]
+        record = self.driver.create_record(
+            name='', zone=zone,
+            type=RecordType.TXT, data='test'
+        )
+        self.assertEqual(record.id, 'TXT:')
+        self.assertEqual(record.name, '')
+        self.assertEqual(record.zone, zone)
+        self.assertEqual(record.type, RecordType.TXT)
+        self.assertEqual(record.data, '"test"')
+
+    def test_create_TXT_record_quoted(self):
+        """
+        Check that TXT values already quoted are not changed
+        """
+        zone = self.driver.list_zones()[0]
+        record = self.driver.create_record(
+            name='', zone=zone,
+            type=RecordType.TXT, data='"test"'
+        )
+        self.assertEqual(record.id, 'TXT:')
+        self.assertEqual(record.name, '')
+        self.assertEqual(record.zone, zone)
+        self.assertEqual(record.type, RecordType.TXT)
+        self.assertEqual(record.data, '"test"')
+
+    def test_create_SPF_record(self):
+        """
+        Check that SPF records are created in quotes
+        """
+        zone = self.driver.list_zones()[0]
+        record = self.driver.create_record(
+            name='', zone=zone,
+            type=RecordType.SPF, data='test'
+        )
+        self.assertEqual(record.id, 'SPF:')
+        self.assertEqual(record.name, '')
+        self.assertEqual(record.zone, zone)
+        self.assertEqual(record.type, RecordType.SPF)
+        self.assertEqual(record.data, '"test"')
+
+    def test_create_SPF_record_quoted(self):
+        """
+        Check that SPF values already quoted are not changed
+        """
+        zone = self.driver.list_zones()[0]
+        record = self.driver.create_record(
+            name='', zone=zone,
+            type=RecordType.SPF, data='"test"'
+        )
+        self.assertEqual(record.id, 'SPF:')
+        self.assertEqual(record.name, '')
+        self.assertEqual(record.zone, zone)
+        self.assertEqual(record.type, RecordType.SPF)
+        self.assertEqual(record.data, '"test"')
+
     def test_create_multi_value_record(self):
         zone = self.driver.list_zones()[0]
         records = self.driver.ex_create_multi_value_record(


### PR DESCRIPTION
## fix route 53 DNS quote encapsulation

Amazon's API stipulates that SPF and TXT records have quotes http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/ResourceRecordTypes.html#TXTFormat
The driver does not have any special casing for these records. I assume that existing users either:
- Get an error - see https://github.com/twisted/txacme/issues/120
- Add quotes before calling the methods, in which case this behaviour should be supported

For more information on contributing, please see [Contributing](http://libcloud.readthedocs.org/en/latest/development.html#contributing)
section of our documentation.

### Status

- work in progress

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
