### PR TITLE
[LIBCLOUD-969] Add pricing information to UpCloud's driver list_sizes

### DIFF
--- a/libcloud/common/upcloud.py
+++ b/libcloud/common/upcloud.py
@@ -211,26 +211,28 @@ class PlanPrice(object):
     def __init__(self, zone_prices):
         self._zone_prices = zone_prices
 
-    def get_prices_in_zones(self, plan_name):
+    def get_price(self, plan_name, location=None):
         """
-        Returns list of prices in different zones,
-        [{'zone_id': 'uk-lon1', 'price': 1.588'},...]
-        If plan is not found in a zone, price is set to None.
+        Returns the plan's price in location. If location
+        is not provided returns None
 
         :param  plan_name: Name of the plan
         :type   plan_name: ```str```
 
-        rtype: ``list``
+        :param  location: Location, which price is returned (optional)
+        :type   location: :class:`.NodeLocation`
+
+
+        rtype: ``float``
         """
+        if location is None:
+            return None
         server_plan_name = 'server_plan_' + plan_name
 
-        prices = []
-
         for zone_price in self._zone_prices:
-            zone_id = zone_price['name']
-            price = zone_price.get(server_plan_name, {}).get('price')
-            prices.append({'zone_id': zone_id, 'price': price})
-        return prices
+            if zone_price['name'] == location.id:
+                return zone_price.get(server_plan_name, {}).get('price')
+        return None
 
 
 class _LoginUser(object):

--- a/libcloud/common/upcloud.py
+++ b/libcloud/common/upcloud.py
@@ -199,6 +199,40 @@ class UpcloudNodeOperations(object):
                                 method='DELETE')
 
 
+class PlanPrice(object):
+    """
+    Helper class to construct plan price in different zones
+
+    :param  zone_prices: List of prices in different zones in UpCloud
+    :type   zone_prices: ```list```
+
+    """
+
+    def __init__(self, zone_prices):
+        self._zone_prices = zone_prices
+
+    def get_prices_in_zones(self, plan_name):
+        """
+        Returns list of prices in different zones,
+        [{'zone_id': 'uk-lon1', 'price': 1.588'},...]
+        If plan is not found in a zone, price is set to None.
+
+        :param  plan_name: Name of the plan
+        :type   plan_name: ```str```
+
+        rtype: ``list``
+        """
+        server_plan_name = 'server_plan_' + plan_name
+
+        prices = []
+
+        for zone_price in self._zone_prices:
+            zone_id = zone_price['name']
+            price = zone_price.get(server_plan_name, {}).get('price')
+            prices.append({'zone_id': zone_id, 'price': price})
+        return prices
+
+
 class _LoginUser(object):
 
     def __init__(self, user_id, auth=None):

--- a/libcloud/compute/drivers/upcloud.py
+++ b/libcloud/compute/drivers/upcloud.py
@@ -106,20 +106,22 @@ class UpcloudDriver(NodeDriver):
         response = self.connection.request('1.2/zone')
         return self._to_node_locations(response.object['zones']['zone'])
 
-    def list_sizes(self):
+    def list_sizes(self, location=None):
         """
         List available plans
 
-        Note: Node.price will be always None, because the pricing depends,
-        where the Node is hosted. Node.extra['zones'] will contain
-        pricing for different hosting zones.
+        :param location: Location of the deployement. Price depends on
+        location. lf location is not given or price not found for
+        location, price will be None (optional)
+        :type location: :class:`.NodeLocation`
 
         :rtype: ``list`` of :class:`NodeSize`
         """
         prices_response = self.connection.request('1.2/price')
         response = self.connection.request('1.2/plan')
         return self._to_node_sizes(response.object['plans']['plan'],
-                                   prices_response.object['prices']['zone'])
+                                   prices_response.object['prices']['zone'],
+                                   location)
 
     def list_images(self):
         """
@@ -270,18 +272,19 @@ class UpcloudDriver(NodeDriver):
         Zone_id format [country]_[city][number], like fi_hel1"""
         return zone_id.split('-')[0].upper()
 
