### PR TITLE
Add ex_fetch_power_state option to list_nodes().

### DIFF
--- a/libcloud/common/azure_arm.py
+++ b/libcloud/common/azure_arm.py
@@ -195,7 +195,7 @@ class AzureResourceManagementConnection(ConnectionUserAndKey):
         Log in and get bearer token used to authorize API requests.
         """
 
-        conn = self.conn_class(self.login_host, 443)
+        conn = self.conn_class(self.login_host, 443, timeout=self.timeout)
         conn.connect()
         params = urlencode({
             "grant_type": "client_credentials",

--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -360,7 +360,9 @@ class AzureNodeDriver(NodeDriver):
                                  ex_offer, ex_sku, ex_version)
             return i[0] if i else None
 
-    def list_nodes(self, ex_resource_group=None, ex_fetch_nic=True, ex_fetch_power_state=True):
+    def list_nodes(self, ex_resource_group=None,
+                   ex_fetch_nic=True,
+                   ex_fetch_power_state=True):
         """
         List all nodes.
 
@@ -368,8 +370,9 @@ class AzureNodeDriver(NodeDriver):
         :type ex_urn: ``str``
 
         :param ex_fetch_nic: Fetch NIC resources in order to get
-        IP address information for nodes.  If True, requires an extra API call
-        for each NIC of each node.  If False, IP addresses will not be returned.
+        IP address information for nodes.  If True, requires an extra API
+        call for each NIC of each node.  If False, IP addresses will not
+        be returned.
         :type ex_urn: ``bool``
 
         :param ex_fetch_power_state: Fetch node power state.  If True, requires
@@ -391,7 +394,9 @@ class AzureNodeDriver(NodeDriver):
                      % (self.subscription_id)
         r = self.connection.request(action,
                                     params={"api-version": "2015-06-15"})
