### PR TITLE
Adds missing docs for param ex_prefix & adds to DummyStore

### DIFF
--- a/libcloud/storage/base.py
+++ b/libcloud/storage/base.py
@@ -221,12 +221,15 @@ class StorageDriver(BaseDriver):
         raise NotImplementedError(
             'iterate_container_objects not implemented for this driver')
 
-    def list_container_objects(self, container):
+    def list_container_objects(self, container, ex_prefix=None):
         """
         Return a list of objects for the given container.
 
         :param container: Container instance.
         :type container: :class:`Container`
+
+        :param ex_prefix: Filter objects starting with a prefix.
+        :type  ex_prefix: ``str``
 
         :return: A list of Object instances.
         :rtype: ``list`` of :class:`Object`

--- a/libcloud/storage/drivers/dummy.py
+++ b/libcloud/storage/drivers/dummy.py
@@ -178,10 +178,13 @@ class DummyStorageDriver(StorageDriver):
         for container in list(self._containers.values()):
             yield container['container']
 
-    def list_container_objects(self, container):
+    def list_container_objects(self, container, ex_prefix=None):
         container = self.get_container(container.name)
 
-        return container.objects
+        objects = list(self._containers[container.name]['objects'].values())
+        if ex_prefix is not None:
+            objects = [o for o in objects if o.name.startswith(ex_prefix)]
+        return objects
 
     def get_container(self, container_name):
         """

--- a/libcloud/test/storage/test_dummy.py
+++ b/libcloud/test/storage/test_dummy.py
@@ -1,0 +1,45 @@
+import pytest
+
+from libcloud.storage.drivers.dummy import DummyStorageDriver
+
+
+@pytest.fixture
+def driver():
+    return DummyStorageDriver('key', 'id')
+
+
+@pytest.fixture
+def container_with_contents(driver):
+    container_name = 'test'
+    object_name = 'test.dat'
+    container = driver.create_container(container_name=container_name)
+    driver.upload_object(
+        __file__, container=container, object_name=object_name
+    )
+    return container_name, object_name
+
+
+def test_list_container_objects(driver, container_with_contents):
+    container_name, object_name = container_with_contents
+    container = driver.get_container(container_name)
+
+    objects = driver.list_container_objects(container=container)
+
+    assert any(o for o in objects if o.name == object_name)
+
+
+def test_list_container_objects_filter_by_prefix(
+    driver, container_with_contents
+):
+    container_name, object_name = container_with_contents
+    container = driver.get_container(container_name)
+
+    objects = driver.list_container_objects(
+        container=container, ex_prefix=object_name[:3]
+    )
+    assert any(o for o in objects if o.name == object_name)
+
+    objects = driver.list_container_objects(
+        container=container, ex_prefix='does-not-exist.dat'
+    )
+    assert not objects


### PR DESCRIPTION
## Adds missing docs for param ex_prefix & adds to DummyStore

### Description

Adds missing docs for param ``ex_prefix`` within list_container_objects method.
    
Also adds ex_prefix functionality to the DummyStore, since all other stores have this feature.


### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [CLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
