### PR TITLE
ECS Aliyun: support modify_security_group_attributes

### DIFF
--- a/libcloud/compute/drivers/ecs.py
+++ b/libcloud/compute/drivers/ecs.py
@@ -848,7 +848,7 @@ class ECSDriver(NodeDriver):
 
         resp = self.connection.request(self.path, params)
         return resp.success()
-        
+
     def ex_list_security_groups(self, ex_filters=None):
         """
         List security groups in the current region.

--- a/libcloud/compute/drivers/ecs.py
+++ b/libcloud/compute/drivers/ecs.py
@@ -820,6 +820,35 @@ class ECSDriver(NodeDriver):
         resp = self.connection.request(self.path, params)
         return resp.success()
 
+    def ex_modify_security_group_by_id(
+            self,
+            group_id=None,
+            name=None,
+            description=None):
+        """
+        Modify a new security group.
+        :keyword group_id: id of the security group
+        :type group_id: ``str``
+        :keyword name: new name of the security group
+        :type name: ``unicode``
+        :keyword description: new description of the security group
+        :type description: ``unicode``
+        """
+
+        params = {'Action': 'ModifySecurityGroupAttribute',
+                  'RegionId': self.region}
+        if not group_id:
+            raise AttributeError('group_id is required')
+        params["SecurityGroupId"] = group_id
+
+        if name:
+            params["SecurityGroupName"] = name
+        if description:
+            params["Description"] = description
+
+        resp = self.connection.request(self.path, params)
+        return resp.success()
+        
     def ex_list_security_groups(self, ex_filters=None):
         """
         List security groups in the current region.

--- a/libcloud/test/compute/fixtures/ecs/create_security_group.xml
+++ b/libcloud/test/compute/fixtures/ecs/create_security_group.xml
@@ -1,4 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
+<CreateSecurityGroupResponse>
 <RequestId>CEF72CEB-54B6-4AE8-B225-F876FF7BA984</RequestId>
 	<SecurityGroupId>sg-F876FF7BA</SecurityGroupId>
 </CreateSecurityGroupResponse>

--- a/libcloud/test/compute/fixtures/ecs/delete_security_group_by_id.xml
+++ b/libcloud/test/compute/fixtures/ecs/delete_security_group_by_id.xml
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <DeleteSecurityGroupResponse>
-	<RequestId>CEF72CEB-54B6-4AE8-B225-F876FF7BA984</RquestID>
+	<RequestId>CEF72CEB-54B6-4AE8-B225-F876FF7BA984</RequestId>
 </DeleteSecurityGroupResponse>

