### PR TITLE
Libcloud 986: Fixing the previous patch

### DIFF
--- a/libcloud/storage/drivers/azure_blobs.py
+++ b/libcloud/storage/drivers/azure_blobs.py
@@ -385,11 +385,13 @@ class AzureBlobsStorageDriver(StorageDriver):
         """
         @inherits: :class:`StorageDriver.iterate_container_objects`
         """
-        params = {'prefix': ex_prefix,
-                  'restype': 'container',
+        params = {'restype': 'container',
                   'comp': 'list',
                   'maxresults': RESPONSES_PER_REQUEST,
                   'include': 'metadata'}
+
+        if ex_prefix:
+            params['prefix'] = ex_prefix
 
         container_path = self._get_container_path(container)
 


### PR DESCRIPTION
## Libcloud 986: Fixing the previous patch

### Description
A slight update to the way the ex_prefix option is applied to the parameters in the iterate container objects.  It seems as if the prefix is there and is None.  The iterate objects returns an empty list. 

### Status
 done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
