### PR TITLE
Made pytest-runner optional

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -125,6 +125,9 @@ install_requires = ['requests']
 if PY2_pre_279:
     install_requires.append('backports.ssl_match_hostname')
 
+needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
+pytest_runner = ['pytest-runner'] if needs_pytest else []
+
 setup(
     name='apache-libcloud',
     version=read_version_string(),
@@ -141,7 +144,7 @@ setup(
     package_data={'libcloud': get_data_files('libcloud', parent='libcloud')},
     license='Apache License (2.0)',
     url='http://libcloud.apache.org/',
-    setup_requires=['pytest-runner'],
+    setup_requires=pytest_runner,
     tests_require=TEST_REQUIREMENTS,
     cmdclass={
         'apidocs': ApiDocsCommand,

--- a/setup.py
+++ b/setup.py
@@ -167,5 +167,6 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython',
-        'Programming Language :: Python :: Implementation :: PyPy']
-    )
+        'Programming Language :: Python :: Implementation :: PyPy'
+    ]
+)


### PR DESCRIPTION
## Switch to optional pytest-runner, required only for tests

### Description

This fixes what was introduced by b4ce936: a forced dependency of the [pytest-runner](https://github.com/pytest-dev/pytest-runner) for any `setup.py` target, including `build` and `install`, which is not really appropriate, since it should be required only for testing, when you invoke `python setup.py test` or its aliases.

Such a forced dependency makes distribution packaging more complicated, since pytest-runner pulls other dependencies (like setuptools_scm) which may have other dependencies or Python version requirements for no reason.

It also breaks libcloud installation on older distros (e.g. Debian Wheezy), where libcloud **2.0.0** worked just perfectly, but anything above it couldn't because pytest-runner and/or its dependencies cannot be installed.

Plus, testing should always be optional.

Thankfully, there's an [official solution](https://github.com/pytest-dev/pytest-runner#conditional-requirement) to make sure pytest-runner is invoked when it's really needed.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] Code linting