### PR TITLE
Ensure RawResponse downloads don't consume RAM

### DIFF
--- a/libcloud/common/base.py
+++ b/libcloud/common/base.py
@@ -278,10 +278,13 @@ class RawResponse(Response):
         if not self._response:
             response = self.connection.connection.getresponse()
             self._response = HttpLibResponseProxy(response)
-            self.body = response.content
             if not self.success():
                 self.parse_error()
         return self._response
+
+    @property
+    def body(self):
+        return self.response.body
 
     @property
     def reason(self):
@@ -587,6 +590,7 @@ class Connection(object):
                     url=url,
                     body=data,
                     headers=headers,
+                    raw=raw,
                     stream=stream)
             else:
                 if retry_enabled:

--- a/libcloud/http.py
+++ b/libcloud/http.py
@@ -319,3 +319,7 @@ class HttpLibResponseProxy(object):
     def version(self):
         # requests doesn't expose this
         return '11'
+
+    @property
+    def body(self):
+        return self._response.content


### PR DESCRIPTION

## Ensure RawResponse downloads don't consume RAM

The fix is general but the cause is very specific: since libcloud 2.0, `download_object()` in the S3 and GCS drivers first places the item in RAM, then writes it to a file. The main reason it broke is that accessing `body` in a requests Response consumes it entirely and loads it in RAM. To fix this, I moved `body` to a property: it is still accessibly, but loaded only if requested.

Tested this change by downloading a 38M file using this code:

```
from libcloud.storage.drivers.google_storage import GoogleStorageDriver

driver = GoogleStorageDriver(key=..., secret=...)
obj = driver.get_object('container_name', 'object_name')
driver.download_object(obj, '/path/to/file')
```

The RAM usage before:

![before](https://user-images.githubusercontent.com/42327/31609057-b172a3f0-b283-11e7-9108-2964978bbcd2.png)

The RAM usage after:

![after](https://user-images.githubusercontent.com/42327/31609063-b846db1a-b283-11e7-97ed-1e6ce365a41b.png)


### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)