### PR TITLE
[LIBCLOUD-1014] Accept tags when create a snapshot

### DIFF
--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -2132,7 +2132,7 @@ class BaseEC2NodeDriver(NodeDriver):
         response = self.connection.request(self.path, params=params).object
         return self._get_boolean(response)
 
-    def create_volume_snapshot(self, volume, name=None):
+    def create_volume_snapshot(self, volume, name=None, ex_metadata=None):
         """
         Create snapshot from volume
 
@@ -2141,6 +2141,10 @@ class BaseEC2NodeDriver(NodeDriver):
 
         :param      name: Name of snapshot (optional)
         :type       name: ``str``
+
+        :keyword    ex_metadata: The Key/Value metadata to associate
+                                 with a snapshot (optional)
+        :type       ex_metadata: ``dict``
 
         :rtype: :class:`VolumeSnapshot`
         """
@@ -2153,11 +2157,15 @@ class BaseEC2NodeDriver(NodeDriver):
             params.update({
                 'Description': name,
             })
+        if ex_metadata is None:
+            ex_metadata = {}
+
         response = self.connection.request(self.path, params=params).object
         snapshot = self._to_snapshot(response, name)
 
-        if name and self.ex_create_tags(snapshot, {'Name': name}):
-            snapshot.extra['tags']['Name'] = name
+        ex_metadata.update(**{'Name': name} if name else {})
+        if self.ex_create_tags(snapshot, ex_metadata):
+            snapshot.extra['tags'] = ex_metadata
 
         return snapshot
 

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -933,6 +933,14 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
         # 2013-08-15T16:22:30.000Z
         self.assertEqual(datetime(2013, 8, 15, 16, 22, 30, tzinfo=UTC), snap.created)
 
+    def test_create_volume_snapshot_with_tags(self):
+        vol = StorageVolume(id='vol-4282672b', name='test',
+                            state=StorageVolumeState.AVAILABLE,
+                            size=10, driver=self.driver)
+        snap = self.driver.create_volume_snapshot(
+            vol, 'Test snapshot', ex_metadata={'my_tag': 'test'})
+        self.assertEqual('test', snap.extra['tags']['my_tag'])
+
     def test_list_snapshots(self):
         snaps = self.driver.list_snapshots()
 

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -1803,13 +1803,12 @@ class NimbusTests(EC2Tests):
         self.assertExecutedMethodCount(0)
 
     def test_create_volume_snapshot_with_tags(self):
-            vol = StorageVolume(id='vol-4282672b', name='test',
-                                state=StorageVolumeState.AVAILABLE,
-                                size=10, driver=self.driver)
-            snap = self.driver.create_volume_snapshot(
-                vol, 'Test snapshot', ex_metadata={'my_tag': 'test'})
-            self.assertDictEqual({}, snap.extra['tags'])
-
+        vol = StorageVolume(id='vol-4282672b', name='test',
+                            state=StorageVolumeState.AVAILABLE,
+                            size=10, driver=self.driver)
+        snap = self.driver.create_volume_snapshot(
+            vol, 'Test snapshot', ex_metadata={'my_tag': 'test'})
+        self.assertDictEqual({}, snap.extra['tags'])
 
 
 class EucTests(LibcloudTestCase, TestCaseMixin):

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -1802,6 +1802,15 @@ class NimbusTests(EC2Tests):
         self.driver.ex_create_tags(resource=node, tags={'foo': 'bar'})
         self.assertExecutedMethodCount(0)
 
+    def test_create_volume_snapshot_with_tags(self):
+            vol = StorageVolume(id='vol-4282672b', name='test',
+                                state=StorageVolumeState.AVAILABLE,
+                                size=10, driver=self.driver)
+            snap = self.driver.create_volume_snapshot(
+                vol, 'Test snapshot', ex_metadata={'my_tag': 'test'})
+            self.assertDictEqual({}, snap.extra['tags'])
+
+
 
 class EucTests(LibcloudTestCase, TestCaseMixin):
 


### PR DESCRIPTION
## Accept tags when create snapshot

### Description
 In my aws account have a lot of snapshots of many different projects. To organize that, i need to create tags in my snapshots. Looking the method [create_volume_snapshot](https://libcloud.readthedocs.io/en/latest/compute/drivers/ec2.html#libcloud.compute.drivers.ec2.BaseEC2NodeDriver.create_volume_snapshot) i can't create tags. This pull request allow you pass tags to snapshot. Link for [jira](https://issues.apache.org/jira/browse/LIBCLOUD-1014)

### Status
- done, ready for review

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
