### PR TITLE
openstack: fix API doc for delete_floating_ip()

### DIFF
--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -2761,7 +2761,7 @@ class OpenStack_1_1_FloatingIpPool(object):
         Delete specified floating IP from the pool
 
         :param      ip: floating IP to remove
-        :type       ip::class:`OpenStack_1_1_FloatingIpAddress`
+        :type       ip: :class:`OpenStack_1_1_FloatingIpAddress`
 
         :rtype: ``bool``
         """


### PR DESCRIPTION
## openstack: fix API doc for delete_floating_ip()

### Description

Prior to this change, Sphinx would not render the "ip" parameter type properly. You can see this here: http://libcloud.readthedocs.io/en/latest/apidocs/libcloud.compute.drivers.html#libcloud.compute.drivers.openstack.OpenStack_1_1_FloatingIpPool.delete_floating_ip

Add a space so Sphinx will interpret the type properly.

### Status

done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
