### PR TITLE
implement OpenStackv2 port attaching/detaching

### DIFF
--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -38,12 +38,13 @@ from libcloud.common.openstack import OpenStackDriverMixin
 from libcloud.common.openstack import OpenStackException
 from libcloud.common.openstack import OpenStackResponse
 from libcloud.utils.networking import is_public_subnet
-from libcloud.compute.base import NodeSize, NodeImage, NodeImageMember
+from libcloud.compute.base import NodeSize, NodeImage, NodeImageMember, \
+    UuidMixin
 from libcloud.compute.base import (NodeDriver, Node, NodeLocation,
                                    StorageVolume, VolumeSnapshot)
 from libcloud.compute.base import KeyPair
 from libcloud.compute.types import NodeState, StorageVolumeState, Provider, \
-    VolumeSnapshotState
+    VolumeSnapshotState, Type
 from libcloud.pricing import get_size_price
 from libcloud.utils.xml import findall
 from libcloud.utils.py3 import ET
@@ -59,6 +60,8 @@ __all__ = [
     'OpenStack_1_1_NodeDriver',
     'OpenStack_1_1_FloatingIpPool',
     'OpenStack_1_1_FloatingIpAddress',
+    'OpenStack_2_PortInterfaceState',
+    'OpenStack_2_PortInterface',
     'OpenStackNodeDriver'
 ]
 
@@ -77,6 +80,12 @@ class OpenStackComputeConnection(OpenStackBaseConnection):
 class OpenStackImageConnection(OpenStackBaseConnection):
     service_type = 'image'
     service_name = 'glance'
+    service_region = 'RegionOne'
+
+
+class OpenStackNetworkConnection(OpenStackBaseConnection):
+    service_type = 'network'
+    service_name = 'neutron'
     service_region = 'RegionOne'
 
 
@@ -2491,6 +2500,25 @@ class OpenStack_2_ImageConnection(OpenStackImageConnection):
         return json.dumps(data)
 
 
