### PR TITLE
Allow shared vpc in gce

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -7073,9 +7073,10 @@ class GCENodeDriver(NodeDriver):
         """
         region_name = None
         if name.startswith('https://'):
-            parts = self._get_components_from_path(name)
+            #parts = self._get_components_from_path(name)
             #name = parts['name']
-            region_name = parts['region']
+            #region_name = parts['region']
+            request = name
         else:
             if isinstance(region, GCERegion):
                 region_name = region.name
@@ -7085,15 +7086,16 @@ class GCENodeDriver(NodeDriver):
                 else:
                     region_name = region
 
-        if not region_name:
-            region = self._set_region(region)
-            if not region:
-                raise ValueError("Could not determine region for subnetwork.")
-            else:
-                region_name = region.name
+            if not region_name:
+                region = self._set_region(region)
+                if not region:
+                    raise ValueError("Could not determine region for subnetwork.")
+                else:
+                    region_name = region.name
 
-        #request = '/regions/%s/subnetworks/%s' % (region_name, name)
-        request = '%s' % (name)
+            request = '/regions/%s/subnetworks/%s' % (region_name, name)
+
+        # request = '/regions/%s/subnetworks/%s' % (region_name, name)
         response = self.connection.request(request, method='GET').object
         return self._to_subnetwork(response)
 

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -7074,7 +7074,7 @@ class GCENodeDriver(NodeDriver):
         region_name = None
         if name.startswith('https://'):
             parts = self._get_components_from_path(name)
-            name = parts['name']
+            #name = parts['name']
             region_name = parts['region']
         else:
             if isinstance(region, GCERegion):
@@ -7092,7 +7092,8 @@ class GCENodeDriver(NodeDriver):
             else:
                 region_name = region.name
 
-        request = '/regions/%s/subnetworks/%s' % (region_name, name)
+        #request = '/regions/%s/subnetworks/%s' % (region_name, name)
+        request = '%s' % (name)
         response = self.connection.request(request, method='GET').object
         return self._to_subnetwork(response)
 
@@ -7106,7 +7107,10 @@ class GCENodeDriver(NodeDriver):
         :return:  A Network object for the network
         :rtype:   :class:`GCENetwork`
         """
-        request = '/global/networks/%s' % (name)
+        if name.startswith('https://'):
+          request = name
+        else:
+          request = '/global/networks/%s' % (name)
         response = self.connection.request(request, method='GET').object
         return self._to_network(response)
 

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -7100,7 +7100,7 @@ class GCENodeDriver(NodeDriver):
         """
         Return a Network object based on a network name.
 
-        :param  name: The name of the network
+        :param  name: The name or URL of the network
         :type   name: ``str``
 
         :return:  A Network object for the network

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -7073,9 +7073,6 @@ class GCENodeDriver(NodeDriver):
         """
         region_name = None
         if name.startswith('https://'):
-            #parts = self._get_components_from_path(name)
-            #name = parts['name']
-            #region_name = parts['region']
             request = name
         else:
             if isinstance(region, GCERegion):
@@ -7095,7 +7092,6 @@ class GCENodeDriver(NodeDriver):
 
             request = '/regions/%s/subnetworks/%s' % (region_name, name)
 
-        # request = '/regions/%s/subnetworks/%s' % (region_name, name)
         response = self.connection.request(request, method='GET').object
         return self._to_subnetwork(response)
 

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -7086,7 +7086,8 @@ class GCENodeDriver(NodeDriver):
             if not region_name:
                 region = self._set_region(region)
                 if not region:
-                    raise ValueError("Could not determine region for subnetwork.")
+                    raise ValueError(
+                        "Could not determine region for subnetwork.")
                 else:
                     region_name = region.name
 
