### PR TITLE
Cleanup and correct third-party drivers doc

### DIFF
--- a/docs/third_party_drivers.rst
+++ b/docs/third_party_drivers.rst
@@ -14,30 +14,30 @@ guarantee the quality of those drivers.
 Compute
 -------
 
-+-------------------+---------------------------------+--------------------------------------+
-| Provider          | PyPi package                    | Source code                          |
-+===================+=================================+======================================+
-| `StratusLab`_     |                                 | `StratusLab/libcloud-drivers`_       |
-+-------------------+---------------------------------+--------------------------------------+
-| `Snooze`_         | `stratuslab-libcloud-drivers`_  | `snooze-libcloud`_                   |
-+-------------------+---------------------------------+--------------------------------------+
++----------------+---------------------------------+---------------------------------+
+| Provider       | PyPi package                    | Source code                     |
++================+=================================+=================================+
+| `StratusLab`_  | `stratuslab-libcloud-drivers`_  | `StratusLab/libcloud-drivers`_  |
++----------------+---------------------------------+---------------------------------+
+| `Snooze`_      |                                 | `msimonin/snooze-libcloud`_     |
++----------------+---------------------------------+---------------------------------+
 
 DNS
 ----
 
-+-------------------+--------------------------+--------------------------------------+
-| Provider          | PyPi package             | Source code                          |
-+===================+==========================+======================================+
-| `DNSMadeEasy`_    | `libcloud-dnsmadeeasy`_  | `moses-palmer/libcloud-dnsmadeeasy`_ |
-+-------------------+--------------------------+--------------------------------------+
++-----------------+--------------------------+---------------------------------------+
+| Provider        | PyPi package             | Source code                           |
++=================+==========================+=======================================+
+| `DNSMadeEasy`_  | `libcloud-dnsmadeeasy`_  | `moses-palmer/libcloud-dnsmadeeasy`_  |
++-----------------+--------------------------+---------------------------------------+
 
 .. _`StratusLab`: http://stratuslab.eu/
-.. _`Snooze`: http://snooze.inria.fr
-.. _`snooze-libcloud`: https://github.com/msimonin/snooze-libcloud
-
 .. _`stratuslab-libcloud-drivers`: https://pypi.python.org/pypi/stratuslab-libcloud-drivers
 .. _`StratusLab/libcloud-drivers`: https://github.com/StratusLab/libcloud-drivers
 
+.. _`Snooze`: http://snooze.inria.fr
+.. _`msimonin/snooze-libcloud`: https://github.com/msimonin/snooze-libcloud
+
 .. _`DNSMadeEasy`: http://www.dnsmadeeasy.com/
-.. _`libcloud-dnsmadeeasy`: https://pypi.python.org/pypi/libcloud-dnsmadeeasy/1.0
+.. _`libcloud-dnsmadeeasy`: https://pypi.python.org/pypi/libcloud-dnsmadeeasy
 .. _`moses-palmer/libcloud-dnsmadeeasy`: https://github.com/moses-palmer/libcloud-dnsmadeeasy


### PR DESCRIPTION
## Cleaned Up And Corrected Third-Party Drivers Document

### Description

- Moved StratusLab's PyPi package link to the correct row
- Made source link for Snooze use consistent naming with other source links (include GitHub username)
- Tightened table spacing
- Rearranged links in footer to maintain grouping by provider
- Removed version number from PyPi link

### Status

- done, ready for review

### Checklist

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks) _[No Code Changes]_
- [X] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html) _[No Code Changes]_
- [X] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
