### PR TITLE
Improve CA_CERTS_PATH defined as list warning

### DIFF
--- a/libcloud/http.py
+++ b/libcloud/http.py
@@ -144,22 +144,24 @@ class LibcloudBaseConnection(object):
     def _setup_verify(self):
         self.verify = libcloud.security.VERIFY_SSL_CERT
 
-    def _setup_ca_cert(self):
+    def _setup_ca_cert(self, **kwargs):
+        # simulating keyword-only argument in Python 2
+        ca_certs_path = kwargs.get('ca_cert', libcloud.security.CA_CERTS_PATH)
+
         if self.verify is False:
             pass
         else:
-            if isinstance(libcloud.security.CA_CERTS_PATH, list):
-                if len(libcloud.security.CA_CERTS_PATH) > 1:
-                    msg = ('Providing a list of CA trusts is no longer '
-                           'supported since libcloud 2.0. Using the first '
-                           'element in the list. See '
-                           'http://libcloud.readthedocs.io/en/latest/other/'
-                           'changes_in_2_0.html#providing-a-list-of-ca-trusts-'
-                           'is-no-longer-supported')
-                    warnings.warn(msg)
-                self.ca_cert = libcloud.security.CA_CERTS_PATH[0]
+            if isinstance(ca_certs_path, list):
+                msg = (
+                    'Providing a list of CA trusts is no longer supported '
+                    'since libcloud 2.0. Using the first element in the list. '
+                    'See http://libcloud.readthedocs.io/en/latest/other/'
+                    'changes_in_2_0.html#providing-a-list-of-ca-trusts-is-no-'
+                    'longer-supported')
+                warnings.warn(msg, DeprecationWarning)
+                self.ca_cert = ca_certs_path[0]
             else:
-                self.ca_cert = libcloud.security.CA_CERTS_PATH
+                self.ca_cert = ca_certs_path
 
     def _setup_signing(self, cert_file=None, key_file=None):
         """

--- a/libcloud/http.py
+++ b/libcloud/http.py
@@ -150,7 +150,13 @@ class LibcloudBaseConnection(object):
         else:
             if isinstance(libcloud.security.CA_CERTS_PATH, list):
                 if len(libcloud.security.CA_CERTS_PATH) > 1:
-                    warnings.warn('Only 1 certificate path is supported')
+                    msg = ('Providing a list of CA trusts is no longer '
+                           'supported since libcloud 2.0. Using the first '
+                           'element in the list. See '
+                           'http://libcloud.readthedocs.io/en/latest/other/'
+                           'changes_in_2_0.html#providing-a-list-of-ca-trusts-'
+                           'is-no-longer-supported')
+                    warnings.warn(msg)
                 self.ca_cert = libcloud.security.CA_CERTS_PATH[0]
             else:
                 self.ca_cert = libcloud.security.CA_CERTS_PATH

--- a/libcloud/test/test_http.py
+++ b/libcloud/test/test_http.py
@@ -16,7 +16,7 @@
 import os
 import sys
 import os.path
-from mock import patch
+import warnings
 
 import libcloud.security
 
@@ -65,6 +65,15 @@ class TestHttpLibSSLTests(unittest.TestCase):
         reload(libcloud.security)
 
         self.assertEqual(libcloud.security.CA_CERTS_PATH, file_path)
+
+    def test_ca_cert_list_warning(self):
+        with warnings.catch_warnings(record=True) as w:
+            self.httplib_object.verify = True
+            self.httplib_object._setup_ca_cert(
+                ca_cert=[ORIGINAL_CA_CERTS_PATH])
+            self.assertEqual(self.httplib_object.ca_cert,
+                             ORIGINAL_CA_CERTS_PATH)
+            self.assertEqual(w[0].category, DeprecationWarning)
 
     def test_setup_ca_cert(self):
         # verify = False, _setup_ca_cert should be a no-op

--- a/libcloud/test/test_http.py
+++ b/libcloud/test/test_http.py
@@ -25,14 +25,14 @@ from libcloud.http import LibcloudConnection
 
 from libcloud.test import unittest
 
-ORIGINAL_CA_CERS_PATH = libcloud.security.CA_CERTS_PATH
+ORIGINAL_CA_CERTS_PATH = libcloud.security.CA_CERTS_PATH
 
 
 class TestHttpLibSSLTests(unittest.TestCase):
 
     def setUp(self):
         libcloud.security.VERIFY_SSL_CERT = False
-        libcloud.security.CA_CERTS_PATH = ORIGINAL_CA_CERS_PATH
+        libcloud.security.CA_CERTS_PATH = ORIGINAL_CA_CERTS_PATH
         self.httplib_object = LibcloudConnection('foo.bar', port=80)
 
     def test_custom_ca_path_using_env_var_doesnt_exist(self):
@@ -66,8 +66,7 @@ class TestHttpLibSSLTests(unittest.TestCase):
 
         self.assertEqual(libcloud.security.CA_CERTS_PATH, file_path)
 
-    @patch('warnings.warn')
-    def test_setup_ca_cert(self, _):
+    def test_setup_ca_cert(self):
         # verify = False, _setup_ca_cert should be a no-op
         self.httplib_object.verify = False
         self.httplib_object._setup_ca_cert()


### PR DESCRIPTION
## Improve "CA_CERTS_PATH defined as list" warning

### Description

See https://github.com/apache/libcloud/pull/1114 for details. As requested by @Kami:

> Not related to your change, but I would prefer this message to be a bit more explicit and user-friendly - https://github.com/apache/libcloud/blob/trunk/libcloud/http.py#L153. And perhaps also point user to the corresponding documentation section.

Is it better? Should the URL be included?

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