--- a/libcloud/test/compute/fixtures/ecs/describe_security_group_attributes.xml
+++ b/libcloud/test/compute/fixtures/ecs/describe_security_group_attributes.xml
@@ -1,26 +1,30 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<DescribeSecurityGroupsResponse>
-	<RequestId>94D38899-626D-434A-891F-7E1F77A81525</RequestId>
-	<TotalCount>4</TotalCount>
-	<PageNumber>1</PageNumber>
-	<PageSize>10</PageSize>
-	<RegionId>cn-hangzhou </RegionId>
-	<SecurityGroups>
-		<SecurityGroup>
-			<SecurityGroupId>sg-F876FF7BA</SecurityGroupId>
-			<Description>Test</Description>
-		</SecurityGroup>
-		<SecurityGroup>
-			<SecurityGroupId>sg-086FFC27A</SecurityGroupId>
-			<Description>test00212</Description>
-		</SecurityGroup>
-		<SecurityGroup>
-			<SecurityGroupId>sg-BA4B7975B</SecurityGroupId>
-			<Description>cn-hangzhou test group</Description>
-		</SecurityGroup>
-		<SecurityGroup>
-			<SecurityGroupId>sg-35F20777C</SecurityGroupId>
-			<Description>cn-hangzhou test group</Description>
-		</SecurityGroup>
-	</SecurityGroups>
-</DescribeSecurityGroupsResponse>
+<DescribeSecurityGroupAttributeResponse>
+	<SecurityGroupId>sg-m5e5vyj2j0atm2gewww4</SecurityGroupId>
+	<InnerAccessPolicy>Accept</InnerAccessPolicy>
+	<SecurityGroupName>sg-m5e5vyj2j0atm2gewww4</SecurityGroupName>
+	<Description>System created security group.</Description>
+	<RegionId>cn-qingdao</RegionId>
+	<RequestId>8A3E0262-EEA1-4961-A403-3D6E69F3539C</RequestId>
+	<Permissions>
+		<Permission>
+			<SourceCidrIp>121.43.18.0/24</SourceCidrIp>
+			<DestCidrIp></DestCidrIp>
+			<Description></Description>
+			<NicType>internet</NicType>
+			<DestGroupName></DestGroupName>
+			<PortRange>-1/-1</PortRange>
+			<DestGroupId></DestGroupId>
+			<Direction>ingress</Direction>
+			<Priority>1</Priority>
+			<IpProtocol>ALL</IpProtocol>
+			<SourceGroupOwnerAccount></SourceGroupOwnerAccount>
+			<Policy>Accept</Policy>
+			<CreateTime>2017-07-08T06:20:39Z</CreateTime>
+			<SourceGroupId></SourceGroupId>
+			<DestGroupOwnerAccount></DestGroupOwnerAccount>
+			<SourceGroupName></SourceGroupName>
+		</Permission>
+	</Permissions>
+	<VpcId></VpcId>
+</DescribeSecurityGroupAttributeResponse>

--- a/libcloud/test/compute/fixtures/ecs/modify_security_group_by_id.xml
+++ b/libcloud/test/compute/fixtures/ecs/modify_security_group_by_id.xml
@@ -1,0 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ModifySecurityGroupAttributeResponse>
+     <RequestId>CEF72CEB-54B6-4AE8-B225-F876FF7BA984</RequestId>
+</ModifySecurityGroupAttributeResponse>

--- a/libcloud/test/compute/test_ecs.py
+++ b/libcloud/test/compute/test_ecs.py
@@ -535,27 +535,29 @@ class ECSDriverTestCase(LibcloudTestCase):
         self.assertEqual('2015-06-26T08:35:30Z', sg.creation_time)
 
     def test_ex_join_security_group(self):
-        ex_security_group_id_value = 'sg-28ou0f3xa'
+        self.sg_id = "sg-28ou0f3xa"
         result = self.driver.ex_join_security_group(self.fake_node,
-                                                    group_id=ex_security_group_id_value)
+                                                    group_id=self.sg_id)
         self.assertTrue(result)
 
     def test_ex_leave_security_group(self):
-        ex_security_group_id_value = 'sg-28ou0f3xa'
+        self.sg_id = "sg-28ou0f3xa"
         result = self.driver.ex_leave_security_group(self.fake_node,
-                                                     group_id=ex_security_group_id_value)
+                                                     group_id=self.sg_id)
         self.assertTrue(result)
 
     def test_ex_delete_security_group_by_id(self):
-        ex_security_group_id_value = "sg-28ou0f3xa"
+        self.sg_id = "sg-28ou0f3xa"
         result = self.driver.ex_delete_security_group_by_id(
-            group_id=ex_security_group_id_value)
+            group_id=self.sg_id)
         self.assertTrue(result)
 
     def test_ex_modify_security_group_by_id(self):
-        ex_security_group_id_value = "sg-28ou0f3xa"
+        self.sg_id = "sg-28ou0f3xa"
+        self.sg_name = "name"
+        self.sg_description = "description"
         result = self.driver.ex_modify_security_group_by_id(
-            group_id=ex_security_group_id_value)
+            group_id=self.sg_id, name=self.sg_name, description=self.sg_description)
         self.assertTrue(result)
 
     def test_ex_list_security_groups_with_ex_filters(self):
