### PR TITLE
Override the auth header for the VCloud 5.5 Connection

### DIFF
--- a/libcloud/compute/drivers/vcloud.py
+++ b/libcloud/compute/drivers/vcloud.py
@@ -863,6 +863,15 @@ class VCloud_1_5_Connection(VCloudConnection):
 
 
 class VCloud_5_5_Connection(VCloud_1_5_Connection):
+
+    def _get_auth_headers(self):
+        """Compatibility for using v5.5+ APIs"""
+        return {
+            'Authorization': "Basic %s" % base64.b64encode(
+                b('%s:%s' % (self.user_id, self.key))).decode('utf-8'),
+            'Accept': 'application/*+xml;version=5.5'
+        }
+
     def add_default_headers(self, headers):
         headers['Accept'] = 'application/*+xml;version=5.5'
         headers['x-vcloud-authorization'] = self.token


### PR DESCRIPTION
## Override the auth header for the VCloud 5.5 Connection

### Description

Newer VCD installs (I'm working against API level 30.0, for reference) enforce a minimum API level on authentication. This simply causes the authentication payload to send a version 5.5 header rather than a version 1.5 header, so our auth request isn't rejected.

### Status

done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
