### PR TITLE
Fix read_in_chunks on Python 3.7

### DIFF
--- a/libcloud/utils/files.py
+++ b/libcloud/utils/files.py
@@ -83,7 +83,7 @@ def read_in_chunks(iterator, chunk_size=None, fill_size=False,
             if empty and yield_empty:
                 yield b('')
 
-            raise StopIteration
+            return
 
         if fill_size:
             if empty or len(data) >= chunk_size:


### PR DESCRIPTION
According to https://www.python.org/dev/peps/pep-0479/#id41, this will stop working in Python 3.7: fix it now.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)