@@ -566,9 +568,10 @@ class ECSDriverTestCase(LibcloudTestCase):
         self.assertEqual(1, len(sgs))
 
     def test_ex_list_security_group_attributes(self):
-        ex_security_group_id_value = 'sg-28ou0f3xa'
+        self.sg_id = 'sg-28ou0f3xa'
+        self.sga_nictype = 'internet'
         sgas = self.driver.ex_list_security_group_attributes(
-            group_id=ex_security_group_id_value)
+            group_id=self.sg_id, nic_type=self.sga_nictype)
         self.assertEqual(1, len(sgas))
         sga = sgas[0]
         self.assertEqual('ALL', sga.ip_protocol)
@@ -945,10 +948,16 @@ class ECSMockHttp(MockHttp):
         return (httplib.OK, resp_body, {}, httplib.responses[httplib.OK])
 
     def _JoinSecurityGroup(self, method, url, body, headers):
+        params = {'InstanceId': self.test.fake_node.id,
+                  'SecurityGroupId': self.test.sg_id}
+        self.assertUrlContainsQueryParams(url, params)
         body = self.fixtures.load('join_security_group_by_id.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
     def _LeaveSecurityGroup(self, method, url, body, headers):
+        params = {'InstanceId': self.test.fake_node.id,
+                  'SecurityGroupId': self.test.sg_id}
+        self.assertUrlContainsQueryParams(url, params)
         body = self.fixtures.load('leave_security_group_by_id.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
@@ -960,27 +969,32 @@ class ECSMockHttp(MockHttp):
 
     def _CreateSecurityGroup(self, method, url, body, headers):
         params = {'RegionId': self.test.region,
-                  'Description': 'description',
-                  'ClientToken': 'client-token'}
+                  'Description': self.test.sg_description,
+                  'ClientToken': self.test.client_token}
         self.assertUrlContainsQueryParams(url, params)
         resp_body = self.fixtures.load('create_security_group.xml')
         return (httplib.OK, resp_body, {}, httplib.responses[httplib.OK])
 
     def _DeleteSecurityGroup(self, method, url, body, headers):
-        params = {'RegionId': self.test.region}
+        params = {'RegionId': self.test.region,
+                  'SecurityGroupId': self.test.sg_id}
         self.assertUrlContainsQueryParams(url, params)
         resp_body = self.fixtures.load('delete_security_group_by_id.xml')
         return (httplib.OK, resp_body, {}, httplib.responses[httplib.OK])
 
     def _ModifySecurityGroupAttribute(self, method, url, body, headers):
-        params = {'RegionId': self.test.region}
+        params = {'RegionId': self.test.region,
+                  'SecurityGroupId': self.test.sg_id,
+                  'SecurityGroupName': self.test.sg_name,
+                  'Description': self.test.sg_description}
         self.assertUrlContainsQueryParams(url, params)
         resp_body = self.fixtures.load('modify_security_group_by_id.xml')
         return (httplib.OK, resp_body, {}, httplib.responses[httplib.OK])
 
     def _DescribeSecurityGroupAttribute(self, method, url, body, headers):
         params = {'RegionId': self.test.region,
-                  'NicType': 'internet'}
+                  'SecurityGroupId': self.test.sg_id,
+                  'NicType': self.test.sga_nictype}
         self.assertUrlContainsQueryParams(url, params)
         resp_body = self.fixtures.load('describe_security_group_attributes.xml')
         return (httplib.OK, resp_body, {}, httplib.responses[httplib.OK])

--- a/libcloud/test/compute/test_ecs.py
+++ b/libcloud/test/compute/test_ecs.py
@@ -942,7 +942,7 @@ class ECSMockHttp(MockHttp):
         self.assertUrlContainsQueryParams(url, params)
         resp_body = self.fixtures.load('delete_security_group_by_id.xml')
         return (httplib.OK, resp_body, {}, httplib.responses[httplib.OK])