-    def _to_node_sizes(self, plans, prices):
+    def _to_node_sizes(self, plans, prices, location):
         plan_price = PlanPrice(prices)
-        return [self._construct_node_size(plan, plan_price) for plan in plans]
+        return [self._to_node_size(plan, plan_price, location)
+                for plan in plans]
 
-    def _construct_node_size(self, plan, plan_price):
+    def _to_node_size(self, plan, plan_price, location):
         extra = self._copy_dict(('core_number', 'storage_tier'), plan)
-        extra['zones'] = plan_price.get_prices_in_zones(plan['name'])
         return NodeSize(id=plan['name'], name=plan['name'],
                         ram=plan['memory_amount'],
                         disk=plan['storage_size'],
                         bandwidth=plan['public_traffic_out'],
-                        price=None, driver=self,
+                        price=plan_price.get_price(plan['name'], location),
+                        driver=self,
                         extra=extra)
 
     def _to_node_images(self, images):

--- a/libcloud/test/common/test_upcloud.py
+++ b/libcloud/test/common/test_upcloud.py
@@ -265,27 +265,21 @@ class TestUpcloudNodeDestroyer(unittest.TestCase):
 
 class TestPlanPrice(unittest.TestCase):
 
-    def test_zone_prices(self):
+    def setUp(self):
         prices = [{'name': 'uk-lon1', 'server_plan_1xCPU-1GB': {'amount': 1, 'price': 1.488}},
                   {'name': 'fi-hel1', 'server_plan_1xCPU-1GB': {'amount': 1, 'price': 1.588}}]
-        pp = PlanPrice(prices)
+        self.pp = PlanPrice(prices)
 
-        zone_prices = pp.get_prices_in_zones('1xCPU-1GB')
-
-        self.assertEqual(len(zone_prices), 2)
-        self.assertIn({'zone_id': 'uk-lon1', 'price': 1.488}, zone_prices)
-        self.assertIn({'zone_id': 'fi-hel1', 'price': 1.588}, zone_prices)
+    def test_zone_prices(self):
+        location = NodeLocation(id='fi-hel1', name='Helsinki #1', country='FI', driver=None)
+        self.assertEqual(self.pp.get_price('1xCPU-1GB', location), 1.588)
 
     def test_plan_not_found_in_zone(self):
-        prices = [{'name': 'uk-lon1', 'server_plan_1xCPU-1GB': {'amount': 1, 'price': 1.488}},
-                  {'name': 'fi-hel1', 'server_plan_4xCPU-1GB': {'amount': 1, 'price': 1.588}}]
-        pp = PlanPrice(prices)
+        location = NodeLocation(id='no_such_location', name='', country='', driver=None)
+        self.assertEqual(self.pp.get_price('1xCPU-1GB', location), None)
 
-        zone_prices = pp.get_prices_in_zones('1xCPU-1GB')
-
-        self.assertEqual(len(zone_prices), 2)
-        self.assertIn({'zone_id': 'uk-lon1', 'price': 1.488}, zone_prices)
-        self.assertIn({'zone_id': 'fi-hel1', 'price': None}, zone_prices)
+    def test_no_location_given(self):
+        self.assertEqual(self.pp.get_price('1xCPU-1GB'), None)
 
 
 if __name__ == '__main__':

