### PR TITLE
LIBCLOUD-986: Add prefix option to azure blob list and iterate containers

### DIFF
--- a/libcloud/storage/drivers/azure_blobs.py
+++ b/libcloud/storage/drivers/azure_blobs.py
@@ -381,11 +381,12 @@ class AzureBlobsStorageDriver(StorageDriver):
             if not params['marker']:
                 break
 
-    def iterate_container_objects(self, container):
+    def iterate_container_objects(self, container, ex_prefix=None):
         """
         @inherits: :class:`StorageDriver.iterate_container_objects`
         """
-        params = {'restype': 'container',
+        params = {'prefix': ex_prefix,
+                  'restype': 'container',
                   'comp': 'list',
                   'maxresults': RESPONSES_PER_REQUEST,
                   'include': 'metadata'}
@@ -415,6 +416,22 @@ class AzureBlobsStorageDriver(StorageDriver):
             params['marker'] = body.findtext('NextMarker')
             if not params['marker']:
                 break
+
+    def list_container_objects(self, container, ex_prefix=None):
+        """
+        Return a list of objects for the given container.
+
+        :param container: Container instance.
+        :type container: :class:`Container`
+
+        :param ex_prefix: Only return objects starting with ex_prefix
+        :type ex_prefix: ``str``
+
+        :return: A list of Object instances.
+        :rtype: ``list`` of :class:`Object`
+        """
+        return list(self.iterate_container_objects(container,
+                                                   ex_prefix=ex_prefix))
 
     def get_container(self, container_name):
         """

--- a/libcloud/test/storage/test_azure_blobs.py
+++ b/libcloud/test/storage/test_azure_blobs.py
@@ -447,6 +447,28 @@ class AzureBlobsTests(unittest.TestCase):
         self.assertTrue('content_encoding' in obj.extra)
         self.assertTrue('content_language' in obj.extra)
 
+    def test_list_container_objects_with_prefix(self):
+        self.mock_response_klass.type = None
+        AzureBlobsStorageDriver.RESPONSES_PER_REQUEST = 2
+
+        container = Container(name='test_container', extra={},
+                              driver=self.driver)
+        objects = self.driver.list_container_objects(container=container,
+                                                     ex_prefix='test_prefix')
+        self.assertEqual(len(objects), 4)
+
+        obj = objects[1]
+        self.assertEqual(obj.name, 'object2.txt')
+        self.assertEqual(obj.hash, '0x8CFB90F1BA8CD8F')
+        self.assertEqual(obj.size, 1048576)
+        self.assertEqual(obj.container.name, 'test_container')
+        self.assertTrue('meta1' in obj.meta_data)
+        self.assertTrue('meta2' in obj.meta_data)
+        self.assertTrue('last_modified' in obj.extra)
+        self.assertTrue('content_type' in obj.extra)
+        self.assertTrue('content_encoding' in obj.extra)
+        self.assertTrue('content_language' in obj.extra)
+
     def test_get_container_doesnt_exist(self):
         self.mock_response_klass.type = None
         try:


### PR DESCRIPTION
## LIBCLOUD-986: Add prefix filter for list and iterate containers to Azure Blob Storage Driver

### Description
While testing out the libcloud storage abstraction I've come across a curious omission in driver support. It seems that for many drivers there is additional support for the list_container_objects() and iterate_container_objects() to support a prefix (or ex_prefix). 

This functionality is not present in the Azure driver for some reason.   I've gone and checked the list_blobs API and it also supports this functionality as seen here:

https://docs.microsoft.com/en-us/rest/api/storageservices/list-blobs

I've added the support to the AzureBlobsStorageDriver with these changes.

### Status
- done, ready for review

### Checklist
- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes)
