### PR TITLE
Fixes LIBCLOUD-1039 - cloudfiles download_object_as_stream

### DIFF
--- a/libcloud/storage/drivers/cloudfiles.py
+++ b/libcloud/storage/drivers/cloudfiles.py
@@ -418,8 +418,12 @@ class CloudFilesStorageDriver(StorageDriver, OpenStackDriverMixin):
 
         return self._get_object(obj=obj, callback=read_in_chunks,
                                 response=response,
-                                callback_kwargs={'iterator': response.response,
-                                                 'chunk_size': chunk_size},
+                                callback_kwargs={
+                                    'iterator': response.iter_content(
+                                        chunk_size
+                                    ),
+                                    'chunk_size': chunk_size
+                                },
                                 success_status_code=httplib.OK)
 
     def upload_object(self, file_path, container, object_name, extra=None,


### PR DESCRIPTION
## Fixes LIBCLOUD-931 - cloudfiles download_object_as_stream results in HttpLibResponseProxy error.

### Description

Related ticket: https://issues.apache.org/jira/browse/LIBCLOUD-1039?

When downloading an object as a stream `download_object_as_stream`
in storage/drivers/cloudfiles.py a generator object should be
returned. Currently a rerquest/response object is returned
resulting in a HttpLibResponseProxy error.

This commit alters the callback_kwargs to use a
requests/response.iter_content resulting in an actual iterator
being returned. This code change is in other storage/driver 
specific code and appears to have been missed in cloudfiles.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
