### PR TITLE
cloudstack: nics can have no addresses

### DIFF
--- a/libcloud/compute/drivers/cloudstack.py
+++ b/libcloud/compute/drivers/cloudstack.py
@@ -4648,6 +4648,8 @@ class CloudStackNodeDriver(CloudStackDriverMixIn, NodeDriver):
         private_ips = []
 
         for nic in data['nic']:
+            if 'ipaddress' not in nic:
+                continue
             if is_private_subnet(nic['ipaddress']):
                 private_ips.append(nic['ipaddress'])
             else:

--- a/libcloud/test/compute/fixtures/cloudstack/listVirtualMachines_noipaddress.json
+++ b/libcloud/test/compute/fixtures/cloudstack/listVirtualMachines_noipaddress.json
@@ -1,0 +1,98 @@
+{
+    "listvirtualmachinesresponse" : {
+	"virtualmachine" : [
+	    {
+		"id":2600,
+		"name":"test",
+		"displayname":"test",
+		"account":"fakeaccount",
+		"domainid":801,
+		"domain":"AA000062-libcloud-dev",
+		"created":"2011-06-23T05:06:42+0000",
+		"state":"Running",
+		"haenable":false,
+		"zoneid":1,
+		"zonename":"Sydney",
+		"templateid":421,
+		"templatename":"XEN Basic Ubuntu 10.04 Server x64 PV r2.0",
+		"templatedisplaytext":"XEN Basic Ubuntu 10.04 Server x64 PV r2.0",
+		"passwordenabled":false,
+		"serviceofferingid":105,
+		"serviceofferingname":"Compute Micro PRD",
+		"cpunumber":1,
+		"cpuspeed":1200,
+		"memory":384,
+		"cpuused":"1.78%",
+		"networkkbsread":2,
+		"networkkbswrite":2,
+		"guestosid":12,
+		"rootdeviceid":0,
+		"rootdevicetype":"IscsiLUN",
+		"securitygroup":[],
+		"nic":[
+		    {
+			"id":3891,
+			"networkid":860,
+			"netmask":"255.255.240.0",
+			"gateway":"1.1.2.1",
+			"ipaddress":"1.1.1.116",
+			"traffictype":"Guest",
+			"type":"Virtual",
+			"isdefault":true
+		    },
+		    {
+			"id":3892,
+			"networkid":861,
+			"type":"Virtual",
+			"isdefault":false
+		    }
+		],
+		"hypervisor":"XenServer",
+		"tags": [
+		    {"key": "testkey", "value": "testvalue"},
+		    {"key": "foo", "value": "bar"}]
+	    },
+	    {
+		"id":2601,
+		"name":"test",
+		"displayname":"test",
+		"account":"fakeaccount",
+		"domainid":801,
+		"domain":"AA000062-libcloud-dev",
+		"created":"2011-06-23T05:09:44+0000",
+		"state":"Starting",
+		"haenable":false,
+		"zoneid":1,
+		"zonename":"Sydney",
+		"templateid":421,
+		"templatename":"XEN Basic Ubuntu 10.04 Server x64 PV r2.0",
+		"templatedisplaytext":"XEN Basic Ubuntu 10.04 Server x64 PV r2.0",
+		"passwordenabled":false,
+		"serviceofferingid":105,
+		"serviceofferingname": "Compute Micro PRD",
+		"cpunumber":1,
+		"cpuspeed":1200,
+		"memory":384,
+		"guestosid":12,
+		"rootdeviceid":0,
+		"rootdevicetype":"IscsiLUN",
+		"securitygroup":[],
+		"jobid":17147,
+		"jobstatus":0,
+		"nic":[
+		    {
+			"id":3892,
+			"networkid":860,
+			"netmask":"255.255.240.0",
+			"gateway":"1.1.2.1",
+			"ipaddress":"1.1.1.203",
+			"traffictype":"Guest",
+			"type":"Virtual",
+			"isdefault":true
+		    }
+		],
+		"hypervisor":"XenServer"
+	    }
+	]
+    }
+}

--- a/libcloud/test/compute/test_cloudstack.py
+++ b/libcloud/test/compute/test_cloudstack.py
@@ -649,6 +649,17 @@ class CloudStackCommonTestCase(TestCaseMixin):
         finally:
             del CloudStackMockHttp._cmd_listVirtualMachines
 
+    def test_list_nodes_noipaddress_filter(self):
+        def list_nodes_mock(self, **kwargs):
+            body, obj = self._load_fixture('listVirtualMachines_noipaddress.json')
+            return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+
+        CloudStackMockHttp._cmd_listVirtualMachines = list_nodes_mock
+        try:
+            self.driver.list_nodes()
+        finally:
+            del CloudStackMockHttp._cmd_listVirtualMachines
+
     def test_ex_get_node(self):
         node = self.driver.ex_get_node(2600)
         self.assertEqual('test', node.name)


### PR DESCRIPTION
## Cloudstack Driver: Handle NICs without addresses

### Description

In cloudstack, addresses may be devoid of addresses. Presence of the 'ipaddress' key in a nic
should thus not be assumed.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
