### PR TITLE
BUGFIX GCE: Allow the setting of service account in instance templates

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -4443,6 +4443,8 @@ class GCENodeDriver(NodeDriver):
         sa = {}
         if 'email' not in service_account:
             sa['email'] = default_email
+        else:
+            sa['email'] = service_account['email']
 
         if 'scopes' not in service_account:
             sa['scopes'] = [self.AUTH_URL + default_scope]

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -213,7 +213,7 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         actual = self.driver._build_service_account_gce_struct(input)
         self.assertTrue('email' in actual)
         self.assertTrue('scopes' in actual)
- 
+
         input = {'scopes': ['compute-ro'], 'email': 'test@test.com'}
         actual = self.driver._build_service_account_with_email_gce_struct(input)
         self.assertTrue('email' in actual)

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -215,7 +215,7 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         self.assertTrue('scopes' in actual)
 
         input = {'scopes': ['compute-ro'], 'email': 'test@test.com'}
-        actual = self.driver._build_service_account_with_email_gce_struct(input)
+        actual = self.driver._build_service_account_gce_struct(input)
         self.assertTrue('email' in actual)
         self.assertEqual(actual['email'], 'test@test.com')
         self.assertTrue('scopes' in actual)

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -194,7 +194,7 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
                           'on_host_maintenance="MIGRATE"', 'preemptible=True')
         # automatic_restart is True and prempt is  True
         self.assertRaises(ValueError,
-                          self.driver._build_service_account_gce_struct,
+                          self.driver._build_service_account_with_email_gce_struct,
                           'automatic_restart="True"', 'preemptible=True')
 
         actual = self.driver._build_scheduling_gce_struct('TERMINATE', True,
@@ -210,6 +210,14 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         self.assertRaises(ValueError,
                           self.driver._build_service_account_gce_struct, None)
         input = {'scopes': ['compute-ro']}
+        actual = self.driver._build_service_account_gce_struct(input)
+        self.assertTrue('email' in actual)
+        self.assertTrue('scopes' in actual)
+
+    def test_build_service_account_with_email_gce_struct(self):
+        self.assertRaises(ValueError,
+                          self.driver._build_service_account_gce_struct, None)
+        input = {'scopes': ['compute-ro'], 'email': 'test@test.com' }
         actual = self.driver._build_service_account_gce_struct(input)
         self.assertTrue('email' in actual)
         self.assertTrue('scopes' in actual)

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -194,7 +194,7 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
                           'on_host_maintenance="MIGRATE"', 'preemptible=True')
         # automatic_restart is True and prempt is  True
         self.assertRaises(ValueError,
-                          self.driver._build_service_account_with_email_gce_struct,
+                          self.driver._build_service_account_gce_struct,
                           'automatic_restart="True"', 'preemptible=True')
 
         actual = self.driver._build_scheduling_gce_struct('TERMINATE', True,
@@ -213,10 +213,7 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         actual = self.driver._build_service_account_gce_struct(input)
         self.assertTrue('email' in actual)
         self.assertTrue('scopes' in actual)
-
-    def test_build_service_account_with_email_gce_struct(self):
-        self.assertRaises(ValueError,
-                          self.driver._build_service_account_gce_struct, None)
+ 
         input = {'scopes': ['compute-ro'], 'email': 'test@test.com' }
         actual = self.driver._build_service_account_with_email_gce_struct(input)
         self.assertTrue('email' in actual)

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -218,7 +218,7 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         self.assertRaises(ValueError,
                           self.driver._build_service_account_gce_struct, None)
         input = {'scopes': ['compute-ro'], 'email': 'test@test.com' }
-        actual = self.driver._build_service_account_gce_struct(input)
+        actual = self.driver._build_service_account_with_email_gce_struct(input)
         self.assertTrue('email' in actual)
         self.assertTrue('scopes' in actual)
 

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -214,7 +214,7 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         self.assertTrue('email' in actual)
         self.assertTrue('scopes' in actual)
  
-        input = {'scopes': ['compute-ro'], 'email': 'test@test.com' }
+        input = {'scopes': ['compute-ro'], 'email': 'test@test.com'}
         actual = self.driver._build_service_account_with_email_gce_struct(input)
         self.assertTrue('email' in actual)
         self.assertEqual(actual['email'], 'test@test.com')

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -220,6 +220,7 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         input = {'scopes': ['compute-ro'], 'email': 'test@test.com' }
         actual = self.driver._build_service_account_with_email_gce_struct(input)
         self.assertTrue('email' in actual)
+        self.assertEqual(actual['email'], 'test@test.com')
         self.assertTrue('scopes' in actual)
 
     def test_build_service_account_gce_list(self):


### PR DESCRIPTION
## BUGFIX: GCE Allow the setting of service account in instance templates and instance properties

### Description
Currently, there is no way for the service account for an instance template to be set, despite that information being passed in. This fixes that problem.

### Status

Done, ready for review

### Checklist (tick everything that applies)

- [X ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [X ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
