### PR TITLE
openstack: document openstack_connection_kwargs

### DIFF
--- a/libcloud/common/openstack.py
+++ b/libcloud/common/openstack.py
@@ -434,6 +434,7 @@ class OpenStackDriverMixin(object):
 
     def openstack_connection_kwargs(self):
         """
+        Returns certain ``ex_*`` parameters for this connection.
 
         :rtype: ``dict``
         """


### PR DESCRIPTION
## openstack: document openstack_connection_kwargs

### Description

`OpenStackDriverMixin` has a `openstack_connection_kwargs()` method. Document what it does.

### Status

done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
