### PR TITLE
[LIBCLOUD-953] Add possibility to define username to Upcloud driver

### DIFF
--- a/libcloud/common/upcloud.py
+++ b/libcloud/common/upcloud.py
@@ -29,9 +29,6 @@ class UpcloudCreateNodeRequestBody(object):
 
     Takes the create_node arguments (**kwargs) and constructs the request body
 
-    :param      user_id: required for authentication (required)
-    :type       user_id: ``str``
-
     :param      name: Name of the created server (required)
     :type       name: ``str``
 
@@ -52,17 +49,21 @@ class UpcloudCreateNodeRequestBody(object):
     :param      ex_hostname: Hostname. Default is 'localhost'. (optional)
     :type       ex_hostname: ``str``
 
+    :param ex_username: User's username, which is created.
+                        Default is 'root'. (optional)
+    :type ex_username: ``str``
     """
 
-    def __init__(self, user_id, name, size, image, location, auth=None,
+    def __init__(self, name, size, image, location, auth=None,
                  **kwargs):
+        username = kwargs.get('ex_username', 'root')
         self.body = {
             'server': {
                 'title': name,
                 'hostname': kwargs.get('ex_hostname', 'localhost'),
                 'plan': size.id,
                 'zone': location.id,
-                'login_user': _LoginUser(user_id, auth).to_dict(),
+                'login_user': _LoginUser(username, auth).to_dict(),
                 'storage_devices': _StorageDevice(image, size).to_dict()
             }
         }

--- a/libcloud/compute/drivers/upcloud.py
+++ b/libcloud/compute/drivers/upcloud.py
@@ -154,11 +154,14 @@ class UpcloudDriver(NodeDriver):
         :param ex_hostname: Hostname. Default is 'localhost'. (optional)
         :type ex_hostname: ``str``
 
+        :param ex_username: User's username, which is created.
+                            Default is 'root'. (optional)
+        :type ex_username: ``str``
+
         :return: The newly created node.
         :rtype: :class:`.Node`
         """
