### PR TITLE
[LIBCLOUD-954] ec2: Allow cn-north-1 even without pricing

### DIFF
--- a/docs/compute/drivers/ec2.rst
+++ b/docs/compute/drivers/ec2.rst
@@ -10,23 +10,29 @@ platform, Amazon Web Services (AWS).
     :width: 300
     :target: https://aws.amazon.com/ec2/
 
-It allows users to rent virtual servers in more than 9 regions such as:
+It allows users to rent virtual servers in more than 15 regions such as:
 
 * US East (Northern Virginia) Region
 * US East (Ohio) Region
 * US West (Oregon) Region
 * US West (Northern California) Region
+* GovCloud (US) Region
+* Canada (Central) Region
 * EU West (Ireland) Region
+* EU West (London) Region
 * EU Central (Frankfurt) Region
 * Asia Pacific (Singapore) Region
 * Asia Pacific (Sydney) Region
 * Asia Pacific (Tokyo) Region
+* Asia Pacific (Seoul) Region
+* Asia Pacific (Mumbai) Region
+* China (Beijing) Region
 * South America (Sao Paulo) Region
 
 Using temporary security credentials
 ------------------------------------
 
-Since Libcloud 0.14.0 above, all the Amazon drivers support using temporary
+Since Libcloud 0.14.0, all the Amazon drivers support using temporary
 security credentials.
 
 Temporary credentials can be used by passing ``token`` argument to the driver

--- a/docs/compute/drivers/ec2.rst
+++ b/docs/compute/drivers/ec2.rst
@@ -29,6 +29,9 @@ It allows users to rent virtual servers in more than 15 regions such as:
 * China (Beijing) Region
 * South America (Sao Paulo) Region
 
+Note that pricing information is not available for China (Beijing)
+region.
+
 Using temporary security credentials
 ------------------------------------
 

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -3059,9 +3059,7 @@ VOLUME_MODIFICATION_ATTRIBUTE_MAP = {
 }
 
 VALID_EC2_REGIONS = REGION_DETAILS.keys()
-VALID_EC2_REGIONS = [
-    r for r in VALID_EC2_REGIONS if r != 'nimbus' and r != 'cn-north-1'
-]
+VALID_EC2_REGIONS = [r for r in VALID_EC2_REGIONS if r != 'nimbus']
 VALID_VOLUME_TYPES = ['standard', 'io1', 'gp2', 'st1', 'sc1']
 
 

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -3568,8 +3568,11 @@ class BaseEC2NodeDriver(NodeDriver):
         for instance_type in available_types:
             attributes = INSTANCE_TYPES[instance_type]
             attributes = copy.deepcopy(attributes)
-            price = self._get_size_price(size_id=instance_type)
-            attributes.update({'price': price})
+            try:
+                price = self._get_size_price(size_id=instance_type)
+                attributes['price'] = price
+            except KeyError:
+                attributes['price'] = None  # pricing not available
             sizes.append(NodeSize(driver=self, **attributes))
         return sizes
 

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -75,11 +75,12 @@ class BaseEC2Tests(LibcloudTestCase):
         unsupported_regions = list()
 
         for region in VALID_EC2_REGIONS:
-            if region in ['cn-north-1']:
-                continue  # pricing not available
+            no_pricing = region in ['cn-north-1']
             driver = EC2NodeDriver(*EC2_PARAMS, **{'region': region})
             try:
-                driver.list_sizes()
+                sizes = driver.list_sizes()
+                if no_pricing:
+                    self.assertTrue(all([s.price is None for s in sizes]))
             except:
                 unsupported_regions.append(region)
 

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -75,6 +75,8 @@ class BaseEC2Tests(LibcloudTestCase):
         unsupported_regions = list()
 
         for region in VALID_EC2_REGIONS:
+            if region in ['cn-north-1']:
+                continue  # pricing not available
             driver = EC2NodeDriver(*EC2_PARAMS, **{'region': region})
             try:
                 driver.list_sizes()


### PR DESCRIPTION
## ec2: Allow cn-north-1 even without pricing

### Description

See https://issues.apache.org/jira/browse/LIBCLOUD-954 and https://github.com/apache/libcloud/commit/1e1d77f320a2314e96c79011ab62ee028a835503

@fjros and @duanshiqiang, what do you think?

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
