### PR TITLE
Fix hash value in azure blob store

### DIFF
--- a/libcloud/common/azure.py
+++ b/libcloud/common/azure.py
@@ -32,7 +32,7 @@ from libcloud.common.base import CertificateConnection
 from libcloud.common.base import XmlResponse
 
 # Azure API version
-API_VERSION = '2014-02-14'
+API_VERSION = '2017-07-29'
 
 # The time format for headers in Azure requests
 AZURE_TIME_FORMAT = '%a, %d %b %Y %H:%M:%S GMT'

--- a/libcloud/common/azure.py
+++ b/libcloud/common/azure.py
@@ -32,7 +32,7 @@ from libcloud.common.base import CertificateConnection
 from libcloud.common.base import XmlResponse
 
 # Azure API version
-API_VERSION = '2012-02-12'
+API_VERSION = '2014-02-14'
 
 # The time format for headers in Azure requests
 AZURE_TIME_FORMAT = '%a, %d %b %Y %H:%M:%S GMT'

--- a/libcloud/storage/drivers/azure_blobs.py
+++ b/libcloud/storage/drivers/azure_blobs.py
@@ -301,7 +301,7 @@ class AzureBlobsStorageDriver(StorageDriver):
         for meta in metadata.getchildren():
             meta_data[meta.tag] = meta.text
 
