### PR TITLE
Pagination in various OpenStack_2_NodeDriver methods

### DIFF
--- a/libcloud/test/compute/fixtures/openstack_v1.1/_v2_0__snapshots_paginate_start.json
+++ b/libcloud/test/compute/fixtures/openstack_v1.1/_v2_0__snapshots_paginate_start.json
@@ -1,4 +1,10 @@
 {
+    "snapshots_links": [
+      {
+        "href": "https://api.example.com:8776/v2/abcdec85bee34bb0a44ab8255eb36fbd/snapshots?&marker=abcde279-4cc0-4b47-a4ee-ec9c9e474b1b",
+        "rel": "next"
+      }
+    ],
     "snapshots": [
         {
             "status": "available",
@@ -6,8 +12,8 @@
                 "name": "test"
             },
             "os-extended-snapshot-attributes:progress": "100%",
-            "name": "snap-001",
-            "volume_id": "373f7b48-c4c1-4e70-9acc-086b39073506",
+            "name": "snap-101",
+            "volume_id": "473f7b48-c4c1-4e70-9acc-086b39073506",
             "os-extended-snapshot-attributes:project_id": "bab7d5c60cd041a0a36f7c4b6e1dd978",
             "created_at": "2012-02-29T03:50:07Z",
             "size": 1,
@@ -17,29 +23,29 @@
         {
             "status": "available",
             "metadata": {
-                "name": "test"
+                "name": "test2"
             },
             "os-extended-snapshot-attributes:progress": "100%",
-            "name": "test-volume-snapshot",
-            "volume_id": "6edbc2f4-1507-44f8-ac0d-eed1d2608d38",
+            "name": "test-volume-snapshot2",
+            "volume_id": "7edbc2f4-1507-44f8-ac0d-eed1d2608d38",
             "os-extended-snapshot-attributes:project_id": "bab7d5c60cd041a0a36f7c4b6e1dd978",
             "created_at": "2015-11-29T02:25:51.000000",
             "size": 1,
-            "id": "4fbbdccf-e058-6502-8844-6feeffdf4cb5",
+            "id": "5fbbdccf-e058-6502-8844-6feeffdf4cb5",
             "description": "volume snapshot"
         },
         {
             "status": "available",
             "metadata": {
-                "name": "test"
+                "name": "test2"
             },
             "os-extended-snapshot-attributes:progress": "100%",
             "name": "test-volume-snapshot",
-            "volume_id": "373f7b48-c4c1-4e70-9acc-086b39073506",
+            "volume_id": "473f7b48-c4c1-4e70-9acc-086b39073506",
             "os-extended-snapshot-attributes:project_id": "bab7d5c60cd041a0a36f7c4b6e1dd978",
             "created_at": "2013-02-29T03:50:07Z",
             "size": 1,
-            "id": "1fbbcccf-d058-4502-8844-6feeffdf4cb5",
+            "id": "2fbbcccf-d058-4502-8844-6feeffdf4cb5",
             "description": "volume snapshot"
         }
     ]


### PR DESCRIPTION
The default max_limits for OpenStack is 1000. If you have more than 1000
resources (i.e. snapshots) then everything but the newest 1000 will not be
listed. If you set the max_limits lower even less will not be returned, etc.
This change implements pagination for ex_list_snapshots, ex_list_ports, and
list_volumes in the OpenStack_2_NodeDriver. This PR builds on top of (and
contains) https://github.com/apache/libcloud/pull/1242. 

Inspired by `_paginated_request` in the [DigitalOcean driver](https://github.com/apache/libcloud/blob/bc097ffe5b04990e0ca302231388ee7d5d6fe911/libcloud/common/digitalocean.py#L176)

before:
```
In [3]: out = conn.list_snapshots()

In [4]: len(out)
Out[4]: 1000
```

after:
```
In [3]: out = conn.list_snapshots()

In [4]: len(out)
Out[4]: 53098
```

before:
```
In [6]: out = conn.list_volumes()

In [7]: len(out)
Out[7]: 1000
```

after:
```
In [3]: out = conn.list_volumes()

In [4]: len(out)
Out[4]: 4876
```

before:
```
In [8]: out = conn.ex_list_ports()

In [9]: len(out)
Out[9]: 123
```

after:
```
In [5]: out = conn.ex_list_ports()

In [6]: len(out)
Out[6]: 123
```

Note that this does not affect the OpenStack_1_1_NodeDriver and those still won't be paginated and will not return anything except for the 1000 most recent resources.

For review, please see https://github.com/apache/libcloud/pull/1263/commits/5c5d45eecae5cc654816e2e25e03ce706ee91beb, that is the change of this PR. Until https://github.com/apache/libcloud/pull/1242 is merged this diff will be large.