### PR TITLE
[LIBCLOUD-977] Adds rebuild and resize commands for DigitalOcean

### DIFF
--- a/libcloud/compute/drivers/digitalocean.py
+++ b/libcloud/compute/drivers/digitalocean.py
@@ -295,7 +295,7 @@ class DigitalOcean_v2_NodeDriver(DigitalOcean_v2_BaseDriver,
                                       data=json.dumps(attr), method='POST')
         return res.status == httplib.CREATED
 
-    def ex_resize_node(self, node, size_slug):
+    def ex_resize_node(self, node, size):
         """
         Resize the node to a different machine size.  Note that some resize
         operations are reversible, and others are irreversible.
@@ -303,13 +303,13 @@ class DigitalOcean_v2_NodeDriver(DigitalOcean_v2_BaseDriver,
         :param node: Node to rebuild
         :type node: :class:`Node`
 
-        :param size_slug: Name for the new size
-        :type node: ``str``
+        :param size: New size for this machine
+        :type node: :class:`NodeSize`
 
         :return True if the operation began successfully
         :rtype ``bool``
         """
-        attr = {'type': 'resize', 'size': size_slug}
+        attr = {'type': 'resize', 'size': size.name}
         res = self.connection.request('/v2/droplets/%s/actions' % (node.id),
                                       data=json.dumps(attr), method='POST')
         return res.status == httplib.CREATED