-        return Object(name=name, size=size, hash=etag, meta_data=meta_data,
+        return Object(name=name, size=size, hash=extra['md5_hash'], meta_data=meta_data,
                       extra=extra, container=container, driver=self)
 
     def _response_to_object(self, object_name, container, response):
@@ -353,7 +353,7 @@ class AzureBlobsStorageDriver(StorageDriver):
                 key = key.split('x-ms-meta-')[1]
                 meta_data[key] = value
 
-        return Object(name=object_name, size=size, hash=etag, extra=extra,
+        return Object(name=object_name, size=size, hash=extra['md5_hash'], extra=extra,
                       meta_data=meta_data, container=container, driver=self)
 
     def iterate_containers(self):
@@ -939,7 +939,7 @@ class AzureBlobsStorageDriver(StorageDriver):
                 object_name=object_name, driver=self)
 
         return Object(name=object_name, size=bytes_transferred,
-                      hash=headers['etag'], extra=None,
+                      hash=server_hash, extra=None,
                       meta_data=meta_data, container=container,
                       driver=self)
 

--- a/libcloud/storage/drivers/azure_blobs.py
+++ b/libcloud/storage/drivers/azure_blobs.py
@@ -301,8 +301,9 @@ class AzureBlobsStorageDriver(StorageDriver):
         for meta in metadata.getchildren():
             meta_data[meta.tag] = meta.text
 
-        return Object(name=name, size=size, hash=extra['md5_hash'], meta_data=meta_data,
-                      extra=extra, container=container, driver=self)
+        return Object(name=name, size=size, hash=extra['md5_hash'],
+                      meta_data=meta_data, extra=extra, container=container,
+                      driver=self)
 
     def _response_to_object(self, object_name, container, response):
         """
@@ -353,8 +354,9 @@ class AzureBlobsStorageDriver(StorageDriver):
                 key = key.split('x-ms-meta-')[1]
                 meta_data[key] = value
 
-        return Object(name=object_name, size=size, hash=extra['md5_hash'], extra=extra,
-                      meta_data=meta_data, container=container, driver=self)
+        return Object(name=object_name, size=size, hash=extra['md5_hash'],
+                      extra=extra, meta_data=meta_data, container=container,
+                      driver=self)
 
     def iterate_containers(self):
         """

--- a/libcloud/test/storage/fixtures/azure_blobs/list_containers_1.xml
+++ b/libcloud/test/storage/fixtures/azure_blobs/list_containers_1.xml
@@ -1,10 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<EnumerationResults AccountName="https://account.blob.core.windows.net/">
+<?xml version="1.0" encoding="utf-8"?>
+<EnumerationResults ServiceEndpoint="https://account.blob.core.windows.net/">
     <MaxResults>2</MaxResults>
     <Containers>
         <Container>
             <Name>container1</Name>
-            <Url>https://account.blob.core.windows.net/container1</Url>
             <Properties>
                 <Last-Modified>Mon, 07 Jan 2013 06:31:06 GMT</Last-Modified>
                 <Etag>"0x8CFBAB7B4F23346"</Etag>
@@ -15,7 +14,6 @@
         </Container>
         <Container>
             <Name>container2</Name>
-            <Url>https://account.blob.core.windows.net/container2</Url>
             <Properties>
                 <Last-Modified>Mon, 07 Jan 2013 06:31:07 GMT</Last-Modified>
                 <Etag>"0x8CFBAB7B5B82D8E"</Etag>

--- a/libcloud/test/storage/fixtures/azure_blobs/list_containers_2.xml
+++ b/libcloud/test/storage/fixtures/azure_blobs/list_containers_2.xml
@@ -1,11 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<EnumerationResults AccountName="https://account.blob.core.windows.net/">
+<?xml version="1.0" encoding="utf-8"?>
+<EnumerationResults ServiceEndpoint="https://account.blob.core.windows.net/">
     <Marker>/account/container3</Marker>
     <MaxResults>2</MaxResults>
     <Containers>
         <Container>
             <Name>container3</Name>
-            <Url>https://account.blob.core.windows.net/container3</Url>
             <Properties>
                 <Last-Modified>Mon, 07 Jan 2013 06:31:08 GMT</Last-Modified>
                 <Etag>"0x8CFBAB7B6452A71"</Etag>
@@ -16,7 +15,6 @@
         </Container>
         <Container>
             <Name>container4</Name>
-            <Url>https://account.blob.core.windows.net/container4</Url>
             <Properties>
                 <Last-Modified>Fri, 04 Jan 2013 08:32:41 GMT</Last-Modified>
                 <Etag>"0x8CFB86D32305484"</Etag>

--- a/libcloud/test/storage/fixtures/azure_blobs/list_containers_empty.xml
+++ b/libcloud/test/storage/fixtures/azure_blobs/list_containers_empty.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<EnumerationResults AccountName="http://account.blob.core.windows.net">
+<EnumerationResults ServiceEndpoint="https://account.blob.core.windows.net/">
   <Prefix></Prefix>
   <Marker></Marker>
   <MaxResults>100</MaxResults>

--- a/libcloud/test/storage/fixtures/azure_blobs/list_objects_1.xml
+++ b/libcloud/test/storage/fixtures/azure_blobs/list_objects_1.xml
@@ -1,10 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<EnumerationResults ContainerName="https://account.blob.core.windows.net/test_container">
+<?xml version="1.0" encoding="utf-8"?>
+<EnumerationResults ServiceEndpoint="https://account.blob.core.windows.net" ContainerName="test_container">
     <MaxResults>2</MaxResults>
     <Blobs>
         <Blob>
             <Name>object1.txt</Name>
-            <Url>https://account.blob.core.windows.net/test_container/object1.txt</Url>
             <Properties>
                 <Last-Modified>Fri, 04 Jan 2013 09:48:06 GMT</Last-Modified>
                 <Etag>0x8CFB877BB56A6FB</Etag>
@@ -25,7 +24,6 @@
         </Blob>
         <Blob>
             <Name>object2.txt</Name>
-            <Url>https://account.blob.core.windows.net/test_container/object2.txt</Url>
             <Properties>
                 <Last-Modified>Sat, 05 Jan 2013 03:51:42 GMT</Last-Modified>
                 <Etag>0x8CFB90F1BA8CD8F</Etag>

--- a/libcloud/test/storage/fixtures/azure_blobs/list_objects_2.xml
+++ b/libcloud/test/storage/fixtures/azure_blobs/list_objects_2.xml
@@ -1,11 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<EnumerationResults ContainerName="https://account.blob.core.windows.net/test_container">
+<?xml version="1.0" encoding="utf-8"?>
+<EnumerationResults ServiceEndpoint="https://account.blob.core.windows.net" ContainerName="test_container">
     <Marker>object3.txt</Marker>
     <MaxResults>2</MaxResults>
     <Blobs>
         <Blob>
             <Name>object3.txt</Name>
-            <Url>https://account.blob.core.windows.net/test_container/object3.txt</Url>
             <Properties>
                 <Last-Modified>Sat, 05 Jan 2013 03:52:08 GMT</Last-Modified>
                 <Etag>0x8CFB90F2B6FC022</Etag>
@@ -23,7 +22,6 @@
         </Blob>
         <Blob>
             <Name>object4.txt</Name>
-            <Url>https://account.blob.core.windows.net/test_container/object4.txt</Url>
             <Properties>
                 <Last-Modified>Fri, 04 Jan 2013 10:20:14 GMT</Last-Modified>
                 <Etag>0x8CFB87C38717450</Etag>

--- a/libcloud/test/storage/fixtures/azure_blobs/list_objects_empty.xml
+++ b/libcloud/test/storage/fixtures/azure_blobs/list_objects_empty.xml
@@ -1,5 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<EnumerationResults ContainerName="https://account.blob.core.windows.net/test_container">
+<?xml version="1.0" encoding="utf-8"?>
+<EnumerationResults ServiceEndpoint="https://account.blob.core.windows.net" ContainerName="test_container">
     <MaxResults>2</MaxResults>
     <Blobs />
     <NextMarker />

--- a/libcloud/test/storage/test_azure_blobs.py
+++ b/libcloud/test/storage/test_azure_blobs.py
@@ -160,6 +160,7 @@ class AzureBlobsMockHttp(MockHttp, unittest.TestCase):
         headers = {}
 
         headers['etag'] = '0x8CFB877BB56A6FB'
+        headers['content-md5'] = '1B2M2Y8AsgTpgAmY7PhCfg=='
         headers['last-modified'] = 'Fri, 04 Jan 2013 09:48:06 GMT'
         headers['content-length'] = '12345'
         headers['content-type'] = 'application/zip'
@@ -437,7 +438,7 @@ class AzureBlobsTests(unittest.TestCase):
 
         obj = objects[1]
         self.assertEqual(obj.name, 'object2.txt')
-        self.assertEqual(obj.hash, '0x8CFB90F1BA8CD8F')
+        self.assertEqual(obj.hash, 'b6d81b360a5672d80c27430f39153e2c')
         self.assertEqual(obj.size, 1048576)
         self.assertEqual(obj.container.name, 'test_container')
         self.assertTrue('meta1' in obj.meta_data)
@@ -459,7 +460,7 @@ class AzureBlobsTests(unittest.TestCase):
 
         obj = objects[1]
         self.assertEqual(obj.name, 'object2.txt')
-        self.assertEqual(obj.hash, '0x8CFB90F1BA8CD8F')
+        self.assertEqual(obj.hash, 'b6d81b360a5672d80c27430f39153e2c')
         self.assertEqual(obj.size, 1048576)
         self.assertEqual(obj.container.name, 'test_container')
         self.assertTrue('meta1' in obj.meta_data)
@@ -513,7 +514,7 @@ class AzureBlobsTests(unittest.TestCase):
         self.assertEqual(obj.name, 'test')
         self.assertEqual(obj.container.name, 'test_container200')
         self.assertEqual(obj.size, 12345)
-        self.assertEqual(obj.hash, '0x8CFB877BB56A6FB')
+        self.assertEqual(obj.hash, 'd41d8cd98f00b204e9800998ecf8427e')
         self.assertEqual(obj.extra['last_modified'],
                          'Fri, 04 Jan 2013 09:48:06 GMT')
         self.assertEqual(obj.extra['content_type'], 'application/zip')


### PR DESCRIPTION

## Upgrade azure blob storage api

### Description

* Upgrade to minimum api version allowed by azure (see )

* Return actual file (md5) hash instead of etag ('"0xFFFFFFFFFFFFFFF"')

The current trunk version of libcloud throws a Libcloud error also described in (https://issues.apache.org/jira/browse/LIBCLOUD-851)

```
Traceback (most recent call last):
  File "...", line 12, in <module>
    c = d.list_containers()[1]
  File "libcloud/libcloud/storage/base.py", line 209, in list_containers
    return list(self.iterate_containers())
  File "libcloud/libcloud/storage/drivers/azure_blobs.py", line 371, in iterate_containers
    (response.status), driver=self)
libcloud.common.types.LibcloudError: <LibcloudError in <libcloud.storage.drivers.azure_blobs.AzureBlobsStorageDriver object at 0x7f7389bf1080> 'Unexpected status code: 400'>
```
and the corresponing response body of the failing request is:
```
response.body
'<?xml version="1.0" encoding="utf-8"?><Error><Code>InvalidHeaderValue</Code><Message>The value for one of the HTTP headers is not in the correct format.\nRequestId:dd262993-501e-0030-6cd1-d58682000000\nTime:2018-04-16T22:24:39.6566784Z</Message><HeaderName>x-ms-version</HeaderName><HeaderValue>2012-02-12</HeaderValue></Error>'
```

From looking at:
https://docs.microsoft.com/en-us/rest/api/storageservices/versioning-for-the-azure-storage-services#for-blob-storage-accounts

the easiest fix is to upgrade the api version to the minumum supported version (2014-02-12).

In addition, the other cloud drivers all provide the actual md5 hash when uploading or getting an object.  This allows the user to check if a file has changed online compared to locally.  The current master version provides the etag value as the "hash" attribute (interestingly with literal quotes around the tag: `'"0xFFFFFFFFFFFFFFF"'`) which is not compatible with the other drivers.

Replace this with the PR description (mention the changes you have made, why
you have made them, provide some background and any references to the provider
documentation if needed, etc.).

I am assuming that these are both bugs and not design decisions (if so feel free to close this request).

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