@@ -7106,9 +7107,9 @@ class GCENodeDriver(NodeDriver):
         :rtype:   :class:`GCENetwork`
         """
         if name.startswith('https://'):
-          request = name
+            request = name
         else:
-          request = '/global/networks/%s' % (name)
+            request = '/global/networks/%s' % (name)
         response = self.connection.request(request, method='GET').object
         return self._to_network(response)
 

--- a/libcloud/test/compute/fixtures/gce/projects_other_name_global_networks_cf.json
+++ b/libcloud/test/compute/fixtures/gce/projects_other_name_global_networks_cf.json
@@ -1,0 +1,11 @@
+{
+ "kind": "compute#network",
+ "id": "5125152985904090792",
+ "creationTimestamp": "2016-03-25T05:34:15.077-07:00",
+ "name": "cf",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/other_name/global/networks/cf",
+ "autoCreateSubnetworks": true,
+ "subnetworks": [
+  "https://www.googleapis.com/compute/v1/projects/other_name/regions/us-central1/subnetworks/cf-972cf02e6ad49114"
+ ]
+}

--- a/libcloud/test/compute/fixtures/gce/projects_other_name_global_networks_lcnetwork.json
+++ b/libcloud/test/compute/fixtures/gce/projects_other_name_global_networks_lcnetwork.json
@@ -1,0 +1,10 @@
+{
+  "IPv4Range": "10.11.0.0/16",
+  "creationTimestamp": "2013-06-26T10:05:03.500-07:00",
+  "gatewayIPv4": "10.11.0.1",
+  "description": "A custom network",
+  "id": "16211908079305042870",
+  "kind": "compute#network",
+  "name": "lcnetwork",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/other_name/global/networks/lcnetwork"
+}

--- a/libcloud/test/compute/fixtures/gce/projects_other_name_regions_us-central1.json
+++ b/libcloud/test/compute/fixtures/gce/projects_other_name_regions_us-central1.json
@@ -1,0 +1,65 @@
+{
+ "kind": "compute#region",
+ "id": "1000",
+ "creationTimestamp": "2014-05-30T18:35:16.413-07:00",
+ "name": "us-central1",
+ "description": "us-central1",
+ "status": "UP",
+ "zones": [
+  "https://www.googleapis.com/compute/v1/projects/other_name/zones/us-central1-a",
+  "https://www.googleapis.com/compute/v1/projects/other_name/zones/us-central1-b"
+ ],
+ "quotas": [
+  {
+   "metric": "CPUS",
+   "limit": 1050.0,
+   "usage": 30.0
+  },
+  {
+   "metric": "DISKS_TOTAL_GB",
+   "limit": 20000.0,
+   "usage": 344.0
+  },
+  {
+   "metric": "STATIC_ADDRESSES",
+   "limit": 10.0,
+   "usage": 2.0
+  },
+  {
+   "metric": "IN_USE_ADDRESSES",
+   "limit": 1050.0,
+   "usage": 11.0
+  },
+  {
+   "metric": "SSD_TOTAL_GB",
+   "limit": 2048.0,
+   "usage": 500.0
+  },
+  {
+   "metric": "LOCAL_SSD_TOTAL_GB",
+   "limit": 10240.0,
+   "usage": 0.0
+  },
+  {
+   "metric": "INSTANCE_GROUPS",
+   "limit": 100.0,
+   "usage": 0.0
+  },
+  {
+   "metric": "INSTANCE_GROUP_MANAGERS",
+   "limit": 50.0,
+   "usage": 0.0
+  },
+  {
+   "metric": "INSTANCES",
+   "limit": 10500.0,
+   "usage": 11.0
+  },
+  {
+   "metric": "AUTOSCALERS",
+   "limit": 50.0,
+   "usage": 0.0
+  }
+ ],
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1"
+}

--- a/libcloud/test/compute/fixtures/gce/projects_other_name_regions_us-central1_subnetworks_cf_972cf02e6ad49114.json
+++ b/libcloud/test/compute/fixtures/gce/projects_other_name_regions_us-central1_subnetworks_cf_972cf02e6ad49114.json
@@ -1,0 +1,12 @@
+{
+ "status": "DONE",
+ "kind": "compute#subnetwork",
+ "id": "4297043163355844285",
+ "creationTimestamp": "2016-03-25T05:34:27.209-07:00",
+ "gatewayAddress": "10.128.0.1",
+ "name": "cf-972cf02e6ad49114",
+ "network": "https://www.googleapis.com/compute/v1/projects/other_name/global/networks/cf",
+ "ipCidrRange": "10.128.0.0/20",
+ "region": "https://www.googleapis.com/compute/v1/projects/other_name/regions/us-central1",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/other_name/regions/us-central1/subnetworks/cf-972cf02e6ad49112"
+}

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -556,6 +556,12 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         # fetch by region object
         subnetwork = self.driver.ex_get_subnetwork(name, region)
         self.assertEqual(subnetwork.name, name)
+        # do the same but this time by resource URL
+        url = 'https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1/subnetworks/cf-972cf02e6ad49112'
+        # fetch by no region
+        subnetwork = self.driver.ex_get_subnetwork(url)
+        self.assertEqual(subnetwork.name, name)
+        self.assertEqual(subnetwork.region.name, region_name)
 
     def test_ex_list_networks(self):
         networks = self.driver.ex_list_networks()
@@ -1741,6 +1747,13 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
 
     def test_ex_get_network(self):
         network_name = 'lcnetwork'
+        network = self.driver.ex_get_network(network_name)
+        self.assertEqual(network.name, network_name)
+        self.assertEqual(network.cidr, '10.11.0.0/16')
+        self.assertEqual(network.extra['gatewayIPv4'], '10.11.0.1')
+        self.assertEqual(network.extra['description'], 'A custom network')
+        # do the same but this time with URL
+        url = 'https://www.googleapis.com/compute/v1/projects/project_name/global/networks/lcnetwork'
         network = self.driver.ex_get_network(network_name)
         self.assertEqual(network.name, network_name)
         self.assertEqual(network.cidr, '10.11.0.0/16')

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -1754,7 +1754,7 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         self.assertEqual(network.extra['description'], 'A custom network')
         # do the same but this time with URL
         url = 'https://www.googleapis.com/compute/v1/projects/project_name/global/networks/lcnetwork'
-        network = self.driver.ex_get_network(network_name)
+        network = self.driver.ex_get_network(url)
         self.assertEqual(network.name, network_name)
         self.assertEqual(network.cidr, '10.11.0.0/16')
         self.assertEqual(network.extra['gatewayIPv4'], '10.11.0.1')

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -562,6 +562,10 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         subnetwork = self.driver.ex_get_subnetwork(url)
         self.assertEqual(subnetwork.name, name)
         self.assertEqual(subnetwork.region.name, region_name)
+        # test with a subnetwork that is under a different project
+        url_other = 'https://www.googleapis.com/compute/v1/projects/other_name/regions/us-central1/subnetworks/cf-972cf02e6ad49114'
+        subnetwork = self.driver.ex_get_subnetwork(url_other)
+        self.assertEqual(subnetwork.name, "cf-972cf02e6ad49114")
 
     def test_ex_list_networks(self):
         networks = self.driver.ex_list_networks()
@@ -1759,6 +1763,13 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         self.assertEqual(network.cidr, '10.11.0.0/16')
         self.assertEqual(network.extra['gatewayIPv4'], '10.11.0.1')
         self.assertEqual(network.extra['description'], 'A custom network')
+        # do the same but with a network under a different project
+        url_other = 'https://www.googleapis.com/compute/v1/projects/other_name/global/networks/lcnetwork'
+        network = self.driver.ex_get_network(url_other)
+        self.assertEqual(network.name, network_name)
+        self.assertEqual(network.cidr, '10.11.0.0/16')
+        self.assertEqual(network.extra['gatewayIPv4'], '10.11.0.1')
+        self.assertEqual(network.extra['description'], 'A custom network')
 
     def test_ex_get_node(self):
         node_name = 'node-name'
@@ -2575,6 +2586,24 @@ class GCEMockHttp(MockHttp):
                                                              body, headers):
         body = self.fixtures.load(
             'regions_us-central1_subnetworks_cf_972cf02e6ad49112.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _projects_other_name_regions_us_central1(self, method, url, body, headers):
+        body = self.fixtures.load('projects_other_name_regions_us-central1.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _projects_other_name_global_networks_lcnetwork(self, method, url, body, headers):
+        body = self.fixtures.load('projects_other_name_global_networks_lcnetwork.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _projects_other_name_global_networks_cf(self, method, url, body, headers):
+        body = self.fixtures.load('projects_other_name_global_networks_cf.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _projects_other_name_regions_us_central1_subnetworks_cf_972cf02e6ad49114(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'projects_other_name_regions_us-central1_subnetworks_cf_972cf02e6ad49114.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
     def _regions_us_central1_operations_operation_regions_us_central1_addresses_lcaddress_delete(


### PR DESCRIPTION
## Allow for use of shared network (vpc) and subnetwork in GCE

### Description

It's currently not possible to create an GCE instance within a [shared VPC](https://cloud.google.com/vpc/docs/shared-vpc) and a shared subnet via ansible although it's possible from the google compute console (see https://github.com/ansible/ansible/issues/30759).

In the code, the problem seems to be that even if a fully qualified resource URL is passed for a network (or subnetwork), it is parsed into parts and then reconstructed assuming the resource is under the configured gcloud project. But since we're using a shared VPC, the resource is under a different project.

 For example, say, I have two projects, `my-main-project` which hosts a shared vpc named `sharedvpc` and `my-other-project` which has shared access to `sharedvpc`. What I want to do is to create a GCE instance under `my-other-project` and within the `sharedvpc` network.

So in the gce module, I pass the resource URLs:
```yml
  - name: Create instance
      gce:
        instance_names: "{{ instance_name }}"
        machine_type: "{{ machine_type }}"
        image: "{{ image_name }}"
        network: https://www.googleapis.com/compute/v1/projects/my-main-project/global/networks/sharedvpc
        subnetwork: https://www.googleapis.com/compute/v1/projects/my-main-project/regions/europe-west2/subnetworks/default"
        zone: "{{ zone }}"
        tags: app-servers
        state: present
```

But, in the module's code, the resource URLs will be parsed and transform respectively to `/global/networks/sharedvpc` and `/regions/europe-west2/subnetworks/default` which implicitly refer to the project configured by glcoud, i.e. `my-other-project`. As a result, I get a `ResourceNotFound` error.

Instead, if a resource (network or subnetwork) is fully qualified via a resource URL (i.e. it starts with `https://`), we can simply use it in the underlying google request. This is what the new code does.

### Status

Done, ready for review. I'm new to libcloud, so I'll happily take feedback and amend the PR.

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
