### PR TITLE
Fix api version used to list and delete NICs.

### DIFF
--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -700,7 +700,7 @@ class AzureNodeDriver(NodeDriver):
         :rtype: ``bool``
         """
 
-        do_node_polling = True
+        do_node_polling = (ex_destroy_nic or ex_destroy_vhd)
 
         # This returns a 202 (Accepted) which means that the delete happens
         # asynchronously.
@@ -720,7 +720,8 @@ class AzureNodeDriver(NodeDriver):
             else:
                 raise
 
-        # Need to poll until the node actually goes away.
+        # Poll until the node actually goes away (otherwise attempt to delete
+        # NIC and VHD will fail with "resource in use" errors).
         while do_node_polling:
             try:
                 time.sleep(10)
@@ -728,7 +729,8 @@ class AzureNodeDriver(NodeDriver):
                     node.id,
                     params={"api-version": RESOURCE_API_VERSION})
             except BaseHTTPError as h:
-                if h.code == 404:
+                if h.code in (204, 404):
+                    # Node is gone
                     break
                 else:
                     raise
@@ -744,10 +746,7 @@ class AzureNodeDriver(NodeDriver):
                         self.ex_destroy_nic(self._to_nic(nic))
                         break
                     except BaseHTTPError as h:
-                        if h.code in (202, 204):
-                            break
-                        inuse = h.message.startswith("[NicInUse]")
-                        if h.code == 400 and inuse:
+                        if h.code == 400 and h.message.startswith("[NicInUse]"):
                             time.sleep(10)
                         else:
                             raise
@@ -1546,11 +1545,19 @@ class AzureNodeDriver(NodeDriver):
         :rtype: ``bool``
         """
 
-        self.connection.request(
-            nic.id,
-            params={"api-version": "2015-06-15"},
-            method='DELETE')
-        return True
+        try:
+            self.connection.request(
+                nic.id,
+                params={"api-version": "2015-06-15"},
+                method='DELETE')
+            return True
+        except BaseHTTPError as h:
+            if h.code in (202, 204):
+                # Deletion is accepted (but deferred), or NIC is already
+                # deleted
+                return True
+            else:
+                raise
 
     def ex_get_node(self, id):
         """
@@ -2023,8 +2030,8 @@ class AzureNodeDriver(NodeDriver):
                                "maxDataDiskCount": data["maxDataDiskCount"]})
 
     def _to_nic(self, data):
-        return AzureNic(data["id"], data["name"], data["location"],
-                        data["properties"])
+        return AzureNic(data["id"], data.get("name"), data.get("location"),
+                        data.get("properties"))
 
     def _to_ip_address(self, data):
         return AzureIPAddress(data["id"], data["name"], data["properties"])

--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -746,7 +746,8 @@ class AzureNodeDriver(NodeDriver):
                         self.ex_destroy_nic(self._to_nic(nic))
                         break
                     except BaseHTTPError as h:
-                        if h.code == 400 and h.message.startswith("[NicInUse]"):
+                        if (h.code == 400 and
+                            h.message.startswith("[NicInUse]")):
                             time.sleep(10)
                         else:
                             raise

--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -747,7 +747,7 @@ class AzureNodeDriver(NodeDriver):
                         break
                     except BaseHTTPError as h:
                         if (h.code == 400 and
-                            h.message.startswith("[NicInUse]")):
+                                h.message.startswith("[NicInUse]")):
                             time.sleep(10)
                         else:
                             raise

--- a/libcloud/test/compute/test_azure_arm.py
+++ b/libcloud/test/compute/test_azure_arm.py
@@ -159,7 +159,7 @@ class AzureNodeDriverTests(LibcloudTestCase):
         node = self.driver.list_nodes()[0]
         AzureMockHttp.responses = [
             # 204 (No content) to the DELETE request on a deleted/non-existent node
-            lambda f: error(BaseHTTPError, code=204, message='Not found'),
+            lambda f: error(BaseHTTPError, code=204, message='No content'),
         ]
         ret = self.driver.destroy_node(node)
         self.assertTrue(ret)
@@ -186,8 +186,8 @@ class AzureNodeDriverTests(LibcloudTestCase):
         AzureMockHttp.responses = [
             # OK to the DELETE request
             lambda f: (httplib.OK, None, {}, 'OK'),
-            # 204 means node destroyed successfully
-            lambda f: error(BaseHTTPError, code=204, message='No content'),
+            # 404 means node is gone
+            lambda f: error(BaseHTTPError, code=404, message='Not found'),
             # 500 - transient error when trying to clean up the NIC
             lambda f: error(BaseHTTPError, code=500, message="Cloud weather"),
         ]

--- a/libcloud/test/compute/test_azure_arm.py
+++ b/libcloud/test/compute/test_azure_arm.py
@@ -141,7 +141,7 @@ class AzureNodeDriverTests(LibcloudTestCase):
         AzureMockHttp.responses = [
             # OK to the DELETE request
             lambda f: (httplib.OK, None, {}, 'OK'),
-            # 404 means node destroyed successfully
+            # 404 means node is gone
             lambda f: error(BaseHTTPError, code=404, message='Not found'),
         ]
         ret = self.driver.destroy_node(node)
@@ -151,15 +151,15 @@ class AzureNodeDriverTests(LibcloudTestCase):
         """
         This simulates the case when destroy_node is being called for the 2nd
         time because some related resource failed to clean up, so the DELETE
-        operation on the node will return 404 (because it was already deleted)
+        operation on the node will return 204 (because it was already deleted)
         but the method should return success.
         """
         def error(e, **kwargs):
             raise e(**kwargs)
         node = self.driver.list_nodes()[0]
         AzureMockHttp.responses = [
-            # 404 (Not Found) to the DELETE request
-            lambda f: error(BaseHTTPError, code=404, message='Not found'),
+            # 204 (No content) to the DELETE request on a deleted/non-existent node
+            lambda f: error(BaseHTTPError, code=204, message='Not found'),
         ]
         ret = self.driver.destroy_node(node)
         self.assertTrue(ret)
@@ -172,7 +172,7 @@ class AzureNodeDriverTests(LibcloudTestCase):
         AzureMockHttp.responses = [
             # 202 - The delete will happen asynchronously
             lambda f: error(BaseHTTPError, code=202, message='Deleting'),
-            # 404 means node destroyed successfully
+            # 404 means node is gone
             lambda f: error(BaseHTTPError, code=404, message='Not found'),
         ]
         ret = self.driver.destroy_node(node)
@@ -186,8 +186,8 @@ class AzureNodeDriverTests(LibcloudTestCase):
         AzureMockHttp.responses = [
             # OK to the DELETE request
             lambda f: (httplib.OK, None, {}, 'OK'),
-            # 404 means node destroyed successfully
-            lambda f: error(BaseHTTPError, code=404, message='Not found'),
+            # 204 means node destroyed successfully
+            lambda f: error(BaseHTTPError, code=204, message='No content'),
             # 500 - transient error when trying to clean up the NIC
             lambda f: error(BaseHTTPError, code=500, message="Cloud weather"),
         ]


### PR DESCRIPTION
## Fix api version used to list and delete NICs.

### Description

Adds ex_destroy_nic.

Also adjust codes to reflect that Azure returns 204 when attempting to destroy
a resource that doesn't exist.

### Status

done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
