### PR TITLE
Make sure we normalize header types for test mock connection class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
       before_script: TOX_ENV=pylint
     - env: ENV=coverage
       python: 2.7
-      before_script: TOX_ENV=coverage
+      before_script: TOX_ENV=coverage-travis
     - env: ENV=docs
       python: 3.5
       before_script: TOX_ENV=docs-travis

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,7 +25,7 @@ Compute
 Tests
 ~~~~~
 
-- Make sure we normalize header values and cast all the numbers to string in
+- Make sure we normalize header values and cast all the numbers to strings in
   base connection classes used by tests. (LIBCLOUD-945, GITHUB-1111)
 
   Reported by Erich Eckner.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,15 @@ Compute
   manner to finish faster.
   [Tomaz Muraus]
 
+Tests
+~~~~~
+
+- Make sure we normalize header values and cast all the numbers to string in
+  base connection classes used by tests. (LIBCLOUD-945, GITHUB-1111)
+
+  Reported by Erich Eckner.
+  [Tomaz Muraus]
+
 Changes in Apache Libcloud 2.2.0
 --------------------------------
 

--- a/libcloud/http.py
+++ b/libcloud/http.py
@@ -201,10 +201,8 @@ class LibcloudConnection(LibcloudBaseConnection):
     def request(self, method, url, body=None, headers=None, raw=False,
                 stream=False):
         url = urlparse.urljoin(self.host, url)
