### PR TITLE
Make tests pass after 2031

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,13 @@ General
   
 - Updating command line arguments to current version in Azure examples (GITHUB-1273) [mitar]
 
+- [GCE, SoftLayer] Update GCE and Softlayer drivers to utilize crypto
+  primitives from the ``cryptography`` library instead of deprecated and
+  unmaintained ``PyCrypto`` library.
+  
+  (GITHUB-1280)
+  [Ryan Petrello]
+
 Common
 ~~~~~~
 

--- a/libcloud/common/google.py
+++ b/libcloud/common/google.py
@@ -24,7 +24,7 @@ OAUTH2: Service Accounts and Client IDs for Installed Applications.
 Both are initially set up from the Cloud Console Console -
 https://cloud.google.com/console
 
-Setting up Service Account authentication (note that you need the PyCrypto
+Setting up Service Account authentication (note that you need the cryptography
 package installed to use this):
 
 - Go to the Console
@@ -89,16 +89,13 @@ from libcloud.common.types import (ProviderError,
                                    LibcloudError)
 
 try:
-    from Crypto.Hash import SHA256
-    from Crypto.PublicKey import RSA
-    from Crypto.Signature import PKCS1_v1_5
-    import Crypto.Random
-    Crypto.Random.atfork()
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.hashes import SHA256
+    from cryptography.hazmat.primitives.asymmetric.padding import PKCS1v15
 except ImportError:
-    # The pycrypto library is unavailable
+    # The cryptography library is unavailable
     SHA256 = None
-    RSA = None
-    PKCS1_v1_5 = None
 
 UTC_TIMESTAMP_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 
@@ -472,8 +469,8 @@ class GoogleServiceAcctAuthConnection(GoogleBaseAuthConnection):
     """Authentication class for "Service Account" authentication."""
     def __init__(self, user_id, key, *args, **kwargs):
         """
-        Check to see if PyCrypto is available, and convert key file path into a
-        key string if the key is in a file.
+        Check to see if cryptography is available, and convert key file path
+        into a key string if the key is in a file.
 
         :param  user_id: Email address to be used for Service Account
                 authentication.
@@ -483,7 +480,7 @@ class GoogleServiceAcctAuthConnection(GoogleBaseAuthConnection):
         :type   key: ``str``
         """
         if SHA256 is None:
-            raise GoogleAuthError('PyCrypto library required for '
+            raise GoogleAuthError('cryptography library required for '
                                   'Service Account Authentication.')
         # Check to see if 'key' is a file and read the file if it is.
         if key.find("PRIVATE KEY---") == -1:
@@ -526,10 +523,17 @@ class GoogleServiceAcctAuthConnection(GoogleBaseAuthConnection):
         # The message contains both the header and claim set
         message = b'.'.join((header_enc, claim_set_enc))
         # Then the message is signed using the key supplied
-        key = RSA.importKey(self.key)
-        hash_func = SHA256.new(message)
-        signer = PKCS1_v1_5.new(key)
-        signature = base64.urlsafe_b64encode(signer.sign(hash_func))
+        key = serialization.load_pem_private_key(
+            b(self.key),
+            password=None,
+            backend=default_backend()
+        )
+        signature = key.sign(
+            data=b(message),
+            padding=PKCS1v15(),
+            algorithm=SHA256()
+        )
+        signature = base64.urlsafe_b64encode(signature)
 
         # Finally the message and signature are sent to get a token
         jwt = b'.'.join((message, signature))

--- a/libcloud/compute/drivers/vcl.py
+++ b/libcloud/compute/drivers/vcl.py
@@ -122,7 +122,10 @@ class VCLNodeDriver(NodeDriver):
         """
 
         image = kwargs["image"]
-        start = kwargs.get('start', int(time.time()))
+
+        # Special case for xmlrpclib not handling 64 bit integers when writting
+        # XML - we always  cast value to string.
+        start = str(kwargs.get('start', str(time.time())))
         length = kwargs.get('length', '60')
 
         res = self._vcl_request(

--- a/libcloud/test/common/test_google.py
+++ b/libcloud/test/common/test_google.py
@@ -40,9 +40,9 @@ from libcloud.test import MockHttp, LibcloudTestCase
 from libcloud.utils.py3 import httplib
 
 
-# Skip some tests if PyCrypto is unavailable
+# Skip some tests if cryptography is unavailable
 try:
-    from Crypto.Hash import SHA256
+    from cryptography.hazmat.primitives.hashes import SHA256
 except ImportError:
     SHA256 = None
 

--- a/libcloud/test/compute/fixtures/openstack/_v1_1__auth.json
+++ b/libcloud/test/compute/fixtures/openstack/_v1_1__auth.json
@@ -2,7 +2,7 @@
     "auth": {
         "token": {
             "id": "aaaaaaaaaaaa-bbb-cccccccccccccc",
-            "expires": "2031-11-23T21:00:14-06:00"
+            "expires": "2999-11-23T21:00:14-06:00"
         },
         "serviceCatalog": {
             "cloudFilesCDN": [

--- a/libcloud/test/compute/fixtures/openstack/_v2_0__auth.json
+++ b/libcloud/test/compute/fixtures/openstack/_v2_0__auth.json
@@ -2,7 +2,7 @@
     "access": {
         "token": {
             "id": "aaaaaaaaaaaa-bbb-cccccccccccccc",
-            "expires": "2031-11-23T21:00:14.000-06:00"
+            "expires": "2999-11-23T21:00:14.000-06:00"
         },
         "serviceCatalog": [
             {

--- a/libcloud/test/compute/fixtures/openstack/_v2_0__auth_deployment.json
+++ b/libcloud/test/compute/fixtures/openstack/_v2_0__auth_deployment.json
@@ -2,7 +2,7 @@
     "access": {
         "token": {
             "id": "aaaaaaaaaaaa-bbb-cccccccccccccc",
-            "expires": "2031-11-23T21:00:14.000-06:00"
+            "expires": "2999-11-23T21:00:14.000-06:00"
         },
         "serviceCatalog": [
             {

--- a/libcloud/test/compute/fixtures/openstack/_v2_0__auth_lon.json
+++ b/libcloud/test/compute/fixtures/openstack/_v2_0__auth_lon.json
@@ -2,7 +2,7 @@
     "access": {
         "token": {
             "id": "aaaaaaaaaaaa-bbb-cccccccccccccc",
-            "expires": "2031-11-23T21:00:14.000-06:00"
+            "expires": "2999-11-23T21:00:14.000-06:00"
         },
         "serviceCatalog": [
             {

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -177,7 +177,7 @@ class OpenStack_1_0_Tests(TestCaseMixin, unittest.TestCase):
         self.driver.connection._populate_hosts_and_request_paths()
 
         expires = self.driver.connection.auth_token_expires
-        self.assertEqual(expires.isoformat(), "2031-11-23T21:00:14-06:00")
+        self.assertEqual(expires.isoformat(), "2999-11-23T21:00:14-06:00")
 
     def test_auth(self):
         if self.driver.connection._auth_version == '2.0':
@@ -686,7 +686,7 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
         self.driver.connection._populate_hosts_and_request_paths()
 
         expires = self.driver.connection.auth_token_expires
-        self.assertEqual(expires.isoformat(), "2031-11-23T21:00:14-06:00")
+        self.assertEqual(expires.isoformat(), "2999-11-23T21:00:14-06:00")
 
     def test_ex_force_base_url(self):
         # change base url and trash the current auth token so we can

--- a/libcloud/test/compute/test_softlayer.py
+++ b/libcloud/test/compute/test_softlayer.py
@@ -16,12 +16,6 @@
 import unittest
 import sys
 import pytest
-try:
-    import Crypto
-    Crypto
-    crypto = True
-except ImportError:
-    crypto = False
 
 from libcloud.common.types import InvalidCredsError
 
@@ -170,17 +164,13 @@ class SoftLayerTests(unittest.TestCase):
 
     @pytest.mark.skip(reason="no way of currently testing this")
     def test_create_key_pair(self):
-        if crypto:
-            key_pair = self.driver.create_key_pair(name='my-key-pair')
-            fingerprint = ('1f:51:ae:28:bf:89:e9:d8:1f:25:5d'
-                           ':37:2d:7d:b8:ca:9f:f5:f1:6f')
+        key_pair = self.driver.create_key_pair(name='my-key-pair')
+        fingerprint = ('1f:51:ae:28:bf:89:e9:d8:1f:25:5d'
+                       ':37:2d:7d:b8:ca:9f:f5:f1:6f')
 
-            self.assertEqual(key_pair.name, 'my-key-pair')
-            self.assertEqual(key_pair.fingerprint, fingerprint)
-            self.assertTrue(key_pair.private_key is not None)
-        else:
-            self.assertRaises(NotImplementedError, self.driver.create_key_pair,
-                              name='my-key-pair')
+        self.assertEqual(key_pair.name, 'my-key-pair')
+        self.assertEqual(key_pair.fingerprint, fingerprint)
+        self.assertTrue(key_pair.private_key is not None)
 
     def test_delete_key_pair(self):
         success = self.driver.delete_key_pair('test1')

--- a/libcloud/test/dns/fixtures/rackspace/auth_2_0.json
+++ b/libcloud/test/dns/fixtures/rackspace/auth_2_0.json
@@ -2,7 +2,7 @@
     "access": {
         "token": {
             "id": "aaaaaaaaaaaa-bbb-cccccccccccccc",
-            "expires": "2031-11-23T21:00:14.000-06:00"
+            "expires": "2999-11-23T21:00:14.000-06:00"
         },
         "serviceCatalog": [
             {

--- a/libcloud/test/loadbalancer/fixtures/rackspace/_v2_0__auth.json
+++ b/libcloud/test/loadbalancer/fixtures/rackspace/_v2_0__auth.json
@@ -2,7 +2,7 @@
     "access": {
         "token": {
             "id": "aaaaaaaaaaaa-bbb-cccccccccccccc",
-            "expires": "2031-11-23T21:00:14.000-06:00"
+            "expires": "2999-11-23T21:00:14.000-06:00"
         },
         "serviceCatalog": [
             {

--- a/libcloud/test/storage/fixtures/cloudfiles/_v2_0__auth.json
+++ b/libcloud/test/storage/fixtures/cloudfiles/_v2_0__auth.json
@@ -2,7 +2,7 @@
     "access": {
         "token": {
             "id": "aaaaaaaaaaaa-bbb-cccccccccccccc",
-            "expires": "2031-11-23T21:00:14.000-06:00"
+            "expires": "2999-11-23T21:00:14.000-06:00"
         },
         "serviceCatalog": [
             {

--- a/libcloud/test/test_utils.py
+++ b/libcloud/test/test_utils.py
@@ -47,6 +47,10 @@ from libcloud.utils.networking import join_ipv4_segments
 from libcloud.utils.networking import increment_ipv4_segments
 from libcloud.utils.decorators import wrap_non_libcloud_exceptions
 from libcloud.utils.connection import get_response_object
+from libcloud.utils.publickey import (
+    get_pubkey_openssh_fingerprint,
+    get_pubkey_ssh2_fingerprint,
+)
 from libcloud.common.types import LibcloudError
 from libcloud.storage.drivers.dummy import DummyIterator
 
@@ -383,6 +387,26 @@ class NetworkingUtilsTestCase(unittest.TestCase):
             result = increment_ipv4_segments(segments=segments)
             result = join_ipv4_segments(segments=result)
             self.assertEqual(result, incremented_ip)
+
+
+class TestPublicKeyUtils(unittest.TestCase):
+
+    PUBKEY = (
+        'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDOfbWSXOlqvYjZmRO84/lIoV4gvuX+'
+        'P1lLg50MMg6jZjLZIlYY081XPRmuom0xY0+BO++J2KgLl7gxJ6xMsKK2VQ+TakdfAH20'
+        'XfMcTohd/zVCeWsbqZQvEhVXBo4hPIktcfNz0u9Ez3EtInO+kb7raLcRhOVi9QmOkOrC'
+        'WtQU9mS71AWJuqI9H0YAnTiI8Hs5bn2tpMIqmTXT3g2bwywC25x1Nx9Hy0/FP+KUL6Ag'
+        'vDXv47l+TgSDfTBEkvq+IF1ITrnaOG+nRE02oZC6cwHYTifM/IOollkujxIQmi2Z+j66'
+        'OHSrjnEQugr0FqGJF2ygKfIh/i2u3fVLM60qE2NN user@example'
+    )
+
+    def test_pubkey_openssh_fingerprint(self):
+        fp = get_pubkey_openssh_fingerprint(self.PUBKEY)
+        assert fp == '35:22:13:5b:82:e2:5d:e1:90:8c:73:74:9f:ef:3b:d8'
+
+    def test_pubkey_ssh2_fingerprint(self):
+        fp = get_pubkey_ssh2_fingerprint(self.PUBKEY)
+        assert fp == '11:ad:5d:4c:5b:99:c9:80:7e:81:03:76:5a:25:9d:8c'
 
 
 def test_decorator():

--- a/libcloud/test/test_utils.py
+++ b/libcloud/test/test_utils.py
@@ -402,11 +402,11 @@ class TestPublicKeyUtils(unittest.TestCase):
 
     def test_pubkey_openssh_fingerprint(self):
         fp = get_pubkey_openssh_fingerprint(self.PUBKEY)
-        assert fp == '35:22:13:5b:82:e2:5d:e1:90:8c:73:74:9f:ef:3b:d8'
+        self.assertEqual(fp, '35:22:13:5b:82:e2:5d:e1:90:8c:73:74:9f:ef:3b:d8')
 
     def test_pubkey_ssh2_fingerprint(self):
         fp = get_pubkey_ssh2_fingerprint(self.PUBKEY)
-        assert fp == '11:ad:5d:4c:5b:99:c9:80:7e:81:03:76:5a:25:9d:8c'
+        self.assertEqual(fp, '11:ad:5d:4c:5b:99:c9:80:7e:81:03:76:5a:25:9d:8c')
 
 
 def test_decorator():

--- a/libcloud/utils/publickey.py
+++ b/libcloud/utils/publickey.py
@@ -16,8 +16,7 @@
 import base64
 import hashlib
 
-from libcloud.utils.py3 import hexadigits
-from libcloud.utils.py3 import bchr
+from libcloud.utils.py3 import hexadigits, b
 
 __all__ = [
     'get_pubkey_openssh_fingerprint',
@@ -26,11 +25,11 @@ __all__ = [
 ]
 
 try:
-    from Crypto.Util.asn1 import DerSequence, DerObject
-    from Crypto.PublicKey.RSA import algorithmIdentifier, importKey
-    pycrypto_available = True
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives import serialization
+    cryptography_available = True
 except ImportError:
-    pycrypto_available = False
+    cryptography_available = False
 
 
 def _to_md5_fingerprint(data):
@@ -40,25 +39,33 @@ def _to_md5_fingerprint(data):
 
 def get_pubkey_openssh_fingerprint(pubkey):
     # We import and export the key to make sure it is in OpenSSH format
-    if not pycrypto_available:
-        raise RuntimeError('pycrypto is not available')
-    k = importKey(pubkey)
-    pubkey = k.exportKey('OpenSSH')[7:]
-    decoded = base64.decodestring(pubkey)
-    return _to_md5_fingerprint(decoded)
+    if not cryptography_available:
+        raise RuntimeError('cryptography is not available')
+    public_key = serialization.load_ssh_public_key(
+        b(pubkey),
+        backend=default_backend()
+    )
+    pub_openssh = public_key.public_bytes(
+        encoding=serialization.Encoding.OpenSSH,
+        format=serialization.PublicFormat.OpenSSH,
+    )[7:]  # strip ssh-rsa prefix
+    return _to_md5_fingerprint(base64.decodestring(pub_openssh))
 
 
 def get_pubkey_ssh2_fingerprint(pubkey):
     # This is the format that EC2 shows for public key fingerprints in its
     # KeyPair mgmt API
-    if not pycrypto_available:
-        raise RuntimeError('pycrypto is not available')
-    k = importKey(pubkey)
-    derPK = DerSequence([k.n, k.e])
-    bitmap = DerObject('BIT STRING')
-    bitmap.payload = bchr(0x00) + derPK.encode()
-    der = DerSequence([algorithmIdentifier, bitmap.encode()])
-    return _to_md5_fingerprint(der.encode())
+    if not cryptography_available:
+        raise RuntimeError('cryptography is not available')
+    public_key = serialization.load_ssh_public_key(
+        b(pubkey),
+        backend=default_backend()
+    )
+    pub_der = public_key.public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return _to_md5_fingerprint(pub_der)
 
 
 def get_pubkey_comment(pubkey, default=None):

--- a/libcloud/utils/publickey.py
+++ b/libcloud/utils/publickey.py
@@ -16,7 +16,8 @@
 import base64
 import hashlib
 
-from libcloud.utils.py3 import hexadigits, bchr, b
+from libcloud.utils.py3 import hexadigits
+from libcloud.utils.py3 import b
 
 __all__ = [
     'get_pubkey_openssh_fingerprint',
@@ -31,8 +32,6 @@ try:
 except ImportError:
     cryptography_available = False
 
-from hashlib import sha1
-
 
 def _to_md5_fingerprint(data):
     hashed = hashlib.md5(data).digest()
@@ -43,7 +42,8 @@ def get_pubkey_openssh_fingerprint(pubkey):
     # We import and export the key to make sure it is in OpenSSH format
     if not cryptography_available:
         raise RuntimeError('cryptography is not available')
-    public_key = serialization.load_ssh_public_key(b(pubkey), backend=default_backend())
+    public_key = serialization.load_ssh_public_key(b(pubkey),
+                                                   backend=default_backend())
     pub_openssh = public_key.public_bytes(
         encoding=serialization.Encoding.OpenSSH,
         format=serialization.PublicFormat.OpenSSH,
@@ -56,7 +56,8 @@ def get_pubkey_ssh2_fingerprint(pubkey):
     # KeyPair mgmt API
     if not cryptography_available:
         raise RuntimeError('cryptography is not available')
-    public_key = serialization.load_ssh_public_key(b(pubkey), backend=default_backend())
+    public_key = serialization.load_ssh_public_key(b(pubkey),
+                                                   backend=default_backend())
     pub_der = public_key.public_bytes(
         encoding=serialization.Encoding.DER,
         format=serialization.PublicFormat.SubjectPublicKeyInfo,

--- a/libcloud/utils/publickey.py
+++ b/libcloud/utils/publickey.py
@@ -16,8 +16,7 @@
 import base64
 import hashlib
 
-from libcloud.utils.py3 import hexadigits
-from libcloud.utils.py3 import bchr
+from libcloud.utils.py3 import hexadigits, bchr, b
 
 __all__ = [
     'get_pubkey_openssh_fingerprint',
@@ -26,11 +25,13 @@ __all__ = [
 ]
 
 try:
-    from Crypto.Util.asn1 import DerSequence, DerObject
-    from Crypto.PublicKey.RSA import algorithmIdentifier, importKey
-    pycrypto_available = True
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives import serialization
+    cryptography_available = True
 except ImportError:
-    pycrypto_available = False
+    cryptography_available = False
+
+from hashlib import sha1
 
 
 def _to_md5_fingerprint(data):
@@ -40,25 +41,27 @@ def _to_md5_fingerprint(data):
 
 def get_pubkey_openssh_fingerprint(pubkey):
     # We import and export the key to make sure it is in OpenSSH format
-    if not pycrypto_available:
-        raise RuntimeError('pycrypto is not available')
-    k = importKey(pubkey)
-    pubkey = k.exportKey('OpenSSH')[7:]
-    decoded = base64.decodestring(pubkey)
-    return _to_md5_fingerprint(decoded)
+    if not cryptography_available:
+        raise RuntimeError('cryptography is not available')
+    public_key = serialization.load_ssh_public_key(b(pubkey), backend=default_backend())
+    pub_openssh = public_key.public_bytes(
+        encoding=serialization.Encoding.OpenSSH,
+        format=serialization.PublicFormat.OpenSSH,
+    )[7:]  # strip ssh-rsa prefix
+    return _to_md5_fingerprint(base64.decodestring(pub_openssh))
 
 
 def get_pubkey_ssh2_fingerprint(pubkey):
     # This is the format that EC2 shows for public key fingerprints in its
     # KeyPair mgmt API
-    if not pycrypto_available:
-        raise RuntimeError('pycrypto is not available')
-    k = importKey(pubkey)
-    derPK = DerSequence([k.n, k.e])
-    bitmap = DerObject('BIT STRING')
-    bitmap.payload = bchr(0x00) + derPK.encode()
-    der = DerSequence([algorithmIdentifier, bitmap.encode()])
-    return _to_md5_fingerprint(der.encode())
+    if not cryptography_available:
+        raise RuntimeError('cryptography is not available')
+    public_key = serialization.load_ssh_public_key(b(pubkey), backend=default_backend())
+    pub_der = public_key.public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return _to_md5_fingerprint(pub_der)
 
 
 def get_pubkey_comment(pubkey, default=None):

--- a/libcloud/utils/py3.py
+++ b/libcloud/utils/py3.py
@@ -126,7 +126,7 @@ if PY3:
 
     def hexadigits(s):
         # s needs to be a byte string.
-        return [format(x, "x") for x in s]
+        return [format(x, "02x") for x in s]
 
 else:
     import httplib  # NOQA

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -8,4 +8,4 @@ coverage<4.0
 requests
 requests_mock
 pytest>=3.4,<3.5
-cryptography
+cryptography==2.6.1

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -8,3 +8,4 @@ coverage<4.0
 requests
 requests_mock
 pytest>=3.4,<3.5
+cryptography


### PR DESCRIPTION
Background:
As part of my work on reproducible builds for openSUSE, I check that software still gives identical build results in the future.
The usual offset is +15 years, because that is how long I expect some software will be used in some places.
This showed up failing tests in our python-apache-libcloud package build.

With this patch, tests completed successfully on i586 and x86_64 in 2034

See https://reproducible-builds.org/ for the overall topic - only slightly relevant here.


- done, ready for review


- [X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [X] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)