### PR TITLE
Fix tests with pytest 3.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ include/
 lib/
 pip-selfcheck.json
 report.html
+.pytest_cache

--- a/libcloud/test/test_init.py
+++ b/libcloud/test/test_init.py
@@ -33,14 +33,17 @@ from libcloud.test import unittest
 
 class TestUtils(unittest.TestCase):
     def test_init_once_and_debug_mode(self):
+        if have_paramiko:
+            paramiko_logger = paramiko.util.logging.getLogger()
+            paramiko_logger.setLevel(logging.NOTSET)
+
         # Debug mode is disabled
         _init_once()
 
         self.assertEqual(LoggingConnection.log, None)
 
         if have_paramiko:
-            logger = paramiko.util.logging.getLogger()
-            paramiko_log_level = logger.getEffectiveLevel()
+            paramiko_log_level = paramiko_logger.getEffectiveLevel()
             self.assertEqual(paramiko_log_level, logging.NOTSET)
 
         # Enable debug mode
@@ -50,8 +53,7 @@ class TestUtils(unittest.TestCase):
         self.assertTrue(LoggingConnection.log is not None)
 
         if have_paramiko:
-            logger = paramiko.util.logging.getLogger()
-            paramiko_log_level = logger.getEffectiveLevel()
+            paramiko_log_level = paramiko_logger.getEffectiveLevel()
             self.assertEqual(paramiko_log_level, logging.DEBUG)
 
     def test_factory(self):

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -7,4 +7,4 @@ codecov
 coverage<4.0
 requests
 requests_mock
-pytest
+pytest>=3.4,<3.5


### PR DESCRIPTION
## Fix tests with pytest 3.4

### Description

The 3.4 pytest release introduced a breaking change: pytest no longer changes log levels: the default log level is now Python's default: WARNING. This commit ensures the test no longer depends on external log levels.

pytest 3.4 also adds a .pytest_cache folder: ignore it.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)