### PR TITLE
fix path for profitbricks list_snapshots() method

### DIFF
--- a/libcloud/compute/drivers/profitbricks.py
+++ b/libcloud/compute/drivers/profitbricks.py
@@ -1223,7 +1223,7 @@ class ProfitBricksNodeDriver(NodeDriver):
         """
 
         response = self.connection.request(
-            action='/snapshots',
+            action='snapshots',
             params={'depth': 3},
             method='GET'
         )


### PR DESCRIPTION
## Fix path for profitbricks compute driver ```list_snapshots``` method

### Description

The leading slash breaks the URL in this method. With it, I get:
```
Traceback (most recent call last):
  File "./profitbricks.py", line 38, in <module>
    snapshots = driver.list_snapshots()
  File "/usr/lib/python2.7/dist-packages/libcloud/compute/drivers/profitbricks.py", line 1176, in list_snapshots
    method='GET'
  File "/usr/lib/python2.7/dist-packages/libcloud/compute/drivers/profitbricks.py", line 143, in request
    raw=raw
  File "/usr/lib/python2.7/dist-packages/libcloud/common/base.py", line 871, in request
    response = responseCls(**kwargs)
  File "/usr/lib/python2.7/dist-packages/libcloud/common/base.py", line 180, in __init__
    headers=self.headers)
libcloud.common.exceptions.BaseHTTPError
```

Removing the slash makes the method work again, and it's in line with the format of the other API requests in the driver that omit the full URL.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