--- a/libcloud/test/compute/fixtures/upcloud/api_1_2_price.json
+++ b/libcloud/test/compute/fixtures/upcloud/api_1_2_price.json
@@ -1,0 +1,683 @@
+{
+   "prices" : {
+      "zone" : [
+         {
+            "firewall" : {
+               "amount" : 1,
+               "price" : 0.56
+            },
+            "io_request_backup" : {
+               "amount" : 1000000,
+               "price" : 0
+            },
+            "io_request_maxiops" : {
+               "amount" : 1000000,
+               "price" : 0
+            },
+            "ipv4_address" : {
+               "amount" : 1,
+               "price" : 0.336
+            },
+            "ipv6_address" : {
+               "amount" : 1,
+               "price" : 0
+            },
+            "name" : "de-fra1",
+            "public_ipv4_bandwidth_in" : {
+               "amount" : 1,
+               "price" : 0
+            },
+            "public_ipv4_bandwidth_out" : {
+               "amount" : 1,
+               "price" : 5.6
+            },
+            "public_ipv6_bandwidth_in" : {
+               "amount" : 1,
+               "price" : 0
+            },
+            "public_ipv6_bandwidth_out" : {
+               "amount" : 1,
+               "price" : 5.6
+            },
+            "server_core" : {
+               "amount" : 1,
+               "price" : 1.12
+            },
+            "server_memory" : {
+               "amount" : 256,
+               "price" : 0.14
+            },
+            "server_plan_12xCPU-32GB" : {
+               "amount" : 1,
+               "price" : 47.619
+            },
+            "server_plan_16xCPU-48GB" : {
+               "amount" : 1,
+               "price" : 71.4286
+            },
+            "server_plan_1xCPU-1GB" : {
+               "amount" : 1,
+               "price" : 1.488
+            },
+            "server_plan_20xCPU-64GB" : {
+               "amount" : 1,
+               "price" : 95.2381
+            },
+            "server_plan_2xCPU-2GB" : {
+               "amount" : 1,
+               "price" : 2.976
+            },
+            "server_plan_4xCPU-4GB" : {
+               "amount" : 1,
+               "price" : 5.952
+            },
+            "server_plan_6xCPU-8GB" : {
+               "amount" : 1,
+               "price" : 11.905
+            },
+            "server_plan_8xCPU-16GB" : {
+               "amount" : 1,
+               "price" : 23.8095
+            },
+            "storage_backup" : {
+               "amount" : 1,
+               "price" : 0.0078
+            },
+            "storage_maxiops" : {
+               "amount" : 1,
+               "price" : 0.031
+            },
+            "storage_template" : {
+               "amount" : 1,
+               "price" : 0.031
+            }
+         },
+         {
+            "firewall" : {
+               "amount" : 1,
+               "price" : 0.56
+            },
+            "io_request_backup" : {
+               "amount" : 1000000,
+               "price" : 0
+            },
+            "io_request_hdd" : {
+               "amount" : 1000000,
+               "price" : 0
+            },
+            "io_request_maxiops" : {
+               "amount" : 1000000,
+               "price" : 0
+            },
+            "ipv4_address" : {
+               "amount" : 1,
+               "price" : 0.336
+            },
+            "ipv6_address" : {
+               "amount" : 1,
+               "price" : 0
+            },
+            "name" : "fi-dev2",
+            "public_ipv4_bandwidth_in" : {
+               "amount" : 1,
+               "price" : 0
+            },
+            "public_ipv4_bandwidth_out" : {
+               "amount" : 1,
+               "price" : 5.6
+            },
+            "public_ipv6_bandwidth_in" : {
+               "amount" : 1,
+               "price" : 0
+            },
+            "public_ipv6_bandwidth_out" : {
+               "amount" : 1,
+               "price" : 5.6
+            },
+            "server_core" : {
+               "amount" : 1,
+               "price" : 1.24
+            },
+            "server_memory" : {
+               "amount" : 256,
+               "price" : 0.34
+            },
+            "server_plan_12xCPU-32GB" : {
+               "amount" : 1,
+               "price" : 71.4286
+            },
+            "server_plan_16xCPU-48GB" : {
+               "amount" : 1,
+               "price" : 107.1429
+            },
+            "server_plan_1xCPU-1GB" : {
+               "amount" : 1,
+               "price" : 2.232
+            },
+            "server_plan_20xCPU-64GB" : {
+               "amount" : 1,
+               "price" : 142.8571
+            },
+            "server_plan_2xCPU-2GB" : {
+               "amount" : 1,
+               "price" : 4.464
+            },
+            "server_plan_4xCPU-4GB" : {
+               "amount" : 1,
+               "price" : 8.928
+            },
+            "server_plan_6xCPU-8GB" : {
+               "amount" : 1,
+               "price" : 17.857
+            },
+            "server_plan_8xCPU-16GB" : {
+               "amount" : 1,
+               "price" : 35.7143
+            },
+            "storage_backup" : {
+               "amount" : 1,
+               "price" : 0.0078
+            },
+            "storage_hdd" : {
+               "amount" : 1,
+               "price" : 0.0145
+            },
+            "storage_maxiops" : {
+               "amount" : 1,
+               "price" : 0.031
+            },
+            "storage_template" : {
+               "amount" : 1,
+               "price" : 0.031
+            }
+         },
+         {
+            "firewall" : {
+               "amount" : 1,
+               "price" : 0.56
+            },
+            "io_request_backup" : {
+               "amount" : 1000000,
+               "price" : 0
+            },
+            "io_request_hdd" : {
+               "amount" : 1000000,
+               "price" : 0
+            },
+            "io_request_maxiops" : {
+               "amount" : 1000000,
+               "price" : 0
+            },
+            "io_request_ssd" : {
+               "amount" : 1000000,
+               "price" : 0
+            },
+            "ipv4_address" : {
+               "amount" : 1,
+               "price" : 0.336
+            },
+            "ipv6_address" : {
+               "amount" : 1,
+               "price" : 0
+            },
+            "name" : "fi-hel1",
+            "public_ipv4_bandwidth_in" : {
+               "amount" : 1,
+               "price" : 0
+            },
+            "public_ipv4_bandwidth_out" : {
+               "amount" : 1,
+               "price" : 5.6
+            },
+            "public_ipv6_bandwidth_in" : {
+               "amount" : 1,
+               "price" : 0
+            },
+            "public_ipv6_bandwidth_out" : {
+               "amount" : 1,
+               "price" : 5.6
+            },
+            "server_core" : {
+               "amount" : 1,
+               "price" : 1.24
+            },
+            "server_memory" : {
+               "amount" : 256,
+               "price" : 0.34
+            },
+            "server_plan_12xCPU-32GB" : {
+               "amount" : 1,
+               "price" : 71.4286
+            },
+            "server_plan_16xCPU-48GB" : {
+               "amount" : 1,
+               "price" : 107.1429
+            },
+            "server_plan_1xCPU-1GB" : {
+               "amount" : 1,
+               "price" : 2.232
+            },
+            "server_plan_20xCPU-64GB" : {
+               "amount" : 1,
+               "price" : 142.8571
+            },
+            "server_plan_2xCPU-2GB" : {
+               "amount" : 1,
+               "price" : 4.464
+            },
+            "server_plan_4xCPU-4GB" : {
+               "amount" : 1,
+               "price" : 8.928
+            },
+            "server_plan_6xCPU-8GB" : {
+               "amount" : 1,
+               "price" : 17.857
+            },
+            "server_plan_8xCPU-16GB" : {
+               "amount" : 1,
+               "price" : 35.7143
+            },
+            "storage_backup" : {
+               "amount" : 1,
+               "price" : 0.0078
+            },
+            "storage_hdd" : {
+               "amount" : 1,
+               "price" : 0.0145
+            },
+            "storage_maxiops" : {
+               "amount" : 1,
+               "price" : 0.031
+            },
+            "storage_ssd" : {
+               "amount" : 1,
+               "price" : 0.056
+            },
+            "storage_template" : {
+               "amount" : 1,
+               "price" : 0.031
+            }
+         },
+         {
+            "firewall" : {
+               "amount" : 1,
+               "price" : 0.56
+            },
+            "io_request_backup" : {
+               "amount" : 1000000,
+               "price" : 0
+            },
+            "io_request_maxiops" : {
+               "amount" : 1000000,
+               "price" : 0
+            },
+            "ipv4_address" : {
+               "amount" : 1,
+               "price" : 0.336
+            },
+            "ipv6_address" : {
+               "amount" : 1,
+               "price" : 0
+            },
+            "name" : "nl-ams1",
+            "public_ipv4_bandwidth_in" : {
+               "amount" : 1,
+               "price" : 0
+            },
+            "public_ipv4_bandwidth_out" : {
+               "amount" : 1,
+               "price" : 5.6
+            },
+            "public_ipv6_bandwidth_in" : {
+               "amount" : 1,
+               "price" : 0
+            },
+            "public_ipv6_bandwidth_out" : {
+               "amount" : 1,
+               "price" : 5.6
+            },
+            "server_core" : {
+               "amount" : 1,
+               "price" : 1.12
+            },
+            "server_memory" : {
+               "amount" : 256,
+               "price" : 0.14
+            },
+            "server_plan_12xCPU-32GB" : {
+               "amount" : 1,
+               "price" : 47.619
+            },
+            "server_plan_16xCPU-48GB" : {
+               "amount" : 1,
+               "price" : 71.4286
+            },
+            "server_plan_1xCPU-1GB" : {
+               "amount" : 1,
+               "price" : 1.488
+            },
+            "server_plan_20xCPU-64GB" : {
+               "amount" : 1,
+               "price" : 95.2381
+            },
+            "server_plan_2xCPU-2GB" : {
+               "amount" : 1,
+               "price" : 2.976
+            },
+            "server_plan_4xCPU-4GB" : {
+               "amount" : 1,
+               "price" : 5.952
+            },
+            "server_plan_6xCPU-8GB" : {
+               "amount" : 1,
+               "price" : 11.905
+            },
+            "server_plan_8xCPU-16GB" : {
+               "amount" : 1,
+               "price" : 23.8095
+            },
+            "storage_backup" : {
+               "amount" : 1,
+               "price" : 0.0078
+            },
+            "storage_maxiops" : {
+               "amount" : 1,
+               "price" : 0.031
+            },
+            "storage_template" : {
+               "amount" : 1,
+               "price" : 0.031
+            }
+         },
+         {
+            "firewall" : {
+               "amount" : 1,
+               "price" : 0.56
+            },
+            "io_request_backup" : {
+               "amount" : 1000000,
+               "price" : 0
+            },
+            "io_request_maxiops" : {
+               "amount" : 1000000,
+               "price" : 0
+            },
+            "ipv4_address" : {
+               "amount" : 1,
+               "price" : 0.336
+            },
+            "ipv6_address" : {
+               "amount" : 1,
+               "price" : 0
+            },
+            "name" : "sg-sin1",
+            "public_ipv4_bandwidth_in" : {
+               "amount" : 1,
+               "price" : 0
+            },
+            "public_ipv4_bandwidth_out" : {
+               "amount" : 1,
+               "price" : 5.6
+            },
+            "public_ipv6_bandwidth_in" : {
+               "amount" : 1,
+               "price" : 0
+            },
+            "public_ipv6_bandwidth_out" : {
+               "amount" : 1,
+               "price" : 5.6
+            },
+            "server_core" : {
+               "amount" : 1,
+               "price" : 1.12
+            },
+            "server_memory" : {
+               "amount" : 256,
+               "price" : 0.14
+            },
+            "server_plan_12xCPU-32GB" : {
+               "amount" : 1,
+               "price" : 47.619
+            },
+            "server_plan_16xCPU-48GB" : {
+               "amount" : 1,
+               "price" : 71.4286
+            },
+            "server_plan_1xCPU-1GB" : {
+               "amount" : 1,
+               "price" : 1.488
+            },
+            "server_plan_20xCPU-64GB" : {
+               "amount" : 1,
+               "price" : 95.2381
+            },
+            "server_plan_2xCPU-2GB" : {
+               "amount" : 1,
+               "price" : 2.976
+            },
+            "server_plan_4xCPU-4GB" : {
+               "amount" : 1,
+               "price" : 5.952
+            },
+            "server_plan_6xCPU-8GB" : {
+               "amount" : 1,
+               "price" : 11.905
+            },
+            "server_plan_8xCPU-16GB" : {
+               "amount" : 1,
+               "price" : 23.8095
+            },
+            "storage_backup" : {
+               "amount" : 1,
+               "price" : 0.0078
+            },
+            "storage_maxiops" : {
+               "amount" : 1,
+               "price" : 0.031
+            },
+            "storage_template" : {
+               "amount" : 1,
+               "price" : 0.031
+            }
+         },
+         {
+            "firewall" : {
+               "amount" : 1,
+               "price" : 0.56
+            },
+            "io_request_backup" : {
+               "amount" : 1000000,
+               "price" : 0
+            },
+            "io_request_hdd" : {
+               "amount" : 1000000,
+               "price" : 0
+            },
+            "io_request_maxiops" : {
+               "amount" : 1000000,
+               "price" : 0
+            },
+            "io_request_ssd" : {
+               "amount" : 1000000,
+               "price" : 0
+            },
+            "ipv4_address" : {
+               "amount" : 1,
+               "price" : 0.336
+            },
+            "ipv6_address" : {
+               "amount" : 1,
+               "price" : 0
+            },
+            "name" : "uk-lon1",
+            "public_ipv4_bandwidth_in" : {
+               "amount" : 1,
+               "price" : 0
+            },
+            "public_ipv4_bandwidth_out" : {
+               "amount" : 1,
+               "price" : 5.6
+            },
+            "public_ipv6_bandwidth_in" : {
+               "amount" : 1,
+               "price" : 0
+            },
+            "public_ipv6_bandwidth_out" : {
+               "amount" : 1,
+               "price" : 5.6
+            },
+            "server_core" : {
+               "amount" : 1,
+               "price" : 1.12
+            },
+            "server_memory" : {
+               "amount" : 256,
+               "price" : 0.14
+            },
+            "server_plan_12xCPU-32GB" : {
+               "amount" : 1,
+               "price" : 47.619
+            },
+            "server_plan_16xCPU-48GB" : {
+               "amount" : 1,
+               "price" : 71.4286
+            },
+            "server_plan_1xCPU-1GB" : {
+               "amount" : 1,
+               "price" : 1.488
+            },
+            "server_plan_20xCPU-64GB" : {
+               "amount" : 1,
+               "price" : 95.2381
+            },
+            "server_plan_2xCPU-2GB" : {
+               "amount" : 1,
+               "price" : 2.976
+            },
+            "server_plan_4xCPU-4GB" : {
+               "amount" : 1,
+               "price" : 5.952
+            },
+            "server_plan_6xCPU-8GB" : {
+               "amount" : 1,
+               "price" : 11.905
+            },
+            "server_plan_8xCPU-16GB" : {
+               "amount" : 1,
+               "price" : 23.8095
+            },
+            "storage_backup" : {
+               "amount" : 1,
+               "price" : 0.0078
+            },
+            "storage_hdd" : {
+               "amount" : 1,
+               "price" : 0.0078
+            },
+            "storage_maxiops" : {
+               "amount" : 1,
+               "price" : 0.031
+            },
+            "storage_ssd" : {
+               "amount" : 1,
+               "price" : 0.031
+            },
+            "storage_template" : {
+               "amount" : 1,
+               "price" : 0.031
+            }
+         },
+         {
+            "firewall" : {
+               "amount" : 1,
+               "price" : 0.56
+            },
+            "io_request_backup" : {
+               "amount" : 1000000,
+               "price" : 0
+            },
+            "io_request_maxiops" : {
+               "amount" : 1000000,
+               "price" : 0
+            },
+            "ipv4_address" : {
+               "amount" : 1,
+               "price" : 0.336
+            },
+            "ipv6_address" : {
+               "amount" : 1,
+               "price" : 0
+            },
+            "name" : "us-chi1",
+            "public_ipv4_bandwidth_in" : {
+               "amount" : 1,
+               "price" : 0
+            },
+            "public_ipv4_bandwidth_out" : {
+               "amount" : 1,
+               "price" : 5.6
+            },
+            "public_ipv6_bandwidth_in" : {
+               "amount" : 1,
+               "price" : 0
+            },
+            "public_ipv6_bandwidth_out" : {
+               "amount" : 1,
+               "price" : 5.6
+            },
+            "server_core" : {
+               "amount" : 1,
+               "price" : 1.12
+            },
+            "server_memory" : {
+               "amount" : 256,
+               "price" : 0.14
+            },
+            "server_plan_12xCPU-32GB" : {
+               "amount" : 1,
+               "price" : 47.619
+            },
+            "server_plan_16xCPU-48GB" : {
+               "amount" : 1,
+               "price" : 71.4286
+            },
+            "server_plan_1xCPU-1GB" : {
+               "amount" : 1,
+               "price" : 1.488
+            },
+            "server_plan_20xCPU-64GB" : {
+               "amount" : 1,
+               "price" : 95.2381
+            },
+            "server_plan_2xCPU-2GB" : {
+               "amount" : 1,
+               "price" : 2.976
+            },
+            "server_plan_4xCPU-4GB" : {
+               "amount" : 1,
+               "price" : 5.952
+            },
+            "server_plan_6xCPU-8GB" : {
+               "amount" : 1,
+               "price" : 11.905
+            },
+            "server_plan_8xCPU-16GB" : {
+               "amount" : 1,
+               "price" : 23.8095
+            },
+            "storage_backup" : {
+               "amount" : 1,
+               "price" : 0.0078
+            },
+            "storage_maxiops" : {
+               "amount" : 1,
+               "price" : 0.031
+            },
+            "storage_template" : {
+               "amount" : 1,
+               "price" : 0.031
+            }
+         }
+      ]
+   }
+}

