### PR TITLE
LIBCLOUD-975 - Compute Cloudstack - Add change size and restore

### DIFF
--- a/libcloud/common/cloudstack.py
+++ b/libcloud/common/cloudstack.py
@@ -162,12 +162,15 @@ class CloudStackConnection(ConnectionUserAndKey, PollingConnection):
         if (command == 'revokesecuritygroupingress' and
                 'revokesecuritygroupingressresponse' not in result.object):
             command = command
+        elif (command == 'restorevirtualmachine' and
+                'restorevmresponse' in result.object):
+            command = "restorevmresponse"
         else:
             command = command + 'response'
 
         if command not in result.object:
             raise MalformedResponseError(
-                "Unknown response format",
+                "Unknown response format {}".format(command),
                 body=result.body,
                 driver=self.driver)
         result = result.object[command]

--- a/libcloud/compute/drivers/cloudstack.py
+++ b/libcloud/compute/drivers/cloudstack.py
@@ -486,6 +486,18 @@ class CloudStackNode(Node):
         """
         return self.driver.ex_delete_port_forwarding_rule(node=self, rule=rule)
 
+    def ex_restore(self, template=None):
+        """
+        Restore virtual machine
+        """
+        return self.driver.ex_restore(node=self, template=template)
+
+    def ex_change_node_size(self, offering):
+        """
+        Change virtual machine offering/size
+        """
+        return self.driver.ex_change_node_size(node=self, offering=offering)
+
     def ex_start(self):
         """
         Starts a stopped virtual machine.
@@ -1692,6 +1704,47 @@ class CloudStackNodeDriver(CloudStackDriverMixIn, NodeDriver):
                             params={'id': node.id},
                             method='GET')
         return True
+
+    def ex_restore(self, node, template=None):
+        """
+        Restore virtual machine
+
+        :param node: Node to restore
+        :type node: :class:`CloudStackNode`
+
+        :param template: Optional new template
+        :type  template: :class:`NodeImage`
+
+        :rtype ``str``
+        """
+        params = {'virtualmachineid': node.id}
+        if template:
+            params['templateid'] = template.id
+
+        res = self._async_request(command='restoreVirtualMachine',
+                                  params=params,
+                                  method='GET')
+        return res['virtualmachine']['templateid']
+
+    def ex_change_node_size(self, node, offering):
+        """
+        Change offering/size of a virtual machine
+
+        :param node: Node to change size
+        :type node: :class:`CloudStackNode`
+
+        :param offering: The new offering
+        :type  offering: :class:`NodeSize`
+
+        :rtype ``str``
+        """
+        res = self._async_request(command='scaleVirtualMachine',
+                                  params={
+                                      'id': node.id,
+                                      'serviceofferingid': offering.id
+                                  },
+                                  method='GET')
+        return res['virtualmachine']['serviceofferingid']
 
     def ex_start(self, node):
         """

--- a/libcloud/test/compute/fixtures/cloudstack/queryAsyncJobResult_88776.json
+++ b/libcloud/test/compute/fixtures/cloudstack/queryAsyncJobResult_88776.json
@@ -1,0 +1,1 @@
+{ "queryasyncjobresultresponse": {"jobprocstatus": 0, "jobstatus": 1, "jobresult": {"virtualmachine": {"serviceofferingid": "eee-fff-ggg-hhh"}}}}

--- a/libcloud/test/compute/fixtures/cloudstack/queryAsyncJobResult_88777.json
+++ b/libcloud/test/compute/fixtures/cloudstack/queryAsyncJobResult_88777.json
@@ -1,0 +1,1 @@
+{ "queryasyncjobresultresponse": {"jobprocstatus": 0, "jobstatus": 1, "jobresult": {"virtualmachine": {"templateid": "aaa-bbb-ccc-ddd"}}}}

--- a/libcloud/test/compute/fixtures/cloudstack/restoreVirtualMachine_default.json
+++ b/libcloud/test/compute/fixtures/cloudstack/restoreVirtualMachine_default.json
@@ -1,0 +1,1 @@
+{ "restorevirtualmachineresponse" : { "jobid" : 88777} }

--- a/libcloud/test/compute/fixtures/cloudstack/scaleVirtualMachine_default.json
+++ b/libcloud/test/compute/fixtures/cloudstack/scaleVirtualMachine_default.json
@@ -1,0 +1,1 @@
+{ "scalevirtualmachineresponse" : { "jobid" : 88776} }

--- a/libcloud/test/compute/test_cloudstack.py
+++ b/libcloud/test/compute/test_cloudstack.py
@@ -25,7 +25,7 @@ try:
 except ImportError:
     import json
 
-from libcloud.compute.base import NodeLocation
+from libcloud.compute.base import NodeLocation, NodeSize, NodeImage
 from libcloud.common.types import ProviderError
 from libcloud.compute.drivers.cloudstack import CloudStackNodeDriver, \
     CloudStackAffinityGroupType
@@ -1275,6 +1275,22 @@ class CloudStackTestCase(CloudStackCommonTestCase, unittest.TestCase):
             cls('key', 'secret', url='https://api.exoscale.ch/compute')
         except Exception:
             self.fail('url provided but driver raised an exception')
+
+    def test_restore(self):
+        template = NodeImage("aaa-bbb-ccc-ddd", "fake-img", None)
+
+        node = self.driver.list_nodes()[0]
+        res = node.ex_restore(template=template)
+
+        self.assertEqual(res, template.id)
+
+    def test_change_offerings(self):
+        offering = NodeSize("eee-fff-ggg-hhh", "fake-size", 1, 4, 5, 0.1, None)
+
+        node = self.driver.list_nodes()[0]
+        res = node.ex_change_node_size(offering=offering)
+
+        self.assertEqual(res, offering.id)
 
 
 class CloudStackMockHttp(MockHttp, unittest.TestCase):


### PR DESCRIPTION
## Compute Cloudstack - Add change size and restore

### Description

Add change size and restore method to Cloudstack compute driver.
Change Size: https://cloudstack.apache.org/api/apidocs-4.10/apis/scaleVirtualMachine.html
Restore: https://cloudstack.apache.org/api/apidocs-4.10/apis/restoreVirtualMachine.html

I added a logic in common.cloudstack.CloudStackConnection._sync_request to handle with old versions of cloudstack restore method.

### Status
- done, ready for review

### Checklist (tick everything that applies)

- [x] Flake8
- [x] Documentation
- [x] Tests
- [x] Real provider scenario tests