-        
+
     def _modify_sg_by_id_ModifySecurityGroup(self, method, url, body, headers):
         params = {'RegionId': self.test.region,
                   'SecurityGroupId': 'sg-fakeSecurityGroupId',

--- a/libcloud/test/compute/test_ecs.py
+++ b/libcloud/test/compute/test_ecs.py
@@ -942,6 +942,15 @@ class ECSMockHttp(MockHttp):
         self.assertUrlContainsQueryParams(url, params)
         resp_body = self.fixtures.load('delete_security_group_by_id.xml')
         return (httplib.OK, resp_body, {}, httplib.responses[httplib.OK])
+        
+    def _modify_sg_by_id_ModifySecurityGroup(self, method, url, body, headers):
+        params = {'RegionId': self.test.region,
+                  'SecurityGroupId': 'sg-fakeSecurityGroupId',
+                  'SecurityGroupName': 'sg-fakeSecurityName',
+                  'Description': 'sg-fakeSecurityDescription'}
+        self.assertUrlContainsQueryParams(url, params)
+        resp_body = self.fixtures.load('modify_security_group_by_id.xml')
+        return (httplib.OK, resp_body, {}, httplib.responses[httplib.OK])
 
     def _list_sgas_DescribeSecurityGroupAttributes(self, method, url, body, headers):
         params = {'RegionId': self.test.region,

--- a/libcloud/test/compute/test_ecs.py
+++ b/libcloud/test/compute/test_ecs.py
@@ -535,25 +535,25 @@ class ECSDriverTestCase(LibcloudTestCase):
         self.assertEqual('2015-06-26T08:35:30Z', sg.creation_time)
 
     def test_ex_join_security_group(self):
-        self.sg_id = "sg-28ou0f3xa"
+        self.sg_id = 'sg-28ou0f3xa'
         result = self.driver.ex_join_security_group(self.fake_node,
                                                     group_id=self.sg_id)
         self.assertTrue(result)
 
     def test_ex_leave_security_group(self):
-        self.sg_id = "sg-28ou0f3xa"
+        self.sg_id = 'sg-28ou0f3xa'
         result = self.driver.ex_leave_security_group(self.fake_node,
                                                      group_id=self.sg_id)
         self.assertTrue(result)
 
     def test_ex_delete_security_group_by_id(self):
-        self.sg_id = "sg-28ou0f3xa"
+        self.sg_id = 'sg-28ou0f3xa'
         result = self.driver.ex_delete_security_group_by_id(
             group_id=self.sg_id)
         self.assertTrue(result)
 
     def test_ex_modify_security_group_by_id(self):
-        self.sg_id = "sg-28ou0f3xa"
+        self.sg_id = 'sg-28ou0f3xa'
         self.sg_name = "name"
         self.sg_description = "description"
         result = self.driver.ex_modify_security_group_by_id(

--- a/libcloud/test/compute/test_ecs.py
+++ b/libcloud/test/compute/test_ecs.py
@@ -554,8 +554,8 @@ class ECSDriverTestCase(LibcloudTestCase):
 
     def test_ex_modify_security_group_by_id(self):
         self.sg_id = 'sg-28ou0f3xa'
-        self.sg_name = "name"
-        self.sg_description = "description"
+        self.sg_name = 'name'
+        self.sg_description = 'description'
         result = self.driver.ex_modify_security_group_by_id(
             group_id=self.sg_id, name=self.sg_name, description=self.sg_description)
         self.assertTrue(result)

--- a/libcloud/test/compute/test_ecs.py
+++ b/libcloud/test/compute/test_ecs.py
@@ -536,18 +536,18 @@ class ECSDriverTestCase(LibcloudTestCase):
         self.assertEqual('2015-06-26T08:35:30Z', sg.creation_time)
 
     def test_ex_join_security_group(self):
-        result = self.driver.ex_join_security_group(self.fake_node,
-                                group_id=self.fake_security_group_id)
+        result = self.driver.ex_join_security_group(
+            self.fake_node, group_id=self.fake_security_group_id)
         self.assertTrue(result)
 
     def test_ex_leave_security_group(self):
-        result = self.driver.ex_leave_security_group(self.fake_node,
-                                group_id=self.fake_security_group_id)
+        result = self.driver.ex_leave_security_group(
+            self.fake_node, group_id=self.fake_security_group_id)
         self.assertTrue(result)
 
     def test_ex_delete_security_group_by_id(self):
         result = self.driver.ex_delete_security_group_by_id(
-                                group_id=self.fake_security_group_id)
+            group_id=self.fake_security_group_id)
         self.assertTrue(result)
 
     def test_ex_modify_security_group_by_id(self):

--- a/libcloud/test/compute/test_ecs.py
+++ b/libcloud/test/compute/test_ecs.py
@@ -59,6 +59,7 @@ class ECSDriverTestCase(LibcloudTestCase):
         self.fake_location = NodeLocation(id=self.region, name=self.region,
                                           country=None, driver=self.driver)
         self.fake_instance_id = 'fake_instance_id'
+        self.fake_security_group_id = 'fake_security_group_id'
 
     def test_list_nodes(self):
         nodes = self.driver.list_nodes()
@@ -535,29 +536,27 @@ class ECSDriverTestCase(LibcloudTestCase):
         self.assertEqual('2015-06-26T08:35:30Z', sg.creation_time)
 
     def test_ex_join_security_group(self):
-        self.sg_id = 'sg-28ou0f3xa'
         result = self.driver.ex_join_security_group(self.fake_node,
-                                                    group_id=self.sg_id)
+                                group_id=self.fake_security_group_id)
         self.assertTrue(result)
 
     def test_ex_leave_security_group(self):
-        self.sg_id = 'sg-28ou0f3xa'
         result = self.driver.ex_leave_security_group(self.fake_node,
-                                                     group_id=self.sg_id)
+                                group_id=self.fake_security_group_id)
         self.assertTrue(result)
 
     def test_ex_delete_security_group_by_id(self):
