### PR TITLE
Aliyun ECS: Add support to modify attributes of security group

### DIFF
--- a/libcloud/compute/drivers/ecs.py
+++ b/libcloud/compute/drivers/ecs.py
@@ -820,38 +820,6 @@ class ECSDriver(NodeDriver):
         resp = self.connection.request(self.path, params)
         return resp.success()
 
-    def ex_modify_security_group_by_id(
-            self,
-            group_id=None,
-            name=None,
-            description=None):
-        """
-        Modify a new security group.
-
-        :keyword group_id: id of the security group
-        :type group_id: ``str``
-
-        :keyword name: new name of the security group
-        :type name: ``unicode``
-
-        :keyword description: new description of the security group
-        :type description: ``unicode``
-        """
-
-        params = {'Action': 'ModifySecurityGroupAttribute',
-                  'RegionId': self.region}
-        if not group_id:
-            raise AttributeError('group_id is required')
-        params["SecurityGroupId"] = group_id
-
-        if name:
-            params["SecurityGroupName"] = name
-        if description:
-            params["Description"] = description
-
-        resp = self.connection.request(self.path, params)
-        return resp.success()
-
     def ex_list_security_groups(self, ex_filters=None):
         """
         List security groups in the current region.

--- a/libcloud/compute/drivers/ecs.py
+++ b/libcloud/compute/drivers/ecs.py
@@ -820,7 +820,11 @@ class ECSDriver(NodeDriver):
         resp = self.connection.request(self.path, params)
         return resp.success()
 
-    def ex_modify_security_group_by_id(self, group_id=None, name=None, description=None):
+    def ex_modify_security_group_by_id(
+            self,
+            group_id=None,
+            name=None,
+            description=None):
         """
         Modify a new security group.
 
@@ -829,22 +833,22 @@ class ECSDriver(NodeDriver):
 
         :keyword name: new name of the security group
         :type name: ``unicode``
-        
+
         :keyword description: new description of the security group
         :type description: ``unicode``
         """
-        
+
         params = {'Action': 'ModifySecurityGroupAttribute',
                   'RegionId': self.region}
         if not group_id:
-            raise AttributeError('group_id is required') 
+            raise AttributeError('group_id is required')
         params["SecurityGroupId"] = group_id
-       
+
         if name:
             params["SecurityGroupName"] = name
         if description:
             params["Description"] = description
-        
+
         resp = self.connection.request(self.path, params)
         return resp.success()
 

--- a/libcloud/compute/drivers/ecs.py
+++ b/libcloud/compute/drivers/ecs.py
@@ -820,6 +820,34 @@ class ECSDriver(NodeDriver):
         resp = self.connection.request(self.path, params)
         return resp.success()
 
+    def ex_modify_security_group_by_id(self, group_id=None, name=None, description=None):
+        """
+        Modify a new security group.
+
+        :keyword group_id: id of the security group
+        :type group_id: ``str``
+
+        :keyword name: new name of the security group
+        :type name: ``unicode``
+        
+        :keyword description: new description of the security group
+        :type description: ``unicode``
+        """
+        
+        params = {'Action': 'ModifySecurityGroupAttribute',
+                  'RegionId': self.region}
+        if not group_id:
+            raise AttributeError('group_id is required') 
+        params["SecurityGroupId"] = group_id
+       
+        if name:
+            params["SecurityGroupName"] = name
+        if description:
+            params["Description"] = description
+        
+        resp = self.connection.request(self.path, params)
+        return resp.success()
+
     def ex_list_security_groups(self, ex_filters=None):
         """
         List security groups in the current region.

--- a/libcloud/compute/drivers/ecs.py
+++ b/libcloud/compute/drivers/ecs.py
@@ -820,6 +820,38 @@ class ECSDriver(NodeDriver):
         resp = self.connection.request(self.path, params)
         return resp.success()
 
