### PR TITLE
fix unexpected body type openstack image sharing

### DIFF
--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -2599,7 +2599,7 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
             headers={'Content-type': 'application/'
                                      'openstack-images-'
                                      'v2.1-json-patch'},
-            method='PATCH', data=json.dumps(data)
+            method='PATCH', data=data
         )
         return self._to_image(response.object)
 
@@ -2652,7 +2652,7 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
         data = {'member': member_id}
         response = self.image_connection.request(
             '/v2/images/%s/members' % image_id,
-            method='POST', data=json.dumps(data)
+            method='POST', data=data
         )
         return self._to_image_member(response.object)
 
@@ -2692,7 +2692,7 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
         data = {'status': 'accepted'}
         response = self.image_connection.request(
             '/v2/images/%s/members/%s' % (image_id, member_id),
-            method='PUT', data=json.dumps(data)
+            method='PUT', data=data
         )
         return self._to_image_member(response.object)
 


### PR DESCRIPTION
Looks like I introduced a bug here [in this PR](https://github.com/apache/libcloud/pull/1176)

before:
```
In [3]: conn.ex_create_image_member('a4f9cd7a-188a-444c-90a6-d24b8c688a63', '1d14ce09c41e4b53a3be31ff980d47e3')
...
[u'Unexpected body type. Expected list/dict.<br /><br />\n\n\n', u'400 Bad Request', u'Bad Request']
```

after:
```
In [3]: conn.ex_create_image_member('a4f9cd7a-188a-444c-90a6-d24b8c688a63', '1d14ce09c41e4b53a3be31ff980d47e3')
Out[3]: <NodeImageMember: id=1d14ce09c41e4b53a3be31ff980d47e3, image_id=a4f9cd7a-188a-444c-90a6-d24b8c688a63, state=pending, driver=OpenStack  ...>
```