+class OpenStack_2_NetworkConnection(OpenStackNetworkConnection):
+    responseCls = OpenStack_1_1_Response
+    accept_format = 'application/json'
+    default_content_type = 'application/json; charset=UTF-8'
+
+    def encode_data(self, data):
+        return json.dumps(data)
+
+
+class OpenStack_2_PortInterfaceState(Type):
+    """
+    Standard states of OpenStack_2_PortInterfaceState
+    """
+    BUILD = 'build'
+    ACTIVE = 'active'
+    DOWN = 'down'
+    UNKNOWN = 'unknown'
+
+
 class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
     """
     OpenStack node driver.
@@ -2514,10 +2542,32 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
     # image/v2/index.html#list-image-members
     image_connectionCls = OpenStack_2_ImageConnection
     image_connection = None
+
+    # Similarly not all node-related operations are exposed through the
+    # compute API
+    # See https://developer.openstack.org/api-ref/compute/
+    # For example, creating a new node in an OpenStack that is configured to
+    # create a new port for every new instance will make it so that if that
+    # port is detached it disappears. But if the port is manually created
+    # beforehand using the neutron network API and node is booted with that
+    # port pre-specified, then detaching that port later will result in that
+    # becoming a re-attachable resource much like a floating ip. So because
+    # even though this is the compute driver, we do connect to the networking
+    # API here because some operations relevant for compute can only be
+    # accessed from there.
+    network_connectionCls = OpenStack_2_NetworkConnection
+    network_connection = None
     type = Provider.OPENSTACK
 
     features = {"create_node": ["generates_password"]}
     _networks_url_prefix = '/os-networks'
+
+    PORT_INTERFACE_MAP = {
+        'BUILD': OpenStack_2_PortInterfaceState.BUILD,
+        'ACTIVE': OpenStack_2_PortInterfaceState.ACTIVE,
+        'DOWN': OpenStack_2_PortInterfaceState.DOWN,
+        'UNKNOWN': OpenStack_2_PortInterfaceState.UNKNOWN
+    }
 
     def __init__(self, *args, **kwargs):
         original_connectionCls = self.connectionCls
@@ -2532,10 +2582,46 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
         super(OpenStack_2_NodeDriver, self).__init__(*args, **kwargs)
         self.image_connection = self.connection
 
-        # We run the init again to get the compute API connection
+        # We run the init again to get the Neutron V2 API connection
+        # and put that on the object under self.network_connection.
+        self.connectionCls = self.network_connectionCls
+        super(OpenStack_2_NodeDriver, self).__init__(*args, **kwargs)
+        self.network_connection = self.connection
+
+        # We run the init once again to get the compute API connection
         # and that's put under self.connection as normal.
         self.connectionCls = original_connectionCls
         super(OpenStack_2_NodeDriver, self).__init__(*args, **kwargs)
+
+    def _to_port(self, element):
+        created = element['created_at']
+        updated = element.get('updated_at')
+        return OpenStack_2_PortInterface(
+            id=element['id'],
+            state=self.PORT_INTERFACE_MAP.get(
+                element.get('status'), OpenStack_2_PortInterfaceState.UNKNOWN
+            ),
+            created=created,
+            driver=self,
+            extra=dict(
+                allowed_address_pairs=element['allowed_address_pairs'],
+                binding_vnic_type=element['binding:vnic_type'],
+                device_id=element['device_id'],
+                description=element['description'],
+                device_owner=element['device_owner'],
+                fixed_ips=element['fixed_ips'],
+                mac_address=element['mac_address'],
+                name=element['name'],
+                network_id=element['network_id'],
+                project_id=element['project_id'],
+                port_security_enabled=element['port_security_enabled'],
+                revision_number=element['revision_number'],
+                security_groups=element['security_groups'],
+                tags=element['tags'],
+                tenant_id=element['tenant_id'],
+                updated=updated,
+            )
+        )
 
     def get_image(self, image_id):
         """
@@ -2696,6 +2782,73 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
         )
         return self._to_image_member(response.object)
 
