### PR TITLE
container/utils: improve docstring for RegistryClient

### DIFF
--- a/docs/container/utilities.rst
+++ b/docs/container/utilities.rst
@@ -3,5 +3,8 @@
 Container Utility API
 =====================
 
+.. autoclass:: libcloud.container.utils.docker.RegistryClient
+    :members:
+
 .. autoclass:: libcloud.container.utils.docker.HubClient
     :members:

--- a/libcloud/container/utils/docker.py
+++ b/libcloud/container/utils/docker.py
@@ -64,12 +64,15 @@ class RegistryClient(object):
 
     def __init__(self, host, username=None, password=None, **kwargs):
         """
-        Construct a Docker hub client
+        Construct a Docker registry client
 
-        :param username: (optional) Your Hub account username
+        :param host: Your registry endpoint, e.g. 'registry.hub.docker.com'
+        :type  host: ``str``
+
+        :param username: (optional) Your registry account username
         :type  username: ``str``
 
-        :param password: (optional) Your hub account password
+        :param password: (optional) Your registry account password
         :type  password: ``str``
         """
         self.connection = self.connectionCls(host,


### PR DESCRIPTION
### Description

Prior to this change, the docstring for the `RegistryClient` class was copy-and-pasted from the `HubClient` class.

Add the definition for the `host` parameter, and change the descriptions to reflect the generalized nature of this `RegistryClient` class.

This also adds `RegistryClient` to the main documentation that Sphinx generates.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)