### PR TITLE
[LIBCLOUD-952] Use disk size and storage tier also when creating node from template

### DIFF
--- a/libcloud/common/upcloud.py
+++ b/libcloud/common/upcloud.py
@@ -230,25 +230,19 @@ class _StorageDevice(object):
             return self._storage_device_for_cdrom_image()
 
     def _storage_device_for_template_image(self):
-        storage_devices = {
-            'storage_device': [{
-                'action': 'clone',
-                'title': self.image.name,
-                'storage': self.image.id
-            }]
+        hdd_device = {
+            'action': 'clone',
+            'storage': self.image.id
         }
-        return storage_devices
+        hdd_device.update(self._common_hdd_device())
+        return {'storage_device': [hdd_device]}
 
     def _storage_device_for_cdrom_image(self):
+        hdd_device = {'action': 'create'}
+        hdd_device.update(self._common_hdd_device())
         storage_devices = {
             'storage_device': [
-                {
-                    'action': 'create',
-                    'title': self.image.name,
-                    'size': self.size.disk,
-                    'tier': self.size.extra['storage_tier']
-
-                },
+                hdd_device,
                 {
                     'action': 'attach',
                     'storage': self.image.id,
@@ -257,3 +251,10 @@ class _StorageDevice(object):
             ]
         }
         return storage_devices
+
+    def _common_hdd_device(self):
+        return {
+            'title': self.image.name,
+            'size': self.size.disk,
+            'tier': self.size.extra.get('storage_tier', 'maxiops')
+        }

--- a/libcloud/test/compute/test_upcloud.py
+++ b/libcloud/test/compute/test_upcloud.py
@@ -114,7 +114,7 @@ class UpcloudDriverTests(LibcloudTestCase):
                           driver=self.driver)
         location = NodeLocation(id='fi-hel1', name='Helsinki #1', country='FI', driver=self.driver)
         size = NodeSize(id='1xCPU-1GB', name='1xCPU-1GB', ram=1024, disk=30, bandwidth=2048,
-                        extra={'core_number': 1, 'storage_tier': 'maxiops'}, price=None, driver=self.driver)
+                        extra={'storage_tier': 'maxiops'}, price=None, driver=self.driver)
         node = self.driver.create_node(name='test_server', size=size, image=image, location=location, ex_hostname='myhost.somewhere')
 
         self.assertTrue(re.match('^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}$', node.id))
@@ -133,7 +133,7 @@ class UpcloudDriverTests(LibcloudTestCase):
                           driver=self.driver)
         location = NodeLocation(id='fi-hel1', name='Helsinki #1', country='FI', driver=self.driver)
         size = NodeSize(id='1xCPU-1GB', name='1xCPU-1GB', ram=1024, disk=30, bandwidth=2048,
-                        extra={'core_number': 1, 'storage_tier': 'maxiops'}, price=None, driver=self.driver)
+                        extra={'storage_tier': 'maxiops'}, price=None, driver=self.driver)
 
         auth = NodeAuthSSHKey('publikey')
         node = self.driver.create_node(name='test_server', size=size, image=image, location=location, auth=auth)


### PR DESCRIPTION
## Add disk size and storage tier

### Description

Added missing storage_tier and disk size to the request body for creating node. Storage_tier has meaningful default value when not provided.  

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
