### PR TITLE
[LIBCLOUD-940]  Add 'end' to ec2 Reserved Instance data

### DIFF
--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -2765,6 +2765,10 @@ RESOURCE_EXTRA_ATTRIBUTES_MAP = {
             'xpath': 'start',
             'transform_func': str
         },
+        'end': {
+            'xpath': 'end',
+            'transform_func': str
+        },
         'duration': {
             'xpath': 'duration',
             'transform_func': int

--- a/libcloud/test/compute/fixtures/ec2/describe_reserved_instances.xml
+++ b/libcloud/test/compute/fixtures/ec2/describe_reserved_instances.xml
@@ -6,6 +6,7 @@
             <instanceType>t1.micro</instanceType>
             <availabilityZone>us-east-1b</availabilityZone>
             <start>2013-06-18T12:07:53.161Z</start>
+            <end>2014-06-18T12:07:53.161Z</end>
             <duration>31536000</duration>
             <fixedPrice>23.0</fixedPrice>
             <usagePrice>0.012</usagePrice>

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -282,6 +282,7 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
         self.assertEqual(node.extra['instance_type'], 't1.micro')
         self.assertEqual(node.extra['availability'], 'us-east-1b')
         self.assertEqual(node.extra['start'], '2013-06-18T12:07:53.161Z')
+        self.assertEqual(node.extra['end'], '2014-06-18T12:07:53.161Z')
         self.assertEqual(node.extra['duration'], 31536000)
         self.assertEqual(node.extra['usage_price'], 0.012)
         self.assertEqual(node.extra['fixed_price'], 23.0)


### PR DESCRIPTION
## Add 'end' to ec2 Reserved Instance data

### Description

The [DescribeReservedInstances API](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeReservedInstances.html) returns 3 fields related to the timeframe of the reservation:

  * start
  * end
  * duration

When a reservation is modified, start changes to the effective date of the modification, but duration remains the same (number of seconds in 1 or 3 years). The only way to determine when a modified reservation expires is to use the end date.

### Status

done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
