### PR TITLE
fix spelling in OpenStack ex_files description

### DIFF
--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -1239,7 +1239,7 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
         :type       ex_metadata: ``dict``
 
         :keyword    ex_files:   File Path => File contents to create on
-                                the no  de
+                                the node
         :type       ex_files:   ``dict``
 
 
@@ -1455,7 +1455,7 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
         :type       ex_metadata: ``dict``
 
         :keyword    ex_files:   File Path => File contents to create on
-                                the no  de
+                                the node
         :type       ex_files:   ``dict``
 
         :keyword    ex_keyname:  Name of existing public key to inject into


### PR DESCRIPTION
## "on the no  de" should be "on the node".

### Description

"on the no  de" should be "on the node" in the API docs

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