-        self.sg_id = 'sg-28ou0f3xa'
         result = self.driver.ex_delete_security_group_by_id(
-            group_id=self.sg_id)
+                                group_id=self.fake_security_group_id)
         self.assertTrue(result)
 
     def test_ex_modify_security_group_by_id(self):
-        self.sg_id = 'sg-28ou0f3xa'
         self.sg_name = 'name'
         self.sg_description = 'description'
         result = self.driver.ex_modify_security_group_by_id(
-            group_id=self.sg_id, name=self.sg_name, description=self.sg_description)
+            group_id=self.fake_security_group_id,
+            name=self.sg_name,
+            description=self.sg_description)
         self.assertTrue(result)
 
     def test_ex_list_security_groups_with_ex_filters(self):
@@ -568,10 +567,9 @@ class ECSDriverTestCase(LibcloudTestCase):
         self.assertEqual(1, len(sgs))
 
     def test_ex_list_security_group_attributes(self):
-        self.sg_id = 'sg-28ou0f3xa'
         self.sga_nictype = 'internet'
         sgas = self.driver.ex_list_security_group_attributes(
-            group_id=self.sg_id, nic_type=self.sga_nictype)
+            group_id=self.fake_security_group_id, nic_type=self.sga_nictype)
         self.assertEqual(1, len(sgas))
         sga = sgas[0]
         self.assertEqual('ALL', sga.ip_protocol)
