### PR TITLE
On Azure ARM, destroy_node() do VHD cleanup even when NIC cleanup fails

### DIFF
--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -744,7 +744,8 @@ class AzureNodeDriver(NodeDriver):
                         if h.code == 400 and inuse:
                             time.sleep(10)
                         else:
-                            return False
+                            # NIC cleanup failed, try cleaning up the VHD.
+                            break
 
         # Optionally clean up OS disk VHD.
         vhd = node.extra["properties"]["storageProfile"]["osDisk"].get("vhd")

--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -695,12 +695,11 @@ class AzureNodeDriver(NodeDriver):
         this node (default True).
         :type node: ``bool``
 
-        :return: True if the destroy was successful, False otherwise.
+        :return: True if the destroy was successful, raises exception otherwise.
         :rtype: ``bool``
         """
 
         do_node_polling = True
-        success = True
 
         # This returns a 202 (Accepted) which means that the delete happens
         # asynchronously.
@@ -718,7 +717,7 @@ class AzureNodeDriver(NodeDriver):
                 # No need to ask again, node already down.
                 do_node_polling = False
             else:
-                return False
+                raise
 
         # Need to poll until the node actually goes away.
         while do_node_polling:
@@ -731,7 +730,7 @@ class AzureNodeDriver(NodeDriver):
                 if h.code == 404:
                     break
                 else:
-                    return False
+                    raise
 
         # Optionally clean up the network
         # interfaces that were attached to this node.
@@ -753,9 +752,7 @@ class AzureNodeDriver(NodeDriver):
                         if h.code == 400 and inuse:
                             time.sleep(10)
                         else:
-                            # NIC cleanup failed, try cleaning up the VHD.
-                            success = False
-                            break
+                            raise
 
         # Optionally clean up OS disk VHD.
         vhd = node.extra["properties"]["storageProfile"]["osDisk"].get("vhd")
@@ -776,10 +773,9 @@ class AzureNodeDriver(NodeDriver):
                         # LibcloudError.  Wait a bit and try again.
                         time.sleep(10)
                     else:
-                        success = False
-                        break
+                        raise
 
-        return success
+        return True
 
     def create_volume(self, size, name, location=None, snapshot=None,
                       ex_resource_group=None, ex_account_type=None,

--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -695,7 +695,8 @@ class AzureNodeDriver(NodeDriver):
         this node (default True).
         :type node: ``bool``
 
-        :return: True if the destroy was successful, raises exception otherwise.
+        :return: True if the destroy was successful, raises exception
+        otherwise.
         :rtype: ``bool``
         """
 

--- a/libcloud/test/compute/test_azure_arm.py
+++ b/libcloud/test/compute/test_azure_arm.py
@@ -191,8 +191,8 @@ class AzureNodeDriverTests(LibcloudTestCase):
             # 500 - transient error when trying to clean up the NIC
             lambda f: error(BaseHTTPError, code=500, message="Cloud weather"),
         ]
-        ret = self.driver.destroy_node(node)
-        self.assertFalse(ret)
+        with self.assertRaises(BaseHTTPError):
+            self.driver.destroy_node(node)
 
     def test_destroy_node__failed(self):
         def error(e, **kwargs):
@@ -202,8 +202,8 @@ class AzureNodeDriverTests(LibcloudTestCase):
             # 403 - There was some problem with your request
             lambda f: error(BaseHTTPError, code=403, message='Forbidden'),
         ]
-        ret = self.driver.destroy_node(node)
-        self.assertFalse(ret)
+        with self.assertRaises(BaseHTTPError):
+            self.driver.destroy_node(node)
 
     def test_list_nodes(self):
         nodes = self.driver.list_nodes()

--- a/libcloud/test/compute/test_azure_arm.py
+++ b/libcloud/test/compute/test_azure_arm.py
@@ -21,7 +21,6 @@ from datetime import datetime
 import mock
 
 from libcloud.common.exceptions import BaseHTTPError
-from libcloud.common.types import LibcloudError
 from libcloud.compute.base import (NodeLocation, NodeSize, VolumeSnapshot,
                                    StorageVolume)
 from libcloud.compute.drivers.azure_arm import AzureImage, NodeAuthPassword


### PR DESCRIPTION
### Description

When calling destroy_node() on Azure ARM, several cloud calls happen. After successfully destroying the VM, the method tries to remove all NICs related to that VM. If one of these attempts fail, the VHD's life is spared.
The updates on this PR make destroy_node() continue with its task after a NIC cleanup fail, trying to remove the remaining NICs and the assigned VHD.
Also added tests for destroy_node(), modified the test suite a little to be able to simulate different HTTP response sequences.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [X] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [X] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
