### PR TITLE
Add Python 3.7 to tox and Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
     - 3.4
     - 3.5
     - 3.6
+    - 3.7
     - pypy
     - pypy3
 os:

--- a/setup.py
+++ b/setup.py
@@ -166,6 +166,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy'
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{2.7,pypy,pypy3,3.4,3.5,3.6},checks,lint,pylint,integration,coverage
+envlist = py{2.7,pypy,pypy3,3.4,3.5,3.6,3.7},checks,lint,pylint,integration,coverage
 
 [testenv]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
@@ -18,6 +18,7 @@ basepython =
     py3.4: python3.4
     py3.5: python3.5
     py3.6: python3.6
+    py3.7: python3.7
 whitelist_externals = cp
                       bash
                       scripts/*.sh


### PR DESCRIPTION
## Python 3.7 support

### Description

This adds Python 3.7 to tox and Travis. I do not expect this to get merged in its current state. There are a number of failures. My aim is to get more visibility into those failures so that we can start fixing them.

### Status

- work in progress

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
