### PR TITLE
fix nttc sphinx error

### DIFF
--- a/libcloud/compute/drivers/nttcis.py
+++ b/libcloud/compute/drivers/nttcis.py
@@ -4871,7 +4871,7 @@ class NttCisNodeDriver(NodeDriver):
         :type consistency_group_id: ``str``
 
         :return: True if response_code contains either
-         IN_PROGRESS' or 'OK' otherwise False
+        IN_PROGRESS' or 'OK' otherwise False
         :rtype: ``bool``
         """
         failover_elm = ET.Element("initiateFailover",
@@ -4891,7 +4891,7 @@ class NttCisNodeDriver(NodeDriver):
         :param consistency_group_id: Id of Consistency Group to delete
         :type ``str``
         :return: True if response_code contains either
-         IN_PROGRESS' or 'OK' otherwise False
+        IN_PROGRESS' or 'OK' otherwise False
         :rtype: ``bool``
         """
         delete_elm = ET.Element("deleteConsistencyGroup",


### PR DESCRIPTION
fixes:
```
Warning, treated as error:
/home/travis/build/apache/libcloud/libcloud/compute/drivers/nttcis.py:docstring of libcloud.compute.drivers.nttcis.NttCisNodeDriver.ex_delete_consistency_group:6:Unexpected indentation.
```
introduced in https://github.com/apache/libcloud/commit/6ae3a29ba5522c566b893f6994cc1748c1c7b149
see for example https://travis-ci.org/apache/libcloud/jobs/469938841