### PR TITLE
Reduce `tox -e lint` verbosity

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -83,7 +83,7 @@ commands = flake8 --ignore=E402 --exclude="test" libcloud/
            flake8 --ignore=E402 integration/
            flake8 --ignore=E402,E902 docs/examples/
            flake8 --ignore=E402,E902 --max-line-length=160 contrib/
-           python -mjson.tool libcloud/data/pricing.json
+           python -mjson.tool libcloud/data/pricing.json /dev/null
 
 [testenv:checks]
 commands = bash ./scripts/check_file_names.sh


### PR DESCRIPTION
## Reduce `tox -e lint` verbosity

### Description

By default, `python -m json.tool` prints to stdout, which makes `tox -e lint` really verbose. This change keeps the errors, if any, but discards the result. There is no automated test to add, but I did check that we were seeing the errors when the input file was not well formed. 

`/dev/null` won't work on Windows, but we already use /bin/bash for `tox -e docs`. Is Windows supported by libcloud? If it is, we should add Appveyor CI. At that point, I'll stop using json.tool for `tox -e lint` but will write a simple Python scripts that uses the `json`module.

Thoughts?

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)