### PR TITLE
[LIBCLOUD-967] Add support for DigitalOcean tags in list_nodes()

### DIFF
--- a/libcloud/compute/drivers/digitalocean.py
+++ b/libcloud/compute/drivers/digitalocean.py
@@ -462,7 +462,8 @@ class DigitalOcean_v2_NodeDriver(DigitalOcean_v2_BaseDriver,
     def _to_node(self, data):
         extra_keys = ['memory', 'vcpus', 'disk', 'region', 'image',
                       'size_slug', 'locked', 'created_at', 'networks',
-                      'kernel', 'backup_ids', 'snapshot_ids', 'features']
+                      'kernel', 'backup_ids', 'snapshot_ids', 'features',
+                      'tags']
         if 'status' in data:
             state = self.NODE_STATE_MAP.get(data['status'], NodeState.UNKNOWN)
         else:

--- a/libcloud/test/compute/fixtures/digitalocean_v2/list_nodes.json
+++ b/libcloud/test/compute/fixtures/digitalocean_v2/list_nodes.json
@@ -79,7 +79,11 @@
           "metadata"
         ],
         "available": null
-      }
+      },
+      "tags": [
+        "environment:prod",
+        "database"
+      ]
     }
   ],
   "links": {},

--- a/libcloud/test/compute/fixtures/digitalocean_v2/list_nodes_page_1.json
+++ b/libcloud/test/compute/fixtures/digitalocean_v2/list_nodes_page_1.json
@@ -79,7 +79,11 @@
           "metadata"
         ],
         "available": null
-      }
+      },
+      "tags": [
+        "environment:prod",
+        "database"
+      ]
     }
   ],
   "links": {

--- a/libcloud/test/compute/test_digitalocean_v2.py
+++ b/libcloud/test/compute/test_digitalocean_v2.py
@@ -94,6 +94,7 @@ class DigitalOcean_v2_Tests(LibcloudTestCase):
         self.assertEqual(nodes[0].public_ips, ['104.236.32.182'])
         self.assertEqual(nodes[0].extra['image']['id'], 6918990)
         self.assertEqual(nodes[0].extra['size_slug'], '512mb')
+        self.assertEqual(len(nodes[0].extra['tags']), 2)
 
     def test_list_nodes_fills_created_datetime(self):
         nodes = self.driver.list_nodes()


### PR DESCRIPTION
## Add support for DigitalOcean tags in list_nodes()

See: https://issues.apache.org/jira/browse/LIBCLOUD-967

### Description

Digital Ocean droplets can be tagged with multiple tags, such as "production" or "database", but these tags are not currently returned by {{list_nodes()}}.

https://www.digitalocean.com/community/tutorials/how-to-tag-digitalocean-droplets

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)

### Tests

Added tags to Digital Ocean fixtures and added test to confirm tags are captured by `list_nodes()`.

```
$ PYTHONPATH=. python3 libcloud/test/compute/test_digitalocean_v2.py
......libcloud/test/compute/test_digitalocean_v2.py:114: DeprecationWarning: Please use assertRaisesRegex instead.
  location=location)
............................
----------------------------------------------------------------------
Ran 34 tests in 0.217s

OK
```

DeprecationWarning in above test was pre-existing and unrelated to this change.