### PR TITLE
Fix: DigitalOcean volume list can be None

### DIFF
--- a/libcloud/compute/drivers/digitalocean.py
+++ b/libcloud/compute/drivers/digitalocean.py
@@ -125,6 +125,8 @@ class DigitalOcean_v2_NodeDriver(DigitalOcean_v2_BaseDriver,
 
     def list_volumes(self):
         data = self._paginated_request('/v2/volumes', 'volumes')
+        if data is None:
+            return []
         return list(map(self._to_volume, data))
 
     def create_node(self, name, size, image, location, ex_create_attr=None,


### PR DESCRIPTION
The returned structure seems to have changed for DigitalOcean and the
data can now be None, which means we have to check before using the
result in the map().

Signed-off-by: Julien Desfossez <jdesfossez@digitalocean.com>