### PR TITLE
typo in documentation in libvirt provider

### DIFF
--- a/libcloud/compute/drivers/libvirt_driver.py
+++ b/libcloud/compute/drivers/libvirt_driver.py
@@ -411,7 +411,7 @@ class LibvirtNodeDriver(NodeDriver):
         Sets up the regexp for parsing out IP addresses from the 'ip neighbor'
         command and pass it along to the parser function.
 
-        :return: Dictionary from the parsing funtion
+        :return: Dictionary from the parsing function
         :rtype: ``dict``
         """
         ip_regex = re.compile('(.*?)\s+.*lladdr\s+(.*?)\s+')


### PR DESCRIPTION
Smallest typo fix.

## Changes Title (replace this with a logical title for your changes)
typo in documentation in libvirt provider
### Description
Small typo.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [X] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
