### PR TITLE
[LIBCLOUD-1007] Resolve RFC3339 date parsing issues with GCE Compute driver.

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -53,8 +53,9 @@ def timestamp_to_datetime(timestamp):
     :rtype:   :class:`datetime.datetime`
     """
     # We remove timezone offset, and parse that seperately
-    ts = datetime.datetime.strptime(timestamp[:timestamp.index('+')],
-                                    '%Y-%m-%dT%H:%M:%S.%f')
+    # Also remove milliseconds value
+    ts = datetime.datetime.strptime(timestamp[:timestamp.index('.')],
+                                    '%Y-%m-%dT%H:%M:%S')
     tz_hours = int(timestamp[-5:-3])
     tz_mins = int(timestamp[-2:]) * int(timestamp[-6:-5] + '1')
     tz_delta = datetime.timedelta(hours=tz_hours, minutes=tz_mins)

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -6528,7 +6528,7 @@ class GCENodeDriver(NodeDriver):
                 except:
                     raise ValueError('%s must be an RFC3339 timestamp' %
                                      attribute)
-                image_data[attribute] = value.isoformat(timespec='milliseconds')
+                image_data[attribute] = value.isoformat()
 
         request = '/global/images/%s/deprecate' % (image.name)
 

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -52,9 +52,9 @@ def timestamp_to_datetime(timestamp):
     :return:  Datetime object corresponding to timestamp
     :rtype:   :class:`datetime.datetime`
     """
-    # We remove timezone offset and microseconds (Python 2.5 strptime doesn't
-    # support %f)
-    ts = datetime.datetime.strptime(timestamp[:-10], '%Y-%m-%dT%H:%M:%S')
+    # We remove timezone offset, and parse that seperately
+    ts = datetime.datetime.strptime(timestamp[:timestamp.index('+')],
+                                    '%Y-%m-%dT%H:%M:%S.%f')
     tz_hours = int(timestamp[-5:-3])
     tz_mins = int(timestamp[-2:]) * int(timestamp[-6:-5] + '1')
     tz_delta = datetime.timedelta(hours=tz_hours, minutes=tz_mins)

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -6523,11 +6523,11 @@ class GCENodeDriver(NodeDriver):
                     continue
 
                 try:
-                    timestamp_to_datetime(value)
+                    value = timestamp_to_datetime(value)
                 except:
                     raise ValueError('%s must be an RFC3339 timestamp' %
                                      attribute)
-                image_data[attribute] = value
+                image_data[attribute] = value.isoformat(timespec='milliseconds')
 
         request = '/global/images/%s/deprecate' % (image.name)
 


### PR DESCRIPTION
## Resolves issue with RFC3339 date parsing in the GCE Compute driver. 
Timestamp strings are now parsed upto and including the microsecond value. 
The call to deprecate the Google Compute image now also correctly formats the date as RFC3339 format. 

Fixes https://issues.apache.org/jira/browse/LIBCLOUD-1007

### Status
- done, ready for review

### Checklist (tick everything that applies)
- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)