### PR TITLE
Extending libcloud ex_create_address to allow internal ip creation

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -2856,11 +2856,11 @@ class GCENodeDriver(NodeDriver):
         :rtype:   :class:`GCEAddress`
         """
         region = region or self.region
-        if region != 'global' and not hasattr(region, 'name'):
-            region = self.ex_get_region(region)
-        elif region is None:
+        if region is None:
             raise ValueError('REGION_NOT_SPECIFIED',
                              'Region must be provided for an address')
+        if region != 'global' and not hasattr(region, 'name'):
+            region = self.ex_get_region(region)
         address_data = {'name': name}
         if address:
             address_data['address'] = address

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -2866,6 +2866,20 @@ class GCENodeDriver(NodeDriver):
             address_data['address'] = address
         if description:
             address_data['description'] = description
+        if address_type:
+            if address_type not in ['EXTERNAL', 'INTERNAL']:
+                raise ValueError('ADDRESS_TYPE_WRONG',
+                                 'Address type must be either EXTERNAL or \
+                                 INTERNAL')
+            else:
+                address_data['addressType'] = address_type
+        if subnetwork and address_type != 'INTERNAL':
+            raise ValueError('INVALID_ARGUMENT_COMBINATION',
+                             'Address type must be internal if subnetwork \
+                             provided')
+        if subnetwork and not hasattr(subnetwork, 'name'):
+            subnetwork = \
+                self.ex_get_subnetwork(subnetwork, region)
         if region == 'global':
             request = '/global/addresses'
         else:

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -2820,7 +2820,8 @@ class GCENodeDriver(NodeDriver):
         return list_zones
 
     def ex_create_address(self, name, region=None, address=None,
-                          description=None):
+                          description=None, address_type='EXTERNAL',
+                          subnetwork=None):
         """
         Create a static address in a region, or a global address.
 
@@ -2837,6 +2838,19 @@ class GCENodeDriver(NodeDriver):
 
         :keyword  description: Optional descriptive comment.
         :type     description: ``str`` or ``None``
+
+        :keyword  address_type: Optional The type of address to reserve,
+                                either INTERNAL or EXTERNAL. If unspecified,
+                                defaults to EXTERNAL.
+        :type     description: ``str``
+
+        :keyword  subnetwork: Optional The URL of the subnetwork in which to
+                              reserve the address. If an IP address is
+                              specified, it must be within the subnetwork's
+                              IP range. This field can only be used with
+                              INTERNAL type with GCE_ENDPOINT/DNS_RESOLVER
+                              purposes.
+        :type     description: ``str``
 
         :return:  Static Address object
         :rtype:   :class:`GCEAddress`

--- a/libcloud/test/compute/fixtures/gce/regions_us-central1_addresses_lcaddressinternal.json
+++ b/libcloud/test/compute/fixtures/gce/regions_us-central1_addresses_lcaddressinternal.json
@@ -1,0 +1,12 @@
+{
+  "address": "10.128.0.12",
+  "creationTimestamp": "2013-06-26T12:21:40.625-07:00",
+  "description": "",
+  "id": "01531551729918243104",
+  "kind": "compute#address",
+  "name": "lcaddressinternal",
+  "addressType": "INTERNAL",
+  "region": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1/addresses/lcaddressinternal",
+  "status": "RESERVED"
+}

--- a/libcloud/test/compute/fixtures/gce/regions_us-central1_subnetworks_subnet_1.json
+++ b/libcloud/test/compute/fixtures/gce/regions_us-central1_subnetworks_subnet_1.json
@@ -1,0 +1,11 @@
+{
+ "kind": "compute#subnetwork",
+ "id": "4297043163355844286",
+ "creationTimestamp": "2016-10-01T05:34:27.209-07:00",
+ "gatewayAddress": "10.128.0.1",
+ "name": "subnet_1",
+ "network": "https://www.googleapis.com/compute/v1/projects/project_name/global/networks/cf",
+ "ipCidrRange": "10.128.0.0/16",
+ "region": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1/subnetworks/subnet_1"
+}

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -735,6 +735,19 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         self.assertTrue(isinstance(address, GCEAddress))
         self.assertEqual(address.name, address_name)
 
+    def test_ex_create_address_internal(self):
+        address_name = 'lcaddressinternal'
+        address = self.driver.ex_create_address(address_name,
+                                                region='us-central1',
+                                                address='10.128.0.12',
+                                                address_type='INTERNAL',
+                                                subnetwork='subnet-1')
+        print address
+        self.assertTrue(isinstance(address, GCEAddress))
+        self.assertEqual(address.name, address_name)
+        self.assertEqual(address.address, '10.128.0.12')
+        self.assertEqual(address.addressType, 'INTERNAL')
+
     def test_ex_create_backend(self):
         # Note: this is an internal object, no API call is made
         # and no fixture is needed specifically for GCEBackend, however
@@ -3009,6 +3022,16 @@ class GCEMockHttp(MockHttp):
     def _regions_us_central1_addresses_testaddress(self, method, url, body,
                                                    headers):
         body = self.fixtures.load('regions_us-central1_addresses_testaddress.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _regions_us_central1_subnetworks_subnet_1(self, method, url, body,
+                                                  headers):
+        body = self.fixtures.load('regions_us-central1_subnetworks_subnet_1.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _regions_us_central1_addresses_lcaddressinternal(self, method, url, body,
+                                                         headers):
+        body = self.fixtures.load('regions_us-central1_addresses_lcaddressinternal.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
     def _regions_us_central1_forwardingRules(self, method, url, body, headers):

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -742,11 +742,9 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
                                                 address='10.128.0.12',
                                                 address_type='INTERNAL',
                                                 subnetwork='subnet-1')
-        print address
         self.assertTrue(isinstance(address, GCEAddress))
         self.assertEqual(address.name, address_name)
         self.assertEqual(address.address, '10.128.0.12')
-        self.assertEqual(address.addressType, 'INTERNAL')
 
     def test_ex_create_backend(self):
         # Note: this is an internal object, no API call is made


### PR DESCRIPTION
## Changes Title (replace this with a logical title for your changes)

### Description

As part of a change for [salt issue 45917](https://github.com/saltstack/salt/issues/45917) to extend it's functionality to allow assignment of static internal ip it is need to extend libcloud.

Extended `ex_create_address` to include two additional parameters 
- addressType
- subnetwork

As described in the [REST endpoint for addresses](https://cloud.google.com/compute/docs/reference/rest/beta/addresses).

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
