### PR TITLE
Add create and get_port to OpenStackv2 driver

### DIFF
--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -2604,6 +2604,7 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
             created=created,
             driver=self,
             extra=dict(
+                admin_state_up=element['admin_state_up'],
                 allowed_address_pairs=element['allowed_address_pairs'],
                 binding_vnic_type=element['binding:vnic_type'],
                 device_id=element['device_id'],
@@ -2848,6 +2849,55 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
             '/servers/{}/os-interface'.format(node.id),
             method='POST', data=data
         ).success()
+
+    def ex_create_port(self, network, description=None,
+                       admin_state_up=True, name=None):
+        """
+        Creates a new OpenStack_2_PortInterface
+
+        :param      network: ID of the network where the newly created
+                    port should be attached to
+        :type       network: :class:`OpenStackNetwork`
+
+        :param      description: Description of the port
+        :type       description: str
+
+        :param      admin_state_up: The administrative state of the
+                    resource, which is up or down
+        :type       admin_state_up: bool
+
+        :param      name: Human-readable name of the resource
+        :type       name: str
+
+        :rtype: :class:`OpenStack_2_PortInterface`
+        """
+        data = {
+            'port':
+                {
+                    'description': description,
+                    'admin_state_up': admin_state_up,
+                    'name': name,
+                    'network_id': network.id,
+                }
+        }
+        response = self.network_connection.request(
+            '/v2.0/ports', method='POST', data=data
+        )
+        return self._to_port(response.object['port'])
+
+    def ex_get_port(self, port_interface_id):
+        """
+        Retrieve the OpenStack_2_PortInterface with the given ID
+
+        :param      port_interface_id: ID of the requested port
+        :type       port_interface_id: str
+
+        :return: :class:`OpenStack_2_PortInterface`
+        """
+        response = self.network_connection.request(
+            '/v2.0/ports/{}'.format(port_interface_id), method='GET'
+        )
+        return self._to_port(response.object['port'])
 
 
 class OpenStack_1_1_FloatingIpPool(object):

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -2874,9 +2874,9 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
         data = {
             'port':
                 {
-                    'description': description,
+                    'description': description or '',
                     'admin_state_up': admin_state_up,
-                    'name': name,
+                    'name': name or '',
                     'network_id': network.id,
                 }
         }

--- a/libcloud/test/compute/fixtures/openstack_v1.1/_port_v2.json
+++ b/libcloud/test/compute/fixtures/openstack_v1.1/_port_v2.json
@@ -1,0 +1,32 @@
+{
+  "port": {
+    "status": "BUILD",
+    "extra_dhcp_opts": [],
+    "description": "Some port description",
+    "allowed_address_pairs": [],
+    "tags": [],
+    "network_id": "123c8a8c-6427-4e8f-a805-2035365f4d43",
+    "tenant_id": "abcdec85bee34bb0a44ab8255eb36abc",
+    "created_at": "2018-07-04T14:38:18Z",
+    "admin_state_up": true,
+    "updated_at": "2018-07-05T14:40:43Z",
+    "binding:vnic_type": "normal",
+    "device_owner": "compute:nova",
+    "name": "Some port name",
+    "revision_number": 2036,
+    "mac_address": "ba:12:12:8a:b2:73",
+    "port_security_enabled": true,
+    "project_id": "abcdec85bee34bb0a44ab8255eb36abc",
+    "fixed_ips": [
+      {
+        "subnet_id": "1231a12a-125b-4329-a3c5-312ea86a7577",
+        "ip_address": "12.123.12.32"
+      }
+    ],
+    "id": "126da55e-cfcb-41c8-ae39-a26cb8a7e723",
+    "security_groups": [
+      "abcfb112-5b5c-4c6b-8b3f-dbaee57df440"
+    ],
+    "device_id": "95e75643-2008-123f-ad13-e20ea64e3c87"
+  }
+}


### PR DESCRIPTION
## Add methods for getting and creating ports on the OpenStackv2 driver

### Description

Adds the `ex_create_port` and `ex_get_port` methods for the OpenStackv2 driver. This complements the PR of @vdloo with these two extra methods.
The description of the Openstack API calls can be found here: https://developer.openstack.org/api-ref/compute/#port-interfaces-servers-os-interface

Output looks like the following:
```
In [8]: conn.ex_create_port(network, description='Creating a new port', name='New port', admin_state_up=True)
Out[8]: <PortInterface: id=72d2c353-343a-458e-9fbe-edadf04d4e26, state=DOWN, driver=OpenStack  ...>
In [9]: conn.ex_get_port('72d2c353-343a-458e-9fbe-edadf04d4e26')
Out[9]: <PortInterface: id=72d2c353-343a-458e-9fbe-edadf04d4e26, state=DOWN, driver=OpenStack  ...>
```

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [X] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)

cc @vdloo 