--- a/libcloud/test/compute/test_upcloud.py
+++ b/libcloud/test/compute/test_upcloud.py
@@ -82,48 +82,18 @@ class UpcloudDriverTests(LibcloudTestCase):
         self.assert_object(expected_node_location, objects=locations)
 
     def test_list_sizes(self):
-        sizes = self.driver.list_sizes()
+        location = NodeLocation(id='fi-hel1', name='Helsinki #1', country='FI', driver=self.driver)
+        sizes = self.driver.list_sizes(location)
         self.assertTrue(len(sizes) >= 1)
-        expected_zones = [
-            {
-                'zone_id': 'de-fra1',
-                'price': 1.488
-            },
-            {
-                'zone_id': 'fi-dev2',
-                'price': 2.232
-            },
-            {
-                'zone_id': 'fi-hel1',
-                'price': 2.232
-            },
-            {
-                'zone_id': 'nl-ams1',
-                'price': 1.488
-            },
-            {
-                'zone_id': 'sg-sin1',
-                'price': 1.488
-            },
-            {
-                'zone_id': 'uk-lon1',
-                'price': 1.488
-            },
-            {
-                'zone_id': 'us-chi1',
-                'price': 1.488
-            }
-        ]
         expected_node_size = NodeSize(id='1xCPU-1GB',
                                       name='1xCPU-1GB',
                                       ram=1024,
                                       disk=30,
                                       bandwidth=2048,
-                                      price=None,
+                                      price=2.232,
                                       driver=self.driver,
                                       extra={'core_number': 1,
-                                             'storage_tier': 'maxiops',
-                                             'zones': expected_zones})
+                                             'storage_tier': 'maxiops'})
         self.assert_object(expected_node_size, objects=sizes)
 
     def test_list_images(self):


### PR DESCRIPTION
## Changes Title (replace this with a logical title for your changes)

### Description

UpCloud's driver were missing the pricing information from list_sizes return values. Added the information to NodeSize.extra data, because pricing zone specific. 

### Status

Replace this: describe the PR status. Examples:

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
