### PR TITLE
[LIBCLOUD-985] Add coverage for newer GCE network and subnet options.

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -3775,8 +3775,7 @@ class GCENodeDriver(NodeDriver):
         :param  secondaryipranges: List of dicts of secondary or "alias" IP
                                    ranges for this subnetwork in
                                    [{"rangeName": "second1",
-                                   "ipCidrRange": "192.168.168.0/24"},
-                                   {k:v, k:v}] format.
+                                   "ipCidrRange": "192.168.168.0/24"} format.
         :type   secondaryipranges: ``list`` of ``dict`` or ``None``
 
         :return:  Subnetwork object
@@ -3870,13 +3869,14 @@ class GCENodeDriver(NodeDriver):
         else:
             network_data['autoCreateSubnetworks'] = (mode.lower() == 'auto')
 
-        if routing_mode.lower() not in ['regional', 'global']:
-            raise ValueError("Invalid Routing Mode: '%s'. Must be 'REGIONAL', "
-                             "or 'GLOBAL'." % routing_mode)
-        else:
-            network_data['routingConfig'] = {
-                'routingMode': routing_mode.upper()
-            }
+        if routing_mode:
+            if routing_mode.upper() not in ['REGIONAL', 'GLOBAL']:
+                raise ValueError("Invalid Routing Mode: '%s'. Must be "
+                                 "'REGIONAL' or 'GLOBAL'." % routing_mode)
+            else:
+                network_data['routingConfig'] = {
+                    'routingMode': routing_mode.upper()
+                }
 
         request = '/global/networks'
 

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -3775,7 +3775,8 @@ class GCENodeDriver(NodeDriver):
         :param  secondaryipranges: List of dicts of secondary or "alias" IP
                                    ranges for this subnetwork in
                                    [{"rangeName": "second1",
-                                   "ipCidrRange": "192.168.168.0/24"} format.
+                                   "ipCidrRange": "192.168.168.0/24"},
+                                   {k:v, k:v}] format.
         :type   secondaryipranges: ``list`` of ``dict`` or ``None``
 
         :return:  Subnetwork object
@@ -3869,14 +3870,13 @@ class GCENodeDriver(NodeDriver):
         else:
             network_data['autoCreateSubnetworks'] = (mode.lower() == 'auto')
 
-        if routing_mode:
-            if routing_mode.upper() not in ['REGIONAL', 'GLOBAL']:
-                raise ValueError("Invalid Routing Mode: '%s'. Must be "
-                                 "'REGIONAL' or 'GLOBAL'." % routing_mode)
-            else:
-                network_data['routingConfig'] = {
-                    'routingMode': routing_mode.upper()
-                }
+        if routing_mode.lower() not in ['regional', 'global']:
+            raise ValueError("Invalid Routing Mode: '%s'. Must be 'REGIONAL', "
+                             "or 'GLOBAL'." % routing_mode)
+        else:
+            network_data['routingConfig'] = {
+                'routingMode': routing_mode.upper()
+            }
 
         request = '/global/networks'
 

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -3748,7 +3748,8 @@ class GCENodeDriver(NodeDriver):
         return self.ex_get_sslcertificate(name)
 
     def ex_create_subnetwork(self, name, cidr=None, network=None, region=None,
-                             description=None):
+                             description=None, privateipgoogleaccess=None,
+                             secondaryipranges=None):
         """
         Create a subnetwork.
 
@@ -3766,6 +3767,17 @@ class GCENodeDriver(NodeDriver):
 
         :param  description: Custom description for the network.
         :type   description: ``str`` or ``None``
+
+        :param  privateipgoogleaccess: Allow access to Google services without
+                                       assigned external IP addresses.
+        :type   privateipgoogleaccess: ``bool` or ``None``
+
+        :param  secondaryipranges: List of dicts of secondary or "alias" IP
+                                   ranges for this subnetwork in
+                                   [{"rangeName": "second1",
+                                   "ipCidrRange": "192.168.168.0/24"},
+                                   {k:v, k:v}] format.
+        :type   secondaryipranges: ``list`` of ``dict`` or ``None``
 
         :return:  Subnetwork object
         :rtype:   :class:`GCESubnetwork`
@@ -3803,6 +3815,8 @@ class GCENodeDriver(NodeDriver):
         subnet_data['ipCidrRange'] = cidr
         subnet_data['network'] = network_url
         subnet_data['region'] = region_url
+        subnet_data['privateIpGoogleAccess'] = privateipgoogleaccess
+        subnet_data['secondaryIpRanges'] = secondaryipranges
         region_name = region_url.split('/')[-1]
 
         request = '/regions/%s/subnetworks' % (region_name)
@@ -3810,7 +3824,8 @@ class GCENodeDriver(NodeDriver):
 
         return self.ex_get_subnetwork(name, region_name)
 
-    def ex_create_network(self, name, cidr, description=None, mode="legacy"):
+    def ex_create_network(self, name, cidr, description=None,
+                          mode="legacy", routing_mode=None):
         """
         Create a network. In November 2015, Google introduced Subnetworks and
         suggests using networks with 'auto' generated subnetworks. See, the
