### PR TITLE
LIBCLOUD-960: Expand GCE Firewall options coverage

### DIFF
--- a/libcloud/test/compute/fixtures/gce/global_firewalls_lcfirewall-deny.json
+++ b/libcloud/test/compute/fixtures/gce/global_firewalls_lcfirewall-deny.json
@@ -1,0 +1,25 @@
+{
+  "denied": [
+    {
+      "IPProtocol": "tcp",
+      "ports": [
+        "4567"
+      ]
+    }
+  ],
+  "creationTimestamp": "2013-06-26T10:04:43.773-09:00",
+  "description": "Libcloud Deny Firewall",
+  "direction": "INGRESS",
+  "id": "0565629596395414123",
+  "kind": "compute#firewall",
+  "name": "lcfirewall-deny",
+  "network": "https://www.googleapis.com/compute/v1/projects/project_name/global/networks/default",
+  "priority": 900,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/firewalls/lcfirewall-deny",
+  "sourceRanges": [
+    "10.240.100.0/24"
+  ],
+  "sourceTags": [
+    "libcloud"
+  ]
+}

--- a/libcloud/test/compute/fixtures/gce/global_firewalls_lcfirewall-egress.json
+++ b/libcloud/test/compute/fixtures/gce/global_firewalls_lcfirewall-egress.json
@@ -1,0 +1,25 @@
+{
+  "allowed": [
+    {
+      "IPProtocol": "tcp",
+      "ports": [
+        "4567"
+      ]
+    }
+  ],
+  "creationTimestamp": "2013-06-26T10:05:43.773-07:00",
+  "description": "Libcloud Egress Firewall",
+  "direction": "EGRESS",
+  "id": "0565629596395414122",
+  "kind": "compute#firewall",
+  "name": "lcfirewall-egress",
+  "network": "https://www.googleapis.com/compute/v1/projects/project_name/global/networks/default",
+  "priority": 900,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/firewalls/lcfirewall-egress",
+  "targetServiceAccounts": [
+    "lctarget@gserviceaccount.com"
+  ],
+  "destinationRanges": [
+    "8.8.8.8/32"
+  ]
+}

--- a/libcloud/test/compute/fixtures/gce/global_firewalls_lcfirewall.json
+++ b/libcloud/test/compute/fixtures/gce/global_firewalls_lcfirewall.json
@@ -12,8 +12,12 @@
   "kind": "compute#firewall",
   "name": "lcfirewall",
   "network": "https://www.googleapis.com/compute/v1/projects/project_name/global/networks/default",
+  "priority": 900,
   "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/firewalls/lcfirewall",
   "sourceTags": [
+    "libcloud"
+  ],
+  "targetTags": [
     "libcloud"
   ]
 }

--- a/libcloud/test/compute/fixtures/gce/global_firewalls_lcfirewall.json
+++ b/libcloud/test/compute/fixtures/gce/global_firewalls_lcfirewall.json
@@ -8,14 +8,16 @@
     }
   ],
   "creationTimestamp": "2013-06-26T10:04:43.773-07:00",
+  "description": "Libcloud Test Firewall",
+  "direction": "INGRESS",
   "id": "0565629596395414121",
   "kind": "compute#firewall",
   "name": "lcfirewall",
   "network": "https://www.googleapis.com/compute/v1/projects/project_name/global/networks/default",
   "priority": 900,
   "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/firewalls/lcfirewall",
-  "sourceTags": [
-    "libcloud"
+  "sourceServiceAccounts": [
+    "lcsource@gserviceaccount.com"
   ],
   "targetTags": [
     "libcloud"

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -820,9 +820,13 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
 
     def test_ex_create_firewall(self):
         firewall_name = 'lcfirewall'
+        priority = 900
         allowed = [{'IPProtocol': 'tcp', 'ports': ['4567']}]
         source_tags = ['libcloud']
+        target_tags = ['libcloud']
         firewall = self.driver.ex_create_firewall(firewall_name, allowed,
+                                                  priority=priority,
+                                                  target_tags=target_tags,
                                                   source_tags=source_tags)
         self.assertTrue(isinstance(firewall, GCEFirewall))
         self.assertEqual(firewall.name, firewall_name)
@@ -1394,7 +1398,7 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         firewall_name = 'lcfirewall'
         firewall = self.driver.ex_get_firewall(firewall_name)
         firewall.source_ranges = ['10.0.0.0/16']
-        firewall.source_tags = ['libcloud', 'test']
+        firewall.target_service_accounts = ['libcloud@apache.com']
         firewall2 = self.driver.ex_update_firewall(firewall)
         self.assertTrue(isinstance(firewall2, GCEFirewall))
 

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -827,10 +827,9 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         target_tags = ['libcloud']
         network = 'default'
         firewall = self.driver.ex_create_firewall(
-                            name, allowed, description=description,
-                            network=network, priority=priority,
-                            target_tags=target_tags,
-                            source_service_accounts=source_service_accounts)
+            name, allowed, description=description,
+            network=network, priority=priority, target_tags=target_tags,
+            source_service_accounts=source_service_accounts)
         self.assertTrue(isinstance(firewall, GCEFirewall))
         self.assertEqual(firewall.name, name)
 
@@ -844,11 +843,11 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         target_ranges = ['8.8.8.8/32']
         network = 'default'
         firewall = self.driver.ex_create_firewall(
-                            name, allowed,
-                            description=description, network=network,
-                            priority=priority, direction=direction,
-                            target_ranges=target_ranges,
-                            target_service_accounts=target_service_accounts)
+            name, allowed,
+            description=description, network=network,
+            priority=priority, direction=direction,
+            target_ranges=target_ranges,
+            target_service_accounts=target_service_accounts)
         self.assertTrue(isinstance(firewall, GCEFirewall))
         self.assertEqual(firewall.name, name)
 
