### PR TITLE
[LIBCLOUD-982] Data stored in wrong format for Packet providers

### DIFF
--- a/libcloud/compute/drivers/packet.py
+++ b/libcloud/compute/drivers/packet.py
@@ -230,7 +230,7 @@ class PacketNodeDriver(NodeDriver):
         for disks in data['specs']['drives']:
             disk += disks['count'] * int(disks['size'].replace('GB', ''))
 
-        price = data['pricing']['hourly']
+        price = data['pricing']['hour']
 
         return NodeSize(id=data['slug'], name=data['name'], ram=ram, disk=disk,
                         bandwidth=0, price=price, extra=extra, driver=self)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/LIBCLOUD-982

A typo in the PacketNodeDriver._to_size() method. 
It's looking for data['pricing']['hourly'], when it's actually stored as data['pricing']['hour']. 