### PR TITLE
Handle Google Storage Interoperability access keys of more than 20 characters

### DIFF
--- a/libcloud/common/google.py
+++ b/libcloud/common/google.py
@@ -610,9 +610,12 @@ class GoogleAuthType(object):
     @staticmethod
     def _is_gcs_s3(user_id):
         """
-        Checks S3 key format: 20 alphanumeric chars starting with GOOG.
+        Checks S3 key format: alphanumeric chars starting with GOOG.
         """
-        return len(user_id) == 20 and user_id.startswith('GOOG')
+        return (
+            len(user_id) >= 20 and len(user_id) < 30 and user_id
+            .startswith('GOOG')
+        )
 
     @staticmethod
     def _is_sa(user_id):

--- a/libcloud/test/common/test_google.py
+++ b/libcloud/test/common/test_google.py
@@ -60,7 +60,9 @@ GCE_PARAMS_JSON_KEY = ('email@developer.gserviceaccount.com', JSON_KEY)
 GCE_PARAMS_KEY = ('email@developer.gserviceaccount.com', KEY_STR)
 GCE_PARAMS_IA = ('client_id', 'client_secret')
 GCE_PARAMS_GCE = ('foo', 'bar')
-GCS_S3_PARAMS = ('GOOG0123456789ABCXYZ',  # GOOG + 16 alphanumeric chars
+GCS_S3_PARAMS_20 = ('GOOG0123456789ABCXYZ',  # GOOG + 16 alphanumeric chars
+                 '0102030405060708091011121314151617181920')  # 40 base64 chars
+GCS_S3_PARAMS_24 = ('GOOGDF5OVRRGU4APFNSTVCXI',  # GOOG + 20 alphanumeric chars
                  '0102030405060708091011121314151617181920')  # 40 base64 chars
 
 STUB_UTCNOW = _utcnow()
@@ -230,7 +232,10 @@ class GoogleAuthTypeTest(GoogleTestCase):
             self.assertEqual(GoogleAuthType.guess_type(GCE_PARAMS[0]),
                              GoogleAuthType.SA)
             self.assertEqual(
-                GoogleAuthType.guess_type(GCS_S3_PARAMS[0]),
+                GoogleAuthType.guess_type(GCS_S3_PARAMS_20[0]),
+                GoogleAuthType.GCS_S3)
+            self.assertEqual(
+                GoogleAuthType.guess_type(GCS_S3_PARAMS_24[0]),
                 GoogleAuthType.GCS_S3)
             self.assertEqual(GoogleAuthType.guess_type(GCE_PARAMS_GCE[0]),
                              GoogleAuthType.GCE)


### PR DESCRIPTION
## Fix _is_gcs_s3 to detect access keys of more than 20 characters

### Description

Google Cloud Storage currently emits access keys of more than 20 characters.

For e.g. an access key generated on my account (revoked since): `GOOGDF5OVRRGU4APFNSTVCXI` (24 characters)

So we can't rely anymore [on the doc](https://cloud.google.com/storage/docs/migrating?hl=fr#keys), when it is stating:
> An access key is a 20 character alphanumeric string

### Status

- done, ready for review

Should we add tests?

### Checklist (tick everything that applies)

- [X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [X] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