+    def ex_list_ports(self):
+        """
+        List all OpenStack_2_PortInterfaces
+
+        https://developer.openstack.org/api-ref/network/v2/#list-ports
+
+        :rtype: ``list`` of :class:`OpenStack_2_PortInterface`
+        """
+        response = self.network_connection.request(
+            '/v2.0/ports'
+        )
+        return [self._to_port(port) for port in response.object['ports']]
+
+    def ex_delete_port(self, port):
+        """
+        Delete an OpenStack_2_PortInterface
+
+        https://developer.openstack.org/api-ref/network/v2/#delete-port
+
+        :param      port: port interface to remove
+        :type       port: :class:`OpenStack_2_PortInterface`
+
+        :rtype: ``bool``
+         """
+        response = self.network_connection.request(
+            '/v2.0/ports/%s' % port.id, method='DELETE'
+        )
+        return response.success()
+
+    def ex_detach_port_interface(self, node, port):
+        """
+        Detaches an OpenStack_2_PortInterface interface from a Node.
+        :param      node: node
+        :type       node: :class:`Node`
+
+        :param      port: port interface to remove
+        :type       port: :class:`OpenStack_2_PortInterface`
+
+        :rtype: ``bool``
+        """
+        return self.connection.request(
+            '/servers/%s/os-interface/%s' % (node.id, port.id),
+            method='DELETE'
+        ).success()
+
+    def ex_attach_port_interface(self, node, port):
+        """
+        Attaches an OpenStack_2_PortInterface to a Node.
+
+        :param      node: node
+        :type       node: :class:`Node`
+
+        :param      port: port interface to remove
+        :type       port: :class:`OpenStack_2_PortInterface`
+
+        :rtype: ``bool``
+        """
+        data = {
+            'interfaceAttachment': {
+                'port_id': port.id
+            }
+        }
+        return self.connection.request(
+            '/servers/{}/os-interface'.format(node.id),
+            method='POST', data=data
+        ).success()
+
 
 class OpenStack_1_1_FloatingIpPool(object):
     """
@@ -2800,3 +2953,53 @@ class OpenStack_1_1_FloatingIpAddress(object):
         return ('<OpenStack_1_1_FloatingIpAddress: id=%s, ip_addr=%s,'
                 ' pool=%s, driver=%s>'
                 % (self.id, self.ip_address, self.pool, self.driver))
+
+
+class OpenStack_2_PortInterface(UuidMixin):
+    """
+    Port Interface info. Similar in functionality to a floating IP (can be
+    attached / detached from a compute instance) but implementation-wise a
+    bit different.
+
+    > A port is a connection point for attaching a single device, such as the
+    > NIC of a server, to a network. The port also describes the associated
+    > network configuration, such as the MAC and IP addresses to be used on
+    > that port.
+    https://docs.openstack.org/python-openstackclient/pike/cli/command-objects/port.html
+
+    Also see:
+    https://developer.openstack.org/api-ref/compute/#port-interfaces-servers-os-interface
+    """
+
+    def __init__(self, id, state, driver, created=None, extra=None):
+        """
+        :param id: Port Interface ID.
+        :type id: ``str``
+        :param state: State of the OpenStack_2_PortInterface.
+        :type state: :class:`.OpenStack_2_PortInterfaceState`
+        :param      created: A datetime object that represents when the
+                             port interface was created
+        :type       created: ``datetime.datetime``
+        :param extra: Optional provided specific attributes associated with
+                      this image.
+        :type extra: ``dict``
+        """
+        self.id = str(id)
+        self.state = state
+        self.driver = driver
+        self.created = created
+        self.extra = extra or {}
+        UuidMixin.__init__(self)
+
+    def delete(self):
+        """
+        Delete this Port Interface
+
+        :rtype: ``bool``
+        """
+        return self.driver.ex_delete_port(self)
+
+    def __repr__(self):
+        return (('<OpenStack_2_PortInterface: id=%s, state=%s, '
+                 'driver=%s  ...>')
+                % (self.id, self.state, self.driver.name))

--- a/libcloud/test/common/test_openstack_identity.py
+++ b/libcloud/test/common/test_openstack_identity.py
@@ -525,7 +525,7 @@ class OpenStackServiceCatalogTestCase(unittest.TestCase):
         catalog = OpenStackServiceCatalog(service_catalog=service_catalog,
                                           auth_version='2.0')
         entries = catalog.get_entries()
-        self.assertEqual(len(entries), 7)
+        self.assertEqual(len(entries), 8)
 
         entry = [e for e in entries if e.service_name == 'cloudServers'][0]
         self.assertEqual(entry.service_type, 'compute')
@@ -591,8 +591,8 @@ class OpenStackServiceCatalogTestCase(unittest.TestCase):
         catalog = OpenStackServiceCatalog(service_catalog=service_catalog,
                                           auth_version='2.0')
         service_types = catalog.get_service_types()
-        self.assertEqual(service_types, ['compute', 'image', 'object-store',
-                                         'rax:object-cdn'])
+        self.assertEqual(service_types, ['compute', 'image', 'network',
+                                         'object-store', 'rax:object-cdn'])
 
         service_types = catalog.get_service_types(region='ORD')
         self.assertEqual(service_types, ['rax:object-cdn'])
@@ -611,6 +611,7 @@ class OpenStackServiceCatalogTestCase(unittest.TestCase):
                                          'cloudServersOpenStack',
                                          'cloudServersPreprod',
                                          'glance',
+                                         'neutron',
                                          'nova'])
 
         service_names = catalog.get_service_names(service_type='compute')

--- a/libcloud/test/compute/fixtures/openstack/_v2_0__auth.json
+++ b/libcloud/test/compute/fixtures/openstack/_v2_0__auth.json
@@ -101,6 +101,28 @@
             {
                 "endpoints": [
                     {
+                        "region": "RegionOne",
+                        "tenantId": "1337",
+                        "publicURL": "https://test_endpoint.com/v2/1337",
+                        "versionInfo": "https://test_endpoint.com/v2/",
+                        "versionList": "https://test_endpoint.com/",
+                        "versionId": "2"
+                    },
+                    {
+                        "region": "fr1",
+                        "tenantId": "1337",
+                        "publicURL": "https://test_endpoint.com/v2/1337",
+                        "versionInfo": "https://test_endpoint.com/v2/",
+                        "versionList": "https://test_endpoint.com/",
+                        "versionId": "2"
+                    }
+                ],
+                "name": "neutron",
+                "type": "network"
+            },
+            {
+                "endpoints": [
+                    {
                         "region": "DFW",
                         "tenantId": "613469",
                         "publicURL": "https://dfw.servers.api.rackspacecloud.com/v2/1337",

--- a/libcloud/test/compute/fixtures/openstack_v1.1/_ports_v2.json
+++ b/libcloud/test/compute/fixtures/openstack_v1.1/_ports_v2.json
@@ -1,0 +1,185 @@
+{
+    "ports": [
+        {
+            "status": "BUILD", 
+            "extra_dhcp_opts": [], 
+            "description": "", 
+            "allowed_address_pairs": [], 
+            "tags": [], 
+            "network_id": "123c8a8c-6427-4e8f-a805-2035365f4d43", 
+            "tenant_id": "abcdec85bee34bb0a44ab8255eb36abc", 
+            "created_at": "2018-07-04T14:38:18Z", 
+            "admin_state_up": true, 
+            "updated_at": "2018-07-05T14:40:43Z", 
+            "binding:vnic_type": "normal", 
+            "device_owner": "compute:nova", 
+            "name": "", 
+            "revision_number": 2036, 
+            "mac_address": "ba:12:12:8a:b2:73", 
+            "port_security_enabled": true, 
+            "project_id": "abcdec85bee34bb0a44ab8255eb36abc", 
+            "fixed_ips": [
+                {
+                    "subnet_id": "1231a12a-125b-4329-a3c5-312ea86a7577", 
+                    "ip_address": "12.123.12.32"
+                }
+            ], 
+            "id": "126da55e-cfcb-41c8-ae39-a26cb8a7e723", 
+            "security_groups": [
+                "abcfb112-5b5c-4c6b-8b3f-dbaee57df440"
+            ], 
+            "device_id": "95e75643-2008-123f-ad13-e20ea64e3c87"
+        }, 
+        {
+            "status": "BUILD", 
+            "extra_dhcp_opts": [], 
+            "description": "porttest", 
+            "allowed_address_pairs": [], 
+            "tags": [], 
+            "network_id": "123c8a8c-6427-4e8f-a805-2035365f4d43", 
+            "tenant_id": "abcdec85bee34bb0a44ab8255eb36abc", 
+            "created_at": "2018-07-05T12:38:50Z", 
+            "admin_state_up": true, 
+            "updated_at": "2018-07-05T14:40:43Z", 
+            "binding:vnic_type": "normal", 
+            "device_owner": "compute:nova", 
+            "name": "porttest", 
+            "revision_number": 865, 
+            "mac_address": "ba:12:12:48:42:9b", 
+            "port_security_enabled": true, 
+            "project_id": "abcdec85bee34bb0a44ab8255eb36abc", 
+            "fixed_ips": [
+                {
+                    "subnet_id": "1231a12a-125b-4329-a3c5-312ea86a7577", 
+                    "ip_address": "12.123.12.31"
+                }
+            ], 
+            "id": "a8f3ddbe-9b29-41ac-9c0a-9ea7cc012dfb", 
+            "security_groups": [
+                "abcfb112-5b5c-4c6b-8b3f-dbaee57df440"
+            ], 
+            "device_id": "7b4743a6-f7f7-4764-9854-cf43312e6d49"
+        }, 
+        {
+            "status": "DOWN", 
+            "extra_dhcp_opts": [], 
+            "description": "", 
+            "allowed_address_pairs": [], 
+            "tags": [], 
+            "network_id": "123c8a8c-6427-4e8f-a805-2035365f4d43", 
+            "tenant_id": "abcdec85bee34bb0a44ab8255eb36abc", 
+            "created_at": "2018-07-05T13:09:27Z", 
+            "admin_state_up": true, 
+            "updated_at": "2018-07-05T13:29:38Z", 
+            "binding:vnic_type": "normal", 
+            "device_owner": "compute:nova", 
+            "name": "", 
+            "revision_number": 10, 
+            "mac_address": "ba:12:12:95:13:cc", 
+            "port_security_enabled": true, 
+            "project_id": "abcdec85bee34bb0a44ab8255eb36abc", 
+            "fixed_ips": [
+                {
+                    "subnet_id": "1231a12a-125b-4329-a3c5-312ea86a7577", 
+                    "ip_address": "12.123.12.44"
+                }
+            ], 
+            "id": "bad9af6a-121d-4772-9ae0-7d127b712f5d", 
+            "security_groups": [
+                "abcfb112-5b5c-4c6b-8b3f-dbaee57df440"
+            ], 
+            "device_id": "500d78d1-f84f-4949-12da-5205c1237121"
+        }, 
+        {
+            "status": "DOWN", 
+            "extra_dhcp_opts": [], 
+            "description": "testport", 
+            "allowed_address_pairs": [], 
+            "tags": [], 
+            "network_id": "123c8a8c-6427-4e8f-a805-2035365f4d43", 
+            "tenant_id": "abcdec85bee34bb0a44ab8255eb36abc", 
+            "created_at": "2018-07-05T11:59:13Z", 
+            "admin_state_up": true, 
+            "updated_at": "2018-07-05T12:39:48Z", 
+            "binding:vnic_type": "normal", 
+            "device_owner": "", 
+            "name": "testport", 
+            "revision_number": 32, 
+            "mac_address": "ba:12:12:6f:ea:12", 
+            "port_security_enabled": true, 
+            "project_id": "abcdec85bee34bb0a44ab8255eb36abc", 
+            "fixed_ips": [
+                {
+                    "subnet_id": "1231a12a-125b-4329-a3c5-312ea86a7577", 
+                    "ip_address": "12.123.12.12"
+                }
+            ], 
+            "id": "c21297ca-4e68-4384-badf-10903cd2cbb0", 
+            "security_groups": [
+                "abcfb112-5b5c-4c6b-8b3f-dbaee57df440"
+            ], 
+            "device_id": ""
+        }, 
+        {
+            "status": "DOWN", 
+            "extra_dhcp_opts": [], 
+            "description": "testport", 
+            "allowed_address_pairs": [], 
+            "tags": [], 
+            "network_id": "123c8a8c-6427-4e8f-a805-2035365f4d43", 
+            "tenant_id": "abcdec85bee34bb0a44ab8255eb36abc", 
+            "created_at": "2018-07-05T11:56:59Z", 
+            "admin_state_up": true, 
+            "updated_at": "2018-07-05T11:57:00Z", 
+            "binding:vnic_type": "normal", 
+            "device_owner": "", 
+            "name": "testport", 
+            "revision_number": 3, 
+            "mac_address": "ba:12:12:e6:03:ba", 
+            "port_security_enabled": true, 
+            "project_id": "abcdec85bee34bb0a44ab8255eb36abc", 
+            "fixed_ips": [
+                {
+                    "subnet_id": "1231a12a-125b-4329-a3c5-312ea86a7577", 
+                    "ip_address": "12.123.12.28"
+                }
+            ], 
+            "id": "ca335147-273c-4c72-9bab-11a122a95ce1", 
+            "security_groups": [
+                "abcfb112-5b5c-4c6b-8b3f-dbaee57df440"
+            ], 
+            "device_id": ""
+        }, 
+        {
+            "status": "DOWN", 
+            "extra_dhcp_opts": [], 
+            "description": "testport", 
+            "allowed_address_pairs": [], 
+            "tags": [], 
+            "network_id": "123c8a8c-6427-4e8f-a805-2035365f4d43", 
+            "tenant_id": "abcdec85bee34bb0a44ab8255eb36abc", 
+            "created_at": "2018-07-05T11:12:17Z", 
+            "admin_state_up": true, 
+            "updated_at": "2018-07-05T11:12:17Z", 
+            "binding:vnic_type": "normal", 
+            "device_owner": "", 
+            "name": "testport", 
+            "revision_number": 3, 
+            "mac_address": "ba:12:12:12:12:12", 
+            "port_security_enabled": true, 
+            "project_id": "abcdec85bee34bb0a44ab8255eb36abc", 
+            "fixed_ips": [
+                {
+                    "subnet_id": "1231a12a-125b-4329-a3c5-312ea86a7577", 
+                    "ip_address": "12.123.12.12"
+                }
+            ], 
+            "id": "a128dec6-4f3a-45c4-a89c-678f69a72044", 
+            "security_groups": [
+                "abcfb112-5b5c-4c6b-8b3f-dbaee57df440"
+            ], 
+            "device_id": ""
+        }
+    ]
+}
+


### PR DESCRIPTION
## Implement OpenStackv2 port attaching/detaching

### Description

Adds Port Interface calls for the OpenStack v2 driver. Similar in
functionality to floating IPs (can be attached / detached from a
compute instance to move IPs between instances) but a bit different.

> A port is a connection point for attaching a single device, such as the
> NIC of a server, to a network. The port also describes the associated
> network configuration, such as the MAC and IP addresses to be used on
> that port.
https://docs.openstack.org/python-openstackclient/pike/cli/command-objects/port.html

Also see:
https://developer.openstack.org/api-ref/compute/#port-interfaces-servers-os-interface

This commit adds:
- a connection to the neutron network API for functionality that is not exposed through
the nova compute api
- an OpenStack_2_PortInterface object
- an OpenStack_2_PortInterfaceState object for port interface states
- an ex_list_ports method (via the neutron api)
- an ex_delete_port method (via the neutron api)
- an ex_detach_port_interface method (via the nova api)
- an ex_attach_port_interface method (via the nova api)

looks like:

listing and deleting a port
```
In [2]: conn.ex_list_ports()
Out[2]: 
[<OpenStack_2_PortInterface: id=586da55e-cfcb-41c8-ae39-a26cb8a7e723, state=build, driver=OpenStack  ...>,
 <OpenStack_2_PortInterface: id=a8f3ddbe-9b29-41ac-9c0a-9ea7cc02fdfb, state=build, driver=OpenStack  ...>,
 <OpenStack_2_PortInterface: id=bad9af6a-921d-4772-9ae0-7d587b758f5d, state=down, driver=OpenStack  ...>,
 <OpenStack_2_PortInterface: id=c29f97ca-4e68-4384-badf-10903cd2cbb0, state=down, driver=OpenStack  ...>,
 <OpenStack_2_PortInterface: id=ca335147-273c-4c72-9fab-11f070a95ce1, state=down, driver=OpenStack  ...>,
 <OpenStack_2_PortInterface: id=f018dec6-4f3a-45c4-a89c-678f69a72022, state=down, driver=OpenStack  ...>]

In [3]: myport = conn.ex_list_ports()[4]

In [4]: myport
Out[4]: <OpenStack_2_PortInterface: id=ca335147-273c-4c72-9fab-11f070a95ce1, state=down, driver=OpenStack  ...>

In [5]: myport.extra
Out[5]: 
{'allowed_address_pairs': [],
 'binding_vnic_type': u'normal',
 'description': u'test1234',
 'device_id': u'',
 'device_owner': u'',
 'fixed_ips': [{u'ip_address': u'12.123.12.12',
   u'subnet_id': u'1231236a-123b-1239-a3c5-358ea86a7577'}],
 'mac_address': u'ab:21:12:12:12:ba',
 'name': test123',
 'network_id': u'123c8a8c-1237-123f-1235-2035365f4d43',
 'port_security_enabled': True,
 'project_id': u'b1232c85bee34bb0a44123255e123fbd',
 'revision_number': 3,
 'security_groups': [u'1231230f-123c-123b-123f-123ee123f220'],
 'tags': [],
 'tenant_id': u'12352123bee31230a44123255e123fbd',
 'updated': u'2018-07-05T11:57:00Z'}

In [6]: myport.delete()
Out[6]: True

In [7]: conn.ex_list_ports()
Out[7]: 
[<OpenStack_2_PortInterface: id=586da55e-cfcb-41c8-ae39-a26cb8a7e723, state=active, driver=OpenStack  ...>,
 <OpenStack_2_PortInterface: id=a8f3ddbe-9b29-41ac-9c0a-9ea7cc02fdfb, state=active, driver=OpenStack  ...>,
 <OpenStack_2_PortInterface: id=bad9af6a-921d-4772-9ae0-7d587b758f5d, state=down, driver=OpenStack  ...>,
 <OpenStack_2_PortInterface: id=c29f97ca-4e68-4384-badf-10903cd2cbb0, state=down, driver=OpenStack  ...>,
 <OpenStack_2_PortInterface: id=f018dec6-4f3a-45c4-a89c-678f69a72022, state=down, driver=OpenStack  ...>]
````

attaching and detaching an IP using a port
```
In [34]: conn.list_nodes()
Out[34]: 
[<Node: uuid=5f4ea5486ef59454e5a70ed092c52148d71d7a6e, name=test-magweb, state=RUNNING, public_ips=[], private_ips=[], provider=OpenStack ...>,
 ...
In [35]: conn.ex_list_ports()
Out[35]: 
[<OpenStack_2_PortInterface: id=586da55e-cfcb-41c8-ae39-a26cb8a7e723, state=active, driver=OpenStack  ...>,
 <OpenStack_2_PortInterface: id=a8f3ddbe-9b29-41ac-9c0a-9ea7cc02fdfb, state=active, driver=OpenStack  ...>,
 <OpenStack_2_PortInterface: id=bad9af6a-921d-4772-9ae0-7d587b758f5d, state=down, driver=OpenStack  ...>,
 <OpenStack_2_PortInterface: id=c29f97ca-4e68-4384-badf-10903cd2cbb0, state=down, driver=OpenStack  ...>,
 <OpenStack_2_PortInterface: id=f018dec6-4f3a-45c4-a89c-678f69a72022, state=down, driver=OpenStack  ...>]

In [38]: conn.ex_attach_port_interface(conn.list_nodes()[0], conn.ex_list_ports()[3])
Out[38]: True

In [39]: conn.list_nodes()
Out[39]: 
[<Node: uuid=5f4ea5486ef59454e5a70ed092c52148d71d7a6e, name=pumbojet-magweb, state=RUNNING, public_ips=[u'12.123.12.43'], private_ips=[], provider=OpenStack ...>,
...
In [40]: conn.ex_detach_port_interface(conn.list_nodes()[0], conn.ex_list_ports()[3])
Out[40]: True
In [41]: conn.list_nodes()
Out[41]: 
[<Node: uuid=5f4ea5486ef59454e5a70ed092c52148d71d7a6e, name=pumbojet-magweb, state=RUNNING, public_ips=[], private_ips=[], provider=OpenStack ...>,
...
```

### Status
- done, ready for review

cc @AlexanderGrooff
