### PR TITLE
Fixed Pytest on Python 2.6 & 3.3

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -7,4 +7,3 @@ codecov
 coverage<4.0
 requests
 requests_mock
-pytest

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ PY2_pre_26 = PY2 and sys.version_info < (2, 6)
 PY2_pre_27 = PY2 and sys.version_info < (2, 7)
 PY2_pre_279 = PY2 and sys.version_info < (2, 7, 9)
 PY3_pre_32 = PY3 and sys.version_info < (3, 2)
+PY3_pre_34 = PY3 and sys.version_info < (3, 4)
 
 HTML_VIEWSOURCE_BASE = 'https://svn.apache.org/viewvc/libcloud/trunk'
 PROJECT_BASE_DIR = 'http://libcloud.apache.org'
@@ -60,12 +61,16 @@ TEST_REQUIREMENTS = [
     'mock',
     'requests',
     'requests_mock',
-    'pytest',
     'pytest-runner'
 ]
 
 if PY2_pre_279 or PY3_pre_32:
     TEST_REQUIREMENTS.append('backports.ssl_match_hostname')
+
+if PY2_pre_27 or PY3_pre_34:
+    TEST_REQUIREMENTS.append('pytest<3.3.0')
+else:
+    TEST_REQUIREMENTS.append('pytest')
 
 if PY2_pre_27:
     unittest2_required = True

--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,8 @@ passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 deps =
     -r{toxinidir}/requirements-tests.txt
     lockfile
-    py{2.6,2.7}: paramiko
     py{2.6}: unittest2
+
 commands = cp libcloud/test/secrets.py-dist libcloud/test/secrets.py
            python setup.py test
 basepython =


### PR DESCRIPTION
## Fixed Pytest on Python 2.6 & 3.3

### Description

CI was failing with  Python 2.6 & 3.3 because new version of Pytest doesn't support.
I make Python 2.6 & 3.3 use the last compatible Pytest version.

https://docs.pytest.org/en/latest/changelog.html#pytest-3-3-0-2017-11-23

### Status

Done

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
