### PR TITLE
Convert object_size to string before adding it to a header.

### DIFF
--- a/libcloud/storage/drivers/azure_blobs.py
+++ b/libcloud/storage/drivers/azure_blobs.py
@@ -903,7 +903,7 @@ class AzureBlobsStorageDriver(StorageDriver):
 
         if blob_type == 'PageBlob':
             headers['Content-Length'] = str('0')
-            headers['x-ms-blob-content-length'] = object_size
+            headers['x-ms-blob-content-length'] = str(object_size)
 
         return headers
 


### PR DESCRIPTION
## Convert object_size to string before adding it to a header.

### Description
Since python-requests 2.11
(see https://github.com/requests/requests/issues/3477), integer values
in headers are no longer automatically converted to strings, so we need
to do it ourselves.

This is the same change that was done a couple of lines above for the
Content-Length header in commit 28a559042.

Without this fix, I get test errors in i386 and armhf (not sure why only in these arches): 
```
self = <libcloud.test.storage.test_azure_blobs.AzureBlobsTests testMethod=test_upload_page_object_success_with_lease>

    def test_upload_page_object_success_with_lease(self):
        self.mock_response_klass.use_param = 'comp'
        file_path = tempfile.mktemp(suffix='.jpg')
        file_size = AZURE_PAGE_CHUNK_SIZE * 4
    
        with open(file_path, 'w') as file_hdl:
            file_hdl.write('0' * file_size)
    
        container = Container(name='foo_bar_container', extra={},
                              driver=self.driver)
        object_name = 'foo_test_upload'
        extra = {'meta_data': {'some-value': 'foobar'}}
        obj = self.driver.upload_object(file_path=file_path,
                                        container=container,
                                        object_name=object_name,
                                        extra=extra,
                                        verify_hash=False,
                                        ex_blob_type='PageBlob',
>                                       ex_use_lease=True)

libcloud/test/storage/test_azure_blobs.py:826: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
libcloud/storage/drivers/azure_blobs.py:771: in upload_object
    use_lease=ex_use_lease)
libcloud/storage/drivers/azure_blobs.py:895: in _put_object
    stream=stream)
libcloud/storage/base.py:627: in _upload_object
    headers=headers, raw=True)
libcloud/common/base.py:590: in request
    stream=stream)
libcloud/test/__init__.py:160: in prepared_request
    raw=raw, stream=stream)
libcloud/http.py:231: in prepared_request
    prepped = self.session.prepare_request(req)
/usr/lib/python2.7/dist-packages/requests/sessions.py:437: in prepare_request
    hooks=merge_hooks(request.hooks, self.hooks),
/usr/lib/python2.7/dist-packages/requests/models.py:306: in prepare
    self.prepare_headers(headers)
/usr/lib/python2.7/dist-packages/requests/models.py:440: in prepare_headers
    check_header_validity(header)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

header = ('x-ms-blob-content-length', 2048L)

    def check_header_validity(header):
        """Verifies that header value is a string which doesn't contain
        leading whitespace or return characters. This prevents unintended
        header injection.
    
        :param header: tuple, in the format (name, value).
        """
        name, value = header
    
        if isinstance(value, bytes):
            pat = _CLEAN_HEADER_REGEX_BYTE
        else:
            pat = _CLEAN_HEADER_REGEX_STR
        try:
            if not pat.match(value):
                raise InvalidHeader("Invalid return character or leading space in header: %s" % name)
        except TypeError:
            raise InvalidHeader("Value for header {%s: %s} must be of type str or "
>                               "bytes, not %s" % (name, value, type(value)))
E           InvalidHeader: Value for header {x-ms-blob-content-length: 2048} must be of type str or bytes, not <type 'long'>

/usr/lib/python2.7/dist-packages/requests/utils.py:872: InvalidHeader

```
### Status
- done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
