### PR TITLE
Updating command line arguments to current version

### DIFF
--- a/docs/compute/drivers/azure_arm.rst
+++ b/docs/compute/drivers/azure_arm.rst
@@ -16,7 +16,7 @@ Connecting to Azure
 -------------------
 
 To connect to Azure you need your tenant ID and subscription ID.  Using the
-Azure cross platform CLI, use ``azure account list`` to get these
+Azure cross platform CLI, use ``az account list`` to get these
 values.
 
 Creating a Service Principal
@@ -27,9 +27,9 @@ https://azure.microsoft.com/en-us/documentation/articles/resource-group-authenti
 
 .. sourcecode:: bash
 
-  azure ad app create --name "<Your Application Display Name>" --home-page "<https://YourApplicationHomePage>" --identifier-uris "<https://YouApplicationUri>" --password <Your_Password>
-  azure ad sp create "<Application_Id>"
-  azure role assignment create --objectId "<Object_Id>" -o Owner -c /subscriptions/{subscriptionId}/
+  az ad app create --display-name "<Your Application Display Name>" --identifier-uris "<https://YouApplicationUri>" --password <Your_Password>
+  az ad sp create --id "<Application_Id>"
+  az role assignment create --assignee "<Object_Id>" --role Owner --scope /subscriptions/{subscriptionId}/
 
 Instantiating a driver
 ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Updating command line arguments to current version

### Description

I was going over instructions for Azure and it seems they were made for an older version of the CLI tool. I updated them to recent command line arguments.

### Status

Replace this: done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
