### PR TITLE
[LIBCLOUD-951] Add possibility to define hostname to UpCloud driver

### DIFF
--- a/libcloud/common/upcloud.py
+++ b/libcloud/common/upcloud.py
@@ -49,13 +49,17 @@ class UpcloudCreateNodeRequestBody(object):
                             (optional)
     :type       auth: :class:`.NodeAuthSSHKey`
 
+    :param      ex_hostname: Hostname. Default is 'localhost'. (optional)
+    :type       ex_hostname: ``str``
+
     """
 
-    def __init__(self, user_id, name, size, image, location, auth=None):
+    def __init__(self, user_id, name, size, image, location, auth=None,
+                 **kwargs):
         self.body = {
             'server': {
                 'title': name,
-                'hostname': 'localhost',
+                'hostname': kwargs.get('ex_hostname', 'localhost'),
                 'plan': size.id,
                 'zone': location.id,
                 'login_user': _LoginUser(user_id, auth).to_dict(),

--- a/libcloud/compute/drivers/upcloud.py
+++ b/libcloud/compute/drivers/upcloud.py
@@ -151,12 +151,16 @@ class UpcloudDriver(NodeDriver):
                             (optional)
         :type auth:   :class:`.NodeAuthSSHKey`
 
+        :param ex_hostname: Hostname. Default is 'localhost'. (optional)
+        :type ex_hostname: ``str``
+
         :return: The newly created node.
         :rtype: :class:`.Node`
         """
         body = UpcloudCreateNodeRequestBody(user_id=self.connection.user_id,
                                             name=name, size=size, image=image,
-                                            location=location, auth=auth)
+                                            location=location, auth=auth,
+                                            **kwargs)
         response = self.connection.request('1.2/server',
                                            method='POST',
                                            data=body.to_json())

--- a/libcloud/test/common/test_upcloud.py
+++ b/libcloud/test/common/test_upcloud.py
@@ -133,6 +133,38 @@ class TestUpcloudCreateNodeRequestBody(unittest.TestCase):
         }
         self.assertDictEqual(expected_body, dict_body)
 
+    def test_creating_node_using_hostname(self):
+        image = NodeImage(id='01000000-0000-4000-8000-000030060200',
+                          name='Ubuntu Server 16.04 LTS (Xenial Xerus)',
+                          driver='',
+                          extra={'type': 'template'})
+        location = NodeLocation(id='fi-hel1', name='Helsinki #1', country='FI', driver='')
+        size = NodeSize(id='1xCPU-1GB', name='1xCPU-1GB', ram=1024, disk=30, bandwidth=2048,
+                        extra={'core_number': 1, 'storage_tier': 'maxiops'}, price=None, driver='')
+
+        body = UpcloudCreateNodeRequestBody(user_id='somename', name='ts', image=image, location=location, size=size,
+                                            ex_hostname='myhost.upcloud.com')
+        json_body = body.to_json()
+        dict_body = json.loads(json_body)
+        expected_body = {
+            'server': {
+                'title': 'ts',
+                'hostname': 'myhost.upcloud.com',
+                'plan': '1xCPU-1GB',
+                'zone': 'fi-hel1',
+                'login_user': {'username': 'somename',
+                               'create_password': 'yes'},
+                'storage_devices': {
+                    'storage_device': [{
+                        'action': 'clone',
+                        'title': 'Ubuntu Server 16.04 LTS (Xenial Xerus)',
+                        'storage': '01000000-0000-4000-8000-000030060200'
+                    }]
+                },
+            }
+        }
+        self.assertDictEqual(expected_body, dict_body)
+
 
 class TestUpcloudNodeDestroyer(unittest.TestCase):
 

--- a/libcloud/test/compute/test_upcloud.py
+++ b/libcloud/test/compute/test_upcloud.py
@@ -115,7 +115,7 @@ class UpcloudDriverTests(LibcloudTestCase):
         location = NodeLocation(id='fi-hel1', name='Helsinki #1', country='FI', driver=self.driver)
         size = NodeSize(id='1xCPU-1GB', name='1xCPU-1GB', ram=1024, disk=30, bandwidth=2048,
                         extra={'core_number': 1, 'storage_tier': 'maxiops'}, price=None, driver=self.driver)
-        node = self.driver.create_node(name='test_server', size=size, image=image, location=location)
+        node = self.driver.create_node(name='test_server', size=size, image=image, location=location, ex_hostname='myhost.somewhere')
 
         self.assertTrue(re.match('^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}$', node.id))
         self.assertEquals(node.name, 'test_server')


### PR DESCRIPTION
## UpCloud driver to support defining hostname

### Description

Added ex_hostname to UpcloudDriver create_node method to define the hostname.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
