### PR TITLE
Oneandone compute driver firewall improvements

### DIFF
--- a/docs/compute/drivers/oneandone.rst
+++ b/docs/compute/drivers/oneandone.rst
@@ -60,7 +60,6 @@ Server Functions
 * ``ex_assign_server_ip`` - Assigns a new IP address to the server
 * ``ex_remove_server_ip`` - Removes an IP address from the server
 * ``ex_get_server_firewall_policies`` - Gets a firewall policy attached to the server's IP address
-* ``ex_remove_server_firewall_policy`` - Removes a firewall policy from  the server's IP address
 * ``ex_add_server_firewall_policy`` - Adds a firewall policy to the server's IP address
 
 Monitoring Policy Functions

--- a/docs/examples/compute/oneandone/create_firewall_policy.py
+++ b/docs/examples/compute/oneandone/create_firewall_policy.py
@@ -14,9 +14,9 @@ my_rules = [
         "source": "0.0.0.0"
     },
     {
+        "description": "Testing firewall improvements",
         "protocol": "TCP",
-        "port_from": 443,
-        "port_to": 443,
+        "port": 443,
         "source": "0.0.0.0"
     }
 ]

--- a/libcloud/compute/drivers/oneandone.py
+++ b/libcloud/compute/drivers/oneandone.py
@@ -418,7 +418,7 @@ class OneAndOneNodeDriver(NodeDriver):
         body = {}
 
         if fixed_instance_size_id is not None:
-            body['firewall_policy_id'] = fixed_instance_size_id
+            body['fixed_instance_size_id'] = fixed_instance_size_id
         if vcore is not None:
             body['vcore'] = vcore
         if cores_per_processor is not None:
@@ -746,26 +746,6 @@ class OneAndOneNodeDriver(NodeDriver):
         )
 
         return response.object
-
-    def ex_remove_server_firewall_policy(self, server_id, ip_id):
-        """
-        Removes a firewall policy from server's IP
-
-        :param server_id: Id of the server
-        :type: ``str``
-
-        :param ip_id: ID of the IP address
-        :type: ``str``
-
-        :return: ``Node`` instance
-        :rtype: ``Node``
-        """
-        response = self.connection.request(
-            action='/servers/%s/ips/%s/firewall_policy' % (server_id, ip_id),
-            method='DELETE'
-        )
-
-        return self._to_node(response.object)
 
     def ex_add_server_firewall_policy(self, server_id, ip_id, firewall_id):
         """

--- a/libcloud/test/compute/test_oneandone.py
+++ b/libcloud/test/compute/test_oneandone.py
@@ -271,11 +271,6 @@ class OneAndOneTests(unittest.TestCase):
             .ex_get_server_firewall_policies("srv_id", "ip_id")
         self.assertNotEqual(firewall, None)
 
-    def test_ex_remove_server_firewall_policies(self):
-        node = self.driver \
-            .ex_remove_server_firewall_policy("srv_id", "ip_id")
-        self.assertNotEqual(node, None)
-
     def test_ex_add_server_firewall_policy(self):
         node = self.driver \
             .ex_add_server_firewall_policy("srv_id", "ip_id", "fw_id")


### PR DESCRIPTION
## Oneandone compute driver firewall improvements

### Description

Removed deprecated API method and updated tests to accommodate [the latest changes](https://cloudpanel-api.1and1.com/documentation/v1/en/api/change_log.html) to the 1and1 Cloud Server API.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
