### PR TITLE
implement OpenStack_1_1_NodeDriver ex_get_snapshot

### DIFF
--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -1703,6 +1703,10 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
         return self._to_snapshots(
             self.connection.request('/os-snapshots').object)
 
+    def ex_get_snapshot(self, snapshotId):
+        return self._to_snapshot(
+            self.connection.request('/os-snapshots/%s' % snapshotId).object)
+
     def list_volume_snapshots(self, volume):
         return [snapshot for snapshot in self.ex_list_snapshots()
                 if snapshot.extra['volume_id'] == volume.id]

--- a/libcloud/test/compute/fixtures/openstack_v1.1/_os_snapshot.json
+++ b/libcloud/test/compute/fixtures/openstack_v1.1/_os_snapshot.json
@@ -1,0 +1,11 @@
+{
+    "snapshot": {
+            "id": "3fbbcccf-d058-4502-8844-6feeffdf4cb5",
+            "display_name": "snap-001",
+            "display_description": "Daily backup",
+            "volume_id": "521752a6-acf6-4b2d-bc7a-119f9148cd8c",
+            "status": "available",
+            "size": 30,
+            "created_at": "2012-02-29T03:50:07Z"
+    }
+}

--- a/libcloud/test/compute/fixtures/openstack_v1.1/_os_snapshot_rackspace.json
+++ b/libcloud/test/compute/fixtures/openstack_v1.1/_os_snapshot_rackspace.json
@@ -1,0 +1,11 @@
+{
+    "snapshot": {
+            "id": "3fbbcccf-d058-4502-8844-6feeffdf4cb5",
+            "displayName": "snap-001",
+            "displayDescription": "Daily backup",
+            "volumeId": "521752a6-acf6-4b2d-bc7a-119f9148cd8c",
+            "status": "available",
+            "size": 30,
+            "createdAt": "2012-02-29T03:50:07Z"
+    }
+}

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -1482,6 +1482,17 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
         # invalid date is parsed as None
         assert snapshots[2].created is None
 
+    def test_ex_get_snapshot(self):
+        if self.driver_type.type == 'rackspace':
+            self.conn_class.type = 'RACKSPACE'
+
+        snapshot = self.driver.ex_get_snapshot('3fbbcccf-d058-4502-8844-6feeffdf4cb5')
+        self.assertEqual(snapshot.created, datetime.datetime(2012, 2, 29, 3, 50, 7, tzinfo=UTC))
+        self.assertEqual(snapshot.extra['created'], "2012-02-29T03:50:07Z")
+        self.assertEqual(snapshot.extra['name'], 'snap-001')
+        self.assertEqual(snapshot.name, 'snap-001')
+        self.assertEqual(snapshot.state, VolumeSnapshotState.AVAILABLE)
+
     def test_list_volume_snapshots(self):
         volume = self.driver.list_volumes()[0]
 
@@ -2242,6 +2253,30 @@ class OpenStack_1_1_MockHttp(MockHttp, unittest.TestCase):
 
         return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
 
+    def _v1_1_slug_os_snapshots_3fbbcccf_d058_4502_8844_6feeffdf4cb5(self, method, url, body, headers):
+        if method == 'GET':
+            body = self.fixtures.load('_os_snapshot.json')
+            status_code = httplib.OK
+        elif method == 'DELETE':
+            body = ''
+            status_code = httplib.NO_CONTENT
+        else:
+            raise NotImplementedError()
+
+        return (status_code, body, self.json_content_headers, httplib.responses[httplib.OK])
+
+    def _v1_1_slug_os_snapshots_3fbbcccf_d058_4502_8844_6feeffdf4cb5_RACKSPACE(self, method, url, body, headers):
+        if method == 'GET':
+            body = self.fixtures.load('_os_snapshot_rackspace.json')
+            status_code = httplib.OK
+        elif method == 'DELETE':
+            body = ''
+            status_code = httplib.NO_CONTENT
+        else:
+            raise NotImplementedError()
+
+        return (status_code, body, self.json_content_headers, httplib.responses[httplib.OK])
+
     def _v1_1_slug_os_snapshots_RACKSPACE(self, method, url, body, headers):
         if method == 'GET':
             body = self.fixtures.load('_os_snapshots_rackspace.json')
@@ -2251,24 +2286,6 @@ class OpenStack_1_1_MockHttp(MockHttp, unittest.TestCase):
             raise NotImplementedError()
 
         return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
-
-    def _v1_1_slug_os_snapshots_3fbbcccf_d058_4502_8844_6feeffdf4cb5(self, method, url, body, headers):
-        if method == 'DELETE':
-            body = ''
-            status_code = httplib.NO_CONTENT
-        else:
-            raise NotImplementedError()
-
-        return (status_code, body, self.json_content_headers, httplib.responses[httplib.OK])
-
-    def _v1_1_slug_os_snapshots_3fbbcccf_d058_4502_8844_6feeffdf4cb5_RACKSPACE(self, method, url, body, headers):
-        if method == 'DELETE':
-            body = ''
-            status_code = httplib.NO_CONTENT
-        else:
-            raise NotImplementedError()
-
-        return (status_code, body, self.json_content_headers, httplib.responses[httplib.OK])
 
     def _v2_1337_v2_0_networks(self, method, url, body, headers):
         if method == 'GET':


### PR DESCRIPTION
to list a specific volume snapshot by ID, similar to `ex_get_volume`

```
In [5]: conn.ex_get_snapshot(myid)
Out[5]: <VolumeSnapshot "hypernode-magweb-2018-11-02T10:16:29Z" id=1142e249-4cc0-4b47-a3ee-ec9c9e444b1b size=40 driver=OpenStack state=available>
```