### PR TITLE
fix OpenStack_2_NodeDriver.detach_volume

### DIFF
--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -322,14 +322,19 @@ class OpenStackNodeDriver(NodeDriver, OpenStackDriverMixin):
         # when ex_node is not provided, volume is detached from all nodes
         failed_nodes = []
         for attachment in volume.extra['attachments']:
-            if not ex_node or ex_node.id == attachment['serverId']:
+            if not ex_node or ex_node.id in filter(None, (attachment.get(
+                'serverId'
+            ), attachment.get('server_id'))):
                 response = self.connection.request(
                     '/servers/%s/os-volume_attachments/%s' %
-                    (attachment['serverId'], attachment['id']),
+                    (attachment.get('serverId') or attachment['server_id'],
+                     attachment['id']),
                     method='DELETE')
 
                 if not response.success():
-                    failed_nodes.append(attachment['serverId'])
+                    failed_nodes.append(
+                        attachment.get('serverId') or attachment['server_id']
+                    )
         if failed_nodes:
             raise OpenStackException(
                 'detach_volume failed for nodes with id: %s' %

--- a/libcloud/test/compute/fixtures/openstack_v1.1/_v2_0__volume_abc6a3a1_c4ce_40f6_9b9f_07a61508938d.json
+++ b/libcloud/test/compute/fixtures/openstack_v1.1/_v2_0__volume_abc6a3a1_c4ce_40f6_9b9f_07a61508938d.json
@@ -1,0 +1,22 @@
+{
+    "volume": {
+        "attachments": [
+            {
+                "device": "/dev/vdb",
+                "id": "cd76a3a1-c4ce-40f6-9b9f-07a61508938d",
+                "server_id": "12065",
+                "volume_id": "cd76a3a1-c4ce-40f6-9b9f-07a61508938d"
+            }
+        ],
+        "availability_zone": "nova",
+        "created_at": "2013-06-24T11:20:13.000000",
+        "display_description": "",
+        "display_name": "test_volume_2",
+        "id": "cd76a3a1-c4ce-40f6-9b9f-07a61508938d",
+        "metadata": {},
+        "size": 2,
+        "snapshot_id": null,
+        "status": "in-use",
+        "volume_type": "None"
+    }
+}

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -1989,6 +1989,14 @@ class OpenStack_2_Tests(OpenStack_1_1_Tests):
         self.assertFalse("display_name" in kwargs["data"]["snapshot"])
         self.assertFalse("display_description" in kwargs["data"]["snapshot"])
 
+    def test_detach_volume(self):
+        node = self.driver.list_nodes()[0]
+        volume = self.driver.ex_get_volume(
+            'abc6a3a1-c4ce-40f6-9b9f-07a61508938d')
+        self.assertEqual(
+            self.driver.attach_volume(node, volume, '/dev/sdb'), True)
+        self.assertEqual(self.driver.detach_volume(volume), True)
+
 
 class OpenStack_1_1_FactoryMethodTests(OpenStack_1_1_Tests):
     should_list_locations = False
@@ -2511,7 +2519,15 @@ class OpenStack_1_1_MockHttp(MockHttp, unittest.TestCase):
         if method == 'DELETE':
             body = ''
             return (httplib.NO_CONTENT, body, self.json_content_headers, httplib.responses[httplib.OK])
-    
+
+    def _v2_1337_volumes_abc6a3a1_c4ce_40f6_9b9f_07a61508938d(self, method, url, body, headers):
+        if method == 'GET':
+            body = self.fixtures.load('_v2_0__volume_abc6a3a1_c4ce_40f6_9b9f_07a61508938d.json')
+            return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
+        if method == 'DELETE':
+            body = ''
+            return (httplib.NO_CONTENT, body, self.json_content_headers, httplib.responses[httplib.OK])
+
     def _v2_1337_snapshots_detail(self, method, url, body, headers):
         if ('unit_test=paginate' in url and 'marker' not in url) or \
                 'unit_test=pagination_loop' in url:


### PR DESCRIPTION
Since https://github.com/apache/libcloud/pull/1242 the OpenStack_2_NodeDriver uses a volume object returned via volumev2_connection. This object will not contain serverId but server_id. This PR makes the detach_volume method compatible with v2 volumes.

Fixes:
```
return connection.detach_volume(volume)
File "/usr/local/venv/project/src/apache-libcloud/libcloud/compute/drivers/openstack.py", line 328, in detach_volume
(attachment['serverId'], attachment['id']),
KeyError: 'serverId'
```