@@ -3831,6 +3846,11 @@ class GCENodeDriver(NodeDriver):
         :param  mode: Create a 'auto', 'custom', or 'legacy' network.
         :type   mode: ``str``
 
+        :param  routing_mode: Create network with 'Global' or 'Regional'
+                              routing mode for BGP advertisements.
+                              Defaults to 'Regional'
+        :type   routing_mode: ``str`` or ``None``
+
         :return:  Network object
         :rtype:   :class:`GCENetwork`
         """
@@ -3843,14 +3863,22 @@ class GCENodeDriver(NodeDriver):
         if cidr and mode in ['auto', 'custom']:
             raise ValueError("Can only specify IPv4Range with 'legacy' mode.")
 
-        request = '/global/networks'
-
         if mode == 'legacy':
             if not cidr:
                 raise ValueError("Must specify IPv4Range with 'legacy' mode.")
             network_data['IPv4Range'] = cidr
         else:
             network_data['autoCreateSubnetworks'] = (mode.lower() == 'auto')
+
+        if routing_mode.lower() not in ['regional', 'global']:
+            raise ValueError("Invalid Routing Mode: '%s'. Must be 'REGIONAL', "
+                             "or 'GLOBAL'." % routing_mode)
+        else:
+            network_data['routingConfig'] = {
+                'routingMode': routing_mode.upper()
+            }
+
+        request = '/global/networks'
 
         self.connection.async_request(request, method='POST',
                                       data=network_data)
@@ -8532,6 +8560,9 @@ class GCENodeDriver(NodeDriver):
         extra['network'] = subnetwork.get('network')
         extra['region'] = subnetwork.get('region')
         extra['selfLink'] = subnetwork.get('selfLink')
+        extra['privateIpGoogleAccess'] = \
+            subnetwork.get('privateIpGoogleAccess')
+        extra['secondaryIpRanges'] = subnetwork.get('secondaryIpRanges')
         network = self._get_object_by_kind(subnetwork.get('network'))
         region = self._get_object_by_kind(subnetwork.get('region'))
 
@@ -8561,6 +8592,7 @@ class GCENodeDriver(NodeDriver):
         # 'auto' or 'custom'
         extra['autoCreateSubnetworks'] = network.get('autoCreateSubnetworks')
         extra['subnetworks'] = network.get('subnetworks')
+        extra['routingConfig'] = network.get('routingConfig')
 
         # match Cloud SDK 'gcloud'
         if 'autoCreateSubnetworks' in network:

--- a/libcloud/test/compute/fixtures/gce/global_networks_lcnetwork.json
+++ b/libcloud/test/compute/fixtures/gce/global_networks_lcnetwork.json
@@ -6,5 +6,8 @@
   "id": "16211908079305042870",
   "kind": "compute#network",
   "name": "lcnetwork",
+  "routingConfig": {
+    "routingMode": "REGIONAL"
+  },
   "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/global/networks/lcnetwork"
 }

--- a/libcloud/test/compute/fixtures/gce/regions_us-central1_subnetworks_cf_972cf02e6ad49112.json
+++ b/libcloud/test/compute/fixtures/gce/regions_us-central1_subnetworks_cf_972cf02e6ad49112.json
@@ -1,12 +1,20 @@
 {
- "status": "DONE",
- "kind": "compute#subnetwork",
- "id": "4297043163355844284",
- "creationTimestamp": "2016-03-25T05:34:27.209-07:00",
- "gatewayAddress": "10.128.0.1",
- "name": "cf-972cf02e6ad49112",
- "network": "https://www.googleapis.com/compute/v1/projects/project_name/global/networks/cf",
- "ipCidrRange": "10.128.0.0/20",
- "region": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1",
- "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1/subnetworks/cf-972cf02e6ad49112"
+  "status": "DONE",
+  "kind": "compute#subnetwork",
+  "id": "4297043163355844284",
+  "creationTimestamp": "2016-03-25T05:34:27.209-07:00",
+  "description": "LCTestSubnet",
+  "gatewayAddress": "10.128.0.1",
+  "name": "cf-972cf02e6ad49112",
+  "network": "https://www.googleapis.com/compute/v1/projects/project_name/global/networks/cf",
+  "ipCidrRange": "10.128.0.0/20",
+  "privateIpGoogleAccess": true,
+  "region": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1",
+  "secondaryIpRanges": [
+    {
+      "ipCidrRange": "192.168.168.0/24",
+      "rangeName": "secondary"
+    }
+  ],
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/regions/us-central1/subnetworks/cf-972cf02e6ad49112"
 }

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -1007,6 +1007,8 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
                           network_name, cidr, mode='foobar')
         self.assertRaises(ValueError, self.driver.ex_create_network,
                           network_name, None, mode='legacy')
+        self.assertRaises(ValueError, self.driver.ex_create_network,
+                          network_name, cidr, routing_mode='universal')
 
     def test_ex_set_machine_type_notstopped(self):
         # get running node, change machine type

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -1004,7 +1004,7 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         network = self.driver.ex_create_network(network_name, cidr,
                                                 description=description,
                                                 routing_mode=routing_mode)
-        self.assertEqual(network.description, description)
+        self.assertEqual(network.extra['description'], description)
         self.assertEqual(network.extra['routingConfig']['routingMode'], routing_mode)
 
     def test_ex_create_network_bad_options(self):

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -522,14 +522,20 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         network = self.driver.ex_get_network(network_name)
         region_name = 'us-central1'
         region = self.driver.ex_get_region(region_name)
+        description = 'LCTestSubnet'
+        privateipgoogleaccess = True
+        secondaryipranges = [{"rangeName": "secondary", "ipCidrRange": "192.168.168.0/24"}]
         # test by network/region name
-        subnet = self.driver.ex_create_subnetwork(name, cidr, network_name,
-                                                  region_name)
+        subnet = self.driver.ex_create_subnetwork(
+            name, cidr, network_name, region_name, description=description,
+            privateipgoogleaccess=privateipgoogleaccess, secondaryipranges=secondaryipranges)
         self.assertTrue(isinstance(subnet, GCESubnetwork))
         self.assertTrue(isinstance(subnet.region, GCERegion))
         self.assertTrue(isinstance(subnet.network, GCENetwork))
         self.assertEqual(subnet.name, name)
         self.assertEqual(subnet.cidr, cidr)
+        self.assertEqual(subnet.extra['privateIpGoogleAccess'], privateipgoogleaccess)
+        self.assertEqual(subnet.extra['secondaryIpRanges'], secondaryipranges)
         # test by network/region object
         subnet = self.driver.ex_create_subnetwork(name, cidr, network, region)
         self.assertTrue(isinstance(subnet, GCESubnetwork))
@@ -537,6 +543,8 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         self.assertTrue(isinstance(subnet.network, GCENetwork))
         self.assertEqual(subnet.name, name)
         self.assertEqual(subnet.cidr, cidr)
+        self.assertEqual(subnet.extra['privateIpGoogleAccess'], privateipgoogleaccess)
+        self.assertEqual(subnet.extra['secondaryIpRanges'], secondaryipranges)
 
     def test_ex_destroy_subnetwork(self):
         name = 'cf-972cf02e6ad49112'
@@ -983,10 +991,12 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
     def test_ex_create_network(self):
         network_name = 'lcnetwork'
         cidr = '10.11.0.0/16'
-        network = self.driver.ex_create_network(network_name, cidr)
+        routing_mode = 'REGIONAL'
+        network = self.driver.ex_create_network(network_name, cidr, routing_mode='regional')
         self.assertTrue(isinstance(network, GCENetwork))
         self.assertEqual(network.name, network_name)
         self.assertEqual(network.cidr, cidr)
+        self.assertEqual(network.extra['routingConfig']['routingMode'], routing_mode)
 
     def test_ex_create_network_bad_options(self):
         network_name = 'lcnetwork'

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -991,11 +991,20 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
     def test_ex_create_network(self):
         network_name = 'lcnetwork'
         cidr = '10.11.0.0/16'
+        description = 'A custom network'
         routing_mode = 'REGIONAL'
-        network = self.driver.ex_create_network(network_name, cidr, routing_mode='regional')
+
+        # Test defaults
+        network = self.driver.ex_create_network(network_name, cidr)
         self.assertTrue(isinstance(network, GCENetwork))
         self.assertEqual(network.name, network_name)
         self.assertEqual(network.cidr, cidr)
+
+        # Test using more options
+        network = self.driver.ex_create_network(network_name, cidr,
+                                                description=description,
+                                                routing_mode=routing_mode)
+        self.assertEqual(network.description, description)
         self.assertEqual(network.extra['routingConfig']['routingMode'], routing_mode)
 
     def test_ex_create_network_bad_options(self):

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -991,11 +991,20 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
     def test_ex_create_network(self):
         network_name = 'lcnetwork'
         cidr = '10.11.0.0/16'
+        description = 'A custom network'
         routing_mode = 'REGIONAL'
-        network = self.driver.ex_create_network(network_name, cidr, routing_mode='regional')
+
+        # Test defaults
+        network = self.driver.ex_create_network(network_name, cidr)
         self.assertTrue(isinstance(network, GCENetwork))
         self.assertEqual(network.name, network_name)
         self.assertEqual(network.cidr, cidr)
+
+        # Test using more options
+        network = self.driver.ex_create_network(network_name, cidr,
+                                                description=description,
+                                                routing_mode=routing_mode)
+        self.assertEqual(network.extra['description'], description)
         self.assertEqual(network.extra['routingConfig']['routingMode'], routing_mode)
 
     def test_ex_create_network_bad_options(self):

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -991,20 +991,11 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
     def test_ex_create_network(self):
         network_name = 'lcnetwork'
         cidr = '10.11.0.0/16'
-        description = 'A custom network'
         routing_mode = 'REGIONAL'
-
-        # Test defaults
-        network = self.driver.ex_create_network(network_name, cidr)
+        network = self.driver.ex_create_network(network_name, cidr, routing_mode='regional')
         self.assertTrue(isinstance(network, GCENetwork))
         self.assertEqual(network.name, network_name)
         self.assertEqual(network.cidr, cidr)
-
-        # Test using more options
-        network = self.driver.ex_create_network(network_name, cidr,
-                                                description=description,
-                                                routing_mode=routing_mode)
-        self.assertEqual(network.extra['description'], description)
         self.assertEqual(network.extra['routingConfig']['routingMode'], routing_mode)
 
     def test_ex_create_network_bad_options(self):


### PR DESCRIPTION
## [LIBCLOUD-985] Add coverage for newer GCE network and subnet options.

### Description

Addressing [LIBCLOUD-985](https://issues.apache.org/jira/browse/LIBCLOUD-985), PR adds the ability to handle a few newer GCE network and subnet options upon creation.
For networks, supports BGP routing mode
For subnetworks, supports secondary IP Ranges, Private IP access to GCP APIs

See [](https://cloud.google.com/compute/docs/reference/rest/v1/networks/insert) and [https://cloud.google.com/compute/docs/reference/rest/v1/subnetworks/insert](url)

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
