### PR TITLE
[LIBCLOUD-943] Add the option to Azure ARM ex_create_network_interfac…

### DIFF
--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -1731,9 +1731,9 @@ class AzureNodeDriver(NodeDriver):
         if (private_ip_allocation_method == "Static" and
             private_ip_address is not None):
             data["properties"]["ipConfigurations"][0]\
-                ["properties"]["privateIPAllocationMethod"] = "Static"
+            ["properties"]["privateIPAllocationMethod"] = "Static"
             data["properties"]["ipConfigurations"][0]\
-                ["properties"]["privateIPAddress"] = private_ip_address
+            ["properties"]["privateIPAddress"] = private_ip_address
 
         r = self.connection.request(target,
                                     params={"api-version": "2015-06-15"},

--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -1730,10 +1730,9 @@ class AzureNodeDriver(NodeDriver):
 
         if (private_ip_allocation_method == "Static" and
             private_ip_address is not None):
-            data["properties"]["ipConfigurations"][0]\
-["properties"]["privateIPAllocationMethod"] = "Static"
-            data["properties"]["ipConfigurations"][0]\
-["properties"]["privateIPAddress"] = private_ip_address
+            ip_config = data["properties"]["ipConfigurations"][0]
+            ip_config["properties"]["privateIPAllocationMethod"] = "Static"
+            ip_config["properties"]["privateIPAddress"] = private_ip_address
 
         r = self.connection.request(target,
                                     params={"api-version": "2015-06-15"},

--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -1729,7 +1729,7 @@ class AzureNodeDriver(NodeDriver):
             }
 
         if (private_ip_allocation_method == "Static" and
-            private_ip_address is not None):
+                private_ip_address is not None):
             ip_config = data["properties"]["ipConfigurations"][0]
             ip_config["properties"]["privateIPAllocationMethod"] = "Static"
             ip_config["properties"]["privateIPAddress"] = private_ip_address

--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -1731,9 +1731,9 @@ class AzureNodeDriver(NodeDriver):
         if (private_ip_allocation_method == "Static" and
             private_ip_address is not None):
             data["properties"]["ipConfigurations"][0]\
-            ["properties"]["privateIPAllocationMethod"] = "Static"
+["properties"]["privateIPAllocationMethod"] = "Static"
             data["properties"]["ipConfigurations"][0]\
-            ["properties"]["privateIPAddress"] = private_ip_address
+["properties"]["privateIPAddress"] = private_ip_address
 
         r = self.connection.request(target,
                                     params={"api-version": "2015-06-15"},

--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -1659,7 +1659,9 @@ class AzureNodeDriver(NodeDriver):
         return self._to_ip_address(r.object)
 
     def ex_create_network_interface(self, name, subnet, resource_group,
-                                    location=None, public_ip=None):
+                                    location=None, public_ip=None,
+                                    private_ip_allocation_method=None,
+                                    private_ip_address=None):
         """
         Create a virtual network interface (NIC).
 
@@ -1679,6 +1681,16 @@ class AzureNodeDriver(NodeDriver):
         :param public_ip: Associate a public IP resource with this NIC
         (optional).
         :type public_ip: :class:`.AzureIPAddress`
+
+        :param private_ip_allocation_method: Call ex_create_network_interface
+        with private_ip_allocation_method="Static" to create a static private
+        IP address
+        :type private_ip_allocation_method: ``str``
+
+        :param private_ip_address: Call ex_create_network_interface with
+        private_ip_address="n.n.n.n" to create a static private IP address
+        "n.n.n.n"
+        :type private_ip_address: ``str``
 
         :return: The newly created NIC
         :rtype: :class:`.AzureNic`
@@ -1715,6 +1727,13 @@ class AzureNodeDriver(NodeDriver):
             ip_config["properties"]["publicIPAddress"] = {
                 "id": public_ip.id
             }
+
+        if (private_ip_allocation_method == "Static" and
+            private_ip_address is not None):
+            data["properties"]["ipConfigurations"][0]\
+                ["properties"]["privateIPAllocationMethod"] = "Static"
+            data["properties"]["ipConfigurations"][0]\
+                ["properties"]["privateIPAddress"] = private_ip_address
 
         r = self.connection.request(target,
                                     params={"api-version": "2015-06-15"},


### PR DESCRIPTION
### [LIBCLOUD-943] Add the option to Azure ARM ex_create_network_interface to create a static IP address

### Description

https://issues.apache.org/jira/browse/LIBCLOUD-943

Azure ARM driver's ex_create_network_interface is missing the option to create
a static IP address. "privateIPAllocationMethod" is set to "Dynamic" in the "data" 
dictionary. This change adds the option to create the network interface with a 
static IP address.

The value for the static IP address is defined with private_ip_address="n.n.n.n" in the 
ex_create_network_interface call.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