-        return [self._to_node(n, fetch_nic=ex_fetch_nic, fetch_power_state=ex_fetch_power_state)
+        return [self._to_node(n,
+                              fetch_nic=ex_fetch_nic,
+                              fetch_power_state=ex_fetch_power_state)
                 for n in r.object["value"]]
 
     def create_node(self,
@@ -1998,15 +2003,16 @@ class AzureNodeDriver(NodeDriver):
         if fetch_power_state:
             state = self._fetch_power_state(data)
         else:
-            if data["provisioningState"] == "creating":
+            ps = data["properties"]["provisioningState"]
+            if ps == "creating":
                 state = NodeState.PENDING
-            elif data["provisioningState"] == "deleting":
+            elif ps == "deleting":
                 state = NodeState.TERMINATED
-            elif data["provisioningState"] == "failed":
+            elif ps == "failed":
                 state = NodeState.ERROR
-            elif data["provisioningState"] == "updating":
+            elif ps == "updating":
                 state = NodeState.UPDATING
-            elif data["provisioningState"] == "succeeded":
+            elif ps == "succeeded":
                 state = NodeState.RUNNING
 
         node = Node(data["id"],

--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -360,7 +360,7 @@ class AzureNodeDriver(NodeDriver):
                                  ex_offer, ex_sku, ex_version)
             return i[0] if i else None
 
-    def list_nodes(self, ex_resource_group=None, ex_fetch_nic=True, ex_fetch_status=True):
+    def list_nodes(self, ex_resource_group=None, ex_fetch_nic=True, ex_fetch_power_state=True):
         """
         List all nodes.
 
@@ -368,10 +368,13 @@ class AzureNodeDriver(NodeDriver):
         :type ex_urn: ``str``
 
         :param ex_fetch_nic: Fetch NIC resources in order to get
-        IP address information for nodes (requires extra API calls).
+        IP address information for nodes.  If True, requires an extra API call
+        for each NIC of each node.  If False, IP addresses will not be returned.
         :type ex_urn: ``bool``
 
-        :param ex_fetch_status: Fetch node instance status (requires extra API calls).
+        :param ex_fetch_power_state: Fetch node power state.  If True, requires
+        an extra API call for each node.  If False, node state
+        will be returned based on provisioning state only.
         :type ex_urn: ``bool``
 
         :return:  list of node objects
@@ -388,7 +391,7 @@ class AzureNodeDriver(NodeDriver):
                      % (self.subscription_id)
         r = self.connection.request(action,
                                     params={"api-version": "2015-06-15"})
-        return [self._to_node(n, fetch_nic=ex_fetch_nic, fetch_status=ex_fetch_status)
+        return [self._to_node(n, fetch_nic=ex_fetch_nic, fetch_power_state=ex_fetch_power_state)
                 for n in r.object["value"]]
 
     def create_node(self,
@@ -1931,7 +1934,45 @@ class AzureNodeDriver(NodeDriver):
         kwargs["cloud_environment"] = self.cloud_environment
         return kwargs
 
-    def _to_node(self, data, fetch_nic=True, fetch_status=True):
+    def _fetch_power_state(self, data):
+        state = NodeState.UNKNOWN
+        try:
+            action = "%s/InstanceView" % (data["id"])
+            r = self.connection.request(action,
+                                        params={"api-version": "2015-06-15"})
+            for status in r.object["statuses"]:
+                if status["code"] in ["ProvisioningState/creating"]:
+                    state = NodeState.PENDING
+                    break
+                elif status["code"] == "ProvisioningState/deleting":
+                    state = NodeState.TERMINATED
+                    break
+                elif status["code"].startswith("ProvisioningState/failed"):
+                    state = NodeState.ERROR
+                    break
+                elif status["code"] == "ProvisioningState/updating":
+                    state = NodeState.UPDATING
+                    break
+                elif status["code"] == "ProvisioningState/succeeded":
+                    pass
+
+                if status["code"] == "PowerState/deallocated":
+                    state = NodeState.STOPPED
+                    break
+                elif status["code"] == "PowerState/stopped":
+                    state = NodeState.PAUSED
+                    break
+                elif status["code"] == "PowerState/deallocating":
+                    state = NodeState.PENDING
+                    break
+                elif status["code"] == "PowerState/running":
+                    state = NodeState.RUNNING
+        except BaseHTTPError:
+            pass
+        return state
+
+
+    def _to_node(self, data, fetch_nic=True, fetch_power_state=True):
         private_ips = []
         public_ips = []
         nics = data["properties"]["networkProfile"]["networkInterfaces"]
@@ -1954,40 +1995,19 @@ class AzureNodeDriver(NodeDriver):
                     pass
 
         state = NodeState.UNKNOWN
-        if fetch_status:
-            try:
-                action = "%s/InstanceView" % (data["id"])
-                r = self.connection.request(action,
-                                            params={"api-version": "2015-06-15"})
-                for status in r.object["statuses"]:
-                    if status["code"] in ["ProvisioningState/creating"]:
-                        state = NodeState.PENDING
-                        break
-                    elif status["code"] == "ProvisioningState/deleting":
-                        state = NodeState.TERMINATED
-                        break
-                    elif status["code"].startswith("ProvisioningState/failed"):
-                        state = NodeState.ERROR
-                        break
-                    elif status["code"] == "ProvisioningState/updating":
-                        state = NodeState.UPDATING
-                        break
-                    elif status["code"] == "ProvisioningState/succeeded":
-                        pass
-
-                    if status["code"] == "PowerState/deallocated":
-                        state = NodeState.STOPPED
-                        break
-                    elif status["code"] == "PowerState/stopped":
-                        state = NodeState.PAUSED
-                        break
-                    elif status["code"] == "PowerState/deallocating":
-                        state = NodeState.PENDING
-                        break
-                    elif status["code"] == "PowerState/running":
-                        state = NodeState.RUNNING
-            except BaseHTTPError:
-                pass
+        if fetch_power_state:
+            state = self._fetch_power_state(data)
+        else:
+            if data["provisioningState"] == "creating":
+                state = NodeState.PENDING
+            elif data["provisioningState"] == "deleting":
+                state = NodeState.TERMINATED
+            elif data["provisioningState"] == "failed":
+                state = NodeState.ERROR
+            elif data["provisioningState"] == "updating":
+                state = NodeState.UPDATING
+            elif data["provisioningState"] == "succeeded":
+                state = NodeState.RUNNING
 
         node = Node(data["id"],
                     data["name"],

--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -1976,7 +1976,6 @@ class AzureNodeDriver(NodeDriver):
             pass
         return state
 
-
     def _to_node(self, data, fetch_nic=True, fetch_power_state=True):
         private_ips = []
         public_ips = []

--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -2003,7 +2003,7 @@ class AzureNodeDriver(NodeDriver):
         if fetch_power_state:
             state = self._fetch_power_state(data)
         else:
-            ps = data["properties"]["provisioningState"]
+            ps = data["properties"]["provisioningState"].lower()
             if ps == "creating":
                 state = NodeState.PENDING
             elif ps == "deleting":


### PR DESCRIPTION
## Add ex_fetch_power_state option to list_nodes().

### Description

Allows caller to skip (potentially expensive) requests for extended node
power state status.

Also set timeout on connection object used to fetch token.

### Status

Ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
