### PR TITLE
Implement new versions of OpenStack API calls [LIBCLOUD-874]

### DIFF
--- a/docs/compute/drivers/openstack.rst
+++ b/docs/compute/drivers/openstack.rst
@@ -99,6 +99,10 @@ Available arguments:
   driver obtains API endpoint URL from the server catalog, but if this argument
   is provided, this step is skipped and the provided value is used directly. Only valid 
   in case of api_version >= 2.0.
+  * ``ex_force_volume_url`` - Base URL to the OpenStack cinder API endpoint. By default,
+  driver obtains API endpoint URL from the server catalog, but if this argument
+  is provided, this step is skipped and the provided value is used directly. Only valid 
+  in case of api_version >= 2.0.
 
 Some examples which show how to use this arguments can be found in the section
 below.

--- a/libcloud/common/openstack.py
+++ b/libcloud/common/openstack.py
@@ -390,7 +390,7 @@ class OpenStackResponse(Response):
             context = self.connection.context
             driver = self.connection.driver
             key_pair_name = context.get('key_pair_name', None)
-            print(values)
+
             if len(values) > 0 and 'code' in values[0] and \
                     values[0]['code'] == 404 and key_pair_name:
                 raise KeyPairDoesNotExistError(name=key_pair_name,

--- a/libcloud/common/openstack.py
+++ b/libcloud/common/openstack.py
@@ -390,8 +390,9 @@ class OpenStackResponse(Response):
             context = self.connection.context
             driver = self.connection.driver
             key_pair_name = context.get('key_pair_name', None)
-
-            if len(values) > 0 and values[0]['code'] == 404 and key_pair_name:
+            print(values)
+            if len(values) > 0 and 'code' in values[0] and \
+                    values[0]['code'] == 404 and key_pair_name:
                 raise KeyPairDoesNotExistError(name=key_pair_name,
                                                driver=driver)
             elif len(values) > 0 and 'message' in values[0]:

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -2688,11 +2688,12 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
                 mac_address=element['mac_address'],
                 name=element['name'],
                 network_id=element['network_id'],
-                project_id=element['project_id'],
-                port_security_enabled=element['port_security_enabled'],
-                revision_number=element['revision_number'],
+                project_id=element.get('project_id', None),
+                port_security_enabled=element.get('port_security_enabled',
+                                                  None),
+                revision_number=element.get('revision_number', None),
                 security_groups=element['security_groups'],
-                tags=element['tags'],
+                tags=element.get('tags', None),
                 tenant_id=element['tenant_id'],
                 updated=updated,
             )
@@ -3398,8 +3399,9 @@ class OpenStack_2_FloatingIpPool(OpenStack_1_1_FloatingIpPool):
     def _to_floating_ip(self, obj):
         instance_id = None
 
+        print(obj)
         # In neutron version prior to 13.0.0 port_details does not exists
