### PR TITLE
Fix improper getresponse() uses

### DIFF
--- a/libcloud/common/brightbox.py
+++ b/libcloud/common/brightbox.py
@@ -78,12 +78,11 @@ class BrightboxConnection(ConnectionUserAndKey):
         response = self.connection.request(method='POST', url='/token',
                                            body=body, headers=headers)
 
-        response = self.connection.getresponse()
-
         if response.status == httplib.OK:
             return json.loads(response.read())['access_token']
         else:
-            responseCls = BrightboxResponse(response=response, connection=self)
+            responseCls = BrightboxResponse(
+                response=response.getresponse(), connection=self)
             message = responseCls.parse_error()
             raise InvalidCredsError(message)
 

--- a/libcloud/common/ovh.py
+++ b/libcloud/common/ovh.py
@@ -104,13 +104,12 @@ class OvhConnection(ConnectionUserAndKey):
         }
         httpcon = LibcloudConnection(host=self.host, port=443)
         httpcon.request(method='POST', url=action, body=data, headers=headers)
-        response = httpcon.getresponse()
+        response = JsonResponse(httpcon.getresponse(), httpcon)
 
         if response.status == httplib.UNAUTHORIZED:
             raise InvalidCredsError()
 
-        body = response.read()
-        json_response = json.loads(body)
+        json_response = response.parse_body()
         httpcon.close()
         return json_response
 


### PR DESCRIPTION
## Fix improper getresponse() uses

### Description

During the migration from httplib to requests, a lot of driver code did not change because they use the high-level libcloud API which hid the change from httplib to requests with the HttpLibResponseProxy adapter. However, in some cases, driver code needs to access the actual response, and does this by calling getresponse().

While this used to return an httlib.HTTPResponse instance, this now returns a requests.Response instance. All code covered by tests was fixed, but OVH and Brightbox common code is not fully covered. I don't have a subscription to either service and can't test the change, but the resulting code can only be more correct since it fixes the `getresponse() result comes from httplib` assumption.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