-        body = UpcloudCreateNodeRequestBody(user_id=self.connection.user_id,
-                                            name=name, size=size, image=image,
+        body = UpcloudCreateNodeRequestBody(name=name, size=size, image=image,
                                             location=location, auth=auth,
                                             **kwargs)
         response = self.connection.request('1.2/server',

--- a/libcloud/test/common/test_upcloud.py
+++ b/libcloud/test/common/test_upcloud.py
@@ -26,16 +26,17 @@ from libcloud.test import unittest
 
 class TestUpcloudCreateNodeRequestBody(unittest.TestCase):
 
-    def test_creating_node_from_template_image(self):
-        image = NodeImage(id='01000000-0000-4000-8000-000030060200',
-                          name='Ubuntu Server 16.04 LTS (Xenial Xerus)',
-                          driver='',
-                          extra={'type': 'template'})
-        location = NodeLocation(id='fi-hel1', name='Helsinki #1', country='FI', driver='')
-        size = NodeSize(id='1xCPU-1GB', name='1xCPU-1GB', ram=1024, disk=30, bandwidth=2048,
-                        extra={'core_number': 1, 'storage_tier': 'maxiops'}, price=None, driver='')
+    def setUp(self):
+        self.image = NodeImage(id='01000000-0000-4000-8000-000030060200',
+                               name='Ubuntu Server 16.04 LTS (Xenial Xerus)',
+                               driver='',
+                               extra={'type': 'template'})
+        self.location = NodeLocation(id='fi-hel1', name='Helsinki #1', country='FI', driver='')
+        self.size = NodeSize(id='1xCPU-1GB', name='1xCPU-1GB', ram=1024, disk=30, bandwidth=2048,
+                             extra={'core_number': 1, 'storage_tier': 'maxiops'}, price=None, driver='')
 
-        body = UpcloudCreateNodeRequestBody(user_id='somename', name='ts', image=image, location=location, size=size)
+    def test_creating_node_from_template_image(self):
+        body = UpcloudCreateNodeRequestBody(name='ts', image=self.image, location=self.location, size=self.size)
         json_body = body.to_json()
         dict_body = json.loads(json_body)
         expected_body = {
@@ -44,7 +45,7 @@ class TestUpcloudCreateNodeRequestBody(unittest.TestCase):
                 'hostname': 'localhost',
                 'plan': '1xCPU-1GB',
                 'zone': 'fi-hel1',
-                'login_user': {'username': 'somename',
+                'login_user': {'username': 'root',
                                'create_password': 'yes'},
                 'storage_devices': {
                     'storage_device': [{
@@ -64,11 +65,7 @@ class TestUpcloudCreateNodeRequestBody(unittest.TestCase):
                           name='Ubuntu Server 16.04 LTS (Xenial Xerus)',
                           driver='',
                           extra={'type': 'cdrom'})
-        location = NodeLocation(id='fi-hel1', name='Helsinki #1', country='FI', driver='')
-        size = NodeSize(id='1xCPU-1GB', name='1xCPU-1GB', ram=1024, disk=30, bandwidth=2048,
-                        extra={'core_number': 1, 'storage_tier': 'maxiops'}, price=None, driver='')
-
-        body = UpcloudCreateNodeRequestBody(user_id='somename', name='ts', image=image, location=location, size=size)
+        body = UpcloudCreateNodeRequestBody(name='ts', image=image, location=self.location, size=self.size)
         json_body = body.to_json()
         dict_body = json.loads(json_body)
         expected_body = {
@@ -77,7 +74,7 @@ class TestUpcloudCreateNodeRequestBody(unittest.TestCase):
                 'hostname': 'localhost',
                 'plan': '1xCPU-1GB',
                 'zone': 'fi-hel1',
-                'login_user': {'username': 'somename',
+                'login_user': {'username': 'root',
                                'create_password': 'yes'},
                 'storage_devices': {
                     'storage_device': [
@@ -99,16 +96,9 @@ class TestUpcloudCreateNodeRequestBody(unittest.TestCase):
         self.assertDictEqual(expected_body, dict_body)
 
     def test_creating_node_using_ssh_keys(self):
-        image = NodeImage(id='01000000-0000-4000-8000-000030060200',
-                          name='Ubuntu Server 16.04 LTS (Xenial Xerus)',
-                          driver='',
-                          extra={'type': 'template'})
-        location = NodeLocation(id='fi-hel1', name='Helsinki #1', country='FI', driver='')
-        size = NodeSize(id='1xCPU-1GB', name='1xCPU-1GB', ram=1024, disk=30, bandwidth=2048,
-                        extra={'core_number': 1, 'storage_tier': 'maxiops'}, price=None, driver='')
         auth = NodeAuthSSHKey('sshkey')
 
-        body = UpcloudCreateNodeRequestBody(user_id='somename', name='ts', image=image, location=location, size=size, auth=auth)
+        body = UpcloudCreateNodeRequestBody(name='ts', image=self.image, location=self.location, size=self.size, auth=auth)
         json_body = body.to_json()
         dict_body = json.loads(json_body)
         expected_body = {
@@ -118,7 +108,7 @@ class TestUpcloudCreateNodeRequestBody(unittest.TestCase):
                 'plan': '1xCPU-1GB',
                 'zone': 'fi-hel1',
                 'login_user': {
-                    'username': 'somename',
+                    'username': 'root',
                     'ssh_keys': {
                         'ssh_key': [
                             'sshkey'
@@ -139,15 +129,7 @@ class TestUpcloudCreateNodeRequestBody(unittest.TestCase):
         self.assertDictEqual(expected_body, dict_body)
 
     def test_creating_node_using_hostname(self):
-        image = NodeImage(id='01000000-0000-4000-8000-000030060200',
-                          name='Ubuntu Server 16.04 LTS (Xenial Xerus)',
-                          driver='',
-                          extra={'type': 'template'})
-        location = NodeLocation(id='fi-hel1', name='Helsinki #1', country='FI', driver='')
-        size = NodeSize(id='1xCPU-1GB', name='1xCPU-1GB', ram=1024, disk=30, bandwidth=2048,
-                        extra={'core_number': 1, 'storage_tier': 'maxiops'}, price=None, driver='')
-
-        body = UpcloudCreateNodeRequestBody(user_id='somename', name='ts', image=image, location=location, size=size,
+        body = UpcloudCreateNodeRequestBody(name='ts', image=self.image, location=self.location, size=self.size,
                                             ex_hostname='myhost.upcloud.com')
         json_body = body.to_json()
         dict_body = json.loads(json_body)
@@ -157,7 +139,7 @@ class TestUpcloudCreateNodeRequestBody(unittest.TestCase):
                 'hostname': 'myhost.upcloud.com',
                 'plan': '1xCPU-1GB',
                 'zone': 'fi-hel1',
-                'login_user': {'username': 'somename',
+                'login_user': {'username': 'root',
                                'create_password': 'yes'},
                 'storage_devices': {
                     'storage_device': [{
@@ -171,6 +153,15 @@ class TestUpcloudCreateNodeRequestBody(unittest.TestCase):
             }
         }
         self.assertDictEqual(expected_body, dict_body)
+
+    def test_creating_node_with_non_default_username(self):
+        body = UpcloudCreateNodeRequestBody(name='ts', image=self.image, location=self.location, size=self.size,
+                                            ex_username='someone')
+        json_body = body.to_json()
+        dict_body = json.loads(json_body)
+
+        login_user = dict_body['server']['login_user']
+        self.assertDictEqual({'username': 'someone', 'create_password': 'yes'}, login_user)
 
 
 class TestStorageDevice(unittest.TestCase):


### PR DESCRIPTION
ex_username parameter added and refactored test to use common parameters

## ex_username added to create_node

### Description

Added ex_username to create_node, so that clients can define username, which is created to host.
The default username is 'root', which is UpCloud's REST API's default username.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
-  [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