@@ -861,10 +860,10 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         source_tags = ['libcloud']
         network = 'default'
         firewall = self.driver.ex_create_firewall(
-                             name, denied=denied,
-                             description=description, network=network,
-                             priority=priority, source_tags=source_tags,
-                             source_ranges=source_ranges)
+            name, denied=denied,
+            description=description, network=network,
+            priority=priority, source_tags=source_tags,
+            source_ranges=source_ranges)
         self.assertTrue(isinstance(firewall, GCEFirewall))
         self.assertEqual(firewall.name, name)
 

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -819,17 +819,54 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         self.assertEqual(image.extra['guestOsFeatures'], expected_features)
 
     def test_ex_create_firewall(self):
-        firewall_name = 'lcfirewall'
+        name = 'lcfirewall'
         priority = 900
+        description = "Libcloud Test Firewall"
         allowed = [{'IPProtocol': 'tcp', 'ports': ['4567']}]
-        source_tags = ['libcloud']
+        source_service_accounts = ['lcsource@gserviceaccount.com']
         target_tags = ['libcloud']
-        firewall = self.driver.ex_create_firewall(firewall_name, allowed,
-                                                  priority=priority,
-                                                  target_tags=target_tags,
-                                                  source_tags=source_tags)
+        network = 'default'
+        firewall = self.driver.ex_create_firewall(
+                            name, allowed, description=description,
+                            network=network, priority=priority,
+                            target_tags=target_tags,
+                            source_service_accounts=source_service_accounts)
         self.assertTrue(isinstance(firewall, GCEFirewall))
-        self.assertEqual(firewall.name, firewall_name)
+        self.assertEqual(firewall.name, name)
+
+    def test_ex_create_firewall_egress(self):
+        name = 'lcfirewall-egress'
+        priority = 900
+        direction = 'EGRESS'
+        description = "Libcloud Egress Firewall"
+        allowed = [{'IPProtocol': 'tcp', 'ports': ['4567']}]
+        target_service_accounts = ['lctarget@gserviceaccount.com']
+        target_ranges = ['8.8.8.8/32']
+        network = 'default'
+        firewall = self.driver.ex_create_firewall(
+                            name, allowed,
+                            description=description, network=network,
+                            priority=priority, direction=direction,
+                            target_ranges=target_ranges,
+                            target_service_accounts=target_service_accounts)
+        self.assertTrue(isinstance(firewall, GCEFirewall))
+        self.assertEqual(firewall.name, name)
+
+    def test_ex_create_firewall_deny(self):
+        name = 'lcfirewall-deny'
+        priority = 900
+        denied = [{'IPProtocol': 'tcp', 'ports': ['4567']}]
+        description = "Libcloud Deny Firewall"
+        source_ranges = ['10.240.100.0/24']
+        source_tags = ['libcloud']
+        network = 'default'
+        firewall = self.driver.ex_create_firewall(
+                             name, denied=denied,
+                             description=description, network=network,
+                             priority=priority, source_tags=source_tags,
+                             source_ranges=source_ranges)
+        self.assertTrue(isinstance(firewall, GCEFirewall))
+        self.assertEqual(firewall.name, name)
 
     def test_ex_create_forwarding_rule(self):
         fwr_name = 'lcforwardingrule'
@@ -1398,7 +1435,7 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         firewall_name = 'lcfirewall'
         firewall = self.driver.ex_get_firewall(firewall_name)
         firewall.source_ranges = ['10.0.0.0/16']
-        firewall.target_service_accounts = ['libcloud@apache.com']
+        firewall.description = "LCFirewall-2"
         firewall2 = self.driver.ex_update_firewall(firewall)
         self.assertTrue(isinstance(firewall2, GCEFirewall))
 
@@ -1664,7 +1701,7 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         firewall = self.driver.ex_get_firewall(firewall_name)
         self.assertEqual(firewall.name, firewall_name)
         self.assertEqual(firewall.network.name, 'default')
-        self.assertEqual(firewall.source_tags, ['libcloud'])
+        self.assertEqual(firewall.target_tags, ['libcloud'])
 
     def test_ex_get_forwarding_rule(self):
         fwr_name = 'lcforwardingrule'
@@ -2286,6 +2323,14 @@ class GCEMockHttp(MockHttp):
             body = self.fixtures.load('global_firewalls_lcfirewall_put.json')
         else:
             body = self.fixtures.load('global_firewalls_lcfirewall.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _global_firewalls_lcfirewall_egress(self, method, url, body, headers):
+        body = self.fixtures.load('global_firewalls_lcfirewall-egress.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _global_firewalls_lcfirewall_deny(self, method, url, body, headers):
+        body = self.fixtures.load('global_firewalls_lcfirewall-deny.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
     def _global_images(self, method, url, body, headers):


### PR DESCRIPTION
## Expand GCE Firewall options coverage

### Description

Expanding coverage for full range of GCP firewall rule options currently in GA:
- Ingress or Egress direction
- Allow or Deny action
- Set Description and Priority values
- Define source and/or targets by service account

I've preserved the existing defaults.

Issue Link: https://issues.apache.org/jira/browse/LIBCLOUD-960

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
