### PR TITLE
Add description to ex_authorize_security_group_ingress (same for all …

### DIFF
--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -4864,7 +4864,7 @@ class BaseEC2NodeDriver(NodeDriver):
 
     def ex_authorize_security_group_ingress(self, id, from_port, to_port,
                                             cidr_ips=None, group_pairs=None,
-                                            protocol='tcp'):
+                                            protocol='tcp', description=None):
         """
         Edit a Security Group to allow specific ingress traffic using
         CIDR blocks or either a group ID, group name or user ID (account).
@@ -4906,7 +4906,8 @@ class BaseEC2NodeDriver(NodeDriver):
                                                         from_port,
                                                         to_port,
                                                         cidr_ips,
-                                                        group_pairs)
+                                                        group_pairs,
+                                                        description)
 
         params["Action"] = 'AuthorizeSecurityGroupIngress'
 
@@ -7429,7 +7430,7 @@ class BaseEC2NodeDriver(NodeDriver):
 
     def _get_common_security_group_params(self, group_id, protocol,
                                           from_port, to_port, cidr_ips,
-                                          group_pairs):
+                                          group_pairs, description=None):
         """
         Return a dictionary with common query parameters which are used when
         operating on security groups.
@@ -7448,6 +7449,9 @@ class BaseEC2NodeDriver(NodeDriver):
 
                 ip_ranges['IpPermissions.1.IpRanges.%s.CidrIp'
                           % (index)] = cidr_ip
+                if description is not None:
+                    ip_ranges['IpPermissions.1.IpRanges.%s.Description'
+                          % (index)] = description
 
             params.update(ip_ranges)
 

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -7450,9 +7450,11 @@ class BaseEC2NodeDriver(NodeDriver):
             for index, cidr_ip in enumerate(cidr_ips):
                 index += 1
 
-                ip_ranges['IpPermissions.1.IpRanges.%s.CidrIp' % (index)] = cidr_ip
+                ip_ranges['IpPermissions.1.IpRanges.%s.CidrIp'
+                            % (index)] = cidr_ip
                 if description is not None:
-                    ip_ranges['IpPermissions.1.IpRanges.%s.Description' % (index)] = description
+                    ip_ranges['IpPermissions.1.IpRanges.%s.Description'
+                                % (index)] = description
 
             params.update(ip_ranges)
 

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -7451,10 +7451,10 @@ class BaseEC2NodeDriver(NodeDriver):
                 index += 1
 
                 ip_ranges['IpPermissions.1.IpRanges.%s.CidrIp'
-                            % (index)] = cidr_ip
+                    % (index)] = cidr_ip
                 if description is not None:
                     ip_ranges['IpPermissions.1.IpRanges.%s.Description'
-                                % (index)] = description
+                        % (index)] = description
 
             params.update(ip_ranges)
 

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -7451,10 +7451,10 @@ class BaseEC2NodeDriver(NodeDriver):
                 index += 1
 
                 ip_ranges['IpPermissions.1.IpRanges.%s.CidrIp'
-                    % (index)] = cidr_ip
+                          % (index)] = cidr_ip
                 if description is not None:
                     ip_ranges['IpPermissions.1.IpRanges.%s.Description'
-                        % (index)] = description
+                              % (index)] = description
 
             params.update(ip_ranges)
 

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -7450,11 +7450,9 @@ class BaseEC2NodeDriver(NodeDriver):
             for index, cidr_ip in enumerate(cidr_ips):
                 index += 1
 
-                ip_ranges['IpPermissions.1.IpRanges.%s.CidrIp'
-                          % (index)] = cidr_ip
+                ip_ranges['IpPermissions.1.IpRanges.%s.CidrIp' % (index)] = cidr_ip
                 if description is not None:
-                    ip_ranges['IpPermissions.1.IpRanges.%s.Description'
-                          % (index)] = description
+                    ip_ranges['IpPermissions.1.IpRanges.%s.Description' % (index)] = description
 
             params.update(ip_ranges)
 

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -4898,6 +4898,9 @@ class BaseEC2NodeDriver(NodeDriver):
         :param      protocol: tcp/udp/icmp
         :type       protocol: ``str``
 
+        :param      description: description to be added to the rules inserted
+        :type       description: ``str``
+
         :rtype: ``bool``
         """
 

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -326,10 +326,12 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
 
     def test_authorize_security_group_ingress(self):
         ranges = ['1.1.1.1/32', '2.2.2.2/32']
-        resp = self.driver.ex_authorize_security_group_ingress('sg-42916629', 22, 22, cidr_ips=ranges)
+        description = "automated authorised IP ingress test"
+        resp = self.driver.ex_authorize_security_group_ingress('sg-42916629', 22, 22, cidr_ips=ranges, description=description)
         self.assertTrue(resp)
         groups = [{'group_id': 'sg-949265ff'}]
-        resp = self.driver.ex_authorize_security_group_ingress('sg-42916629', 22, 23, group_pairs=groups)
+        description = "automated authorised group ingress test"
+        resp = self.driver.ex_authorize_security_group_ingress('sg-42916629', 22, 23, group_pairs=groups, description=description)
         self.assertTrue(resp)
 
     def test_authorize_security_group_egress(self):


### PR DESCRIPTION
…cidrIps)

## Add description to ex_authorize_security_group_ingress 

### Description

Added 'description' parameter to the ex_authorize_security_group_ingress method.
If provided, it will add the given description to the cidr_ip's affected by the insertion

### Status

- done, ready for review
- future work could be done to add the possibility of add a different description to each cidr_ip in the the ipranges

### Checklist (tick everything that applies)

- [X] [Code linting]
- [ ] Documentation
- [X] [Tests] Tested on our aws integration
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
