### PR TITLE
Azure ARM fix delete_old_vhd

### DIFF
--- a/libcloud/common/azure.py
+++ b/libcloud/common/azure.py
@@ -193,6 +193,10 @@ class AzureConnection(ConnectionUserAndKey):
             header = header.lower()  # Just for safety
             if header in headers_copy:
                 special_header_values.append(headers_copy[header])
+            elif header == "content-length" and method != "GET":
+                # Must be '0' unless method is GET
+                # https://docs.microsoft.com/en-us/rest/api/storageservices/authentication-for-the-azure-storage-services
+                special_header_values.append('0')
             else:
                 special_header_values.append('')
 

--- a/libcloud/common/azure.py
+++ b/libcloud/common/azure.py
@@ -193,8 +193,8 @@ class AzureConnection(ConnectionUserAndKey):
             header = header.lower()  # Just for safety
             if header in headers_copy:
                 special_header_values.append(headers_copy[header])
-            elif header == "content-length" and method != "GET":
-                # Must be '0' unless method is GET
+            elif header == "content-length" and method not in ("GET", "HEAD"):
+                # Must be '0' unless method is GET or HEAD
                 # https://docs.microsoft.com/en-us/rest/api/storageservices/authentication-for-the-azure-storage-services
                 special_header_values.append('0')
             else:

--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -1948,8 +1948,9 @@ class AzureNodeDriver(NodeDriver):
                 keys["key1"],
                 host="%s.blob%s" % (storageAccount,
                                     self.connection.storage_suffix))
-            return blobdriver.delete_object(blobdriver.get_object(blobContainer,
-                                                           blob))
+            return blobdriver.delete_object(
+                blobdriver.get_object(blobContainer,
+                                      blob))
         except ObjectDoesNotExistError:
             return True
 

--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -2088,12 +2088,16 @@ class AzureNodeDriver(NodeDriver):
                                   name,
                                   n)
                 if self._ex_delete_old_vhd(ex_resource_group, instance_vhd):
-                    # We were able to remove it or it doesn't exist, so we can use it.
+                    # We were able to remove it or it doesn't exist,
+                    # so we can use it.
                     return instance_vhd
             except LibcloudError as lce:
                 errors.append(str(lce))
             n += 1
-        raise LibcloudError("Unable to find a name for a VHD to use for instance in 10 tries, errors were:\n  - %s" % ("\n  - ".join(errors)))
+        raise LibcloudError("Unable to find a name for a VHD to use for "
+                            "instance in 10 tries, errors were:\n  - %s" %
+                            ("\n  - ".join(errors)))
+
 
 def _split_blob_uri(uri):
     uri = uri.split('/')


### PR DESCRIPTION
Azure ARM fix delete_old_vhd

### Description

Fix delete_old_vhd:

* Returns "False" on failure instead of raising an exception (which was what it had expected) so now checks the return code
* Fix longstanding bug in AzureConnection for non-GET requests that don't include a Content-Length header (affects delete_object()).

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
