### PR TITLE
openstack: handle missing user "enabled" attribute

### DIFF
--- a/libcloud/common/openstack_identity.py
+++ b/libcloud/common/openstack_identity.py
@@ -1383,7 +1383,7 @@ class OpenStackIdentity_3_0_Connection(OpenStackIdentityConnection):
                                      email=data.get('email'),
                                      description=data.get('description',
                                                           None),
-                                     enabled=data['enabled'])
+                                     enabled=data.get('enabled'))
         return user
 
     def _to_roles(self, data):

--- a/libcloud/test/common/test_openstack_identity.py
+++ b/libcloud/test/common/test_openstack_identity.py
@@ -379,6 +379,12 @@ class OpenStackIdentity_3_0_ConnectionTests(unittest.TestCase):
         self.assertEqual(user.name, 'userwithoutemail')
         self.assertEqual(user.email, None)
 
+    def test_get_user_without_enabled(self):
+        user = self.auth_instance.get_user(user_id='c')
+        self.assertEqual(user.id, 'c')
+        self.assertEqual(user.name, 'userwithoutenabled')
+        self.assertEqual(user.enabled, None)
+
     def test_create_user(self):
         user = self.auth_instance.create_user(email='test2@localhost', password='test1',
                                               name='test2', domain_id='default')
@@ -709,6 +715,13 @@ class OpenStackIdentity_3_0_MockHttp(MockHttp):
         if method == 'GET':
             # look up a user
             body = self.fixtures.load('v3_users_b.json')
+            return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
+        raise NotImplementedError()
+
+    def _v3_users_c(self, method, url, body, headers):
+        if method == 'GET':
+            # look up a user
+            body = self.fixtures.load('v3_users_c.json')
             return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
         raise NotImplementedError()
 

--- a/libcloud/test/compute/fixtures/openstack_identity/v3/v3_users_c.json
+++ b/libcloud/test/compute/fixtures/openstack_identity/v3/v3_users_c.json
@@ -1,0 +1,14 @@
+{
+    "user":
+      {
+          "name": "userwithoutenabled",
+          "links": {
+              "self": "http://192.168.18.100:5000/v3/users/c"
+          },
+          "domain_id": "default",
+          "id": "c",
+          "email": "c@example.com",
+          "password_expires_at": null,
+          "options": {}
+      }
+}


### PR DESCRIPTION
### Description

Keystone may not always return an "enabled" attribute for a user account. Prior to this change, we could crash if we queried a user that lacked an "enabled" attribute. Gracefully handle this case by setting "enabled" to None.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
