### PR TITLE
Support for AWS EC2 Spot Instances

### DIFF
--- a/example_compute_ec2spot.py
+++ b/example_compute_ec2spot.py
@@ -1,0 +1,52 @@
+import os
+import time
+from libcloud.compute.types import Provider
+from libcloud.compute.providers import get_driver
+from libcloud.compute.base import NodeImage
+from libcloud.compute.types import NodeState
+
+SIZE_ID = 't2.micro'
+AMI_ID = 'ami-4e79ed36'
+REGION = 'us-west-2'
+KEYPAIR_NAME = 'mykey'
+SECURITY_GROUP_NAMES = ['default', 'ssh']
+NODE_NAME = 'test-spot-node'
+
+def create_spot_request(accessid, secretkey):
+    cls = get_driver(Provider.EC2)
+    driver = cls(accessid, secretkey, region=REGION)
+
+    sizes = driver.list_sizes()
+    size = [s for s in sizes if s.id == SIZE_ID][0]
+    image = NodeImage(id=AMI_ID, name=None, driver=driver)
+
+    # create the spot instance
+    node = driver.create_node(
+        image=image,
+        size=size,
+        ex_spot_market=True,
+        ex_spot_price=0.005,
+        name=NODE_NAME,
+        keyname=KEYPAIR_NAME,
+        security_groups=SECURITY_GROUP_NAMES)
+
+    print("Spot instance created: '%s" % node.id)
+    assert node.extra.get('instance_lifecycle') == 'spot'
+    print("Destroying node...")
+    driver.destroy_node(node)
+    while node.state != NodeState.TERMINATED:
+        print("...waiting to be terminated (State: %s)" % node.state)
+        node = driver.list_nodes(ex_node_ids=[node.id])[0]
+        time.sleep(5)
+
+def main():
+    accessid = os.getenv('ACCESSID')
+    secretkey = os.getenv('SECRETKEY')
+
+    if accessid and secretkey:
+        create_spot_request(accessid, secretkey)
+    else:
+        print('ACCESSID and SECRETKEY are sourced from the environment')
+
+if __name__ == "__main__":
+    main()

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -3934,8 +3934,9 @@ class BaseEC2NodeDriver(NodeDriver):
                                     of requesting On-Demand.
         :type       ex_spot_market: ``bool``
 
-        :keyword    ex_spot_price: Maximum price to pay for the spot instance. If
-                                   not specified, the on-demand price will be used.
+        :keyword    ex_spot_price: Maximum price to pay for the spot instance.
+                                   If not specified, the on-demand price will
+                                   be used.
         :type       ex_spot_price: ``float``
 
         :keyword    ex_placement_group: The name of the placement group to
@@ -3972,8 +3973,8 @@ class BaseEC2NodeDriver(NodeDriver):
         if kwargs.get("ex_spot_market", False):
             params["InstanceMarketOptions.MarketType"] = "spot"
             if kwargs.get("ex_spot_price", False):
-                params["InstanceMarketOptions.SpotOptions.MaxPrice"] = \
-                str(kwargs.get("ex_spot_price"))
+                params["InstanceMarketOptions.SpotOptions.MaxPrice"] =\
+                    str(kwargs.get("ex_spot_price"))
 
         if kwargs.get("ex_terminate_on_shutdown", False):
             params["InstanceInitiatedShutdownBehavior"] = "terminate"

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -3930,6 +3930,14 @@ class BaseEC2NodeDriver(NodeDriver):
         :keyword    ex_subnet: The subnet to launch the instance into.
         :type       ex_subnet: :class:`.EC2Subnet`
 
+        :keyword    ex_spot_market: If true, ask for a Spot Instance instead
+                                    of requesting On-Demand.
+        :type       ex_spot_market: ``bool``
+
+        :keyword    ex_spot_price: Maximum price to pay for the spot instance. If
+                                   not specified, the on-demand price will be used.
+        :type       ex_spot_price: ``float``
+
         :keyword    ex_placement_group: The name of the placement group to
                                         launch the instance into.
         :type       ex_placement_group: ``str``
@@ -3959,6 +3967,13 @@ class BaseEC2NodeDriver(NodeDriver):
             'MaxCount': str(kwargs.get('ex_maxcount', '1')),
             'InstanceType': size.id
         }
+
+        # Spot instances support
+        if kwargs.get("ex_spot_market", False):
+            params["InstanceMarketOptions.MarketType"] = "spot"
+            if kwargs.get("ex_spot_price", False):
+                params["InstanceMarketOptions.SpotOptions.MaxPrice"] = \
+                str(kwargs.get("ex_spot_price"))
 
         if kwargs.get("ex_terminate_on_shutdown", False):
             params["InstanceInitiatedShutdownBehavior"] = "terminate"


### PR DESCRIPTION
## Basic support for EC2 Spot Instances

### Description

Spot instances on AWS are a way to get cheaper nodes taking advantage of Amazon's over capacity. The downside of using this kind of instances is that whenever AWS need the allocated spot instances to deliver normal (on-demand) ones (at full price), it will shutdown them after a 2 minute period, so this has to be taken into account when designing systems so they can recover correctly.

Recently, AWS was updated so that requesting Spot instances is easier than ever, the client just to add a couple of parameters to the usual RunInstances call, immediately getting an instance id from the API that can be treated as a normal Node.

For testing purposes I added a new example script that creates t2.micro spot instances.

Ref:
* https://aws.amazon.com/blogs/compute/new-amazon-ec2-spot-pricing/
* https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_InstanceMarketOptionsRequest.html

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [X] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [X] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)