### PR TITLE
Allow shared vpc in managed instance group creation

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -9025,13 +9025,11 @@ class GCENodeDriver(NodeDriver):
         # does not contain instances.
         network = instancegroup.get('network', None)
         if network:
-            obj_name = self._get_components_from_path(network)['name']
-            network = self.ex_get_network(obj_name)
+            network = self.ex_get_network(network)
 
         subnetwork = instancegroup.get('subnetwork', None)
         if subnetwork:
-            parts = self._get_components_from_path(subnetwork)
-            subnetwork = self.ex_get_subnetwork(parts['name'], parts['region'])
+            subnetwork = self.ex_get_subnetwork(subnetwork)
 
         return GCEInstanceGroup(
             id=instancegroup['id'], name=instancegroup['name'], zone=zone,

--- a/libcloud/test/compute/fixtures/gce/global_instanceTemplates_my_instance_template_shared_network.json
+++ b/libcloud/test/compute/fixtures/gce/global_instanceTemplates_my_instance_template_shared_network.json
@@ -1,0 +1,61 @@
+{
+    "creationTimestamp": "2016-07-18T09:53:22.323-07:00",
+    "description": "",
+    "id": "8161922600535111533",
+    "kind": "compute#instanceTemplate",
+    "name": "my-instance-template_shared_network",
+    "properties": {
+        "canIpForward": false,
+        "disks": [
+            {
+                "autoDelete": true,
+                "boot": true,
+                "deviceName": "my-instance-template_shared_network",
+                "initializeParams": {
+                    "diskSizeGb": "10",
+                    "diskType": "pd-standard",
+                    "sourceImage": "projects/project_name/global/images/my-new-image1"
+                },
+                "kind": "compute#attachedDisk",
+                "mode": "READ_WRITE",
+                "type": "PERSISTENT"
+            }
+        ],
+        "machineType": "n1-standard-1",
+        "metadata": {
+            "fingerprint": "Jt9ALJ07B8Q=",
+            "kind": "compute#metadata"
+        },
+        "networkInterfaces": [
+            {
+                "accessConfigs": [
+                    {
+                        "kind": "compute#accessConfig",
+                        "name": "External NAT",
+                        "type": "ONE_TO_ONE_NAT"
+                    }
+                ],
+                "network": "https://www.googleapis.com/compute/v1/projects/other_name/global/networks/cf",
+                "subnetwork": "https://www.googleapis.com/compute/v1/projects/other_name/regions/us-central1/subnetworks/cf-972cf02e6ad49112"
+            }
+        ],
+        "scheduling": {
+            "automaticRestart": true,
+            "onHostMaintenance": "MIGRATE",
+            "preemptible": false
+        },
+        "serviceAccounts": [
+            {
+                "email": "default",
+                "scopes": [
+                    "https://www.googleapis.com/auth/devstorage.read_only",
+                    "https://www.googleapis.com/auth/logging.write",
+                    "https://www.googleapis.com/auth/monitoring.write",
+                    "https://www.googleapis.com/auth/servicecontrol",
+                    "https://www.googleapis.com/auth/service.management"
+                ]
+            }
+        ]
+    },
+    "selfLink": "https://content.googleapis.com/compute/v1/projects/project_name/global/instanceTemplates/my-instance-template_shared_network"
+}

--- a/libcloud/test/compute/fixtures/gce/global_instanceTemplates_my_instance_template_shared_network.json
+++ b/libcloud/test/compute/fixtures/gce/global_instanceTemplates_my_instance_template_shared_network.json
@@ -35,8 +35,8 @@
                         "type": "ONE_TO_ONE_NAT"
                     }
                 ],
