### PR TITLE
LIBCLOUD-971 - wait_until_running should only append addresses if the

### DIFF
--- a/libcloud/compute/base.py
+++ b/libcloud/compute/base.py
@@ -1345,8 +1345,11 @@ class NodeDriver(BaseDriver):
 
             running_nodes = [node for node in matching_nodes
                              if node.state == NodeState.RUNNING]
-            addresses = [filter_addresses(getattr(node, ssh_interface))
-                         for node in running_nodes]
+            addresses = []
+            for node in running_nodes:
+                node_addresses = filter_addresses(getattr(node, ssh_interface))
+                if len(node_addresses) >= 1:
+                    addresses.append(node_addresses)
 
             if len(running_nodes) == len(uuids) == len(addresses):
                 return list(zip(running_nodes, addresses))

--- a/libcloud/test/compute/fixtures/openstack/v1_slug_servers_detail_deployment_ipv6.xml
+++ b/libcloud/test/compute/fixtures/openstack/v1_slug_servers_detail_deployment_ipv6.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<servers xmlns="http://docs.rackspacecloud.com/servers/api/v1.0">
+  <server status="ACTIVE" progress="100" hostId="9dd380940fcbe39cb30255ed4664f1f3" flavorId="1" imageId="11" id="12345" name="racktest">
+    <metadata/>
+    <addresses>
+      <public>
+        <ip addr="2001:DB8::1"/>
+      </public>
+      <private>
+        <ip addr="2001:DB8:1::1"/>
+      </private>
+    </addresses>
+  </server>
+</servers>

--- a/libcloud/test/compute/fixtures/openstack/v1_slug_servers_detail_deployment_no_ip.xml
+++ b/libcloud/test/compute/fixtures/openstack/v1_slug_servers_detail_deployment_no_ip.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<servers xmlns="http://docs.rackspacecloud.com/servers/api/v1.0">
+  <server status="ACTIVE" progress="100" hostId="9dd380940fcbe39cb30255ed4664f1f3" flavorId="1" imageId="11" id="12345" name="racktest">
+    <metadata/>
+    <addresses>
+      <public>
+        <ip addr="2001:DB8::1"/>
+      </public>
+      <private>
+        <ip addr="2001:DB8:1::1"/>
+      </private>
+    </addresses>
+  </server>
+</servers>


### PR DESCRIPTION
## LIBCLOUD-971 

### Description

 LIBCLOUD-971 - wait_until_running should only append ip addresses if the list is not empty.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [X] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
