### PR TITLE
[LIBCLOUD-930] Use TagSpecification parameter on EC2 create_node

### DIFF
--- a/libcloud/__init__.py
+++ b/libcloud/__init__.py
@@ -36,7 +36,7 @@ __all__ = [
     '__version__',
     'enable_debug'
 ]
-__version__ = '2.2.0'
+__version__ = '2.2.0.dev1'
 
 
 def enable_debug(fo):

--- a/libcloud/__init__.py
+++ b/libcloud/__init__.py
@@ -36,7 +36,7 @@ __all__ = [
     '__version__',
     'enable_debug'
 ]
-__version__ = '2.2.0.dev1'
+__version__ = '2.2.0'
 
 
 def enable_debug(fo):

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -3772,7 +3772,7 @@ class BaseEC2NodeDriver(NodeDriver):
         tagspec_root = 'TagSpecification.1.'
         params[tagspec_root + 'ResourceType'] = 'instance'
         tag_nr = 1
-        for k, v in tags.iteritems():
+        for k, v in tags.items():
             tag_root = tagspec_root + "Tag.{}.".format(tag_nr)
             params[tag_root + "Key"] = k
             params[tag_root + "Value"] = v

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -3773,9 +3773,9 @@ class BaseEC2NodeDriver(NodeDriver):
         params[tagspec_root + 'ResourceType'] = 'instance'
         tag_nr = 1
         for k, v in tags.items():
-            tag_root = tagspec_root + "Tag.{}.".format(tag_nr)
-            params[tag_root + "Key"] = k
-            params[tag_root + "Value"] = v
+            tag_root = tagspec_root + 'Tag.%d.' % tag_nr
+            params[tag_root + 'Key'] = k
+            params[tag_root + 'Value'] = v
             tag_nr += 1
 
         object = self.connection.request(self.path, params=params).object

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -1526,10 +1526,6 @@ class EC2MockHttp(MockHttp):
         body = self.fixtures.load('modify_snapshot_attribute.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
-    def _idempotent_CreateTags(self, method, url, body, headers):
-        body = self.fixtures.load('create_tags.xml')
-        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
-
     def _CreateVolume(self, method, url, body, headers):
         body = self.fixtures.load('create_volume.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
@@ -1740,10 +1736,6 @@ class EucMockHttp(EC2MockHttp):
     def _services_Eucalyptus_RunInstances(self, method, url, body,
                                           headers):
         return self._RunInstances(method, url, body, headers)
-
-    def _services_Eucalyptus_CreateTags(self, method, url, body,
-                                        headers):
-        return self._CreateTags(method, url, body, headers)
 
     def _services_Eucalyptus_DescribeInstanceTypes(self, method, url, body,
                                                    headers):


### PR DESCRIPTION
## [LIBCLOUD-930] Take advantage of AWS EC2 tag-on-create feature

### Description

This small patch changes the way EC2 compute nodes are tagged when created, by adding the tags on the creation call instead of doing it immediately after. This avoids eventual consistency issues that sometimes happen when an instance isn't created yet so it can't be tagged.

For reference, the AWS docs are here: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RunInstances.html

This PR would tackle a colleague of mine has reported some weeks ago:
https://issues.apache.org/jira/browse/LIBCLOUD-930

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [X] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes) (I've just submitted it.)