### PR TITLE
Added ability to define OS disk size for Azure ARM compute during creating node

### DIFF
--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -415,6 +415,7 @@ class AzureNodeDriver(NodeDriver):
                     ex_tags={},
                     ex_customdata="",
                     ex_use_managed_disks=False,
+                    ex_disk_size=None,
                     ex_storage_account_type="Standard_LRS"):
         """Create a new node instance. This instance will be started
         automatically.
@@ -512,6 +513,9 @@ class AzureNodeDriver(NodeDriver):
             storage accounts on your own. Managed disks may not be available
             in all regions (default False).
         :type ex_use_managed_disks: ``bool``
+
+        :param ex_disk_size: Custom OS disk size in GB
+        :type ex_disk_size: ``int``
 
         :param ex_storage_account_type: The Storage Account type,
             ``Standard_LRS``(HDD disks) or ``Premium_LRS``(SSD disks).
@@ -625,6 +629,11 @@ class AzureNodeDriver(NodeDriver):
                 }
             }
         }
+
+        if ex_disk_size:
+            data['properties']['storageProfile']['osDisk'].update({
+                'diskSizeGB': ex_disk_size
+            })
 
         if ex_customdata:
             data["properties"]["osProfile"]["customData"] = \

--- a/libcloud/test/compute/test_azure_arm.py
+++ b/libcloud/test/compute/test_azure_arm.py
@@ -124,6 +124,48 @@ class AzureNodeDriverTests(LibcloudTestCase):
         self.assertEqual(os_profile['adminUsername'], 'any_user')
         self.assertEqual(os_profile['adminPassword'], 'any_password')
         self.assertTrue('managedDisk' in storage_profile['osDisk'])
+        self.assertTrue('diskSizeGB' not in storage_profile['osDisk'])
+        self.assertTrue(storage_profile['imageReference'], {
+            'publisher': image.publisher,
+            'offer': image.offer,
+            'sku': image.sku,
+            'version': image.version
+        })
+
+    def test_create_node_ex_disk_size(self):
+        location = NodeLocation('any_location', '', '', self.driver)
+        size = NodeSize('any_size', '', 0, 0, 0, 0, driver=self.driver)
+        image = AzureImage('1', '1', 'ubuntu', 'pub', location.id, self.driver)
+        auth = NodeAuthPassword('any_password')
+
+        node = self.driver.create_node(
+            'test-node-1',
+            size,
+            image,
+            auth,
+            location=location,
+            ex_resource_group='000000',
+            ex_storage_account='000000',
+            ex_user_name='any_user',
+            ex_network='000000',
+            ex_subnet='000000',
+            ex_disk_size=100,
+            ex_use_managed_disks=True
+        )
+        hardware_profile = node.extra['properties']['hardwareProfile']
+        os_profile = node.extra['properties']['osProfile']
+        storage_profile = node.extra['properties']['storageProfile']
+
+        self.assertEqual(node.name, 'test-node-1')
+        self.assertEqual(node.state, NodeState.UPDATING)
+        self.assertEqual(node.private_ips, ['10.0.0.1'])
+        self.assertEqual(node.public_ips, [])
+        self.assertEqual(node.extra['location'], location.id)
+        self.assertEqual(hardware_profile['vmSize'], size.id)
+        self.assertEqual(os_profile['adminUsername'], 'any_user')
+        self.assertEqual(os_profile['adminPassword'], 'any_password')
+        self.assertTrue('managedDisk' in storage_profile['osDisk'])
+        self.assertEqual(storage_profile['osDisk']['diskSizeGB'], 100)
         self.assertTrue(storage_profile['imageReference'], {
             'publisher': image.publisher,
             'offer': image.offer,


### PR DESCRIPTION
## Added ability to define OS disk size for Azure ARM compute during creating node

### Description

Current Azure ARM compute doesn't allow to specify OS disk size, so just added another `ex_` argument to `create_node` method.  

See [Azure docs](https://docs.microsoft.com/en-us/rest/api/compute/virtualmachines/createorupdate#osdisk)

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