@@ -949,14 +947,14 @@ class ECSMockHttp(MockHttp):
 
     def _JoinSecurityGroup(self, method, url, body, headers):
         params = {'InstanceId': self.test.fake_node.id,
-                  'SecurityGroupId': self.test.sg_id}
+                  'SecurityGroupId': self.test.fake_security_group_id}
         self.assertUrlContainsQueryParams(url, params)
         body = self.fixtures.load('join_security_group_by_id.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
     def _LeaveSecurityGroup(self, method, url, body, headers):
         params = {'InstanceId': self.test.fake_node.id,
-                  'SecurityGroupId': self.test.sg_id}
+                  'SecurityGroupId': self.test.fake_security_group_id}
         self.assertUrlContainsQueryParams(url, params)
         body = self.fixtures.load('leave_security_group_by_id.xml')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
@@ -977,14 +975,14 @@ class ECSMockHttp(MockHttp):
 
     def _DeleteSecurityGroup(self, method, url, body, headers):
         params = {'RegionId': self.test.region,
-                  'SecurityGroupId': self.test.sg_id}
+                  'SecurityGroupId': self.test.fake_security_group_id}
         self.assertUrlContainsQueryParams(url, params)
         resp_body = self.fixtures.load('delete_security_group_by_id.xml')
         return (httplib.OK, resp_body, {}, httplib.responses[httplib.OK])
 
     def _ModifySecurityGroupAttribute(self, method, url, body, headers):
         params = {'RegionId': self.test.region,
-                  'SecurityGroupId': self.test.sg_id,
+                  'SecurityGroupId': self.test.fake_security_group_id,
                   'SecurityGroupName': self.test.sg_name,
                   'Description': self.test.sg_description}
         self.assertUrlContainsQueryParams(url, params)
@@ -993,7 +991,7 @@ class ECSMockHttp(MockHttp):
 
     def _DescribeSecurityGroupAttribute(self, method, url, body, headers):
         params = {'RegionId': self.test.region,
-                  'SecurityGroupId': self.test.sg_id,
+                  'SecurityGroupId': self.test.fake_security_group_id,
                   'NicType': self.test.sga_nictype}
         self.assertUrlContainsQueryParams(url, params)
         resp_body = self.fixtures.load('describe_security_group_attributes.xml')

--- a/libcloud/test/compute/test_ecs.py
+++ b/libcloud/test/compute/test_ecs.py
@@ -972,13 +972,13 @@ class ECSMockHttp(MockHttp):
         resp_body = self.fixtures.load('delete_security_group_by_id.xml')
         return (httplib.OK, resp_body, {}, httplib.responses[httplib.OK])
 
-    def _ModifySecurityGroup(self, method, url, body, headers):
+    def _ModifySecurityGroupAttribute(self, method, url, body, headers):
         params = {'RegionId': self.test.region}
         self.assertUrlContainsQueryParams(url, params)
         resp_body = self.fixtures.load('modify_security_group_by_id.xml')
         return (httplib.OK, resp_body, {}, httplib.responses[httplib.OK])
 
-    def _DescribeSecurityGroupAttributes(self, method, url, body, headers):
+    def _DescribeSecurityGroupAttribute(self, method, url, body, headers):
         params = {'RegionId': self.test.region,
                   'NicType': 'internet'}
         self.assertUrlContainsQueryParams(url, params)


### PR DESCRIPTION
## Aliyun ECS: Add support to modify attributes of security group

### Description

- [describe_security_group_attributes.xml](https://github.com/apache/libcloud/blob/trunk/libcloud/test/compute/fixtures/ecs/describe_security_group_attributes.xml) doesn't match its title.
- Can't modify security group name or description via ECS driver currently

Reference: 
[Aliyun API Doc - DescribeSecurityGroupAttribute](https://help.aliyun.com/document_detail/25555.html?spm=5176.doc25556.6.893.9yP6oY)
[Aliyun API Doc - ModifySecurityGroupAttribute](https://help.aliyun.com/document_detail/25559.html?spm=5176.doc25555.6.897.J4hUYN)

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)

  
  