### PR TITLE
[GCE] address_data is missing subnetwork parameter

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -4698,7 +4698,7 @@ class GCENodeDriver(NodeDriver):
                                'type': 'ONE_TO_ONE_NAT'}]
             if hasattr(external_ip, 'address'):
                 access_configs[0]['natIP'] = external_ip.address
-            ni['accessConfigs'] = access_configs
+            ni['accessConfigs'] = access_configs.address
 
         if internal_ip:
             ni['networkIP'] = internal_ip

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -4698,10 +4698,10 @@ class GCENodeDriver(NodeDriver):
                                'type': 'ONE_TO_ONE_NAT'}]
             if hasattr(external_ip, 'address'):
                 access_configs[0]['natIP'] = external_ip.address
-            ni['accessConfigs'] = access_configs.address
+            ni['accessConfigs'] = access_configs
 
         if internal_ip:
-            ni['networkIP'] = internal_ip
+            ni['networkIP'] = internal_ip.address
 
         return ni
 

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -2910,6 +2910,9 @@ class GCENodeDriver(NodeDriver):
         if subnetwork and not hasattr(subnetwork, 'name'):
             subnetwork = \
                 self.ex_get_subnetwork(subnetwork, region)
+            address_data['subnetwork'] = subnetwork.extra['selfLink']
+        else:
+            address_data['subnetwork'] = subnetwork.extra['selfLink']
         if region == 'global':
             request = '/global/addresses'
         else:

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -2907,11 +2907,10 @@ class GCENodeDriver(NodeDriver):
             raise ValueError('INVALID_ARGUMENT_COMBINATION',
                              'Address type must be internal if subnetwork \
                              provided')
-        if subnetwork and not hasattr(subnetwork, 'name'):
-            subnetwork = \
-                self.ex_get_subnetwork(subnetwork, region)
-            address_data['subnetwork'] = subnetwork.extra['selfLink']
-        else:
+        if subnetwork:
+            if not hasattr(subnetwork, 'name'):
+                subnetwork = \
+                    self.ex_get_subnetwork(subnetwork, region)
             address_data['subnetwork'] = subnetwork.extra['selfLink']
         if region == 'global':
             request = '/global/addresses'


### PR DESCRIPTION
## When an address of type INTERNAL is created in GCE, address_data is missing required subnetwork parameter

### Description

this is a quick work around for the above problem which results in this traceback:

```
File "/src/apache-libcloud/libcloud/compute/drivers/gce.py", line 2921, in ex_create_address
  data=address_data)
File "/src/apache-libcloud/libcloud/common/base.py", line 772, in async_request
  response = request(**kwargs)
File "/src/apache-libcloud/libcloud/compute/drivers/gce.py", line 121, in request
  response = super(GCEConnection, self).request(*args, **kwargs)
File "/src/apache-libcloud/libcloud/common/google.py", line 808, in request
  *args, **kwargs)
File "/src/apache-libcloud/libcloud/common/base.py", line 637, in request
  response = responseCls(**kwargs)
File "/src/apache-libcloud/libcloud/common/base.py", line 155, in __init__
  self.object = self.parse_body()
File "/src/apache-libcloud/libcloud/common/google.py", line 288, in parse_body
  raise InvalidRequestError(message, self.status, code)
InvalidRequestError: {u'domain': u'global', u'message': u"Invalid value for field 'resource.subnetwork': ''. No default subnetwork was found for an address with type INTERNAL.", u'reason': u'invalid'}
 ```

### Status

Replace this: describe the PR status. Examples:

- needs review/opinion
