### PR TITLE
Bug fixes for GCENodeDriver.ex_create_firewall()

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -3268,12 +3268,13 @@ class GCENodeDriver(NodeDriver):
         firewall_data['direction'] = direction
         firewall_data['priority'] = priority
         firewall_data['description'] = description
-        if direction == 'INGRESS':
+        if allowed is not None:
             firewall_data['allowed'] = allowed
-        elif direction == 'EGRESS':
+        if denied is not None:
             firewall_data['denied'] = denied
         firewall_data['network'] = nw.extra['selfLink']
-        if source_ranges is None and source_tags is None \
+        if direction == 'INGRESS' and source_ranges is None \
+                and source_tags is None \
                 and source_service_accounts is None:
             source_ranges = ['0.0.0.0/0']
         if source_ranges is not None:


### PR DESCRIPTION
Remove incorrect firewall direction check for allow/deny rules.

Only default source_ranges to 0.0.0.0/0 if direction is INGRESS.

## Bug fixes for GCENodeDriver.ex_create_firewall()

### Description

Fixed two small bugs in GCENodeDriver.ex_create_firewall().

The first issue was that a direction check was being applied to determine whether allowed or denied would be passed to the GCE API call. Both ingress and egress rules can have allowed or denied blocks so this shouldn't be conditional on the direction.

The second issue was that source_ranges was automatically set to [0.0.0.0/0] if no other source filters were applied. Since source filters are invalid for egress rules, I added a check for the INGRESS direction prior to setting a default source range.

### Status

done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