--- a/libcloud/compute/drivers/digitalocean.py
+++ b/libcloud/compute/drivers/digitalocean.py
@@ -281,12 +281,34 @@ class DigitalOcean_v2_NodeDriver(DigitalOcean_v2_BaseDriver,
         return res.status == httplib.CREATED
 
     def ex_rebuild_node(self, node):
+        """
+        Destroy and rebuild the node using its base image.
+
+        :param node: Node to rebuild
+        :type node: :class:`Node`
+
+        :return True if the operation began successfully
+        :rtype ``bool``
+        """
         attr = {'type': 'rebuild', 'image': node.extra['image']['id']}
         res = self.connection.request('/v2/droplets/%s/actions' % (node.id),
                                       data=json.dumps(attr), method='POST')
         return res.status == httplib.CREATED
 
     def ex_resize_node(self, node, size_slug):
+        """
+        Resize the node to a different machine size.  Note that some resize
+        operations are reversible, and others are irreversible.
+
+        :param node: Node to rebuild
+        :type node: :class:`Node`
+
+        :param size_slug: Name for the new size
+        :type node: ``str``
+
+        :return True if the operation began successfully
+        :rtype ``bool``
+        """
         attr = {'type': 'resize', 'size': size_slug}
         res = self.connection.request('/v2/droplets/%s/actions' % (node.id),
                                       data=json.dumps(attr), method='POST')

--- a/libcloud/compute/drivers/digitalocean.py
+++ b/libcloud/compute/drivers/digitalocean.py
@@ -280,6 +280,18 @@ class DigitalOcean_v2_NodeDriver(DigitalOcean_v2_BaseDriver,
                                       data=json.dumps(attr), method='POST')
         return res.status == httplib.CREATED
 
+    def ex_rebuild_node(self, node):
+        attr = {'type': 'rebuild', 'image': node.extra['image']['id']}
+        res = self.connection.request('/v2/droplets/%s/actions' % (node.id),
+                                      data=json.dumps(attr), method='POST')
+        return res.status == httplib.CREATED
+
+    def ex_resize_node(self, node, size_slug):
+        attr = {'type': 'resize', 'size': size_slug}
+        res = self.connection.request('/v2/droplets/%s/actions' % (node.id),
+                                      data=json.dumps(attr), method='POST')
+        return res.status == httplib.CREATED
+
     def create_key_pair(self, name, public_key=''):
         """
         Create a new SSH key.

--- a/libcloud/test/compute/fixtures/digitalocean_v2/ex_rebuild_node.json
+++ b/libcloud/test/compute/fixtures/digitalocean_v2/ex_rebuild_node.json
@@ -1,0 +1,12 @@
+{
+  "action": {
+    "id": 36804758,
+    "status": "in-progress",
+    "type": "rebuild",
+    "started_at": "2014-11-14T16:31:19Z",
+    "completed_at": null,
+    "resource_id": 3164450,
+    "resource_type": "droplet",
+    "region_slug": "nyc3"
+  }
+}

--- a/libcloud/test/compute/fixtures/digitalocean_v2/ex_resize_node.json
+++ b/libcloud/test/compute/fixtures/digitalocean_v2/ex_resize_node.json
@@ -1,0 +1,12 @@
+{
+  "action": {
+    "id": 36804758,
+    "status": "in-progress",
+    "type": "resize",
+    "started_at": "2014-11-14T16:31:19Z",
+    "completed_at": null,
+    "resource_id": 3164450,
+    "resource_type": "droplet",
+    "region_slug": "nyc3"
+  }
+}

--- a/libcloud/test/compute/test_digitalocean_v2.py
+++ b/libcloud/test/compute/test_digitalocean_v2.py
@@ -155,6 +155,18 @@ class DigitalOcean_v2_Tests(LibcloudTestCase):
         result = self.driver.ex_hard_reboot(node)
         self.assertTrue(result)
 
+    def test_ex_rebuild_node_success(self):
+        node = self.driver.list_nodes()[0]
+        DigitalOceanMockHttp.type = 'REBUILD'
+        result = self.driver.ex_rebuild_node(node)
+        self.assertTrue(result)
+
+    def test_ex_resize_node_success(self):
+        node = self.driver.list_nodes()[0]
+        DigitalOceanMockHttp.type = 'RESIZE'
+        result = self.driver.ex_resize_node(node, '2gb')
+        self.assertTrue(result)
+
     def test_destroy_node_success(self):
         node = self.driver.list_nodes()[0]
         DigitalOceanMockHttp.type = 'DESTROY'
@@ -360,6 +372,18 @@ class DigitalOceanMockHttp(MockHttp):
                                                 body, headers):
         # ex_hard_reboot
         body = self.fixtures.load('ex_hard_reboot.json')
+        return (httplib.CREATED, body, {}, httplib.responses[httplib.OK])
+
+    def _v2_droplets_3164444_actions_REBUILD(self, method, url,
+                                             body, headers):
+        # ex_rebuild_node
+        body = self.fixtures.load('ex_rebuild_node.json')
+        return (httplib.CREATED, body, {}, httplib.responses[httplib.OK])
+
+    def _v2_droplets_3164444_actions_RESIZE(self, method, url,
+                                            body, headers):
+        # ex_resize_node
+        body = self.fixtures.load('ex_resize_node.json')
         return (httplib.CREATED, body, {}, httplib.responses[httplib.OK])
 
     def _v2_account_keys(self, method, url, body, headers):

--- a/libcloud/test/compute/test_digitalocean_v2.py
+++ b/libcloud/test/compute/test_digitalocean_v2.py
@@ -163,8 +163,9 @@ class DigitalOcean_v2_Tests(LibcloudTestCase):
 
     def test_ex_resize_node_success(self):
         node = self.driver.list_nodes()[0]
+        size = self.driver.list_sizes()[0]
         DigitalOceanMockHttp.type = 'RESIZE'
-        result = self.driver.ex_resize_node(node, '2gb')
+        result = self.driver.ex_resize_node(node, size)
         self.assertTrue(result)
 
     def test_destroy_node_success(self):


### PR DESCRIPTION
## Adds rebuild and resize commands for DigitalOcean 

### Description

https://issues.apache.org/jira/browse/LIBCLOUD-977

Implement the following DigitalOcean APIs as driver-specific extensions,
* https://developers.digitalocean.com/documentation/v2/#rebuild-a-droplet
* https://developers.digitalocean.com/documentation/v2/#resize-a-droplet

Smoke tests locally.

### Status

Ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)