-        if 'port_details' not in obj and 'port_id' in obj:
+        if 'port_details' not in obj and 'port_id' in obj and obj['port_id']:
             port = self.connection.driver.ex_get_port(obj['port_id'])
             if port:
                 obj['port_details'] = {"device_id": port.extra["device_id"],

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -3060,10 +3060,23 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
         return self._to_port(response.object['port'])
 
     def list_volumes(self):
+        """
+        Get a list of Volumes that are available.
+
+        :rtype: ``list`` of :class:`StorageVolume`
+        """
         return self._to_volumes(
             self.volumev2_connection.request('/volumes/detail').object)
 
     def ex_get_volume(self, volumeId):
+        """
+        Retrieve the StorageVolume with the given ID
+
+        :param volumeId: ID of the volume
+        :type volumeId: ``string``
+
+        :return: :class:`StorageVolume`
+        """
         return self._to_volume(
             self.volumev2_connection.request('/volumes/%s' % volumeId).object)
 
@@ -3118,10 +3131,23 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
         return self._to_volume(resp.object)
 
     def destroy_volume(self, volume):
+        """
+        Delete a Volume.
+
+        :param volume: Volume to be deleted
+        :type  volume: :class:`StorageVolume`
+
+        :rtype: ``bool``
+        """
         return self.volumev2_connection.request('/volumes/%s' % volume.id,
                                                 method='DELETE').success()
 
     def ex_list_snapshots(self):
+        """
+        Get a list of Snapshot that are available.
+
+        :rtype: ``list`` of :class:`VolumeSnapshot`
+        """
         return self._to_snapshots(
             self.volumev2_connection.request('/snapshots/detail').object)
 

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -91,7 +91,7 @@ class OpenStackNetworkConnection(OpenStackBaseConnection):
 
 class OpenStackVolumeV2Connection(OpenStackBaseConnection):
     service_type = 'volumev2'
-    service_name = 'cinder'
+    service_name = 'cinderv2'
     service_region = 'RegionOne'
 
 

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -2216,14 +2216,13 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
 
         return StorageVolume(
             id=api_node['id'],
-            name=api_node.get('name', api_node.get('displayName')),
+            name=api_node.get('displayName', api_node.get('name')),
             size=api_node['size'],
             state=state,
             driver=self,
             extra={
-                'description': api_node.get('description',
-                                            api_node.get('displayDescription')
-                                            ),
+                'description': api_node.get('displayDescription',
+                                            api_node.get('description')),
                 'attachments': [att for att in api_node['attachments'] if att],
                 # TODO: remove in 1.18.0
                 'state': api_node.get('status', None),

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -3269,7 +3269,7 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
         """
         List available floating IP pools
 
-        :rtype: ``list`` of :class:`OpenStack_1_1_FloatingIpPool`
+        :rtype: ``list`` of :class:`OpenStack_2_FloatingIpPool`
         """
         return self._to_floating_ip_pools(
             self.network_connection.request('/v2.0/networks?router:external'

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -1849,8 +1849,6 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
 
         :rtype: ``list`` of :class:`OpenStackSecurityGroup`
         """
-        print(vars(self.connection.request(
-            '/servers/%s/os-security-groups' % (node.id))))
         return self._to_security_groups(
             self.connection.request('/servers/%s/os-security-groups' %
                                     (node.id)).object)
@@ -3438,7 +3436,6 @@ class OpenStack_2_FloatingIpPool(OpenStack_1_1_FloatingIpPool):
     def _to_floating_ip(self, obj):
         instance_id = None
 
-        print(obj)
         # In neutron version prior to 13.0.0 port_details does not exists
         if 'port_details' not in obj and 'port_id' in obj and obj['port_id']:
             port = self.connection.driver.ex_get_port(obj['port_id'])

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -3063,13 +3063,13 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
             volume['snapshot_id'] = snapshot.id
 
         resp = self.volumev2_connection.request('/volumes',
-                                       method='POST',
-                                       data={'volume': volume})
+                                                method='POST',
+                                                data={'volume': volume})
         return self._to_volume(resp.object)
 
     def destroy_volume(self, volume):
         return self.volumev2_connection.request('/volumes/%s' % volume.id,
-                                       method='DELETE').success()
+                                                method='DELETE').success()
 
     def ex_list_snapshots(self):
         return self._to_snapshots(
@@ -3104,13 +3104,13 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
         if ex_description is not None:
             data['snapshot']['description'] = ex_description
 
-        return self._to_snapshot(self.volumev2_connection.request('/snapshots',
-                                                         method='POST',
-                                                         data=data).object)
+        return self._to_snapshot(
+            self.volumev2_connection.request('/snapshots', method='POST',
+                                             data=data).object)
 
     def destroy_volume_snapshot(self, snapshot):
         resp = self.volumev2_connection.request('/snapshots/%s' % snapshot.id,
-                                       method='DELETE')
+                                                method='DELETE')
         return resp.status == httplib.ACCEPTED
 
 

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -1168,7 +1168,8 @@ class OpenStackSecurityGroupRule(object):
                 self.direction = direction
             else:
                 raise OpenStackException("Security group direction incorrect "
-                                         "value: ingress or egress.")
+                                         "value: ingress or egress.", 500,
+                                         driver)
 
         self.tenant_id = tenant_id
         self.extra = extra or {}

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -2216,27 +2216,26 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
 
         return StorageVolume(
             id=api_node['id'],
-            name=api_node.get('name', api_node.get('displayName', None)),
+            name=api_node.get('name', api_node.get('displayName')),
             size=api_node['size'],
             state=state,
             driver=self,
             extra={
                 'description': api_node.get('description',
-                                            api_node.get('displayDescription',
-                                                         None)),
+                                            api_node.get('displayDescription')
+                                            ),
                 'attachments': [att for att in api_node['attachments'] if att],
                 # TODO: remove in 1.18.0
                 'state': api_node.get('status', None),
                 'snapshot_id': api_node.get('snapshot_id',
-                                            api_node.get('snapshotId', None)),
+                                            api_node.get('snapshotId')),
                 'location': api_node.get('availability_zone',
-                                         api_node.get('availabilityZone',
-                                                      None)),
+                                         api_node.get('availabilityZone')),
                 'volume_type': api_node.get('volume_type',
-                                            api_node.get('volumeType', None)),
+                                            api_node.get('volumeType')),
                 'metadata': api_node.get('metadata', None),
                 'created_at': api_node.get('created_at',
-                                           api_node.get('createdAt', None))
+                                           api_node.get('createdAt'))
             }
         )
 
@@ -3162,6 +3161,14 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
                                              data=data).object)
 
     def destroy_volume_snapshot(self, snapshot):
+        """
+        Delete a Volume Snapshot.
+
+        :param snapshot: Snapshot to be deleted
+        :type  snapshot: :class:`VolumeSnapshot`
+
+        :rtype: ``bool``
+        """
         resp = self.volumev2_connection.request('/snapshots/%s' % snapshot.id,
                                                 method='DELETE')
         return resp.status in (httplib.NO_CONTENT, httplib.ACCEPTED)
@@ -3419,7 +3426,7 @@ class OpenStack_1_1_FloatingIpAddress(object):
                 % (self.id, self.ip_address, self.pool, self.driver))
 
 
-class OpenStack_2_FloatingIpPool(OpenStack_1_1_FloatingIpPool):
+class OpenStack_2_FloatingIpPool(object):
     """
     Floating IP Pool info.
     """

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -3236,6 +3236,7 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
         return self._to_security_group_rule(self.network_connection.request(
             '/v2.0/security-group-rules', method='POST',
             data={'security_group_rule': {
+                'direction': 'ingress',
                 'protocol': ip_protocol,
                 'port_range_min': from_port,
                 'port_range_max': to_port,

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -89,6 +89,12 @@ class OpenStackNetworkConnection(OpenStackBaseConnection):
     service_region = 'RegionOne'
 
 
+class OpenStackVolumeConnection(OpenStackBaseConnection):
+    service_type = 'volume'
+    service_name = 'cinder'
+    service_region = 'RegionOne'
+
+
 class OpenStackNodeDriver(NodeDriver, OpenStackDriverMixin):
     """
     Base OpenStack node driver. Should not be used directly.
@@ -2196,20 +2202,27 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
 
         return StorageVolume(
             id=api_node['id'],
-            name=api_node['displayName'],
+            name=api_node.get('name', api_node.get('displayName', None)),
             size=api_node['size'],
             state=state,
             driver=self,
             extra={
-                'description': api_node['displayDescription'],
+                'description': api_node.get('description',
+                                            api_node.get('displayDescription',
+                                                         None)),
                 'attachments': [att for att in api_node['attachments'] if att],
                 # TODO: remove in 1.18.0
                 'state': api_node.get('status', None),
-                'snapshot_id': api_node.get('snapshotId', None),
-                'location': api_node.get('availabilityZone', None),
-                'volume_type': api_node.get('volumeType', None),
+                'snapshot_id': api_node.get('snapshot_id',
+                                            api_node.get('snapshotId', None)),
+                'location': api_node.get('availability_zone',
+                                         api_node.get('availabilityZone',
+                                                      None)),
+                'volume_type': api_node.get('volume_type',
+                                            api_node.get('volumeType', None)),
                 'metadata': api_node.get('metadata', None),
-                'created_at': api_node.get('createdAt', None)
+                'created_at': api_node.get('created_at',
+                                           api_node.get('createdAt', None))
             }
         )
 
@@ -2218,10 +2231,13 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
             data = data['snapshot']
 
         volume_id = data.get('volume_id', data.get('volumeId', None))
-        display_name = data.get('display_name', data.get('displayName', None))
+        display_name = data.get('name',
+                                data.get('display_name',
+                                         data.get('displayName', None)))
         created_at = data.get('created_at', data.get('createdAt', None))
-        description = data.get('display_description',
-                               data.get('displayDescription', None))
+        description = data.get('description',
+                               data.get('display_description',
+                                        data.get('displayDescription', None)))
         status = data.get('status', None)
 
         extra = {'volume_id': volume_id,
@@ -2510,6 +2526,15 @@ class OpenStack_2_NetworkConnection(OpenStackNetworkConnection):
         return json.dumps(data)
 
 
+class OpenStack_2_VolumeConnection(OpenStackVolumeConnection):
+    responseCls = OpenStack_1_1_Response
+    accept_format = 'application/json'
+    default_content_type = 'application/json; charset=UTF-8'
+
+    def encode_data(self, data):
+        return json.dumps(data)
+
+
 class OpenStack_2_PortInterfaceState(Type):
     """
     Standard states of OpenStack_2_PortInterfaceState
@@ -2558,6 +2583,14 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
     # accessed from there.
     network_connectionCls = OpenStack_2_NetworkConnection
     network_connection = None
+
+    # Similarly not all node-related operations are exposed through the
+    # compute API
+    # See https://developer.openstack.org/api-ref/compute/
+    # For example, volume management are made in the cinder service
+    volume_connectionCls = OpenStack_2_VolumeConnection
+    volume_connection = None
+
     type = Provider.OPENSTACK
 
     features = {"create_node": ["generates_password"]}
@@ -2590,8 +2623,18 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
         super(OpenStack_2_NodeDriver, self).__init__(*args, **kwargs)
         self.image_connection = self.connection
 
+        # We run the init once to get the Cinder V2 API connection
+        # and put that on the object under self.volume_connection.
+        if original_ex_force_base_url or kwargs.get('ex_force_volume_url'):
+            kwargs['ex_force_base_url'] = \
+                str(kwargs.pop('ex_force_volume_url',
+                               original_ex_force_base_url))
+        self.connectionCls = self.volume_connectionCls
+        super(OpenStack_2_NodeDriver, self).__init__(*args, **kwargs)
+        self.volume_connection = self.connection
+
         # We run the init once to get the Neutron V2 API connection
-        # and put that on the object under self.image_connection.
+        # and put that on the object under self.network_connection.
         if original_ex_force_base_url or kwargs.get('ex_force_network_url'):
             kwargs['ex_force_base_url'] = \
                 str(kwargs.pop('ex_force_network_url',
@@ -2965,6 +3008,110 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
             '/v2.0/ports/{}'.format(port_interface_id), method='GET'
         )
         return self._to_port(response.object['port'])
+
+    def list_volumes(self):
+        return self._to_volumes(
+            self.connection.request('/volumes/detail').object)
+
+    def ex_get_volume(self, volumeId):
+        return self._to_volume(
+            self.connection.request('/volumes/%s' % volumeId).object)
+
+    def create_volume(self, size, name, location=None, snapshot=None,
+                      ex_volume_type=None):
+        """
+        Create a new volume.
+
+        :param size: Size of volume in gigabytes (required)
+        :type size: ``int``
+
+        :param name: Name of the volume to be created
+        :type name: ``str``
+
+        :param location: Which data center to create a volume in. If
+                               empty, undefined behavior will be selected.
+                               (optional)
+        :type location: :class:`.NodeLocation`
+
+        :param snapshot:  Snapshot from which to create the new
+                          volume.  (optional)
+        :type snapshot:  :class:`.VolumeSnapshot`
+
+        :param ex_volume_type: What kind of volume to create.
+                            (optional)
+        :type ex_volume_type: ``str``
+
+        :return: The newly created volume.
+        :rtype: :class:`StorageVolume`
+        """
+        volume = {
+            'name': name,
+            'description': name,
+            'size': size,
+            'metadata': {
+                'contents': name,
+            },
+        }
+
+        if ex_volume_type:
+            volume['volume_type'] = ex_volume_type
+
+        if location:
+            volume['availability_zone'] = location
+
+        if snapshot:
+            volume['snapshot_id'] = snapshot.id
+
+        resp = self.connection.request('/volumes',
+                                       method='POST',
+                                       data={'volume': volume})
+        return self._to_volume(resp.object)
+
+    def destroy_volume(self, volume):
+        return self.connection.request('/volumes/%s' % volume.id,
+                                       method='DELETE').success()
+
+    def ex_list_snapshots(self):
+        return self._to_snapshots(
+            self.connection.request('/snapshots/detail').object)
+
+    def create_volume_snapshot(self, volume, name=None, ex_description=None,
+                               ex_force=True):
+        """
+        Create snapshot from volume
+
+        :param volume: Instance of `StorageVolume`
+        :type  volume: `StorageVolume`
+
+        :param name: Name of snapshot (optional)
+        :type  name: `str` | `NoneType`
+
+        :param ex_description: Description of the snapshot (optional)
+        :type  ex_description: `str` | `NoneType`
+
+        :param ex_force: Specifies if we create a snapshot that is not in
+                         state `available`. For example `in-use`. Defaults
+                         to True. (optional)
+        :type  ex_force: `bool`
+
+        :rtype: :class:`VolumeSnapshot`
+        """
+        data = {'snapshot': {'volume_id': volume.id, 'force': ex_force}}
+
+        if name is not None:
+            data['snapshot']['name'] = name
+
+        if ex_description is not None:
+            data['snapshot']['description'] = ex_description
+
+        return self._to_snapshot(self.connection.request('/snapshots',
+                                                         method='POST',
+                                                         data=data).object)
+
+    def destroy_volume_snapshot(self, snapshot):
+        resp = self.connection.request('/snapshots/%s' % snapshot.id,
+                                       method='DELETE')
+        return resp.status == httplib.ACCEPTED
 
 
 class OpenStack_1_1_FloatingIpPool(object):

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -1812,7 +1812,8 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
                 security_groups]
 
     def _to_security_group(self, obj):
-        rules = self._to_security_group_rules(obj.get('rules', []))
+        rules = self._to_security_group_rules(obj.get('security_group_rules',
+                                                      obj.get('rules', [])))
         return OpenStackSecurityGroup(id=obj['id'],
                                       tenant_id=obj['tenant_id'],
                                       name=obj['name'],
@@ -3112,6 +3113,47 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
         resp = self.volumev2_connection.request('/snapshots/%s' % snapshot.id,
                                                 method='DELETE')
         return resp.status == httplib.ACCEPTED
+
+
+    def ex_list_security_groups(self):
+        """
+        Get a list of Security Groups that are available.
+
+        :rtype: ``list`` of :class:`OpenStackSecurityGroup`
+        """
+        return self._to_security_groups(
+            self.network_connection.request('/v2.0/security-groups').object)
+
+    def ex_create_security_group(self, name, description):
+        """
+        Create a new Security Group
+
+        :param name: Name of the new Security Group
+        :type  name: ``str``
+
+        :param description: Description of the new Security Group
+        :type  description: ``str``
+
+        :rtype: :class:`OpenStackSecurityGroup`
+        """
+        return self._to_security_group(self.network_connection .request(
+            '/v2.0/security-groups', method='POST',
+            data={'security_group': {'name': name, 'description': description}}
+        ).object['security_group'])
+
+    def ex_delete_security_group(self, security_group):
+        """
+        Delete a Security Group.
+
+        :param security_group: Security Group should be deleted
+        :type  security_group: :class:`OpenStackSecurityGroup`
+
+        :rtype: ``bool``
+        """
+        resp = self.network_connection.request('/v2.0/security-groups/%s' %
+                                       (security_group.id),
+                                       method='DELETE')
+        return resp.status==httplib.NO_CONTENT
 
 
 class OpenStack_1_1_FloatingIpPool(object):

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -2664,7 +2664,7 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
         super(OpenStack_2_NodeDriver, self).__init__(*args, **kwargs)
 
     def _to_port(self, element):
-        created = element['created_at']
+        created = element.get('created_at')
         updated = element.get('updated_at')
         return OpenStack_2_PortInterface(
             id=element['id'],

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -89,8 +89,8 @@ class OpenStackNetworkConnection(OpenStackBaseConnection):
     service_region = 'RegionOne'
 
 
-class OpenStackVolumeConnection(OpenStackBaseConnection):
-    service_type = 'volume'
+class OpenStackVolumeV2Connection(OpenStackBaseConnection):
+    service_type = 'volumev2'
     service_name = 'cinder'
     service_region = 'RegionOne'
 
@@ -2526,7 +2526,7 @@ class OpenStack_2_NetworkConnection(OpenStackNetworkConnection):
         return json.dumps(data)
 
 
-class OpenStack_2_VolumeConnection(OpenStackVolumeConnection):
+class OpenStack_2_VolumeV2Connection(OpenStackVolumeV2Connection):
     responseCls = OpenStack_1_1_Response
     accept_format = 'application/json'
     default_content_type = 'application/json; charset=UTF-8'
@@ -2588,8 +2588,8 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
     # compute API
     # See https://developer.openstack.org/api-ref/compute/
     # For example, volume management are made in the cinder service
-    volume_connectionCls = OpenStack_2_VolumeConnection
-    volume_connection = None
+    volumev2_connectionCls = OpenStack_2_VolumeV2Connection
+    volumev2_connection = None
 
     type = Provider.OPENSTACK
 
@@ -2624,14 +2624,14 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
         self.image_connection = self.connection
 
         # We run the init once to get the Cinder V2 API connection
-        # and put that on the object under self.volume_connection.
+        # and put that on the object under self.volumev2_connection.
         if original_ex_force_base_url or kwargs.get('ex_force_volume_url'):
             kwargs['ex_force_base_url'] = \
                 str(kwargs.pop('ex_force_volume_url',
                                original_ex_force_base_url))
-        self.connectionCls = self.volume_connectionCls
+        self.connectionCls = self.volumev2_connectionCls
         super(OpenStack_2_NodeDriver, self).__init__(*args, **kwargs)
-        self.volume_connection = self.connection
+        self.volumev2_connection = self.connection
 
         # We run the init once to get the Neutron V2 API connection
         # and put that on the object under self.network_connection.

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -2927,8 +2927,8 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
         """
         data = {'subnet': {'cidr': cidr, 'network_id': network.id,
                            'ip_version': ip_version, 'name': name}}
-        response = self.connection.request(self._subnets_url_prefix,
-                                           method='POST', data=data).object
+        response = self.network_connection.request(
+            self._subnets_url_prefix, method='POST', data=data).object
         return self._to_subnet(response['subnet'])
 
     def ex_delete_subnet(self, subnet):
@@ -2940,9 +2940,8 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
 
         :rtype: ``bool``
         """
-        resp = self.connection.request('%s/%s' % (self._subnets_url_prefix,
-                                                  subnet.id),
-                                       method='DELETE')
+        resp = self.network_connection.request('%s/%s' % (
+            self._subnets_url_prefix, subnet.id), method='DELETE')
         return resp.status in (httplib.NO_CONTENT, httplib.ACCEPTED)
 
     def ex_list_ports(self):

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -2596,10 +2596,9 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
     network_connectionCls = OpenStack_2_NetworkConnection
     network_connection = None
 
-    # Similarly not all node-related operations are exposed through the
-    # compute API
-    # See https://developer.openstack.org/api-ref/compute/
-    # For example, volume management are made in the cinder service
+    # Similarly all image operations are noe exposed through the block-storage
+    # API of the cinde service:
+    # https://developer.openstack.org/api-ref/block-storage/
     volumev2_connectionCls = OpenStack_2_VolumeV2Connection
     volumev2_connection = None
 

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -1681,7 +1681,7 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
 
     def ex_delete_network(self, network):
         """
-        Get a list of NodeNetorks that are available.
+        Delete a Network
 
         :param network: Network which should be used
         :type network: :class:`OpenStackNetwork`
@@ -2910,6 +2910,44 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
             self._subnets_url_prefix).object
         return self._to_subnets(response)
 
+    def ex_create_subnet(self, name, network, cidr, ip_version=4):
+        """
+        Create a new Subnet
+
+        :param name: Name of subnet which should be used
+        :type name: ``str``
+
+        :param network: Parent network of the subnet
+        :type network: ``OpenStackNetwork``
+
+        :param cidr: cidr of network which should be used
+        :type cidr: ``str``
+
+        :param ip_version: ip_version of subnet which should be used
+        :type ip_version: ``int``
+
+        :rtype: :class:`OpenStack_2_SubNet`
+        """
+        data = {'subnet': {'cidr': cidr, 'network_id': network.id,
+                           'ip_version': ip_version, 'name': name}}
+        response = self.connection.request(self._subnets_url_prefix,
+                                           method='POST', data=data).object
+        return self._to_subnet(response['subnet'])
+
+    def ex_delete_subnet(self, subnet):
+        """
+        Delete a Subnet
+
+        :param subnet: Subnet which should be deleted
+        :type subnet: :class:`OpenStack_2_SubNet`
+
+        :rtype: ``bool``
+        """
+        resp = self.connection.request('%s/%s' % (self._subnets_url_prefix,
+                                                  subnet.id),
+                                       method='DELETE')
+        return resp.status in (httplib.NO_CONTENT, httplib.ACCEPTED)
+
     def ex_list_ports(self):
         """
         List all OpenStack_2_PortInterfaces
@@ -3236,6 +3274,7 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
         return self._to_security_group_rule(self.network_connection.request(
             '/v2.0/security-group-rules', method='POST',
             data={'security_group_rule': {
+                'direction': 'ingress',
                 'protocol': ip_protocol,
                 'port_range_min': from_port,
                 'port_range_max': to_port,

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -3011,11 +3011,11 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
 
     def list_volumes(self):
         return self._to_volumes(
-            self.connection.request('/volumes/detail').object)
+            self.volumev2_connection.request('/volumes/detail').object)
 
     def ex_get_volume(self, volumeId):
         return self._to_volume(
-            self.connection.request('/volumes/%s' % volumeId).object)
+            self.volumev2_connection.request('/volumes/%s' % volumeId).object)
 
     def create_volume(self, size, name, location=None, snapshot=None,
                       ex_volume_type=None):
@@ -3062,18 +3062,18 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
         if snapshot:
             volume['snapshot_id'] = snapshot.id
 
-        resp = self.connection.request('/volumes',
+        resp = self.volumev2_connection.request('/volumes',
                                        method='POST',
                                        data={'volume': volume})
         return self._to_volume(resp.object)
 
     def destroy_volume(self, volume):
-        return self.connection.request('/volumes/%s' % volume.id,
+        return self.volumev2_connection.request('/volumes/%s' % volume.id,
                                        method='DELETE').success()
 
     def ex_list_snapshots(self):
         return self._to_snapshots(
-            self.connection.request('/snapshots/detail').object)
+            self.volumev2_connection.request('/snapshots/detail').object)
 
     def create_volume_snapshot(self, volume, name=None, ex_description=None,
                                ex_force=True):
@@ -3104,12 +3104,12 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
         if ex_description is not None:
             data['snapshot']['description'] = ex_description
 
-        return self._to_snapshot(self.connection.request('/snapshots',
+        return self._to_snapshot(self.volumev2_connection.request('/snapshots',
                                                          method='POST',
                                                          data=data).object)
 
     def destroy_volume_snapshot(self, snapshot):
-        resp = self.connection.request('/snapshots/%s' % snapshot.id,
+        resp = self.volumev2_connection.request('/snapshots/%s' % snapshot.id,
                                        method='DELETE')
         return resp.status == httplib.ACCEPTED
 

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -1112,7 +1112,7 @@ class OpenStackSecurityGroupRule(object):
 
     def __init__(self, id, parent_group_id, ip_protocol, from_port, to_port,
                  driver, ip_range=None, group=None, tenant_id=None,
-                 extra=None):
+                 direction=None, extra=None):
         """
         Constructor.
 
@@ -1140,6 +1140,9 @@ class OpenStackSecurityGroupRule(object):
         :keyword    tenant_id: Owner of the security group.
         :type       tenant_id: ``str``
 
+        :keyword    direction: Security group Direction (ingress or egress).
+        :type       direction: ``str``
+
         :keyword    extra: Extra attributes associated with this rule.
         :type       extra: ``dict``
         """
@@ -1151,11 +1154,20 @@ class OpenStackSecurityGroupRule(object):
         self.driver = driver
         self.ip_range = ''
         self.group = {}
+        self.direction = 'ingress'
 
         if group is None:
             self.ip_range = ip_range
         else:
             self.group = {'name': group, 'tenant_id': tenant_id}
+
+        # by default in old versions only ingress was used
+        if direction is not None:
+            if direction in ['ingress', 'egress']:
+                self.direction = direction
+            else:
+                raise OpenStackException("Security group direction incorrect "
+                                         "value: ingress or egress.")
 
         self.tenant_id = tenant_id
         self.extra = extra or {}
@@ -1678,7 +1690,7 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
         resp = self.connection.request('%s/%s' % (self._networks_url_prefix,
                                                   network.id),
                                        method='DELETE')
-        return resp.status == httplib.ACCEPTED
+        return resp.status in (httplib.NO_CONTENT, httplib.ACCEPTED)
 
     def ex_get_console_output(self, node, length=None):
         """
@@ -1836,6 +1848,8 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
 
         :rtype: ``list`` of :class:`OpenStackSecurityGroup`
         """
+        print(vars(self.connection.request(
+            '/servers/%s/os-security-groups' % (node.id))))
         return self._to_security_groups(
             self.connection.request('/servers/%s/os-security-groups' %
                                     (node.id)).object)
@@ -3112,8 +3126,7 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
     def destroy_volume_snapshot(self, snapshot):
         resp = self.volumev2_connection.request('/snapshots/%s' % snapshot.id,
                                                 method='DELETE')
-        return resp.status == httplib.ACCEPTED
-
+        return resp.status in (httplib.NO_CONTENT, httplib.ACCEPTED)
 
     def ex_list_security_groups(self):
         """
@@ -3151,9 +3164,96 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
         :rtype: ``bool``
         """
         resp = self.network_connection.request('/v2.0/security-groups/%s' %
-                                       (security_group.id),
-                                       method='DELETE')
-        return resp.status==httplib.NO_CONTENT
+                                               (security_group.id),
+                                               method='DELETE')
+        return resp.status == httplib.NO_CONTENT
+
+    def _to_security_group_rule(self, obj):
+        ip_range = group = tenant_id = parent_id = None
+        protocol = from_port = to_port = direction = None
+
+        if 'parent_group_id' in obj:
+            if obj['group'] == {}:
+                ip_range = obj['ip_range'].get('cidr', None)
+            else:
+                group = obj['group'].get('name', None)
+                tenant_id = obj['group'].get('tenant_id', None)
+
+            parent_id = obj['parent_group_id']
+            from_port = obj['from_port']
+            to_port = obj['to_port']
+            protocol = obj['ip_protocol']
+        else:
+            ip_range = obj.get('remote_ip_prefix', None)
+            group = obj.get('remote_group_id', None)
+            tenant_id = obj.get('tenant_id', None)
+
+            parent_id = obj['security_group_id']
+            from_port = obj['port_range_min']
+            to_port = obj['port_range_max']
+            protocol = obj['protocol']
+
+        return OpenStackSecurityGroupRule(
+            id=obj['id'], parent_group_id=parent_id,
+            ip_protocol=protocol, from_port=from_port,
+            to_port=to_port, driver=self, ip_range=ip_range,
+            group=group, tenant_id=tenant_id, direction=direction)
+
+    def ex_create_security_group_rule(self, security_group, ip_protocol,
+                                      from_port, to_port, cidr=None,
+                                      source_security_group=None):
+        """
+        Create a new Rule in a Security Group
+
+        :param security_group: Security Group in which to add the rule
+        :type  security_group: :class:`OpenStackSecurityGroup`
+
+        :param ip_protocol: Protocol to which this rule applies
+                            Examples: tcp, udp, ...
+        :type  ip_protocol: ``str``
+
+        :param from_port: First port of the port range
+        :type  from_port: ``int``
+
+        :param to_port: Last port of the port range
+        :type  to_port: ``int``
+
+        :param cidr: CIDR notation of the source IP range for this rule
+        :type  cidr: ``str``
+
+        :param source_security_group: Existing Security Group to use as the
+                                      source (instead of CIDR)
+        :type  source_security_group: L{OpenStackSecurityGroup
+
+        :rtype: :class:`OpenStackSecurityGroupRule`
+        """
+        source_security_group_id = None
+        if type(source_security_group) == OpenStackSecurityGroup:
+            source_security_group_id = source_security_group.id
+
+        return self._to_security_group_rule(self.network_connection.request(
+            '/v2.0/security-group-rules', method='POST',
+            data={'security_group_rule': {
+                'protocol': ip_protocol,
+                'port_range_min': from_port,
+                'port_range_max': to_port,
+                'remote_ip_prefix': cidr,
+                'remote_group_id': source_security_group_id,
+                'security_group_id': security_group.id}}
+        ).object['security_group_rule'])
+
+    def ex_delete_security_group_rule(self, rule):
+        """
+        Delete a Rule from a Security Group.
+
+        :param rule: Rule should be deleted
+        :type  rule: :class:`OpenStackSecurityGroupRule`
+
+        :rtype: ``bool``
+        """
+        resp = self.connection.request('/v2.0/security-group-rules/%s' %
+                                       (rule.id), method='DELETE')
+        return resp.status == httplib.NO_CONTENT
 
 
 class OpenStack_1_1_FloatingIpPool(object):

--- a/libcloud/test/common/test_openstack_identity.py
+++ b/libcloud/test/common/test_openstack_identity.py
@@ -614,7 +614,7 @@ class OpenStackServiceCatalogTestCase(unittest.TestCase):
                                           auth_version='2.0')
 
         service_names = catalog.get_service_names()
-        self.assertEqual(service_names, ['cinder', 'cloudFiles',
+        self.assertEqual(service_names, ['cinderv2', 'cloudFiles',
                                          'cloudFilesCDN', 'cloudServers',
                                          'cloudServersOpenStack',
                                          'cloudServersPreprod',

--- a/libcloud/test/common/test_openstack_identity.py
+++ b/libcloud/test/common/test_openstack_identity.py
@@ -532,7 +532,7 @@ class OpenStackServiceCatalogTestCase(unittest.TestCase):
         catalog = OpenStackServiceCatalog(service_catalog=service_catalog,
                                           auth_version='2.0')
         entries = catalog.get_entries()
-        self.assertEqual(len(entries), 8)
+        self.assertEqual(len(entries), 9)
 
         entry = [e for e in entries if e.service_name == 'cloudServers'][0]
         self.assertEqual(entry.service_type, 'compute')
@@ -599,7 +599,8 @@ class OpenStackServiceCatalogTestCase(unittest.TestCase):
                                           auth_version='2.0')
         service_types = catalog.get_service_types()
         self.assertEqual(service_types, ['compute', 'image', 'network',
-                                         'object-store', 'rax:object-cdn'])
+                                         'object-store', 'rax:object-cdn',
+                                         'volumev2'])
 
         service_types = catalog.get_service_types(region='ORD')
         self.assertEqual(service_types, ['rax:object-cdn'])
@@ -613,8 +614,8 @@ class OpenStackServiceCatalogTestCase(unittest.TestCase):
                                           auth_version='2.0')
 
         service_names = catalog.get_service_names()
-        self.assertEqual(service_names, ['cloudFiles', 'cloudFilesCDN',
-                                         'cloudServers',
+        self.assertEqual(service_names, ['cinder', 'cloudFiles',
+                                         'cloudFilesCDN', 'cloudServers',
                                          'cloudServersOpenStack',
                                          'cloudServersPreprod',
                                          'glance',

--- a/libcloud/test/compute/fixtures/openstack/_v2_0__auth.json
+++ b/libcloud/test/compute/fixtures/openstack/_v2_0__auth.json
@@ -123,6 +123,28 @@
             {
                 "endpoints": [
                     {
+                        "region": "RegionOne",
+                        "tenantId": "1337",
+                        "publicURL": "https://test_endpoint.com/v2/1337",
+                        "versionInfo": "https://test_endpoint.com/v2/",
+                        "versionList": "https://test_endpoint.com/",
+                        "versionId": "2"
+                    },
+                    {
+                        "region": "fr1",
+                        "tenantId": "1337",
+                        "publicURL": "https://test_endpoint.com/v2/1337",
+                        "versionInfo": "https://test_endpoint.com/v2/",
+                        "versionList": "https://test_endpoint.com/",
+                        "versionId": "2"
+                    }
+                ],
+                "name": "cinder",
+                "type": "volumev2"
+            },
+            {
+                "endpoints": [
+                    {
                         "region": "DFW",
                         "tenantId": "613469",
                         "publicURL": "https://dfw.servers.api.rackspacecloud.com/v2/1337",

--- a/libcloud/test/compute/fixtures/openstack/_v2_0__auth.json
+++ b/libcloud/test/compute/fixtures/openstack/_v2_0__auth.json
@@ -139,7 +139,7 @@
                         "versionId": "2"
                     }
                 ],
-                "name": "cinder",
+                "name": "cinderv2",
                 "type": "volumev2"
             },
             {

--- a/libcloud/test/compute/fixtures/openstack_v1.1/_v2_0__floatingip.json
+++ b/libcloud/test/compute/fixtures/openstack_v1.1/_v2_0__floatingip.json
@@ -1,0 +1,23 @@
+{
+    "floatingip": 
+    {
+        "router_id": null,
+        "description": "for test",
+        "dns_domain": "my-domain.org.",
+        "dns_name": "myfip2",
+        "created_at": "2016-12-21T11:55:50Z",
+        "updated_at": "2016-12-21T11:55:53Z",
+        "revision_number": 2,
+        "project_id": "4969c491a3c74ee4af974e6d800c62de",
+        "tenant_id": "4969c491a3c74ee4af974e6d800c62de",
+        "floating_network_id": "376da547-b977-4cfe-9cba-275c80debf57",
+        "fixed_ip_address": null,
+        "floating_ip_address": "10.3.1.42",
+        "port_id": null,
+        "id": "09ea1784-2f81-46dc-8c91-244b4df75bde",
+        "status": "DOWN",
+        "port_details": null,
+        "tags": ["tag1,tag2"],
+        "port_forwardings": []
+    }
+}

--- a/libcloud/test/compute/fixtures/openstack_v1.1/_v2_0__floatingips.json
+++ b/libcloud/test/compute/fixtures/openstack_v1.1/_v2_0__floatingips.json
@@ -1,0 +1,52 @@
+{
+    "floatingips": [
+        {
+            "router_id": null,
+            "description": "for test",
+            "dns_domain": "my-domain.org.",
+            "dns_name": "myfip2",
+            "created_at": "2016-12-21T11:55:50Z",
+            "updated_at": "2016-12-21T11:55:53Z",
+            "revision_number": 2,
+            "project_id": "4969c491a3c74ee4af974e6d800c62de",
+            "tenant_id": "4969c491a3c74ee4af974e6d800c62de",
+            "floating_network_id": "376da547-b977-4cfe-9cba-275c80debf57",
+            "fixed_ip_address": null,
+            "floating_ip_address": "10.3.1.42",
+            "port_id": null,
+            "id": "09ea1784-2f81-46dc-8c91-244b4df75bde",
+            "status": "DOWN",
+            "port_details": null,
+            "tags": ["tag1,tag2"],
+            "port_forwardings": []
+        },
+        {
+            "router_id": "d23abc8d-2991-4a55-ba98-2aaea84cc72f",
+            "description": "for test",
+            "dns_domain": "my-domain.org.",
+            "dns_name": "myfip",
+            "created_at": "2016-12-21T10:55:50Z",
+            "updated_at": "2016-12-21T10:55:53Z",
+            "revision_number": 1,
+            "project_id": "4969c491a3c74ee4af974e6d800c62de",
+            "tenant_id": "4969c491a3c74ee4af974e6d800c62de",
+            "floating_network_id": "376da547-b977-4cfe-9cba-275c80debf57",
+            "fixed_ip_address": "10.0.0.3",
+            "floating_ip_address": "10.3.1.1",
+            "port_id": "ce705c24-c1ef-408a-bda3-7bbd946164ab",
+            "id": "04c5336a-0629-4694-ba30-04b0bdfa88a4",
+            "status": "ACTIVE",
+            "port_details": {
+                "status": "ACTIVE",
+                "name": "",
+                "admin_state_up": true,
+                "network_id": "02dd8479-ef26-4398-a102-d19d0a7b3a1f",
+                "device_owner": "compute:nova",
+                "mac_address": "fa:16:3e:b1:3b:30",
+                "device_id": "fcfc96da-19e2-40fd-8497-f29da1b21143"
+            },
+            "tags": ["tag1,tag2"],
+            "port_forwardings": []
+        }
+    ]
+}

--- a/libcloud/test/compute/fixtures/openstack_v1.1/_v2_0__networks_public.json
+++ b/libcloud/test/compute/fixtures/openstack_v1.1/_v2_0__networks_public.json
@@ -1,0 +1,64 @@
+{
+    "networks": [
+        {
+            "admin_state_up": true,
+            "availability_zone_hints": [],
+            "availability_zones": [
+                "nova"
+            ],
+            "created_at": "2016-03-08T20:19:41",
+            "dns_domain": "my-domain.org.",
+            "id": "d32019d3-bc6e-4319-9c1d-6722fc136a22",
+            "ipv4_address_scope": null,
+            "ipv6_address_scope": null,
+            "l2_adjacency": false,
+            "mtu": 1500,
+            "name": "public",
+            "port_security_enabled": true,
+            "project_id": "4fd44f30292945e481c7b8a0c8908869",
+            "qos_policy_id": "6a8454ade84346f59e8d40665f878b2e",
+            "revision_number": 1,
+            "router:external": true,
+            "shared": false,
+            "status": "ACTIVE",
+            "subnets": [
+                "54d6f61d-db07-451c-9ab3-b9609b6b6f0b"
+            ],
+            "tenant_id": "4fd44f30292945e481c7b8a0c8908869",
+            "updated_at": "2016-03-08T20:19:41",
+            "vlan_transparent": true,
+            "description": "",
+            "is_default": false
+        },
+        {
+            "admin_state_up": true,
+            "availability_zone_hints": [],
+            "availability_zones": [
+                "nova"
+            ],
+            "created_at": "2016-03-08T20:19:41",
+            "dns_domain": "my-domain.org.",
+            "id": "d32019d3-bc6e-4319-9c1d-6722fc136a22",
+            "ipv4_address_scope": null,
+            "ipv6_address_scope": null,
+            "l2_adjacency": false,
+            "mtu": 1500,
+            "name": "foobar",
+            "port_security_enabled": true,
+            "project_id": "4fd44f30292945e481c7b8a0c8908869",
+            "qos_policy_id": "6a8454ade84346f59e8d40665f878b2e",
+            "revision_number": 1,
+            "router:external": true,
+            "shared": false,
+            "status": "ACTIVE",
+            "subnets": [
+                "54d6f61d-db07-451c-9ab3-b9609b6b6f0b"
+            ],
+            "tenant_id": "4fd44f30292945e481c7b8a0c8908869",
+            "updated_at": "2016-03-08T20:19:41",
+            "vlan_transparent": true,
+            "description": "",
+            "is_default": false
+        }
+    ]
+}

--- a/libcloud/test/compute/fixtures/openstack_v1.1/_v2_0__security_group.json
+++ b/libcloud/test/compute/fixtures/openstack_v1.1/_v2_0__security_group.json
@@ -1,0 +1,20 @@
+{
+    "security_group":
+        {
+            "description": "FTP Client-Server - Open 20-21 ports", 
+            "id": 4, 
+            "name": "ftp", 
+            "security_group_rules": [
+                {
+                    "security_group_id": "4",
+                    "direction": "ingress",
+                    "port_range_max": 21, 
+                    "port_range_min": 20, 
+                    "remote_ip_prefix": "0.0.0.0/0", 
+                    "id": 1, 
+                    "protocol": "tcp"
+                }
+            ], 
+            "tenant_id": "68"
+        }
+}

--- a/libcloud/test/compute/fixtures/openstack_v1.1/_v2_0__security_group.json
+++ b/libcloud/test/compute/fixtures/openstack_v1.1/_v2_0__security_group.json
@@ -1,20 +1,10 @@
 {
     "security_group":
         {
-            "description": "FTP Client-Server - Open 20-21 ports", 
-            "id": 4, 
-            "name": "ftp", 
-            "security_group_rules": [
-                {
-                    "security_group_id": "4",
-                    "direction": "ingress",
-                    "port_range_max": 21, 
-                    "port_range_min": 20, 
-                    "remote_ip_prefix": "0.0.0.0/0", 
-                    "id": 1, 
-                    "protocol": "tcp"
-                }
-            ], 
+            "description": "Test Security Group", 
+            "id": 6, 
+            "name": "test", 
+            "security_group_rules": [], 
             "tenant_id": "68"
         }
 }

--- a/libcloud/test/compute/fixtures/openstack_v1.1/_v2_0__security_group_rule.json
+++ b/libcloud/test/compute/fixtures/openstack_v1.1/_v2_0__security_group_rule.json
@@ -1,0 +1,13 @@
+{
+    "security_group_rule":
+        {
+            "security_group_id": 6,
+            "direction": "ingress",
+            "port_range_max": 16, 
+            "port_range_min": 14, 
+            "remote_ip_prefix": "0.0.0.0/0", 
+            "id": 2, 
+            "protocol": "tcp"
+        }
+}
+

--- a/libcloud/test/compute/fixtures/openstack_v1.1/_v2_0__security_groups.json
+++ b/libcloud/test/compute/fixtures/openstack_v1.1/_v2_0__security_groups.json
@@ -1,0 +1,29 @@
+{
+    "security_groups": [
+        {
+            "description": "default", 
+            "id": 2, 
+            "name": "default", 
+            "security_group_rules": [], 
+            "tenant_id": "68"
+        }, 
+        {
+            "description": "FTP Client-Server - Open 20-21 ports", 
+            "id": 4, 
+            "name": "ftp", 
+            "security_group_rules": [
+                {
+                    "security_group_id": "4",
+                    "direction": "ingress",
+                    "port_range_max": 21, 
+                    "port_range_min": 20, 
+                    "remote_ip_prefix": "0.0.0.0/0", 
+                    "id": 1, 
+                    "protocol": "tcp"
+                }
+            ], 
+            "tenant_id": "68"
+        }
+    ]
+}
+

--- a/libcloud/test/compute/fixtures/openstack_v1.1/_v2_0__security_groups.json
+++ b/libcloud/test/compute/fixtures/openstack_v1.1/_v2_0__security_groups.json
@@ -13,7 +13,7 @@
             "name": "ftp", 
             "security_group_rules": [
                 {
-                    "security_group_id": "4",
+                    "security_group_id": 4,
                     "direction": "ingress",
                     "port_range_max": 21, 
                     "port_range_min": 20, 

--- a/libcloud/test/compute/fixtures/openstack_v1.1/_v2_0__snapshot.json
+++ b/libcloud/test/compute/fixtures/openstack_v1.1/_v2_0__snapshot.json
@@ -1,0 +1,14 @@
+{
+    "snapshot": {
+        "status": "available",
+        "os-extended-snapshot-attributes:progress": "100%",
+        "description": "Daily backup",
+        "created_at": "2013-02-25T04:13:17.07Z",
+        "metadata": {},
+        "volume_id": "5aa119a8-d25b-45a7-8d1b-88e127885635",
+        "os-extended-snapshot-attributes:project_id": "0c2eba2c5af04d3f9e9d0d410b371fde",
+        "size": 1,
+        "id": "3fbbcccf-d058-4502-8844-6feeffdf4cb5",
+        "name": "test"
+    }
+}

--- a/libcloud/test/compute/fixtures/openstack_v1.1/_v2_0__snapshots.json
+++ b/libcloud/test/compute/fixtures/openstack_v1.1/_v2_0__snapshots.json
@@ -1,0 +1,46 @@
+{
+    "snapshots": [
+        {
+            "status": "available",
+            "metadata": {
+                "name": "test"
+            },
+            "os-extended-snapshot-attributes:progress": "100%",
+            "name": "snap-001",
+            "volume_id": "373f7b48-c4c1-4e70-9acc-086b39073506",
+            "os-extended-snapshot-attributes:project_id": "bab7d5c60cd041a0a36f7c4b6e1dd978",
+            "created_at": "2012-02-29T03:50:07Z",
+            "size": 1,
+            "id": "3fbbcccf-d058-4502-8844-6feeffdf4cb5",
+            "description": "volume snapshot"
+        },
+        {
+            "status": "available",
+            "metadata": {
+                "name": "test"
+            },
+            "os-extended-snapshot-attributes:progress": "100%",
+            "name": "test-volume-snapshot",
+            "volume_id": "6edbc2f4-1507-44f8-ac0d-eed1d2608d38",
+            "os-extended-snapshot-attributes:project_id": "bab7d5c60cd041a0a36f7c4b6e1dd978",
+            "created_at": "2015-11-29T02:25:51.000000",
+            "size": 1,
+            "id": "4fbbdccf-e058-6502-8844-6feeffdf4cb5",
+            "description": "volume snapshot"
+        },
+        {
+            "status": "available",
+            "metadata": {
+                "name": "test"
+            },
+            "os-extended-snapshot-attributes:progress": "100%",
+            "name": "test-volume-snapshot",
+            "volume_id": "373f7b48-c4c1-4e70-9acc-086b39073506",
+            "os-extended-snapshot-attributes:project_id": "bab7d5c60cd041a0a36f7c4b6e1dd978",
+            "created_at": "2013-02-29T03:50:07Z",
+            "size": 1,
+            "id": "1fbbcccf-d058-4502-8844-6feeffdf4cb5",
+            "description": "volume snapshot"
+        }
+    ]
+}

--- a/libcloud/test/compute/fixtures/openstack_v1.1/_v2_0__subnet.json
+++ b/libcloud/test/compute/fixtures/openstack_v1.1/_v2_0__subnet.json
@@ -1,0 +1,32 @@
+{
+    "subnet":
+        {
+            "name": "name",
+            "enable_dhcp": true,
+            "network_id": "db193ab3-96e3-4cb3-8fc5-05f4296d0324",
+            "segment_id": null,
+            "project_id": "26a7980765d0414dbc1fc1f88cdb7e6e",
+            "tenant_id": "26a7980765d0414dbc1fc1f88cdb7e6e",
+            "dns_nameservers": [],
+            "allocation_pools": [
+                {
+                    "start": "10.0.0.2",
+                    "end": "10.0.0.254"
+                }
+            ],
+            "host_routes": [],
+            "ip_version": 4,
+            "gateway_ip": "10.0.0.1",
+            "cidr": "10.0.0.0/24",
+            "id": "08eae331-0402-425a-923c-34f7cfe39c1b",
+            "created_at": "2016-10-10T14:35:34Z",
+            "description": "",
+            "ipv6_address_mode": null,
+            "ipv6_ra_mode": null,
+            "revision_number": 2,
+            "service_types": [],
+            "subnetpool_id": null,
+            "tags": ["tag1,tag2"],
+            "updated_at": "2016-10-10T14:35:34Z"
+        }
+}

--- a/libcloud/test/compute/fixtures/openstack_v1.1/_v2_0__volume.json
+++ b/libcloud/test/compute/fixtures/openstack_v1.1/_v2_0__volume.json
@@ -1,0 +1,18 @@
+{
+    "volume": {
+        "status": "available",
+        "attachments": [],
+        "availability_zone": "nova",
+        "bootable": "false",
+        "os-vol-host-attr:host": "ip-10-168-107-25",
+        "source_volid": null,
+        "snapshot_id": null,
+        "id": "cd76a3a1-c4ce-40f6-9b9f-07a61508938d",
+        "description": "Super volume.",
+        "name": "test",
+        "created_at": "2013-02-25T02:40:21.000000",
+        "volume_type": "None",
+        "size": 1,
+        "metadata": {}
+    }
+}

--- a/libcloud/test/compute/fixtures/openstack_v1.1/_v2_0__volumes.json
+++ b/libcloud/test/compute/fixtures/openstack_v1.1/_v2_0__volumes.json
@@ -1,0 +1,44 @@
+{
+    "volumes": [
+        {
+            "status": "in-use",
+            "attachments": [
+                {
+                    "server_id": "f4fda93b-06e0-4743-8117-bc8bcecd651b",
+                    "attachment_id": "3b4db356-253d-4fab-bfa0-e3626c0b8405",
+                    "volume_id": "6edbc2f4-1507-44f8-ac0d-eed1d2608d38",
+                    "device": "/dev/vdb",
+                    "id": "6edbc2f4-1507-44f8-ac0d-eed1d2608d38"
+                }
+            ],
+            "availability_zone": "nova",
+            "replication_status": "disabled",
+            "snapshot_id": null,
+            "id": "6edbc2f4-1507-44f8-ac0d-eed1d2608d38",
+            "size": 2,
+            "user_id": "32779452fcd34ae1a53a797ac8a1e064",
+            "metadata": {},
+            "description": "",
+            "name": "test-volume-attachments",
+            "created_at": "2013-06-24T11:20:13.000000",
+            "volume_type": "lvmdriver-1"
+        },
+        {
+            "status": "some-unknown-state",
+            "migration_status": null,
+            "attachments": [],
+            "availability_zone": "nova",
+            "replication_status": "disabled",
+            "snapshot_id": "01f48111-7866-4cd2-986a-e92683c4a363",
+            "id": "cfcec3bc-b736-4db5-9535-4c24112691b5",
+            "size": 50,
+            "user_id": "32779452fcd34ae1a53a797ac8a1e064",
+            "metadata": {},
+            "description": "some description",
+            "name": "test_volume",
+            "bootable": "false",
+            "created_at": "2013-06-21T12:39:02.000000",
+            "volume_type": null
+        }
+    ]
+}

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -2370,7 +2370,7 @@ class OpenStack_1_1_MockHttp(MockHttp, unittest.TestCase):
             return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
         if method == 'DELETE':
             body = ''
-            return (httplib.ACCEPTED, body, self.json_content_headers, httplib.responses[httplib.OK])
+            return (httplib.NO_CONTENT, body, self.json_content_headers, httplib.responses[httplib.OK])
 
     def _v2_1337_v2_0_subnets(self, method, url, body, headers):
         body = self.fixtures.load('_v2_0__subnets.json')
@@ -2391,7 +2391,7 @@ class OpenStack_1_1_MockHttp(MockHttp, unittest.TestCase):
             return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
         if method == 'DELETE':
             body = ''
-            return (httplib.ACCEPTED, body, self.json_content_headers, httplib.responses[httplib.OK])
+            return (httplib.NO_CONTENT, body, self.json_content_headers, httplib.responses[httplib.OK])
     
     def _v2_1337_snapshots_detail(self, method, url, body, headers):
         body = self.fixtures.load('_v2_0__snapshots.json')
@@ -2408,15 +2408,33 @@ class OpenStack_1_1_MockHttp(MockHttp, unittest.TestCase):
             return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
         if method == 'DELETE':
             body = ''
-            return (httplib.ACCEPTED, body, self.json_content_headers, httplib.responses[httplib.OK])
+            return (httplib.NO_CONTENT, body, self.json_content_headers, httplib.responses[httplib.OK])
 
     def _v2_1337_v2_0_security_groups(self, method, url, body, headers):
         if method == 'POST':
             body = self.fixtures.load('_v2_0__security_group.json')
             return (httplib.CREATED, body, self.json_content_headers, httplib.responses[httplib.OK])
         if method == 'GET':
+            body = self.fixtures.load('_v2_0__security_groups.json')
+            return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
+
+    def _v2_1337_v2_0_security_groups_6(self, method, url, body, headers):
+        if method == 'GET':
             body = self.fixtures.load('_v2_0__security_group.json')
             return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
+        if method == 'DELETE':
+            body = ''
+            return (httplib.NO_CONTENT, body, self.json_content_headers, httplib.responses[httplib.OK])
+
+    def _v2_1337_v2_0_security_group_rules(self, method, url, body, headers):
+        if method == 'POST':
+            body = self.fixtures.load('_v2_0__security_group_rule.json')
+            return (httplib.CREATED, body, self.json_content_headers, httplib.responses[httplib.OK])
+
+    def _v2_1337_v2_0_security_group_rules_2(self, method, url, body, headers):
+        if method == 'DELETE':
+            body = ''
+            return (httplib.NO_CONTENT, body, self.json_content_headers, httplib.responses[httplib.OK])
 
 # This exists because the nova compute url in devstack has v2 in there but the v1.1 fixtures
 # work fine.

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -2383,7 +2383,7 @@ class OpenStack_1_1_MockHttp(MockHttp, unittest.TestCase):
     def _v2_1337_volumes(self, method, url, body, headers):
         if method == 'POST':
             body = self.fixtures.load('_v2_0__volume.json')
-            return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
+            return (httplib.CREATED, body, self.json_content_headers, httplib.responses[httplib.OK])
 
     def _v2_1337_volumes_cd76a3a1_c4ce_40f6_9b9f_07a61508938d(self, method, url, body, headers):
         if method == 'GET':
@@ -2400,7 +2400,7 @@ class OpenStack_1_1_MockHttp(MockHttp, unittest.TestCase):
     def _v2_1337_snapshots(self, method, url, body, headers):
         if method == 'POST':
             body = self.fixtures.load('_v2_0__snapshot.json')
-            return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
+            return (httplib.CREATED, body, self.json_content_headers, httplib.responses[httplib.OK])
 
     def _v2_1337_snapshots_3fbbcccf_d058_4502_8844_6feeffdf4cb5(self, method, url, body, headers):
         if method == 'GET':

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -2383,7 +2383,7 @@ class OpenStack_1_1_MockHttp(MockHttp, unittest.TestCase):
     def _v2_1337_volumes(self, method, url, body, headers):
         if method == 'POST':
             body = self.fixtures.load('_v2_0__volume.json')
-            return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
+            return (httplib.CREATED, body, self.json_content_headers, httplib.responses[httplib.OK])
 
     def _v2_1337_volumes_cd76a3a1_c4ce_40f6_9b9f_07a61508938d(self, method, url, body, headers):
         if method == 'GET':
@@ -2400,7 +2400,7 @@ class OpenStack_1_1_MockHttp(MockHttp, unittest.TestCase):
     def _v2_1337_snapshots(self, method, url, body, headers):
         if method == 'POST':
             body = self.fixtures.load('_v2_0__snapshot.json')
-            return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
+            return (httplib.CREATED, body, self.json_content_headers, httplib.responses[httplib.OK])
 
     def _v2_1337_snapshots_3fbbcccf_d058_4502_8844_6feeffdf4cb5(self, method, url, body, headers):
         if method == 'GET':
@@ -2409,7 +2409,14 @@ class OpenStack_1_1_MockHttp(MockHttp, unittest.TestCase):
         if method == 'DELETE':
             body = ''
             return (httplib.ACCEPTED, body, self.json_content_headers, httplib.responses[httplib.OK])
-    
+
+    def _v2_1337_v2_0_security_groups(self, method, url, body, headers):
+        if method == 'POST':
+            body = self.fixtures.load('_v2_0__security_group.json')
+            return (httplib.CREATED, body, self.json_content_headers, httplib.responses[httplib.OK])
+        if method == 'GET':
+            body = self.fixtures.load('_v2_0__security_group.json')
+            return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
 
 # This exists because the nova compute url in devstack has v2 in there but the v1.1 fixtures
 # work fine.

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -45,7 +45,7 @@ from libcloud.compute.drivers.openstack import (
     OpenStack_1_1_NodeDriver, OpenStackSecurityGroup,
     OpenStackSecurityGroupRule, OpenStack_1_1_FloatingIpPool,
     OpenStack_1_1_FloatingIpAddress, OpenStackKeyPair,
-    OpenStack_1_0_Connection,
+    OpenStack_1_0_Connection, OpenStack_2_FloatingIpPool,
     OpenStackNodeDriver,
     OpenStack_2_NodeDriver, OpenStack_2_PortInterfaceState, OpenStackNetwork)
 from libcloud.compute.base import Node, NodeImage, NodeSize
@@ -1399,6 +1399,53 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
 
         self.assertEqual(pool.delete_floating_ip.call_count, 1)
 
+    def test_OpenStack_2_FloatingIpPool_list_floating_ips(self):
+        pool = OpenStack_2_FloatingIpPool(1, 'foo', self.driver.connection)
+        ret = pool.list_floating_ips()
+
+        self.assertEqual(ret[0].id, '09ea1784-2f81-46dc-8c91-244b4df75bde')
+        self.assertEqual(ret[0].pool, pool)
+        self.assertEqual(ret[0].ip_address, '10.3.1.42')
+        self.assertEqual(ret[0].node_id, None)
+        self.assertEqual(ret[1].id, '04c5336a-0629-4694-ba30-04b0bdfa88a4')
+        self.assertEqual(ret[1].pool, pool)
+        self.assertEqual(ret[1].ip_address, '10.3.1.1')
+        self.assertEqual(
+            ret[1].node_id, 'fcfc96da-19e2-40fd-8497-f29da1b21143')
+
+    def test_OpenStack_2_FloatingIpPool_get_floating_ip(self):
+        pool = OpenStack_2_FloatingIpPool(1, 'foo', self.driver.connection)
+        ret = pool.get_floating_ip('10.3.1.42')
+
+        self.assertEqual(ret.id, '09ea1784-2f81-46dc-8c91-244b4df75bde')
+        self.assertEqual(ret.pool, pool)
+        self.assertEqual(ret.ip_address, '10.3.1.42')
+        self.assertEqual(ret.node_id, None)
+
+    def test_OpenStack_2_FloatingIpPool_create_floating_ip(self):
+        pool = OpenStack_2_FloatingIpPool(1, 'foo', self.driver.connection)
+        ret = pool.create_floating_ip()
+
+        self.assertEqual(ret.id, '09ea1784-2f81-46dc-8c91-244b4df75bde')
+        self.assertEqual(ret.pool, pool)
+        self.assertEqual(ret.ip_address, '10.3.1.42')
+        self.assertEqual(ret.node_id, None)
+
+    def test_OpenStack_2_FloatingIpPool_delete_floating_ip(self):
+        pool = OpenStack_2_FloatingIpPool(1, 'foo', self.driver.connection)
+        ip = OpenStack_1_1_FloatingIpAddress('foo-bar-id', '42.42.42.42', pool)
+
+        self.assertTrue(pool.delete_floating_ip(ip))
+
+    def test_OpenStack_2_FloatingIpAddress_delete(self):
+        pool = OpenStack_2_FloatingIpPool(1, 'foo', self.driver.connection)
+        pool.delete_floating_ip = Mock()
+        ip = OpenStack_1_1_FloatingIpAddress('foo-bar-id', '42.42.42.42', pool)
+
+        ip.pool.delete_floating_ip()
+
+        self.assertEqual(pool.delete_floating_ip.call_count, 1)
+
     def test_ex_get_metadata_for_node(self):
         image = NodeImage(id=11, name='Ubuntu 8.10 (intrepid)', driver=self.driver)
         size = NodeSize(1, '256 slice', None, None, None, None, driver=self.driver)
@@ -2357,8 +2404,12 @@ class OpenStack_1_1_MockHttp(MockHttp, unittest.TestCase):
 
     def _v2_1337_v2_0_networks(self, method, url, body, headers):
         if method == 'GET':
-            body = self.fixtures.load('_v2_0__networks.json')
-            return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
+            if "router:external=True" in url:
+                body = self.fixtures.load('_v2_0__networks_public.json')
+                return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
+            else:
+                body = self.fixtures.load('_v2_0__networks.json')
+                return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
         elif method == 'POST':
             body = self.fixtures.load('_v2_0__networks_POST.json')
             return (httplib.ACCEPTED, body, self.json_content_headers, httplib.responses[httplib.OK])
@@ -2432,6 +2483,19 @@ class OpenStack_1_1_MockHttp(MockHttp, unittest.TestCase):
             return (httplib.CREATED, body, self.json_content_headers, httplib.responses[httplib.OK])
 
     def _v2_1337_v2_0_security_group_rules_2(self, method, url, body, headers):
+        if method == 'DELETE':
+            body = ''
+            return (httplib.NO_CONTENT, body, self.json_content_headers, httplib.responses[httplib.OK])
+
+    def _v2_1337_v2_0_floatingips(self, method, url, body, headers):
+        if method == 'POST':
+            body = self.fixtures.load('_v2_0__floatingip.json')
+            return (httplib.CREATED, body, self.json_content_headers, httplib.responses[httplib.OK])
+        if method == 'GET':
+            body = self.fixtures.load('_v2_0__floatingips.json')
+            return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
+    
+    def _v2_1337_v2_0_floatingips_foo_bar_id(self, method, url, body, headers):
         if method == 'DELETE':
             body = ''
             return (httplib.NO_CONTENT, body, self.json_content_headers, httplib.responses[httplib.OK])

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -1807,6 +1807,49 @@ class OpenStack_2_Tests(OpenStack_1_1_Tests):
 
         self.assertTrue(ret)
 
+    def test_list_volumes(self):
+        volumes = self.driver.list_volumes()
+        self.assertEqual(len(volumes), 2)
+        volume = volumes[0]
+
+        self.assertEqual('6edbc2f4-1507-44f8-ac0d-eed1d2608d38', volume.id)
+        self.assertEqual('test-volume-attachments', volume.name)
+        self.assertEqual(StorageVolumeState.INUSE, volume.state)
+        self.assertEqual(2, volume.size)
+        self.assertEqual(volume.extra, {
+            'description': '',
+            'attachments': [{
+                "attachment_id": "3b4db356-253d-4fab-bfa0-e3626c0b8405",
+                "id": '6edbc2f4-1507-44f8-ac0d-eed1d2608d38',
+                "device": "/dev/vdb",
+                "server_id": "f4fda93b-06e0-4743-8117-bc8bcecd651b",
+                "volume_id": "6edbc2f4-1507-44f8-ac0d-eed1d2608d38",
+            }],
+            'snapshot_id': None,
+            'state': 'in-use',
+            'location': 'nova',
+            'volume_type': 'lvmdriver-1',
+            'metadata': {},
+            'created_at': '2013-06-24T11:20:13.000000'
+        })
+
+        # also test that unknown state resolves to StorageVolumeState.UNKNOWN
+        volume = volumes[1]
+        self.assertEqual('cfcec3bc-b736-4db5-9535-4c24112691b5', volume.id)
+        self.assertEqual('test_volume', volume.name)
+        self.assertEqual(50, volume.size)
+        self.assertEqual(StorageVolumeState.UNKNOWN, volume.state)
+        self.assertEqual(volume.extra, {
+            'description': 'some description',
+            'attachments': [],
+            'snapshot_id': '01f48111-7866-4cd2-986a-e92683c4a363',
+            'state': 'some-unknown-state',
+            'location': 'nova',
+            'volume_type': None,
+            'metadata': {},
+            'created_at': '2013-06-21T12:39:02.000000',
+        })
+
 
 class OpenStack_1_1_FactoryMethodTests(OpenStack_1_1_Tests):
     should_list_locations = False
@@ -2290,6 +2333,41 @@ class OpenStack_1_1_MockHttp(MockHttp, unittest.TestCase):
     def _v2_1337_v2_0_subnets(self, method, url, body, headers):
         body = self.fixtures.load('_v2_0__subnets.json')
         return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
+
+    def _v2_1337_volumes_detail(self, method, url, body, headers):
+        body = self.fixtures.load('_v2_0__volumes.json')
+        return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
+
+    def _v2_1337_volumes(self, method, url, body, headers):
+        if method == 'POST':
+            body = self.fixtures.load('_v2_0__volume.json')
+            return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
+
+    def _v2_1337_volumes_cd76a3a1_c4ce_40f6_9b9f_07a61508938d(self, method, url, body, headers):
+        if method == 'GET':
+            body = self.fixtures.load('_v2_0__volume.json')
+            return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
+        if method == 'DELETE':
+            body = ''
+            return (httplib.ACCEPTED, body, self.json_content_headers, httplib.responses[httplib.OK])
+    
+    def _v2_1337_snapshots_detail(self, method, url, body, headers):
+        body = self.fixtures.load('_v2_0__snapshots.json')
+        return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
+
+    def _v2_1337_snapshots(self, method, url, body, headers):
+        if method == 'POST':
+            body = self.fixtures.load('_v2_0__snapshot.json')
+            return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
+
+    def _v2_1337_snapshots_3fbbcccf_d058_4502_8844_6feeffdf4cb5(self, method, url, body, headers):
+        if method == 'GET':
+            body = self.fixtures.load('_v2_0__snapshot.json')
+            return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
+        if method == 'DELETE':
+            body = ''
+            return (httplib.ACCEPTED, body, self.json_content_headers, httplib.responses[httplib.OK])
+    
 
 # This exists because the nova compute url in devstack has v2 in there but the v1.1 fixtures
 # work fine.

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -1747,6 +1747,17 @@ class OpenStack_2_Tests(OpenStack_1_1_Tests):
         self.assertEqual(subnet.name, 'private-subnet')
         self.assertEqual(subnet.cidr, '10.0.0.0/24')
 
+    def test_ex_create_subnet(self):
+        network = self.driver.ex_list_networks()[0]
+        subnet = self.driver.ex_create_subnet('name', network, '10.0.0.0/24')
+
+        self.assertEqual(subnet.name, 'name')
+        self.assertEqual(subnet.cidr, '10.0.0.0/24')
+
+    def test_ex_delete_subnet(self):
+        subnet = self.driver.ex_list_subnets()[0]
+        self.assertTrue(self.driver.ex_delete_subnet(subnet=subnet))
+
     def test_ex_list_network(self):
         networks = self.driver.ex_list_networks()
         network = networks[0]
@@ -2423,9 +2434,21 @@ class OpenStack_1_1_MockHttp(MockHttp, unittest.TestCase):
             body = ''
             return (httplib.NO_CONTENT, body, self.json_content_headers, httplib.responses[httplib.OK])
 
+    def _v2_1337_v2_0_subnets_08eae331_0402_425a_923c_34f7cfe39c1b(self, method, url, body, headers):
+        if method == 'GET':
+            body = self.fixtures.load('_v2_0__subnet.json')
+            return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
+        if method == 'DELETE':
+            body = ''
+            return (httplib.NO_CONTENT, body, self.json_content_headers, httplib.responses[httplib.OK])
+
     def _v2_1337_v2_0_subnets(self, method, url, body, headers):
-        body = self.fixtures.load('_v2_0__subnets.json')
-        return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
+        if method == 'POST':
+            body = self.fixtures.load('_v2_0__subnet.json')
+            return (httplib.CREATED, body, self.json_content_headers, httplib.responses[httplib.OK])
+        else:
+            body = self.fixtures.load('_v2_0__subnets.json')
+            return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
 
     def _v2_1337_volumes_detail(self, method, url, body, headers):
         body = self.fixtures.load('_v2_0__volumes.json')


### PR DESCRIPTION
## Implement new versions of OpenStack API calls [LIBCLOUD-874]

### Description

This PR overwrite the usage of the deprecated nova API methods:
- /os-volumes
- /os-snapshots
- /os-security-groups
- /os-security-group-rules
- /os-floating-ips
- /os-floating-ip-pools

Replacing them with corresponding calls to neutron and cinder.

Also other minor fixes has been made as fixing the function parse_error to avoid error if "code" is not in the response message or fixing _to_port function to make it work with old OpenStack versions where some fields as: port_security_enabled or project_id are not returned by the API.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
