### PR TITLE
[LIBCLOUD-1004] Add launch template support to EC2 create_node

### DIFF
--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -1862,16 +1862,46 @@ class BaseEC2NodeDriver(NodeDriver):
                                               the operating systems command
                                               for system shutdown.
         :type       ex_terminate_on_shutdown: ``bool``
+
+        :keyword    ex_launch_template_name: Template to create the instance
+                                             from.
+        :type       ex_launch_template_name: ``str`` or ``None``
+
+        :keyword    ex_launch_template_id:   Template ID to create instance
+                                             from.
+        :type       ex_launch_template_id:   ``str`` or ``None``
+
+        :keyword    ex_launch_template_version: Template version to create
+                                                instance from.
+        :type       ex_launch_template_version: ``str``, ``int`` or ``None``
         """
-        image = kwargs["image"]
-        size = kwargs["size"]
+
         params = {
             'Action': 'RunInstances',
-            'ImageId': image.id,
             'MinCount': str(kwargs.get('ex_mincount', '1')),
             'MaxCount': str(kwargs.get('ex_maxcount', '1')),
-            'InstanceType': size.id
         }
+
+        if 'ex_launch_template_name' in kwargs:
+            params[
+                'LaunchTemplate.LaunchTemplateName'
+            ] = kwargs['ex_launch_template_name']
+
+        if 'ex_launch_template_id' in kwargs:
+            params[
+                'LaunchTemplate.LaunchTemplateId'
+            ] = kwargs['ex_launch_template_id']
+
+        if 'ex_launch_template_version' in kwargs:
+            params[
+                'LaunchTemplate.Version'
+            ] = str(kwargs['ex_launch_template_version'])
+
+        if 'image' in kwargs:
+            params['ImageId'] = kwargs['image'].id
+
+        if 'size' in kwargs:
+            params['InstanceType'] = kwargs['size'].id
 
         if kwargs.get("ex_terminate_on_shutdown", False):
             params["InstanceInitiatedShutdownBehavior"] = "terminate"

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -126,6 +126,14 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
         self.assertEqual(node.extra['tags']['Name'], 'foo')
         self.assertEqual(len(node.extra['tags']), 1)
 
+        def test_create_node_with_launch_template(self):
+            node = self.driver.create_node(name='foo',
+                                           ex_launch_template_name='foo')
+            self.assertEqual(node.id, 'i-2ba64342')
+            self.assertEqual(node.name, 'foo')
+            self.assertEqual(node.extra['tags']['Name'], 'foo')
+            self.assertEqual(len(node.extra['tags']), 1)
+
     def test_create_node_with_ex_mincount(self):
         image = NodeImage(id='ami-be3adfd7',
                           name=self.image_name,


### PR DESCRIPTION
## Launch template support for EC2 create_node

### Allows Nodes to be created from EC2 Launch Templates

This change allows Nodes to be created from predefined Launch Templates in EC2.  
This is useful in a number of scenarios:
* Organizational standards are implemented with Templates.
* etc.

The attributes specified in the call to create_node will take precedence over those defined in the template (per provider documentation).

#### Provider docs: 
- https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RunInstances.html
- https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_LaunchTemplateSpecification.html

### Status
- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)