### PR TITLE
openstack: add get_user method

### DIFF
--- a/libcloud/common/openstack_identity.py
+++ b/libcloud/common/openstack_identity.py
@@ -1130,6 +1130,20 @@ class OpenStackIdentity_3_0_Connection(OpenStackIdentityConnection):
         result = self._to_domain(data=response.object['domain'])
         return result
 
+    def get_user(self, user_id):
+        """
+        Get a user account by ID.
+
+        :param user_id: User's id.
+        :type name: ``str``
+
+        :return: Located user.
+        :rtype: :class:`.OpenStackIdentityUser`
+        """
+        response = self.authenticated_request('/v3/users/%s' % user_id)
+        user = self._to_user(data=response.object['user'])
+        return user
+
     def list_user_projects(self, user):
         """
         Retrieve all the projects user belongs to.

--- a/libcloud/test/common/test_openstack_identity.py
+++ b/libcloud/test/common/test_openstack_identity.py
@@ -366,6 +366,13 @@ class OpenStackIdentity_3_0_ConnectionTests(unittest.TestCase):
         domain = self.auth_instance.get_domain(domain_id='default')
         self.assertEqual(domain.name, 'Default')
 
+    def test_get_user(self):
+        user = self.auth_instance.get_user(user_id='a')
+        self.assertEqual(user.id, 'a')
+        self.assertEqual(user.domain_id, 'default')
+        self.assertEqual(user.enabled, True)
+        self.assertEqual(user.email, 'openstack-test@localhost')
+
     def test_create_user(self):
         user = self.auth_instance.create_user(email='test2@localhost', password='test1',
                                               name='test2', domain_id='default')
@@ -681,6 +688,10 @@ class OpenStackIdentity_3_0_MockHttp(MockHttp):
         raise NotImplementedError()
 
     def _v3_users_a(self, method, url, body, headers):
+        if method == 'GET':
+            # look up a user
+            body = self.fixtures.load('v3_users_a.json')
+            return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
         if method == 'PATCH':
             # enable / disable user
             body = self.fixtures.load('v3_users_a.json')


### PR DESCRIPTION
## openstack: add get_user method

### Description

libcloud's OpenStack compute nodes have a `userId` value in `node.extra`.

Add a new `get_user()` method to the `OpenStackIdentityConnection` v3 class to look up this user by the user ID value.

This allows callers to discover more information about the user that created a node (for example).

### Status

done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
