### PR TITLE
Dummy Node ID doesn't allow 0

### DIFF
--- a/libcloud/compute/drivers/dummy.py
+++ b/libcloud/compute/drivers/dummy.py
@@ -84,16 +84,17 @@ class DummyNodeDriver(NodeDriver):
             self.nl = []
             startip = _ip_to_int('127.0.0.1')
             for i in range(num):
-                ip = _int_to_ip(startip + i)
-                self.nl.append(
-                    Node(id=i,
-                         name='dummy-%d' % (i),
-                         state=NodeState.RUNNING,
-                         public_ips=[ip],
-                         private_ips=[],
-                         driver=self,
-                         extra={'foo': 'bar'})
-                )
+                if i:
+                    ip = _int_to_ip(startip + i)
+                    self.nl.append(
+                        Node(id=i,
+                             name='dummy-%d' % (i),
+                             state=NodeState.RUNNING,
+                             public_ips=[ip],
+                             private_ips=[],
+                             driver=self,
+                             extra={'foo': 'bar'})
+                    )
         else:
             self.nl = [
                 Node(id=1,


### PR DESCRIPTION
## Dummy Node ID doesn't allow 0

### Description

If Dummy Node ID is `0`, it sets `None` when Node init.
Refs: https://github.com/apache/libcloud/blob/v2.4.0/libcloud/compute/base.py#L205
I think this is not the expected behavior.
So, I did not to allow it is `0`.

Before
```
[(None, 'dummy-0'), ('1', 'dummy-1'), ('2', 'dummy-2')]
```
After
```
[('1', 'dummy-1'), ('2', 'dummy-2')]
```

### Status
- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