-                "network": "https://www.googleapis.com/compute/v1/projects/other_name/global/networks/cf",
-                "subnetwork": "https://www.googleapis.com/compute/v1/projects/other_name/regions/us-central1/subnetworks/cf-972cf02e6ad49112"
+                "network": "https://www.googleapis.com/compute/v1/projects/other_name/global/networks/shared_network_for_mig",
+                "subnetwork": "https://www.googleapis.com/compute/v1/projects/other_name/regions/us-central1/subnetworks/shared_subnetwork_for_mig"
             }
         ],
         "scheduling": {

--- a/libcloud/test/compute/fixtures/gce/projects_other_name_global_networks_shared_network_for_mig.json
+++ b/libcloud/test/compute/fixtures/gce/projects_other_name_global_networks_shared_network_for_mig.json
@@ -1,0 +1,11 @@
+{
+ "kind": "compute#network",
+ "id": "5125152985904090796",
+ "creationTimestamp": "2016-03-25T05:34:15.077-07:00",
+ "name": "shared_network_for_mig",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/other_name/global/networks/shared_network_for_mig",
+ "autoCreateSubnetworks": true,
+ "subnetworks": [
+  "https://www.googleapis.com/compute/v1/projects/other_name/regions/us-central1/subnetworks/shared_subnetwork_for_mig"
+ ]
+}

--- a/libcloud/test/compute/fixtures/gce/projects_other_name_regions_us-central1_subnetworks_shared_subnetwork_for_mig.json
+++ b/libcloud/test/compute/fixtures/gce/projects_other_name_regions_us-central1_subnetworks_shared_subnetwork_for_mig.json
@@ -1,0 +1,12 @@
+{
+ "status": "DONE",
+ "kind": "compute#subnetwork",
+ "id": "4297043163355844289",
+ "creationTimestamp": "2016-03-25T05:34:27.209-07:00",
+ "gatewayAddress": "10.128.0.1",
+ "name": "shared_subnetwork_for_mig",
+ "network": "https://www.googleapis.com/compute/v1/projects/other_name/global/networks/shared_network_for_mig",
+ "ipCidrRange": "10.128.0.0/20",
+ "region": "https://www.googleapis.com/compute/v1/projects/other_name/regions/us-central1",
+ "selfLink": "https://www.googleapis.com/compute/v1/projects/other_name/regions/us-central1/subnetworks/shared_subnetwork_for_mig"
+}

--- a/libcloud/test/compute/fixtures/gce/zones_us-central1-a_instanceGroupManagers_myinstancegroup_shared_network.json
+++ b/libcloud/test/compute/fixtures/gce/zones_us-central1-a_instanceGroupManagers_myinstancegroup_shared_network.json
@@ -1,0 +1,24 @@
+{
+
+    "kind": "compute#instanceGroupManager",
+    "id": "8604381270851510465",
+    "creationTimestamp": "2016-07-18T15:54:39.153-07:00",
+    "zone": "https://content.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a",
+    "name": "myinstancegroup-shared-network",
+    "description": "my description for myinstancegroup",
+    "instanceTemplate": "https://content.googleapis.com/compute/v1/projects/project_name/global/instanceTemplates/my-instance-template-shared-network",
+    "instanceGroup": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/instanceGroups/myinstancegroup-shared-network",
+    "baseInstanceName": "base-foo",
+    "fingerprint": "Q21hYveq9do=",
+    "currentActions": {
+	"none": 4,
+	"creating": 0,
+	"recreating": 0,
+	"deleting": 0,
+	"abandoning": 0,
+	"restarting": 0,
+	"refreshing": 0
+    },
+    "targetSize": 4,
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/instanceGroupManagers/myinstancegroup-shared-network"
+}

--- a/libcloud/test/compute/fixtures/gce/zones_us-central1-a_instanceGroup_myinstancegroup_shared_network.json
+++ b/libcloud/test/compute/fixtures/gce/zones_us-central1-a_instanceGroup_myinstancegroup_shared_network.json
@@ -1,0 +1,14 @@
+{
+
+    "kind": "compute#instanceGroup",
+    "id": "1968709502073089770",
+    "creationTimestamp": "2016-08-11T16:53:42.413-07:00",
+    "zone": "https://content.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a",
+    "name": "myinstancegroup_shared_network",
+    "description": "This instance group is controlled by Instance Group Manager 'myinstancegroup'. To modify instances in this group, use the Instance Group Manager API: https://cloud.google.com/compute/docs/reference/latest/instanceGroupManagers",
+    "network": "https://www.googleapis.com/compute/v1/projects/other_name/global/networks/shared_network_for_mig",
+    "subnetwork": "https://www.googleapis.com/compute/v1/projects/other_name/regions/us-central1/subnetworks/shared_subnetwork_for_mig",
+    "fingerprint": "42WmSpB8rSM=",
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/instanceGroups/myinstancegroup_shared_network",
+    "size": 4
+}

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -461,6 +461,19 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         self.assertEqual(mig.size, size)
         self.assertEqual(mig.zone.name, zone)
 
+    def test_ex_create_instancegroupmanager_shared_network(self):
+        name = 'myinstancegroup'
+        zone = 'us-central1-a'
+        size = 4
+        template_name = 'my-instance-template-shared-network'
+        template = self.driver.ex_get_instancetemplate(template_name)
+        mig = self.driver.ex_create_instancegroupmanager(
+            name, zone, template, size, base_instance_name='base-foo')
+
+        self.assertEqual(mig.name, name)
+        self.assertEqual(mig.size, size)
+        self.assertEqual(mig.zone.name, zone)
+
     def test_ex_create_instancetemplate(self):
         name = 'my-instance-template1'
         actual = self.driver.ex_create_instancetemplate(
@@ -3546,6 +3559,12 @@ class GCEMockHttp(MockHttp):
                                                         body, headers):
         body = self.fixtures.load(
             'global_instanceTemplates_my_instance_template1.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _global_instanceTemplates_my_instance_template_shared_network(self, method, url,
+                                                        body, headers):
+        body = self.fixtures.load(
+            'global_instanceTemplates_my_instance_template_shared_network.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
     def _aggregated_autoscalers(self, method, url, body, headers):

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -462,7 +462,7 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         self.assertEqual(mig.zone.name, zone)
 
     def test_ex_create_instancegroupmanager_shared_network(self):
-        name = 'myinstancegroup'
+        name = 'myinstancegroup-shared-network'
         zone = 'us-central1-a'
         size = 4
         template_name = 'my-instance-template-shared-network'
@@ -2707,10 +2707,20 @@ class GCEMockHttp(MockHttp):
         body = self.fixtures.load('projects_other_name_global_networks_cf.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
+    def _projects_other_name_global_networks_shared_network_for_mig(self, method, url, body, headers):
+        body = self.fixtures.load('projects_other_name_global_networks_shared_network_for_mig.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
     def _projects_other_name_regions_us_central1_subnetworks_cf_972cf02e6ad49114(
             self, method, url, body, headers):
         body = self.fixtures.load(
             'projects_other_name_regions_us-central1_subnetworks_cf_972cf02e6ad49114.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _projects_other_name_regions_us_central1_subnetworks_shared_subnetwork_for_mig(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'projects_other_name_regions_us-central1_subnetworks_shared_subnetwork_for_mig.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
     def _regions_us_central1_operations_operation_regions_us_central1_addresses_lcaddress_delete(
@@ -3497,10 +3507,22 @@ class GCEMockHttp(MockHttp):
             'zones_us-east1-b_instanceGroup_myinstancegroup.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
+    def _zones_us_central1_a_instanceGroups_myinstancegroup_shared_network(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'zones_us-central1-a_instanceGroup_myinstancegroup_shared_network.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
     def _zones_us_central1_a_instanceGroupManagers_myinstancegroup(
             self, method, url, body, headers):
         body = self.fixtures.load(
             'zones_us-central1-a_instanceGroupManagers_myinstancegroup.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _zones_us_central1_a_instanceGroupManagers_myinstancegroup_shared_network(
+            self, method, url, body, headers):
+        body = self.fixtures.load(
+            'zones_us-central1-a_instanceGroupManagers_myinstancegroup_shared_network.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
     def _zones_us_central1_b_instanceGroupManagers_myinstancegroup(

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -3561,8 +3561,8 @@ class GCEMockHttp(MockHttp):
             'global_instanceTemplates_my_instance_template1.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
-    def _global_instanceTemplates_my_instance_template_shared_network(self, method, url,
-                                                        body, headers):
+    def _global_instanceTemplates_my_instance_template_shared_network(
+            self, method, url, body, headers):
         body = self.fixtures.load(
             'global_instanceTemplates_my_instance_template_shared_network.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])


### PR DESCRIPTION
## Allow creation of MIG with an instance template whose network and subnetwork are shared from a different project

### Description

It's currently not possible to create a Managed Instance Group with an instance template that creates instances in a network and subnetwork that are shared from a different project.

The problem seems to be that, when parsing the json representing the instance group (in `_to_instancegroup`), the name part of the network (or subnetwork) is extracted from a fully qualified URL, i.e. implictly assuming that the network is under the same project that we are in. But if we're using a shared VPC, the network resource will be under a different project and we must stick to using fully qualified URL.

This PR modifies the `_to_instancegroup` method so that the network and subnetwork values contained in the json representation are used as they are and passed directly to `ex_get_network` and `ex_get_subnetwork` which know how to handle fully qualified resource URLs.

### Status

Done, ready for review. To be honest I am not sure the test I've added is useful, but I am not too sure about how to test this: I'll happily receive feedback.

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
