### PR TITLE
Fixed upload/download streams

### DIFF
--- a/libcloud/storage/drivers/azure_blobs.py
+++ b/libcloud/storage/drivers/azure_blobs.py
@@ -579,11 +579,14 @@ class AzureBlobsStorageDriver(StorageDriver):
         @inherits: :class:`StorageDriver.download_object_as_stream`
         """
         obj_path = self._get_object_path(obj.container, obj.name)
-        response = self.connection.request(obj_path, raw=True, data=None)
+        response = self.connection.request(obj_path, method='GET',
+                                           stream=True, raw=True)
+        iterator = response.iter_content(AZURE_CHUNK_SIZE)
 
-        return self._get_object(obj=obj, callback=read_in_chunks,
+        return self._get_object(obj=obj,
+                                callback=read_in_chunks,
                                 response=response,
-                                callback_kwargs={'iterator': response.response,
+                                callback_kwargs={'iterator': iterator,
                                                  'chunk_size': chunk_size},
                                 success_status_code=httplib.OK)
 
@@ -810,11 +813,27 @@ class AzureBlobsStorageDriver(StorageDriver):
         if ex_blob_type is None:
             ex_blob_type = self.ex_blob_type
 
+        """
+        Azure requires that for page blobs that a maximum size that the page
+        can grow to.  For block blobs, it is required that the Content-Length
+        header be set.  The size of the block blob will be the total size of
+        the stream minus the current position, so in this case
+        ex_page_blob_size should be 0 (and will be checked in
+        self._check_values).
+        Source:
+        https://docs.microsoft.com/en-us/rest/api/storageservices/put-blob
+        """
         self._check_values(ex_blob_type, ex_page_blob_size)
+        if ex_blob_type == "BlockBlob":
+            iterator.seek(0, os.SEEK_END)
+            blob_size = iterator.tell()
+            iterator.seek(0)
+        else:
+            blob_size = ex_page_blob_size
 
         return self._put_object(container=container,
                                 object_name=object_name,
-                                object_size=ex_page_blob_size,
+                                object_size=blob_size,
                                 extra=extra, verify_hash=verify_hash,
                                 blob_type=ex_blob_type,
                                 use_lease=ex_use_lease,

--- a/libcloud/test/storage/test_azure_blobs.py
+++ b/libcloud/test/storage/test_azure_blobs.py
@@ -650,7 +650,6 @@ class AzureBlobsTests(unittest.TestCase):
 
         consumed_stream = ''.join(chunk.decode('utf-8') for chunk in stream)
         self.assertEqual(len(consumed_stream), obj.size)
-        self.assertTrue(hasattr(stream, '__iter__'))
 
     def test_upload_object_invalid_ex_blob_type(self):
         # Invalid hash is detected on the amazon side and BAD_REQUEST is

--- a/libcloud/test/storage/test_azure_blobs.py
+++ b/libcloud/test/storage/test_azure_blobs.py
@@ -647,6 +647,9 @@ class AzureBlobsTests(unittest.TestCase):
 
         stream = self.driver.download_object_as_stream(obj=obj,
                                                        chunk_size=None)
+
+        consumed_stream = ''.join(chunk.decode('utf-8') for chunk in stream)
+        self.assertEqual(len(consumed_stream), obj.size)
         self.assertTrue(hasattr(stream, '__iter__'))
 
     def test_upload_object_invalid_ex_blob_type(self):


### PR DESCRIPTION
## Azure Driver upload_object_via_stream and download_object_as_stream fix

### Description
When trying to use upload_object_via_stream method, without this fix, a
403 error would be raised because of incorrect headers regarding content
length.  This PR fixes it by setting the object size to the blob size.

When trying to use download_object_as_stream, while consuming the 
result, a TypeError is thrown. This error surfaces because response.response
is not an iterator, unlike response.iter_content.

### Status
done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
