### PR TITLE
storage: Fix hash computation performance on upload

### DIFF
--- a/libcloud/storage/base.py
+++ b/libcloud/storage/base.py
@@ -643,9 +643,9 @@ class StorageDriver(BaseDriver):
     def _hash_buffered_stream(self, stream, hasher, blocksize=65536):
         total_len = 0
         if hasattr(stream, '__next__'):
-            data = libcloud.utils.files.exhaust_iterator(iterator=stream)
-            hasher.update(b(data))
-            total_len = len(data)
+            for chunk in libcloud.utils.files.read_in_chunks(iterator=stream):
+                hasher.update(b(chunk))
+                total_len += len(chunk)
             return (hasher.hexdigest(), total_len)
         if not hasattr(stream, '__exit__'):
             for s in stream:


### PR DESCRIPTION
## storage: Fix hash computation performance on upload

### Description

The storage base driver computes the hash of uploaded files: individual drivers use it to ensure the reported hash is correct. Before libcloud 2.x, this was done efficiently: the file was only read once, and we were using `hash.update()` to avoid keeping the whole file in memory. With the switch to the requests module, both of these optimizations were removed inadvertently. It turns out the important one is using `hash.update()`: computing the hash on the whole file in memory is orders of magnitude slower.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)