### PR TITLE
Fix trigger_rtd_build.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ matrix:
             - libvirt-dev
       # Trigger ReadTheDocs build on docs builder
       after_success:
-        - ./contrib/trigger_rtd_build.py 8284
+        - python3 ./contrib/trigger_rtd_build.py 8284
 
 install:
   - pip install --upgrade "pip==9.0.1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ matrix:
             - libvirt-dev
       # Trigger ReadTheDocs build on docs builder
       after_success:
+        - pip3 install requests
         - python3 ./contrib/trigger_rtd_build.py 8284
 
 install:

--- a/contrib/trigger_rtd_build.py
+++ b/contrib/trigger_rtd_build.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -15,11 +15,10 @@
 # limitations under the License.
 
 import sys
-import urllib2
+import requests
 
 
 key = sys.argv[1]
 url = 'https://readthedocs.org/build/%s' % (key)
-req = urllib2.Request(url, '')
-f = urllib2.urlopen(req)
-print f.read()
+r = requests.post(url)
+print(r.text)

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,6 @@ deps = pysphere
        backports.ssl_match_hostname
        lockfile
        rstcheck
-       requests
 changedir = docs
 commands = pip install sphinx~=1.6.0
            rstcheck --report warning ../CHANGES.rst

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ deps = pysphere
        backports.ssl_match_hostname
        lockfile
        rstcheck
+       requests
 changedir = docs
 commands = pip install sphinx~=1.6.0
            rstcheck --report warning ../CHANGES.rst


### PR DESCRIPTION
## Fix ReadTheDocs build trigger

### Description

I think this was broken when switching more tox.ini entries to Python 3. See https://readthedocs.org/projects/libcloud/builds/: the only builds more recent than 6 months are my tests. 

### Status

- work in progress

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