-        # all headers should be strings
-        for header, value in headers.items():
-            if isinstance(headers[header], int):
-                headers[header] = str(value)
+        headers = self._normalize_headers(headers=headers)
+
         self.response = self.session.request(
             method=method.lower(),
             url=url,
@@ -217,10 +215,8 @@ class LibcloudConnection(LibcloudBaseConnection):
 
     def prepared_request(self, method, url, body=None,
                          headers=None, raw=False, stream=False):
-        # all headers should be strings
-        for header, value in headers.items():
-            if isinstance(headers[header], int):
-                headers[header] = str(value)
+        headers = self._normalize_headers(headers=headers)
+
         req = requests.Request(method, ''.join([self.host, url]),
                                data=body, headers=headers)
 
@@ -261,6 +257,16 @@ class LibcloudConnection(LibcloudBaseConnection):
     def close(self):  # pragma: no cover
         # return connection back to pool
         self.response.close()
+
+    def _normalize_headers(self, headers):
+        headers = headers or {}
+
+        # all headers should be strings
+        for key, value in headers.items():
+            if isinstance(value, (int, float)):
+                headers[key] = str(value)
+
+        return headers
 
 
 class HttpLibResponseProxy(object):

--- a/libcloud/storage/drivers/azure_blobs.py
+++ b/libcloud/storage/drivers/azure_blobs.py
@@ -634,7 +634,7 @@ class AzureBlobsStorageDriver(StorageDriver):
             chunk_hash = base64.b64encode(b(chunk_hash.digest()))
 
             headers['Content-MD5'] = chunk_hash.decode('utf-8')
-            headers['Content-Length'] = content_length
+            headers['Content-Length'] = str(content_length)
 
             if blob_type == 'BlockBlob':
                 # Block id can be any unique string that is base64 encoded
@@ -861,10 +861,10 @@ class AzureBlobsStorageDriver(StorageDriver):
         self._update_metadata(headers, meta_data)
 
         if object_size is not None:
-            headers['Content-Length'] = object_size
+            headers['Content-Length'] = str(object_size)
 
         if blob_type == 'PageBlob':
-            headers['Content-Length'] = 0
+            headers['Content-Length'] = str('0')
             headers['x-ms-blob-content-length'] = object_size
 
         return headers

--- a/libcloud/test/__init__.py
+++ b/libcloud/test/__init__.py
@@ -133,6 +133,7 @@ class MockHttp(LibcloudConnection):
         return meth(method, url, body, headers)
 
     def request(self, method, url, body=None, headers=None, raw=False, stream=False):
+        headers = self._normalize_headers(headers=headers)
         r_status, r_body, r_headers, r_reason = self._get_request(method, url, body, headers)
         if r_body is None:
             r_body = ''
@@ -153,6 +154,7 @@ class MockHttp(LibcloudConnection):
 
     def prepared_request(self, method, url, body=None,
                          headers=None, raw=False, stream=False):
+        headers = self._normalize_headers(headers=headers)
         r_status, r_body, r_headers, r_reason = self._get_request(method, url, body, headers)
 
         with requests_mock.mock() as m:

--- a/libcloud/test/storage/test_azure_blobs.py
+++ b/libcloud/test/storage/test_azure_blobs.py
@@ -17,7 +17,6 @@ from __future__ import with_statement
 
 import os
 import sys
-import unittest
 import tempfile
 from io import BytesIO
 
@@ -25,6 +24,7 @@ from libcloud.utils.py3 import httplib
 from libcloud.utils.py3 import urlparse
 from libcloud.utils.py3 import parse_qs
 from libcloud.utils.py3 import b
+from libcloud.utils.py3 import basestring
 
 from libcloud.common.types import InvalidCredsError
 from libcloud.common.types import LibcloudError
@@ -39,12 +39,13 @@ from libcloud.storage.drivers.azure_blobs import AzureBlobsStorageDriver
 from libcloud.storage.drivers.azure_blobs import AZURE_BLOCK_MAX_SIZE
 from libcloud.storage.drivers.azure_blobs import AZURE_PAGE_CHUNK_SIZE
 
+from libcloud.test import unittest
 from libcloud.test import MockHttp, generate_random_data  # pylint: disable-msg=E0611
 from libcloud.test.file_fixtures import StorageFileFixtures  # pylint: disable-msg=E0611
 from libcloud.test.secrets import STORAGE_AZURE_BLOBS_PARAMS
 
 
-class AzureBlobsMockHttp(MockHttp):
+class AzureBlobsMockHttp(MockHttp, unittest.TestCase):
 
     fixtures = StorageFileFixtures('azure_blobs')
     base_headers = {}
@@ -247,6 +248,8 @@ class AzureBlobsMockHttp(MockHttp):
 
     def _foo_bar_container_foo_test_upload(self, method, url, body, headers):
         # test_upload_object_success
+        self._assert_content_length_header_is_string(headers=headers)
+
         body = ''
         headers = {}
         headers['etag'] = '0x8CFB877BB56A6FB'
@@ -259,6 +262,8 @@ class AzureBlobsMockHttp(MockHttp):
     def _foo_bar_container_foo_test_upload_block(self, method, url,
                                                  body, headers):
         # test_upload_object_success
+        self._assert_content_length_header_is_string(headers=headers)
+
         body = ''
         headers = {}
         headers['etag'] = '0x8CFB877BB56A6FB'
@@ -281,6 +286,8 @@ class AzureBlobsMockHttp(MockHttp):
     def _foo_bar_container_foo_test_upload_blocklist(self, method, url,
                                                      body, headers):
         # test_upload_object_success
+        self._assert_content_length_header_is_string(headers=headers)
+
         body = ''
         headers = {}
         headers['etag'] = '0x8CFB877BB56A6FB'
@@ -294,6 +301,8 @@ class AzureBlobsMockHttp(MockHttp):
     def _foo_bar_container_foo_test_upload_lease(self, method, url,
                                                  body, headers):
         # test_upload_object_success
+        self._assert_content_length_header_is_string(headers=headers)
+
         action = headers['x-ms-lease-action']
         rheaders = {'x-ms-lease-id': 'someleaseid'}
         body = ''
@@ -318,12 +327,14 @@ class AzureBlobsMockHttp(MockHttp):
 
     def _foo_bar_container_foo_test_upload_INVALID_HASH(self, method, url,
                                                         body, headers):
+        # test_upload_object_invalid_hash1
+        self._assert_content_length_header_is_string(headers=headers)
+
         body = ''
         headers = {}
         headers['etag'] = '0x8CFB877BB56A6FB'
         headers['content-md5'] = 'd4fe4c9829f7ca1cc89db7ad670d2bbd'
 
-        # test_upload_object_invalid_hash1
         return (httplib.CREATED,
                 body,
                 headers,
@@ -331,6 +342,8 @@ class AzureBlobsMockHttp(MockHttp):
 
     def _foo_bar_container_foo_bar_object(self, method, url, body, headers):
         # test_upload_object_invalid_file_size
+        self._assert_content_length_header_is_string(headers=headers)
+
         body = generate_random_data(1000)
         return (httplib.OK,
                 body,
@@ -340,11 +353,17 @@ class AzureBlobsMockHttp(MockHttp):
     def _foo_bar_container_foo_bar_object_INVALID_SIZE(self, method, url,
                                                        body, headers):
         # test_upload_object_invalid_file_size
+        self._assert_content_length_header_is_string(headers=headers)
+
         body = ''
         return (httplib.OK,
                 body,
                 headers,
                 httplib.responses[httplib.OK])
+
+    def _assert_content_length_header_is_string(self, headers):
+        if 'Content-Length' in headers:
+            self.assertTrue(isinstance(headers['Content-Length'], basestring))
 
 
 class AzureBlobsTests(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -91,6 +91,13 @@ deps = -r{toxinidir}/integration/requirements.txt
 commands = python -m integration
 
 [testenv:coverage]
+deps =
+    -r{toxinidir}/requirements-tests.txt
+set-env =
+commands = cp libcloud/test/secrets.py-dist libcloud/test/secrets.py
+           coverage run --source=libcloud setup.py test
+
+[testenv:coverage-travis]
 passenv = TOXENV CI TRAVIS TRAVIS_*
 deps =
     -r{toxinidir}/requirements-tests.txt


### PR DESCRIPTION
This pull request fixes the issue reported in https://issues.apache.org/jira/browse/LIBCLOUD-945.

We normalized header types inside the actual Connection class, but not inside the Connection class used by the tests. That's why some of the tests failed with newer version of `requests` which doesn't automatically cast header values to strings anymore.
