### PR TITLE
Rename 'async' to 'async_'

### DIFF
--- a/libcloud/compute/drivers/azure.py
+++ b/libcloud/compute/drivers/azure.py
@@ -1435,7 +1435,7 @@ class AzureNodeDriver(NodeDriver):
 
         return response
 
-    def _perform_post(self, path, body, response_type=None, async_=False):
+    def _perform_post(self, path, body, response_type=None):
         request = AzureHTTPRequest()
         request.method = 'POST'
         request.host = AZURE_SERVICE_MANAGEMENT_HOST
@@ -1447,7 +1447,7 @@ class AzureNodeDriver(NodeDriver):
 
         return response
 
-    def _perform_put(self, path, body, response_type=None, async_=False):
+    def _perform_put(self, path, body, response_type=None):
         request = AzureHTTPRequest()
         request.method = 'PUT'
         request.host = AZURE_SERVICE_MANAGEMENT_HOST
@@ -1459,7 +1459,7 @@ class AzureNodeDriver(NodeDriver):
 
         return response
 
-    def _perform_delete(self, path, async_=False):
+    def _perform_delete(self, path):
         request = AzureHTTPRequest()
         request.method = 'DELETE'
         request.host = AZURE_SERVICE_MANAGEMENT_HOST
@@ -1469,9 +1469,6 @@ class AzureNodeDriver(NodeDriver):
         response = self._perform_request(request)
 
         self.raise_for_response(response, 202)
-
-        if async_:
-            return self._parse_response_for_async_op(response)
 
     def _perform_request(self, request):
         try:

--- a/libcloud/compute/drivers/azure.py
+++ b/libcloud/compute/drivers/azure.py
@@ -1435,7 +1435,7 @@ class AzureNodeDriver(NodeDriver):
 
         return response
 
-    def _perform_post(self, path, body, response_type=None, async=False):
+    def _perform_post(self, path, body, response_type=None, async_=False):
         request = AzureHTTPRequest()
         request.method = 'POST'
         request.host = AZURE_SERVICE_MANAGEMENT_HOST
@@ -1447,7 +1447,7 @@ class AzureNodeDriver(NodeDriver):
 
         return response
 
-    def _perform_put(self, path, body, response_type=None, async=False):
+    def _perform_put(self, path, body, response_type=None, async_=False):
         request = AzureHTTPRequest()
         request.method = 'PUT'
         request.host = AZURE_SERVICE_MANAGEMENT_HOST
@@ -1459,7 +1459,7 @@ class AzureNodeDriver(NodeDriver):
 
         return response
 
-    def _perform_delete(self, path, async=False):
+    def _perform_delete(self, path, async_=False):
         request = AzureHTTPRequest()
         request.method = 'DELETE'
         request.host = AZURE_SERVICE_MANAGEMENT_HOST
@@ -1470,7 +1470,7 @@ class AzureNodeDriver(NodeDriver):
 
         self.raise_for_response(response, 202)
 
-        if async:
+        if async_:
             return self._parse_response_for_async_op(response)
 
     def _perform_request(self, request):


### PR DESCRIPTION
## Rename 'async', it's a reserved keyword with py3.7

### Description

This is a simple change that just renames 'async' to 'async_'. Starting with python 3.7, async became a reserved keyword and without this change we see errors like these:
```
  File "/usr/lib/python3/dist-packages/libcloud/compute/drivers/azure.py", line 1438
    def _perform_post(self, path, body, response_type=None, async=False):
                                                                ^
                                                                SyntaxError: invalid syntax
```
In https://github.com/apache/libcloud/pull/1227#issuecomment-405817214, it was suggested to remove this argument entirely, but I'm not familiar enough with the code to do that, and this seems like a simpler fix to get things going.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
