### PR TITLE
pin libvirt-python to 4.0.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 deps =
     -r{toxinidir}/requirements-tests.txt
     lockfile
-    libvirt-python
+    libvirt-python==4.0.0
     py2.7: paramiko
 commands = cp libcloud/test/secrets.py-dist libcloud/test/secrets.py
            python setup.py test
@@ -96,7 +96,7 @@ commands = python -m integration
 [testenv:coverage]
 deps =
     -r{toxinidir}/requirements-tests.txt
-    libvirt-python
+    libvirt-python==4.0.0
     lockfile
 set-env =
 commands = cp libcloud/test/secrets.py-dist libcloud/test/secrets.py
@@ -106,7 +106,7 @@ commands = cp libcloud/test/secrets.py-dist libcloud/test/secrets.py
 passenv = TOXENV CI TRAVIS TRAVIS_*
 deps =
     -r{toxinidir}/requirements-tests.txt
-    libvirt-python
+    libvirt-python==4.0.0
     lockfile
 set-env =
 commands = cp libcloud/test/secrets.py-dist libcloud/test/secrets.py


### PR DESCRIPTION
version was not constrained and the latest update broke the build because the libvirtmod extension failed to compile.

> According to https://bugs.launchpad.net/openstack-requirements/+bug/1753539, pinning libvirt-python to 4.0.0 should fix our issue.
> Do you think you could open a pull request wich replaces all libvirt-python occurrences to libvirt-python==4.0.0 in tox.ini? That would be really helpful. Thanks

\- @pquentin 