### PR TITLE
[scaleway] Fix the pagination

### DIFF
--- a/libcloud/compute/drivers/scaleway.py
+++ b/libcloud/compute/drivers/scaleway.py
@@ -104,6 +104,7 @@ class ScalewayConnection(ConnectionUserAndKey):
             next = self.request(links['next']['url'], data=data,
                                 headers=headers, method=method,
                                 raw=raw, stream=stream).object
+            links = self.connection.getresponse().links
             merged = {root: child + next[root]
                       for root, child in list(results.items())}
             results = merged


### PR DESCRIPTION
Pagination was broken in the original PR. The `links` variable wasn't being updated after loading each new page, so it kept requesting page 2 in an infinite loop. This hotfix resolves that issue.