### PR TITLE
add ex_enable_ipv6 in DigitalOcean_v2 driver

### DIFF
--- a/libcloud/compute/drivers/digitalocean.py
+++ b/libcloud/compute/drivers/digitalocean.py
@@ -250,6 +250,12 @@ class DigitalOcean_v2_NodeDriver(DigitalOcean_v2_BaseDriver,
                                       data=json.dumps(attr), method='POST')
         return res.status == httplib.CREATED
 
+    def ex_enable_ipv6(self, node):
+        attr = {'type': 'enable_ipv6'}
+        res = self.connection.request('/v2/droplets/%s/actions' % (node.id),
+                                      data=json.dumps(attr), method='POST')
+        return res.status == httplib.CREATED
+
     def ex_rename_node(self, node, name):
         attr = {'type': 'rename', 'name': name}
         res = self.connection.request('/v2/droplets/%s/actions' % (node.id),

--- a/libcloud/test/compute/fixtures/digitalocean_v2/ex_enable_ipv6.json
+++ b/libcloud/test/compute/fixtures/digitalocean_v2/ex_enable_ipv6.json
@@ -1,0 +1,13 @@
+{
+  "action": {
+    "id": 36804954,
+    "status": "in-progress",
+    "type": "enable_ipv6",
+    "started_at": "2014-11-14T16:34:24Z",
+    "completed_at": null,
+    "resource_id": 3164450,
+    "resource_type": "droplet",
+    "region": "ams2",
+    "region_slug": "ams2"
+  }
+}

--- a/libcloud/test/compute/test_digitalocean_v2.py
+++ b/libcloud/test/compute/test_digitalocean_v2.py
@@ -166,6 +166,12 @@ class DigitalOcean_v2_Tests(LibcloudTestCase):
         result = self.driver.ex_change_kernel(node, 7515)
         self.assertTrue(result)
 
+    def test_ex_enable_ipv6_success(self):
+        node = self.driver.list_nodes()[0]
+        DigitalOceanMockHttp.type = 'ENABLEIPV6'
+        result = self.driver.ex_enable_ipv6(node)
+        self.assertTrue(result)
+
     def test_ex_rename_node_success(self):
         node = self.driver.list_nodes()[0]
         DigitalOceanMockHttp.type = 'RENAME'
@@ -310,6 +316,11 @@ class DigitalOceanMockHttp(MockHttp):
     def _v2_droplets_3164444_actions_KERNELCHANGE(self, method, url, body, headers):
         # change_kernel
         body = self.fixtures.load('ex_change_kernel.json')
+        return (httplib.CREATED, body, {}, httplib.responses[httplib.CREATED])
+
+    def _v2_droplets_3164444_actions_ENABLEIPV6(self, method, url, body, headers):
+        # enable_ipv6
+        body = self.fixtures.load('ex_enable_ipv6.json')
         return (httplib.CREATED, body, {}, httplib.responses[httplib.CREATED])
 
     def _v2_droplets_3164444_actions_RENAME(self, method, url, body, headers):


### PR DESCRIPTION
### add ex_enable_ipv6 in DigitalOcean_v2 driver
#### So ipv6 can be enabled on a Droplet using the API

> To enable IPv6 networking on an existing Droplet (within a region that has IPv6 available), send
> a POST request to /v2/droplets/$DROPLET_ID/actions. Set the "type" attribute to enable_ipv6.

https://developers.digitalocean.com/documentation/v2/#enable-ipv6