### PR TITLE
docs: Fix mailing list typos in committer guide

### DIFF
--- a/docs/committer_guide.rst
+++ b/docs/committer_guide.rst
@@ -16,8 +16,8 @@ First congratulations and welcome to the team!
 1. Subscribe to the public mailing lists
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you haven't yet, subscribe to {dev,users,commits}@apache.libcloud.org
-mailing lists. Committs mailing list is especially important because all of
+If you haven't yet, subscribe to {dev,users,notifications}@libcloud.apache.org
+mailing lists. Notifications mailing list is especially important because all of
 the JIRA notification, Github Pull Request notifications and build notifications
 are sent there.
 


### PR DESCRIPTION
## Fix mailing list typos in commiter guide

done, ready for review

Changes:

 * apache.libcloud.org -> libcloud.apache.org
 * commits -> notifications
 * Committs (sic) -> Notifications

I would like feedback specifically on notifications vs. commits. It looks like the two mailing lists exist. Thanks.