### PR TITLE
Retry-After header handling fixes

### DIFF
--- a/libcloud/common/base.py
+++ b/libcloud/common/base.py
@@ -154,7 +154,8 @@ class Response(object):
 
         if not self.success():
             raise exception_from_message(code=self.status,
-                                         message=self.parse_error())
+                                         message=self.parse_error(),
+                                         headers=self.headers)
 
         self.object = self.parse_body()
 

--- a/libcloud/common/exceptions.py
+++ b/libcloud/common/exceptions.py
@@ -51,7 +51,14 @@ class RateLimitReachedError(BaseHTTPError):
     message = '%s Rate limit exceeded' % (code)
 
     def __init__(self, *args, **kwargs):
-        self.retry_after = int(kwargs.pop('headers', {}).get('retry-after', 0))
+        headers = kwargs.pop('headers', None)
+        super(RateLimitReachedError, self).__init__(self.code,
+                                                    self.message,
+                                                    headers)
+        if self.headers is not None:
+            self.retry_after = int(self.headers.get('retry-after', 0))
+        else:
+            self.retry_after = 0
 
 
 _error_classes = [RateLimitReachedError]
@@ -62,9 +69,22 @@ def exception_from_message(code, message, headers=None):
     """
     Return an instance of BaseHTTPException or subclass based on response code.
 
+    If headers include Retry-After, RFC 2616 says that its value may be one of
+    two formats: HTTP-date or delta-seconds, for example:
+
+    Retry-After: Fri, 31 Dec 1999 23:59:59 GMT
+    Retry-After: 120
+
+    If Retry-After comes in HTTP-date, it'll be translated to a positive
+    delta-seconds value when passing it to the exception constructor.
+
+    Also, RFC 2616 says that Retry-After isn't just only applicable to 429
+    HTTP status, but also to other responses, like 503 and 3xx.
+
     Usage::
         raise exception_from_message(code=self.status,
-                                     message=self.parse_error())
+                                     message=self.parse_error(),
+                                     headers=self.headers)
     """
     kwargs = {
         'code': code,

--- a/libcloud/test/common/test_base.py
+++ b/libcloud/test/common/test_base.py
@@ -18,7 +18,8 @@ import sys
 
 import mock
 
-from libcloud.common.base import LazyObject
+from libcloud.common.base import LazyObject, Response
+from libcloud.common.exceptions import BaseHTTPError, RateLimitReachedError
 from libcloud.test import LibcloudTestCase
 
 
@@ -53,6 +54,56 @@ class LazyObjectTest(LibcloudTestCase):
         wrapped_lazy_obj = object.__getattribute__(a, '_lazy_obj')
         self.assertEqual(a.z, 'baz')
         self.assertEqual(wrapped_lazy_obj.z, 'baz')
+
+
+class ErrorResponseTest(LibcloudTestCase):
+    def mock_response(self, code, headers={}):
+        m = mock.MagicMock()
+        m.request = mock.Mock()
+        m.headers = headers
+        m.status_code = code
+        m.text = None
+        return m
+
+    def test_rate_limit_response(self):
+        resp_mock = self.mock_response(429, {'Retry-After': '120'})
+        try:
+            Response(resp_mock, mock.MagicMock())
+        except RateLimitReachedError as e:
+            self.assertEqual(e.retry_after, 120)
+        except:
+            # We should have got a RateLimitReachedError
+            self.fail("Catched exception should have been RateLimitReachedError")
+        else:
+            # We should have got an exception
+            self.fail("HTTP Status 429 response didn't raised an exception")
+
+    def test_error_with_retry_after(self):
+        # 503 Service Unavailable may include Retry-After header
+        resp_mock = self.mock_response(503, {'Retry-After': '300'})
+        try:
+            Response(resp_mock, mock.MagicMock())
+        except BaseHTTPError as e:
+            self.assertIn('retry-after', e.headers)
+            self.assertEqual(e.headers['retry-after'], '300')
+        else:
+            # We should have got an exception
+            self.fail("HTTP Status 503 response didn't raised an exception")
+
+    @mock.patch('time.time', return_value=1231006505)
+    def test_error_with_retry_after_http_date_format(self, time_mock):
+        retry_after = 'Sat, 03 Jan 2009 18:20:05 -0000'
+        # 503 Service Unavailable may include Retry-After header
+        resp_mock = self.mock_response(503, {'Retry-After': retry_after})
+        try:
+            Response(resp_mock, mock.MagicMock())
+        except BaseHTTPError as e:
+            self.assertIn('retry-after', e.headers)
+            # HTTP-date got translated to delay-secs
+            self.assertEqual(e.headers['retry-after'], '300')
+        else:
+            # We should have got an exception
+            self.fail("HTTP Status 503 response didn't raised an exception")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Retry-After header handling fixes

### Description

* Pass response headers to exception_from_message() when receiving an error response.
* Pass Retry-After header to BaseHTTPException, some other errors than 429 may include it. (Example: 503 Service Unavailable)
* Retry-After header may include an HTTP-date value, so check if that's the case and if so, translate it to a delay seconds value.
* Added tests.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [X] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [X] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)