### PR TITLE
[LIBCLOUD-963] Adds support for GCE accelerators in the GCE driver.

### DIFF
--- a/libcloud/test/compute/fixtures/gce/zones_us_central1_a_acceleratorTypes_nvidia_tesla_k80.json
+++ b/libcloud/test/compute/fixtures/gce/zones_us_central1_a_acceleratorTypes_nvidia_tesla_k80.json
@@ -1,0 +1,10 @@
+{
+  "kind": "compute#acceleratorType",
+  "description": "NVIDIA Tesla K80",
+  "creationTimestamp": "1969-12-31T16:00:00.000-08:00",
+  "maximumCardsPerInstance": 8,
+  "name": "nvidia-tesla-k80",
+  "zone": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/acceleratorTypes/nvidia-tesla-k80",
+  "id": "10002"
+}

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -543,6 +543,13 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         self.assertTrue(hasattr(ssl, 'certificate'))
         self.assertTrue(len(ssl.certificate))
 
+    def test_ex_get_accelerator_type(self):
+        name = 'nvidia-tesla-k80'
+        zone = self.driver.ex_get_zone('us-central1-a')
+        accelerator_type = self.driver.ex_get_accelerator_type(name, zone)
+        self.assertEqual(accelerator_type.name, name)
+        self.assertEqual(accelerator_type.zone, zone)
+
     def test_ex_get_subnetwork(self):
         name = 'cf-972cf02e6ad49112'
         region_name = 'us-central1'
@@ -1235,6 +1242,19 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         self.assertEqual(len(data['metadata']['items']), 1)
         self.assertEqual(data['metadata']['items'][0]['key'], 'k0')
         self.assertEqual(data['metadata']['items'][0]['value'], 'v0')
+
+    def test_create_node_with_accelerator(self):
+        node_name = 'node-name'
+        image = self.driver.ex_get_image('debian-7')
+        size = self.driver.ex_get_size('n1-standard-1')
+        zone = self.driver.ex_get_zone('us-central1-a')
+        request, data = self.driver._create_node_req(
+            node_name, size, image, zone,
+            ex_accelerator_type='nvidia-tesla-k80', ex_accelerator_count=3)
+        self.assertTrue('guestAccelerators' in data)
+        self.assertEqual(len(data['guestAccelerators']), 1)
+        self.assertTrue('nvidia-tesla-k80' in data['guestAccelerators'][0]['acceleratorType'])
+        self.assertEqual(data['guestAccelerators'][0]['acceleratorCount'], 3)
 
     def test_create_node_with_labels(self):
         node_name = 'node-name'
@@ -2130,6 +2150,13 @@ class GCEMockHttp(MockHttp):
                                                       headers):
         body = self.fixtures.load(
             'zones_us_central1_a_instances_node_name_stop.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _zones_us_central1_a_acceleratorTypes_nvidia_tesla_k80(self, method,
+                                                               url, body,
+                                                               headers):
+        body = self.fixtures.load(
+            'zones_us_central1_a_acceleratorTypes_nvidia_tesla_k80.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
     def _zones_us_central1_a_instances_node_name_setMetadata(self, method, url,


### PR DESCRIPTION
## [LIBCLOUD-963] Add option to attach GPU when creating instances in GCE
### Description

Adding GCE accelerator request to the create_node function. I am from Google on the cloud accelerators team and we are working on some projects to want to deploy VMs using libcloud with accelerators attached. 

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [X] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
