### PR TITLE
Remove final mentions of CA_CERTS_PATHS as list

### DIFF
--- a/libcloud/security.py
+++ b/libcloud/security.py
@@ -20,7 +20,7 @@ Usage:
     libcloud.security.VERIFY_SSL_CERT = True
 
     # Optional.
-    libcloud.security.CA_CERTS_PATH.append('/path/to/cacert.txt')
+    libcloud.security.CA_CERTS_PATH = '/path/to/certfile'
 """
 
 import os
@@ -71,7 +71,7 @@ if environment_cert_file is not None:
 
     # If a provided file exists we ignore other common paths because we
     # don't want to fall-back to a potentially less restrictive bundle
-    CA_CERTS_PATH = [environment_cert_file]
+    CA_CERTS_PATH = environment_cert_file
 
 CA_CERTS_UNAVAILABLE_ERROR_MSG = (
     'No CA Certificates were found in CA_CERTS_PATH. For information on '

--- a/libcloud/test/test_http.py
+++ b/libcloud/test/test_http.py
@@ -64,7 +64,7 @@ class TestHttpLibSSLTests(unittest.TestCase):
 
         reload(libcloud.security)
 
-        self.assertEqual(libcloud.security.CA_CERTS_PATH, [file_path])
+        self.assertEqual(libcloud.security.CA_CERTS_PATH, file_path)
 
     @patch('warnings.warn')
     def test_setup_ca_cert(self, _):
@@ -78,7 +78,7 @@ class TestHttpLibSSLTests(unittest.TestCase):
         # a valid path
         self.httplib_object.verify = True
 
-        libcloud.security.CA_CERTS_PATH = [os.path.abspath(__file__)]
+        libcloud.security.CA_CERTS_PATH = os.path.abspath(__file__)
         self.httplib_object._setup_ca_cert()
 
         self.assertTrue(self.httplib_object.ca_cert is not None)


### PR DESCRIPTION
## Remove final mentions of CA_CERTS_PATHS as list

Since libcloud 2.0, CA_CERTS_PATHS is no longer a list, but there were a
few mentions left in the code, which was confusing.

Thanks to @llazzaro for the inital report in #1113.

done, ready for review

### Checklist

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