+    def ex_modify_security_group_by_id(
+            self,
+            group_id=None,
+            name=None,
+            description=None):
+        """
+        Modify a new security group.
+
+        :keyword group_id: id of the security group
+        :type group_id: ``str``
+
+        :keyword name: new name of the security group
+        :type name: ``unicode``
+
+        :keyword description: new description of the security group
+        :type description: ``unicode``
+        """
+
+        params = {'Action': 'ModifySecurityGroupAttribute',
+                  'RegionId': self.region}
+        if not group_id:
+            raise AttributeError('group_id is required')
+        params["SecurityGroupId"] = group_id
+
+        if name:
+            params["SecurityGroupName"] = name
+        if description:
+            params["Description"] = description
+
+        resp = self.connection.request(self.path, params)
+        return resp.success()
+
     def ex_list_security_groups(self, ex_filters=None):
         """
         List security groups in the current region.

--- a/libcloud/test/compute/fixtures/ecs/delete_security_group_by_id.xml
+++ b/libcloud/test/compute/fixtures/ecs/delete_security_group_by_id.xml
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <DeleteSecurityGroupResponse>
-	<RequestId>CEF72CEB-54B6-4AE8-B225-F876FF7BA984</RquestID>
+	<RequestId>CEF72CEB-54B6-4AE8-B225-F876FF7BA984</RequestId>
 </DeleteSecurityGroupResponse>

--- a/libcloud/test/compute/fixtures/ecs/delete_security_group_by_id.xml
+++ b/libcloud/test/compute/fixtures/ecs/delete_security_group_by_id.xml
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <DeleteSecurityGroupResponse>
-	<RequestId>CEF72CEB-54B6-4AE8-B225-F876FF7BA984</RquestId>
+	<RequestId>CEF72CEB-54B6-4AE8-B225-F876FF7BA984</RquestID>
 </DeleteSecurityGroupResponse>

--- a/libcloud/test/compute/fixtures/ecs/delete_security_group_by_id.xml
+++ b/libcloud/test/compute/fixtures/ecs/delete_security_group_by_id.xml
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <DeleteSecurityGroupResponse>
-	<RequestId>CEF72CEB-54B6-4AE8-B225-F876FF7BA984</RquestID>
+	<RequestId>CEF72CEB-54B6-4AE8-B225-F876FF7BA984</RquestId>
 </DeleteSecurityGroupResponse>

--- a/libcloud/test/compute/fixtures/ecs/describe_security_group_attributes.xml
+++ b/libcloud/test/compute/fixtures/ecs/describe_security_group_attributes.xml
@@ -1,26 +1,30 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<DescribeSecurityGroupsResponse>
-	<RequestId>94D38899-626D-434A-891F-7E1F77A81525</RequestId>
-	<TotalCount>4</TotalCount>
-	<PageNumber>1</PageNumber>
-	<PageSize>10</PageSize>
-	<RegionId>cn-hangzhou </RegionId>
-	<SecurityGroups>
-		<SecurityGroup>
-			<SecurityGroupId>sg-F876FF7BA</SecurityGroupId>
-			<Description>Test</Description>
-		</SecurityGroup>
-		<SecurityGroup>
-			<SecurityGroupId>sg-086FFC27A</SecurityGroupId>
-			<Description>test00212</Description>
-		</SecurityGroup>
-		<SecurityGroup>
-			<SecurityGroupId>sg-BA4B7975B</SecurityGroupId>
-			<Description>cn-hangzhou test group</Description>
-		</SecurityGroup>
-		<SecurityGroup>
-			<SecurityGroupId>sg-35F20777C</SecurityGroupId>
-			<Description>cn-hangzhou test group</Description>
-		</SecurityGroup>
-	</SecurityGroups>
-</DescribeSecurityGroupsResponse>
+<DescribeSecurityGroupAttributeResponse>
+	<SecurityGroupId>sg-m5e5vyj2j0atm2gewww4</SecurityGroupId>
+	<InnerAccessPolicy>Accept</InnerAccessPolicy>
+	<SecurityGroupName>sg-m5e5vyj2j0atm2gewww4</SecurityGroupName>
+	<Description>System created security group.</Description>
+	<RegionId>cn-qingdao</RegionId>
+	<RequestId>8A3E0262-EEA1-4961-A403-3D6E69F3539C</RequestId>
+	<Permissions>
+		<Permission>
+			<SourceCidrIp>121.43.18.0/24</SourceCidrIp>
+			<DestCidrIp></DestCidrIp>
+			<Description></Description>
+			<NicType>internet</NicType>
+			<DestGroupName></DestGroupName>
+			<PortRange>-1/-1</PortRange>
+			<DestGroupId></DestGroupId>
+			<Direction>ingress</Direction>
+			<Priority>1</Priority>
+			<IpProtocol>ALL</IpProtocol>
+			<SourceGroupOwnerAccount></SourceGroupOwnerAccount>
+			<Policy>Accept</Policy>
+			<CreateTime>2017-07-08T06:20:39Z</CreateTime>
+			<SourceGroupId></SourceGroupId>
+			<DestGroupOwnerAccount></DestGroupOwnerAccount>
+			<SourceGroupName></SourceGroupName>
+		</Permission>
+	</Permissions>
+	<VpcId></VpcId>
+</DescribeSecurityGroupAttributeResponse>

--- a/libcloud/test/compute/fixtures/ecs/describe_security_group_attributes.xml
+++ b/libcloud/test/compute/fixtures/ecs/describe_security_group_attributes.xml
@@ -1,30 +1,26 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<DescribeSecurityGroupAttributeResponse>
-	<SecurityGroupId>sg-m5e5vyj2j0atm2gewww4</SecurityGroupId>
-	<InnerAccessPolicy>Accept</InnerAccessPolicy>
-	<SecurityGroupName>sg-m5e5vyj2j0atm2gewww4</SecurityGroupName>
-	<Description>System created security group.</Description>
-	<RegionId>cn-qingdao</RegionId>
-	<RequestId>8A3E0262-EEA1-4961-A403-3D6E69F3539C</RequestId>
-	<Permissions>
-		<Permission>
-			<SourceCidrIp>121.43.18.0/24</SourceCidrIp>
-			<DestCidrIp></DestCidrIp>
-			<Description></Description>
-			<NicType>internet</NicType>
-			<DestGroupName></DestGroupName>
-			<PortRange>-1/-1</PortRange>
-			<DestGroupId></DestGroupId>
-			<Direction>ingress</Direction>
-			<Priority>1</Priority>
-			<IpProtocol>ALL</IpProtocol>
-			<SourceGroupOwnerAccount></SourceGroupOwnerAccount>
-			<Policy>Accept</Policy>
-			<CreateTime>2017-07-08T06:20:39Z</CreateTime>
-			<SourceGroupId></SourceGroupId>
-			<DestGroupOwnerAccount></DestGroupOwnerAccount>
-			<SourceGroupName></SourceGroupName>
-		</Permission>
-	</Permissions>
-	<VpcId></VpcId>
-</DescribeSecurityGroupAttributeResponse>
+<DescribeSecurityGroupsResponse>
+	<RequestId>94D38899-626D-434A-891F-7E1F77A81525</RequestId>
+	<TotalCount>4</TotalCount>
+	<PageNumber>1</PageNumber>
+	<PageSize>10</PageSize>
+	<RegionId>cn-hangzhou </RegionId>
+	<SecurityGroups>
+		<SecurityGroup>
+			<SecurityGroupId>sg-F876FF7BA</SecurityGroupId>
+			<Description>Test</Description>
+		</SecurityGroup>
+		<SecurityGroup>
+			<SecurityGroupId>sg-086FFC27A</SecurityGroupId>
+			<Description>test00212</Description>
+		</SecurityGroup>
+		<SecurityGroup>
+			<SecurityGroupId>sg-BA4B7975B</SecurityGroupId>
+			<Description>cn-hangzhou test group</Description>
+		</SecurityGroup>
+		<SecurityGroup>
+			<SecurityGroupId>sg-35F20777C</SecurityGroupId>
+			<Description>cn-hangzhou test group</Description>
+		</SecurityGroup>
+	</SecurityGroups>
+</DescribeSecurityGroupsResponse>

--- a/libcloud/test/compute/fixtures/ecs/describe_security_group_attributes.xml
+++ b/libcloud/test/compute/fixtures/ecs/describe_security_group_attributes.xml
@@ -9,10 +9,10 @@
 	<Permissions>
 		<Permission>
 			<SourceCidrIp>121.43.18.0/24</SourceCidrIp>
-			<DestCidrIp></DestCidrIp/>
+			<DestCidrIp></DestCidrIp>
 			<Description></Description>
 			<NicType>internet</NicType>
-			<DestGroupName></DestGroupName/>
+			<DestGroupName></DestGroupName>
 			<PortRange>-1/-1</PortRange>
 			<DestGroupId></DestGroupId>
 			<Direction>ingress</Direction>

--- a/libcloud/test/compute/fixtures/ecs/describe_security_group_attributes.xml
+++ b/libcloud/test/compute/fixtures/ecs/describe_security_group_attributes.xml
@@ -1,26 +1,30 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<DescribeSecurityGroupsResponse>
-	<RequestId>94D38899-626D-434A-891F-7E1F77A81525</RequestId>
-	<TotalCount>4</TotalCount>
-	<PageNumber>1</PageNumber>
-	<PageSize>10</PageSize>
-	<RegionId>cn-hangzhou </RegionId>
-	<SecurityGroups>
-		<SecurityGroup>
-			<SecurityGroupId>sg-F876FF7BA</SecurityGroupId>
-			<Description>Test</Description>
-		</SecurityGroup>
-		<SecurityGroup>
-			<SecurityGroupId>sg-086FFC27A</SecurityGroupId>
-			<Description>test00212</Description>
-		</SecurityGroup>
-		<SecurityGroup>
-			<SecurityGroupId>sg-BA4B7975B</SecurityGroupId>
-			<Description>cn-hangzhou test group</Description>
-		</SecurityGroup>
-		<SecurityGroup>
-			<SecurityGroupId>sg-35F20777C</SecurityGroupId>
-			<Description>cn-hangzhou test group</Description>
-		</SecurityGroup>
-	</SecurityGroups>
-</DescribeSecurityGroupsResponse>
+<DescribeSecurityGroupAttributeResponse>
+	<SecurityGroupId>sg-m5e5vyj2j0atm2gewww4</SecurityGroupId>
+	<InnerAccessPolicy>Accept</InnerAccessPolicy>
+	<SecurityGroupName>sg-m5e5vyj2j0atm2gewww4</SecurityGroupName>
+	<Description>System created security group.</Description>
+	<RegionId>cn-qingdao</RegionId>
+	<RequestId>8A3E0262-EEA1-4961-A403-3D6E69F3539C</RequestId>
+	<Permissions>
+		<Permission>
+			<SourceCidrIp>121.43.18.0/24</SourceCidrIp>
+			<DestCidrIp></DestCidrIp/>
+			<Description></Description>
+			<NicType>internet</NicType>
+			<DestGroupName></DestGroupName/>
+			<PortRange>-1/-1</PortRange>
+			<DestGroupId></DestGroupId>
+			<Direction>ingress</Direction>
+			<Priority>1</Priority>
+			<IpProtocol>ALL</IpProtocol>
+			<SourceGroupOwnerAccount></SourceGroupOwnerAccount>
+			<Policy>Accept</Policy>
+			<CreateTime>2017-07-08T06:20:39Z</CreateTime>
+			<SourceGroupId></SourceGroupId>
+			<DestGroupOwnerAccount></DestGroupOwnerAccount>
+			<SourceGroupName></SourceGroupName>
+		</Permission>
+	</Permissions>
+	<VpcId></VpcId>
+</DescribeSecurityGroupAttributeResponse>

--- a/libcloud/test/compute/fixtures/ecs/modify_security_group_by_id.xml
+++ b/libcloud/test/compute/fixtures/ecs/modify_security_group_by_id.xml
@@ -1,4 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<ModifySecurityGroupAttributeResponse>
-     <RequestId>CEF72CEB-54B6-4AE8-B225-F876FF7BA984</RequestId>
-</ModifySecurityGroupAttributeResponse>

--- a/libcloud/test/compute/fixtures/ecs/modify_security_group_by_id.xml
+++ b/libcloud/test/compute/fixtures/ecs/modify_security_group_by_id.xml
@@ -1,0 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ModifySecurityGroupAttributeResponse>
+     <RequestId>CEF72CEB-54B6-4AE8-B225-F876FF7BA984</RequestId>
+</ModifySecurityGroupAttributeResponse>

--- a/libcloud/test/compute/test_ecs.py
+++ b/libcloud/test/compute/test_ecs.py
@@ -942,6 +942,14 @@ class ECSMockHttp(MockHttp):
         self.assertUrlContainsQueryParams(url, params)
         resp_body = self.fixtures.load('delete_security_group_by_id.xml')
         return (httplib.OK, resp_body, {}, httplib.responses[httplib.OK])
+    
+    def _modify_sg_by_id_ModifySecurityGroup(self, method, url, body, headers):
+        params = {'RegionId': self.test.region,
+                  'SecurityGroupId': 'sg-fakeSecurityGroupId'}
+        self.assertUrlContainsQueryParams(url, params)
+        resp_body = self.fixtures.load('modify_security_group_by_id.xml')
+        return (httplib.OK, resp_body, {}, httplib.responses[httplib.OK])
+
 
     def _list_sgas_DescribeSecurityGroupAttributes(self, method, url, body, headers):
         params = {'RegionId': self.test.region,

--- a/libcloud/test/compute/test_ecs.py
+++ b/libcloud/test/compute/test_ecs.py
@@ -943,6 +943,15 @@ class ECSMockHttp(MockHttp):
         resp_body = self.fixtures.load('delete_security_group_by_id.xml')
         return (httplib.OK, resp_body, {}, httplib.responses[httplib.OK])
 
+    def _modify_sg_by_id_ModifySecurityGroup(self, method, url, body, headers):
+        params = {'RegionId': self.test.region,
+                  'SecurityGroupId': 'sg-fakeSecurityGroupId',
+                  'SecurityGroupName': 'sg-fakeSecurityName',
+                  'Description': 'sg-fakeSecurityDescription'}
+        self.assertUrlContainsQueryParams(url, params)
+        resp_body = self.fixtures.load('modify_security_group_by_id.xml')
+        return (httplib.OK, resp_body, {}, httplib.responses[httplib.OK])
+
     def _list_sgas_DescribeSecurityGroupAttributes(self, method, url, body, headers):
         params = {'RegionId': self.test.region,
                   'SecurityGroupId': 'sg-fakeSecurityGroupId',

--- a/libcloud/test/compute/test_ecs.py
+++ b/libcloud/test/compute/test_ecs.py
@@ -943,15 +943,6 @@ class ECSMockHttp(MockHttp):
         resp_body = self.fixtures.load('delete_security_group_by_id.xml')
         return (httplib.OK, resp_body, {}, httplib.responses[httplib.OK])
 
-    def _modify_sg_by_id_ModifySecurityGroup(self, method, url, body, headers):
-        params = {'RegionId': self.test.region,
-                  'SecurityGroupId': 'sg-fakeSecurityGroupId',
-                  'SecurityGroupName': 'sg-fakeSecurityName',
-                  'Description': 'sg-fakeSecurityDescription'}
-        self.assertUrlContainsQueryParams(url, params)
-        resp_body = self.fixtures.load('modify_security_group_by_id.xml')
-        return (httplib.OK, resp_body, {}, httplib.responses[httplib.OK])
-
     def _list_sgas_DescribeSecurityGroupAttributes(self, method, url, body, headers):
         params = {'RegionId': self.test.region,
                   'SecurityGroupId': 'sg-fakeSecurityGroupId',

--- a/libcloud/test/compute/test_ecs.py
+++ b/libcloud/test/compute/test_ecs.py
@@ -942,14 +942,15 @@ class ECSMockHttp(MockHttp):
         self.assertUrlContainsQueryParams(url, params)
         resp_body = self.fixtures.load('delete_security_group_by_id.xml')
         return (httplib.OK, resp_body, {}, httplib.responses[httplib.OK])
-    
+
     def _modify_sg_by_id_ModifySecurityGroup(self, method, url, body, headers):
         params = {'RegionId': self.test.region,
-                  'SecurityGroupId': 'sg-fakeSecurityGroupId'}
+                  'SecurityGroupId': 'sg-fakeSecurityGroupId',
+                  'SecurityGroupName': 'sg-fakeSecurityName',
+                  'Description': 'sg-fakeSecurityDescription'}
         self.assertUrlContainsQueryParams(url, params)
         resp_body = self.fixtures.load('modify_security_group_by_id.xml')
         return (httplib.OK, resp_body, {}, httplib.responses[httplib.OK])
-
 
     def _list_sgas_DescribeSecurityGroupAttributes(self, method, url, body, headers):
         params = {'RegionId': self.test.region,


### PR DESCRIPTION
## Aliyun ECS: Add support to modify attributes of security group

### Description

- [describe_security_group_attributes.xml](https://github.com/apache/libcloud/blob/trunk/libcloud/test/compute/fixtures/ecs/describe_security_group_attributes.xml) doesn't match its title.
- Can't modify security group name or description via ECS driver currently

Reference: 
[Aliyun API Doc - DescribeSecurityGroupAttribute](https://help.aliyun.com/document_detail/25555.html?spm=5176.doc25556.6.893.9yP6oY)
[Aliyun API Doc - ModifySecurityGroupAttribute](https://help.aliyun.com/document_detail/25559.html?spm=5176.doc25555.6.897.J4hUYN)

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
