### PR TITLE
certifi where() return a str and not a list

### DIFF
--- a/libcloud/security.py
+++ b/libcloud/security.py
@@ -55,7 +55,7 @@ else:
 
 if has_certifi and USE_CERTIFI:
     certifi_ca_bundle_path = certifi.where()
-    CA_CERTS_PATH = certifi_ca_bundle_path
+    CA_CERTS_PATH = [certifi_ca_bundle_path]
 
 # Allow user to explicitly specify which CA bundle to use, using an environment
 # variable


### PR DESCRIPTION
## certifi where() return a str and not a list

### Description
When using certifi and other libs assumes that you will get a list on CA_CERTS_PATH it will raise error when doing appends.

certifi.where() return a string instead of a list.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [ X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)

