### PR TITLE
Unset the http_proxy environment variable before running tests.

### DIFF
--- a/libcloud/test/test_connection.py
+++ b/libcloud/test/test_connection.py
@@ -84,6 +84,14 @@ class BaseConnectionClassTestCase(unittest.TestCase):
                                 proxy_url=proxy_url)
 
     def test_constructor(self):
+        proxy_url = 'http://127.0.0.2:3128'
+        os.environ['http_proxy'] = proxy_url
+        conn = LibcloudConnection(host='localhost', port=80)
+        self.assertEqual(conn.proxy_scheme, 'http')
+        self.assertEqual(conn.proxy_host, '127.0.0.2')
+        self.assertEqual(conn.proxy_port, 3128)
+
+        _ = os.environ.pop('http_proxy', None)
         conn = LibcloudConnection(host='localhost', port=80)
         self.assertEqual(conn.proxy_scheme, None)
         self.assertEqual(conn.proxy_host, None)

--- a/libcloud/test/test_connection.py
+++ b/libcloud/test/test_connection.py
@@ -32,6 +32,14 @@ from libcloud.utils.misc import retry
 
 
 class BaseConnectionClassTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.orig_proxy = os.environ.pop('http_proxy', None)
+
+    def tearDown(self):
+        if self.orig_proxy:
+            os.environ['http_proxy'] = self.orig_proxy
+
     def test_parse_proxy_url(self):
         conn = LibcloudBaseConnection()
 


### PR DESCRIPTION

## Unset the http_proxy environment variable before running tests.

### Description

Two connection tests (test_constructor and test_connection_to_unusual_port)
assume that there is no external real proxy in the test environment. Turns
out LibcloudConnection() will honor a http_proxy shell variable if it's set,
so if the test suite is run in such an environment, these tests will fail:
```
self = <libcloud.test.test_connection.BaseConnectionClassTestCase testMethod=test_connection_to_unusual_port>

    def test_connection_to_unusual_port(self):
        conn = LibcloudConnection(host='localhost', port=8080)
>       self.assertEqual(conn.proxy_scheme, None)
E       AssertionError: 'http' != None

libcloud/test/test_connection.py:107: AssertionError

self = <libcloud.test.test_connection.BaseConnectionClassTestCase testMethod=test_constructor>

    def test_constructor(self):
        conn = LibcloudConnection(host='localhost', port=80)
>       self.assertEqual(conn.proxy_scheme, None)
E       AssertionError: 'http' != None

libcloud/test/test_connection.py:80: AssertionError

```
I also added a test for this behavior (the honoring of `http_proxy`) to the existing `test_constructor` test.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
