### PR TITLE
Add support for DigitalOcean Spaces AMS3 region.

### DIFF
--- a/libcloud/storage/drivers/digitalocean_spaces.py
+++ b/libcloud/storage/drivers/digitalocean_spaces.py
@@ -22,7 +22,8 @@ __all__ = [
     'DigitalOceanSpacesStorageDriver'
 ]
 
-DO_SPACES_HOSTS_BY_REGION = {'nyc3': 'nyc3.digitaloceanspaces.com'}
+DO_SPACES_HOSTS_BY_REGION = {'nyc3': 'nyc3.digitaloceanspaces.com',
+                             'ams3': 'ams3.digitaloceanspaces.com'}
 DO_SPACES_DEFAULT_REGION = 'nyc3'
 DEFAULT_SIGNATURE_VERSION = '2'
 S3_API_VERSION = '2006-03-01'

--- a/libcloud/test/storage/test_digitalocean_spaces.py
+++ b/libcloud/test/storage/test_digitalocean_spaces.py
@@ -105,12 +105,14 @@ class DigitalOceanSpacesDoubleInstanceTests(LibcloudTestCase):
     driver_type = DigitalOceanSpacesStorageDriver
     driver_args = STORAGE_S3_PARAMS
     default_host = 'nyc3.digitaloceanspaces.com'
+    alt_host = 'ams3.digitaloceanspaces.com'
 
     def setUp(self):
         self.driver_v2 = self.driver_type(*self.driver_args,
                                           signature_version='2')
         self.driver_v4 = self.driver_type(*self.driver_args,
-                                          signature_version='4')
+                                          signature_version='4',
+                                          region='ams3')
 
     def test_connection_class_type(self):
         res = self.driver_v2.connectionCls is DOSpacesConnectionAWS2
@@ -129,7 +131,7 @@ class DigitalOceanSpacesDoubleInstanceTests(LibcloudTestCase):
         self.assertEqual(host, self.default_host)
 
         host = self.driver_v4.connectionCls.host
-        self.assertEqual(host, self.default_host)
+        self.assertEqual(host, self.alt_host)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Add support for DigitalOcean Spaces AMS3 region.

### Description

Adds ams3.digitaloceanspaces.com to `DO_SPACES_HOSTS_BY_REGION` and updates a test to ensure setting `ams3` as the region produces the correct host.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
