### PR TITLE
openstack: handle missing user email

### DIFF
--- a/libcloud/common/openstack_identity.py
+++ b/libcloud/common/openstack_identity.py
@@ -1380,7 +1380,7 @@ class OpenStackIdentity_3_0_Connection(OpenStackIdentityConnection):
         user = OpenStackIdentityUser(id=data['id'],
                                      domain_id=data['domain_id'],
                                      name=data['name'],
-                                     email=data['email'],
+                                     email=data.get('email'),
                                      description=data.get('description',
                                                           None),
                                      enabled=data['enabled'])

--- a/libcloud/test/common/test_openstack_identity.py
+++ b/libcloud/test/common/test_openstack_identity.py
@@ -373,6 +373,12 @@ class OpenStackIdentity_3_0_ConnectionTests(unittest.TestCase):
         self.assertEqual(user.enabled, True)
         self.assertEqual(user.email, 'openstack-test@localhost')
 
+    def test_get_user_without_email(self):
+        user = self.auth_instance.get_user(user_id='b')
+        self.assertEqual(user.id, 'b')
+        self.assertEqual(user.name, 'userwithoutemail')
+        self.assertEqual(user.email, None)
+
     def test_create_user(self):
         user = self.auth_instance.create_user(email='test2@localhost', password='test1',
                                               name='test2', domain_id='default')
@@ -696,6 +702,13 @@ class OpenStackIdentity_3_0_MockHttp(MockHttp):
         if method == 'PATCH':
             # enable / disable user
             body = self.fixtures.load('v3_users_a.json')
+            return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
+        raise NotImplementedError()
+
+    def _v3_users_b(self, method, url, body, headers):
+        if method == 'GET':
+            # look up a user
+            body = self.fixtures.load('v3_users_b.json')
             return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
         raise NotImplementedError()
 

--- a/libcloud/test/compute/fixtures/openstack_identity/v3/v3_users_b.json
+++ b/libcloud/test/compute/fixtures/openstack_identity/v3/v3_users_b.json
@@ -1,0 +1,17 @@
+{
+    "user":
+      {
+          "name": "userwithoutemail",
+          "links": {
+              "self": "http://192.168.18.100:5000/v3/users/b"
+          },
+          "domain_id": "default",
+          "enabled": true,
+          "id": "b"
+      },
+    "links": {
+        "self": "http://192.168.18.100:5000/v3/users",
+        "previous": null,
+        "next": null
+    }
+}


### PR DESCRIPTION
### Description

Keystone may not always return an "email" entry for a user account.
Prior to this change, we could crash if we queried a user that lacked an
email record. Gracefully handle this case by setting email to None.

### Status

- done, ready for review

### Checklist

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)