### PR TITLE
Added EC2 M5 sizes

### DIFF
--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -292,6 +292,66 @@ INSTANCE_TYPES = {
             'cpu': 64
         }
     },
+    'm5.large': {
+        'id': 'm5.large',
+        'name': 'Large Instance',
+        'ram': GiB(8),
+        'disk': 0,  # EBS only
+        'bandwidth': None,
+        'extra': {
+            'cpu': 2
+        }
+    },
+    'm5.xlarge': {
+        'id': 'm5.xlarge',
+        'name': 'Extra Large Instance',
+        'ram': GiB(16),
+        'disk': 0,  # EBS only
+        'bandwidth': None,
+        'extra': {
+            'cpu': 4
+        }
+    },
+    'm5.2xlarge': {
+        'id': 'm5.2xlarge',
+        'name': 'Double Extra Large Instance',
+        'ram': GiB(32),
+        'disk': 0,  # EBS only
+        'bandwidth': None,
+        'extra': {
+            'cpu': 8
+        }
+    },
+    'm5.4xlarge': {
+        'id': 'm5.4xlarge',
+        'name': 'Quadruple Extra Large Instance',
+        'ram': GiB(64),
+        'disk': 0,  # EBS only
+        'bandwidth': None,
+        'extra': {
+            'cpu': 16
+        }
+    },
+    'm5.12xlarge': {
+        'id': 'm5.12xlarge',
+        'name': '12 Extra Large Instance',
+        'ram': GiB(192),
+        'disk': 0,  # EBS only
+        'bandwidth': None,
+        'extra': {
+            'cpu': 48
+        }
+    },
+    'm5.24xlarge': {
+        'id': 'm5.24xlarge',
+        'name': '24 Extra Large Instance',
+        'ram': GiB(384),
+        'disk': 0,  # EBS only
+        'bandwidth': None,
+        'extra': {
+            'cpu': 96
+        }
+    },
     'cg1.4xlarge': {
         'id': 'cg1.4xlarge',
         'name': 'Cluster GPU Quadruple Extra Large Instance',
@@ -969,6 +1029,12 @@ REGION_DETAILS = {
             'm4.4xlarge',
             'm4.10xlarge',
             'm4.16xlarge',
+            'm5.large',
+            'm5.xlarge',
+            'm5.2xlarge',
+            'm5.4xlarge',
+            'm5.12xlarge',
+            'm5.24xlarge',
             'c1.medium',
             'c1.xlarge',
             'cc2.8xlarge',
@@ -1213,6 +1279,12 @@ REGION_DETAILS = {
             'm4.4xlarge',
             'm4.10xlarge',
             'm4.16xlarge',
+            'm5.large',
+            'm5.xlarge',
+            'm5.2xlarge',
+            'm5.4xlarge',
+            'm5.12xlarge',
+            'm5.24xlarge',
             'c1.medium',
             'c1.xlarge',
             'g2.2xlarge',
@@ -1295,6 +1367,12 @@ REGION_DETAILS = {
             'm4.4xlarge',
             'm4.10xlarge',
             'm4.16xlarge',
+            'm5.large',
+            'm5.xlarge',
+            'm5.2xlarge',
+            'm5.4xlarge',
+            'm5.12xlarge',
+            'm5.24xlarge',
             'c1.medium',
             'c1.xlarge',
             'g2.2xlarge',

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -448,7 +448,7 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
                 self.assertTrue('m2.4xlarge' in ids)
 
             if region_name == 'us-east-1':
-                self.assertEqual(len(sizes), 78)
+                self.assertEqual(len(sizes), 84)
                 self.assertTrue('cg1.4xlarge' in ids)
                 self.assertTrue('cc2.8xlarge' in ids)
                 self.assertTrue('cr1.8xlarge' in ids)
@@ -456,13 +456,13 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
             elif region_name == 'us-west-1':
                 self.assertEqual(len(sizes), 67)
             if region_name == 'us-west-2':
-                self.assertEqual(len(sizes), 73)
+                self.assertEqual(len(sizes), 79)
             elif region_name == 'ap-southeast-1':
                 self.assertEqual(len(sizes), 59)
             elif region_name == 'ap-southeast-2':
                 self.assertEqual(len(sizes), 63)
             elif region_name == 'eu-west-1':
-                self.assertEqual(len(sizes), 76)
+                self.assertEqual(len(sizes), 82)
             elif region_name == 'ap-south-1':
                 self.assertEqual(len(sizes), 41)
 


### PR DESCRIPTION
## Added EC2 M5 sizes

### Description

See:
https://aws.amazon.com/about-aws/whats-new/2017/11/introducing-amazon-ec2-m5-instances/?nc1=h_ls
https://aws.amazon.com/ec2/instance-types/m5/?nc1=h_ls

### Status

Replace this: describe the PR status. Examples:

Done

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
