### PR TITLE
LIBCLOUD-1040_CloudSigma_provider_ex_list_subscriptions_fails_if_your…

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,9 +1,7 @@
 [MASTER]
 # Add <file or directory> to the black list. It should be a base name, not a
 # path. You may set this option multiple times.
-ignore=test
-ignore=constants
-
+ignore=test,constants
 
 # Pickle collected data for later comparisons.
 persistent=yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ matrix:
 install:
   - pip install --upgrade "pip==9.0.1"
   - pip install "virtualenv==15.1.0"
-  - pip install "tox==2.8.2"
+  - pip install "tox==3.12.1"
   - TOX_ENV=py$TRAVIS_PYTHON_VERSION
 
 script:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -109,6 +109,11 @@ Compute
 - [OpenStack] Fix ``detach_volume`` method so it works with v2 volumes. (GITHUB-1267)
   [Rick van de Loo]
 
+- [CloudSigma] Fix CloudSigma driver so it correctly handles subscription
+  objects without the ``start_time`` and / or ``end_time`` attribute. (GITHUB-1284)
+  (LIBCLOUD-1040)
+  [aki-k, Tomaz Muraus]
+
 Container
 ~~~~~~~~~
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,13 +15,13 @@ General
 
 - Use assertIsNone instead of assertEqual with None in tests (GITHUB-1264)
   [Ken Dreyer]
-  
+
 - Updating command line arguments to current version in Azure examples (GITHUB-1273) [mitar]
 
 - [GCE, SoftLayer] Update GCE and Softlayer drivers to utilize crypto
   primitives from the ``cryptography`` library instead of deprecated and
   unmaintained ``PyCrypto`` library.
-  
+
   (GITHUB-1280)
   [Ryan Petrello]
 
@@ -105,6 +105,9 @@ Compute
 
 - [NTT CIS] Change endpoint 'canada' to 'ca' in libcloud/common/nttcis.py (GITHUB-1270)
   [Mitch Raful]
+
+- [OpenStack] Fix ``detach_volume`` method so it works with v2 volumes. (GITHUB-1267)
+  [Rick van de Loo]
 
 Container
 ~~~~~~~~~

--- a/contrib/generate_contributor_list.py
+++ b/contrib/generate_contributor_list.py
@@ -66,7 +66,7 @@ def parse_changes_file(file_path, versions=None):
             line = line.strip()
 
             match = re.search(r'Changes with Apache Libcloud '
-                              '(\d+\.\d+\.\d+(-\w+)?).*?$', line)
+                              r'(\d+\.\d+\.\d+(-\w+)?).*?$', line)
 
             if match:
                 active_version = match.groups()[0]
@@ -150,6 +150,7 @@ def convert_to_markdown(contributors_map, include_tickets=False):
 
     result = '\n'.join(result)
     return result
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Assemble provider logos '

--- a/contrib/generate_provider_feature_matrix_table.py
+++ b/contrib/generate_provider_feature_matrix_table.py
@@ -307,8 +307,7 @@ def generate_providers_table(api):
                 features = getattr(cls, 'features', {}).get('create_node', [])
                 is_implemented = len(features) >= 1
             else:
-                is_implemented = (id(driver_method) !=
-                                  id(base_method))
+                is_implemented = (id(driver_method) != id(base_method))
 
             result[name]['methods'][method_name] = is_implemented
 
@@ -467,5 +466,6 @@ def generate_tables():
         with open(supported_methods_path, 'w') as fp:
             fp.write(HEADER + '\n\n')
             fp.write(supported_methods)
+
 
 generate_tables()

--- a/contrib/generate_provider_logos_collage_image.py
+++ b/contrib/generate_provider_logos_collage_image.py
@@ -110,6 +110,7 @@ def main(input_path, output_path):
     assemble_final_image(resized_images=resized_images,
                          output_path=output_path)
 
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Assemble provider logos '
                                                  ' in a single image')

--- a/contrib/scrape-ec2-prices.py
+++ b/contrib/scrape-ec2-prices.py
@@ -163,11 +163,11 @@ def scrape_ec2_pricing():
     for url in LINUX_PRICING_URLS:
         response = requests.get(url)
 
-        if re.match('.*?\.json$', url):
+        if re.match(r'.*?\.json$', url):
             data = response.json()
-        elif re.match('.*?\.js$', url):
+        elif re.match(r'.*?\.js$', url):
             data = response.content
-            match = re.match('^.*callback\((.*?)\);?$', data,
+            match = re.match(r'^.*callback\((.*?)\);?$', data,
                              re.MULTILINE | re.DOTALL)
             data = match.group(1)
             # demjson supports non-strict mode and can parse unquoted objects

--- a/contrib/scrape-ec2-prices.py
+++ b/contrib/scrape-ec2-prices.py
@@ -24,7 +24,7 @@ import time
 from collections import defaultdict, OrderedDict
 
 import requests
-import demjson
+import demjson  # pylint: disable=import-error
 
 LINUX_PRICING_URLS = [
     # Deprecated instances (JSON format)

--- a/contrib/scrape-ec2-sizes.py
+++ b/contrib/scrape-ec2-sizes.py
@@ -34,8 +34,8 @@ import ijson
 FILEPATH = os.environ.get('TMP_JSON', '/tmp/ec.json')
 URL = "https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/index.json"
 IGNORED_FIELDS = ['locationType', 'operatingSystem']
-REG_STORAGE = re.compile('(\d+) x ([0-9,]+)')
-REG_BANDWIDTH = re.compile('\D*(\d+)\D*')
+REG_STORAGE = re.compile(r'(\d+) x ([0-9,]+)')
+REG_BANDWIDTH = re.compile(r'\D*(\d+)\D*')
 #  From <https://aws.amazon.com/marketplace/help/200777880>
 REGION_DETAILS = {
     # America

--- a/contrib/scrape-ec2-sizes.py
+++ b/contrib/scrape-ec2-sizes.py
@@ -29,7 +29,7 @@ import os
 import json
 
 import requests
-import ijson
+import ijson  # pylint: disable=import-error
 
 FILEPATH = os.environ.get('TMP_JSON', '/tmp/ec.json')
 URL = "https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/index.json"

--- a/contrib/update_google_prices.py
+++ b/contrib/update_google_prices.py
@@ -20,7 +20,6 @@ Loads Google Cloud Platform prices and updates the `pricing.json` data file.
 
 import os
 import json
-import simplejson
 import sys
 import time
 import urllib2
@@ -80,8 +79,8 @@ def main(argv):
 
     # Write updated price list.
     with open(PRICING_FILE_PATH, 'w') as libcloud_out:
-        json_str = simplejson.dumps(libcloud_data, indent=4 * ' ',
-                                    item_sort_key=utils.sortKeysNumerically)
+        json_str = json.dumps(libcloud_data, indent=4 * ' ',
+                              item_sort_key=utils.sortKeysNumerically)
         libcloud_out.write(json_str)
 
 

--- a/contrib/utils_test.py
+++ b/contrib/utils_test.py
@@ -16,9 +16,10 @@
 #
 ################################################################################
 
-import simplejson
 import unittest
 import utils
+
+import json
 
 
 class SplitStringToAlphaNumTest(unittest.TestCase):
@@ -56,8 +57,8 @@ class SortKeysNumericallyTest(unittest.TestCase):
 }\
 """
         self.assertEqual(
-            simplejson.dumps(input, indent=4 * ' ',
-                             item_sort_key=utils.sortKeysNumerically),
+            json.dumps(input, indent=4 * ' ',
+                       item_sort_key=utils.sortKeysNumerically),
             output)
 
 

--- a/demos/compute_demo.py
+++ b/demos/compute_demo.py
@@ -114,5 +114,6 @@ def main(argv):
         print("A fatal error occurred: " + e)
         return 1
 
+
 if __name__ == '__main__':
     sys.exit(main(sys.argv))

--- a/demos/example_aliyun_oss.py
+++ b/demos/example_aliyun_oss.py
@@ -68,6 +68,7 @@ def data_iter(limit):
         if i >= limit:
             break
 
+
 print('Starting to upload 1MB using multipart api')
 one_mb = 1024 * 1024
 obj = oss.upload_object_via_stream(data_iter(one_mb), c1, upload_object_name)

--- a/demos/gce_demo.py
+++ b/demos/gce_demo.py
@@ -48,7 +48,7 @@ import time
 
 try:
     import argparse
-except:
+except Exception:
     print('This script uses the python "argparse" module. Please use Python '
           '2.7 or greater.')
     raise
@@ -329,7 +329,7 @@ def clean_up(gce, base_name, node_list=None, resource_list=None):
             except ResourceNotFoundError:
                 display('   Not found: %s (%s)' % (resrc.name,
                                                    resrc.__class__.__name__))
-            except:
+            except Exception:
                 class_name = resrc.__class__.__name__
                 display('   Failed to Delete %s (%s)' % (resrc.name,
                                                          class_name))

--- a/demos/gce_demo.py
+++ b/demos/gce_demo.py
@@ -78,7 +78,8 @@ from libcloud.dns.providers import get_driver as get_driver_dns
 from libcloud.dns.base import Record, Zone
 from libcloud.utils.py3 import PY3
 if PY3:
-    import urllib.request as url_req  # pylint: disable=no-name-in-module
+    # pylint: disable=no-name-in-module,import-error
+    import urllib.request as url_req
 else:
     import urllib2 as url_req
 

--- a/docs/compute/drivers/exoscale.rst
+++ b/docs/compute/drivers/exoscale.rst
@@ -1,13 +1,13 @@
 Exoscale Computer Driver Documentation
 ======================================
 
-`Exoscale`_ is a public cloud provider based in Switzerland with data centers
-in Geneva, Switzerland.
+`Exoscale`_ is a public European cloud provider with data centers in Germany,
+Austria, and Switzerland.
 
 .. figure:: /_static/images/provider_logos/exoscale.png
     :align: center
     :width: 300
-    :target: https://www.exoscale.ch
+    :target: https://www.exoscale.com
 
 Exoscale driver is based on the CloudStack one and uses basic zones. For more
 information and CloudStack specific documentation, please refer to

--- a/docs/examples/compute/dimensiondata/Nodes_Create_mcp2_Uncustomised.py
+++ b/docs/examples/compute/dimensiondata/Nodes_Create_mcp2_Uncustomised.py
@@ -14,8 +14,8 @@ location = driver.ex_get_location_by_id(id='AU9')
 # Get network domain by location
 networkDomainName = "Test Apache Libcloud"
 network_domains = driver.ex_list_network_domains(location=location)
-my_network_domain = [d for d in network_domains if d.name ==
-                     networkDomainName][0]
+my_network_domain = [d for d in network_domains if
+                     d.name == networkDomainName][0]
 
 vlan = driver.ex_list_vlans(name='Libcloud Test VLAN')[0]
 

--- a/docs/examples/compute/nttcis/Firewall_Create_Complex_Firewall_Rule.py
+++ b/docs/examples/compute/nttcis/Firewall_Create_Complex_Firewall_Rule.py
@@ -14,8 +14,8 @@ location = driver.ex_get_location_by_id(id='EU6')
 # Get network domain by location
 networkDomainName = "sdk_test_1"
 network_domains = driver.ex_list_network_domains(location=location.id)
-my_network_domain = [d for d in network_domains if d.name ==
-                     networkDomainName][0]
+my_network_domain = [d for d in network_domains if
+                     d.name == networkDomainName][0]
 
 # Create an instance of NttCisFirewallAddress for source
 source_firewall_address = NttCisFirewallAddress(any_ip='ANY')

--- a/docs/examples/compute/nttcis/Nodes_Create_mcp2_Uncustomised.py
+++ b/docs/examples/compute/nttcis/Nodes_Create_mcp2_Uncustomised.py
@@ -14,8 +14,8 @@ location = driver.ex_get_location_by_id(id='EU7')
 # Get network domain by location
 networkDomainName = "Test Apache Libcloud"
 network_domains = driver.ex_list_network_domains(location=location)
-my_network_domain = [d for d in network_domains if d.name ==
-                     networkDomainName][0]
+my_network_domain = [d for d in network_domains if
+                     d.name == networkDomainName][0]
 
 vlan = driver.ex_list_vlans(name='Libcloud Test VLAN')[0]
 

--- a/docs/examples/misc/twisted_create_node.py
+++ b/docs/examples/misc/twisted_create_node.py
@@ -28,6 +28,7 @@ def _thread_create_node(name):
 def stop(*args, **kwargs):
     reactor.stop()
 
+
 d = create_node(name='my-lc-node')
 d.addCallback(stop)  # pylint: disable=no-member
 d.addErrback(stop)  # pylint: disable=no-member

--- a/docs/examples/storage/concurrent_file_download_using_gevent.py
+++ b/docs/examples/storage/concurrent_file_download_using_gevent.py
@@ -23,6 +23,7 @@ def download_obj(container, obj):
     print 'Downloading: %s to %s' % (obj.name, path)
     obj.download(destination_path=path)
 
+
 containers = driver.list_containers()
 
 jobs = []

--- a/docs/examples/storage/publish_static_website_on_cf.py
+++ b/docs/examples/storage/publish_static_website_on_cf.py
@@ -24,5 +24,5 @@ driver.ex_enable_static_website(container=container)
 driver.ex_set_error_page(container=container, file_name='error.html')
 driver.enable_container_cdn(container=container)
 
-print('All done you can view the website at: ' +
-      driver.get_container_cdn_url(container=container))
+print('All done you can view the website at: %s' % (
+      driver.get_container_cdn_url(container=container)))

--- a/integration/__main__.py
+++ b/integration/__main__.py
@@ -34,6 +34,7 @@ class IntegrationTest(unittest.TestCase):
         data = self.instance.ex_report_data()
         self.assertEqual(data, REPORT_DATA)
 
+
 if __name__ == '__main__':
     import libcloud
     with open('/tmp/testing.log', 'w') as f:

--- a/libcloud/__init__.py
+++ b/libcloud/__init__.py
@@ -82,4 +82,5 @@ def _init_once():
             paramiko_logger = paramiko.util.logging.getLogger()
             paramiko_logger.setLevel(logging.DEBUG)
 
+
 _init_once()

--- a/libcloud/common/aliyun.py
+++ b/libcloud/common/aliyun.py
@@ -64,7 +64,7 @@ class AliyunXmlResponse(XmlResponse):
                     body = ET.XML(self.body)
                 except ValueError:
                     body = ET.XML(self.body.encode('utf-8'))
-        except:
+        except Exception:
             raise MalformedResponseError('Failed to parse XML',
                                          body=self.body,
                                          driver=self.connection.driver)

--- a/libcloud/common/azure_arm.py
+++ b/libcloud/common/azure_arm.py
@@ -56,6 +56,7 @@ class AzureAuthJsonResponse(JsonResponse):
         else:
             return str(b)
 
+
 # Based on
 # https://github.com/Azure/azure-xplat-cli/blob/master/lib/util/profile/environment.js
 publicEnvironments = {

--- a/libcloud/common/base.py
+++ b/libcloud/common/base.py
@@ -202,7 +202,7 @@ class JsonResponse(Response):
 
         try:
             body = json.loads(self.body)
-        except:
+        except Exception:
             raise MalformedResponseError(
                 'Failed to parse JSON',
                 body=self.body,
@@ -227,7 +227,7 @@ class XmlResponse(Response):
             except ValueError:
                 # lxml wants a bytes and tests are basically hard-coded to str
                 body = ET.XML(self.body.encode('utf-8'))
-        except:
+        except Exception:
             raise MalformedResponseError('Failed to parse XML',
                                          body=self.body,
                                          driver=self.connection.driver)

--- a/libcloud/common/cloudstack.py
+++ b/libcloud/common/cloudstack.py
@@ -152,6 +152,7 @@ class CloudStackConnection(ConnectionUserAndKey, PollingConnection):
             params = {}
 
         params['command'] = command
+        # pylint: disable=maybe-no-member
         result = self.request(action=self.driver.path, params=params,
                               data=data, headers=headers, method=method)
 

--- a/libcloud/common/digitalocean.py
+++ b/libcloud/common/digitalocean.py
@@ -92,6 +92,7 @@ class DigitalOcean_v2_Connection(ConnectionKey):
         This method adds ``per_page`` to the request to reduce the total
         number of paginated requests to the API.
         """
+        # pylint: disable=maybe-no-member
         params['per_page'] = self.driver.ex_per_page
         return params
 
@@ -111,6 +112,7 @@ class DigitalOceanBaseDriver(BaseDriver):
     """
     DigitalOcean BaseDriver
     """
+
     name = 'DigitalOcean'
     website = 'https://www.digitalocean.com'
 

--- a/libcloud/common/google.py
+++ b/libcloud/common/google.py
@@ -237,7 +237,7 @@ class GoogleResponse(JsonResponse):
         json_error = False
         try:
             body = json.loads(self.body)
-        except:
+        except Exception:
             # If there is both a JSON parsing error and an unsuccessful http
             # response (like a 404), we want to raise the http error and not
             # the JSON one, so don't raise JsonParseError here.
@@ -721,7 +721,7 @@ class GoogleOAuth2Credential(object):
             with os.fdopen(os.open(filename, write_flags,
                                    int('600', 8)), 'w') as f:
                 f.write(data)
-        except:
+        except Exception:
             # Note: Failure to write (cache) token in a file is not fatal. It
             # simply means degraded performance since we will need to acquire a
             # new token each time script runs.

--- a/libcloud/common/linode.py
+++ b/libcloud/common/linode.py
@@ -117,7 +117,7 @@ class LinodeResponse(JsonResponse):
                 ret.append(obj["DATA"])
                 errs.extend(self._make_excp(e) for e in obj["ERRORARRAY"])
             return (ret, errs)
-        except:
+        except Exception:
             return (None, [self.invalid])
 
     def success(self):

--- a/libcloud/common/nttcis.py
+++ b/libcloud/common/nttcis.py
@@ -974,6 +974,7 @@ class NttCisFirewallRule(object):
                    self.protocol, self.source, self.destination,
                    self.enabled))
 
+
 """
 class NttCisFirewallAddress(object):
     The source or destination model in a firewall rule

--- a/libcloud/common/openstack.py
+++ b/libcloud/common/openstack.py
@@ -360,7 +360,7 @@ class OpenStackResponse(Response):
         if self.has_content_type('application/xml'):
             try:
                 return ET.XML(self.body)
-            except:
+            except Exception:
                 raise MalformedResponseError(
                     'Failed to parse XML',
                     body=self.body,
@@ -369,7 +369,7 @@ class OpenStackResponse(Response):
         elif self.has_content_type('application/json'):
             try:
                 return json.loads(self.body)
-            except:
+            except Exception:
                 raise MalformedResponseError(
                     'Failed to parse JSON',
                     body=self.body,

--- a/libcloud/common/openstack_identity.py
+++ b/libcloud/common/openstack_identity.py
@@ -553,7 +553,7 @@ class OpenStackAuthResponse(Response):
         if content_type == 'application/json':
             try:
                 data = json.loads(self.body)
-            except:
+            except Exception:
                 driver = OpenStackIdentityConnection
                 raise MalformedResponseError('Failed to parse JSON',
                                              body=self.body,

--- a/libcloud/compute/deployment.py
+++ b/libcloud/compute/deployment.py
@@ -118,7 +118,7 @@ class ScriptDeployment(Deployment):
     Runs an arbitrary shell script on the server.
 
     This step works by first writing the content of the shell script (script
-    argument) in a \*.sh file on a remote server and then running that file.
+    argument) in a *.sh file on a remote server and then running that file.
 
     If you are running a non-shell script, make sure to put the appropriate
     shebang to the top of the script. You are also advised to do that even if

--- a/libcloud/compute/drivers/azure.py
+++ b/libcloud/compute/drivers/azure.py
@@ -1351,7 +1351,7 @@ class AzureNodeDriver(NodeDriver):
         _affinity_group = res.hosted_service_properties.affinity_group
         _cloud_service_location = res.hosted_service_properties.location
 
-        if _affinity_group is not None and _affinity_group is not '':
+        if _affinity_group is not None and _affinity_group != '':
             return self.service_location(True, _affinity_group)
         elif _cloud_service_location is not None:
             return self.service_location(False, _cloud_service_location)
@@ -1932,6 +1932,7 @@ class AzureNodeDriver(NodeDriver):
             values = (response.error, response.body, response.status)
             message = 'Message: %s, Body: %s, Status code: %s' % (values)
             raise LibcloudError(message, driver=self)
+
 
 """
 XML Serializer
@@ -2867,6 +2868,7 @@ class AzureXmlSerializer(object):
 
             return xml
 
+
 """
 Data Classes
 
@@ -3501,6 +3503,7 @@ class AzureHTTPResponse(object):
         self.message = message
         self.headers = headers
         self.body = body
+
 
 """
 Helper classes and functions.

--- a/libcloud/compute/drivers/cloudsigma.py
+++ b/libcloud/compute/drivers/cloudsigma.py
@@ -1961,8 +1961,16 @@ class CloudSigma_2_0_NodeDriver(CloudSigmaNodeDriver):
         return subscriptions
 
     def _to_subscription(self, data):
-        start_time = parse_date(data['start_time'])
-        end_time = parse_date(data['end_time'])
+        if data.get('start_time', None):
+            start_time = parse_date(data['start_time'])
+        else:
+            start_time = None
+
+        if data.get('end_time', None):
+            end_time = parse_date(data['end_time'])
+        else:
+            end_time = None
+
         obj_uuid = data['subscribed_object']
 
         subscription = CloudSigmaSubscription(id=data['id'],

--- a/libcloud/compute/drivers/cloudsigma.py
+++ b/libcloud/compute/drivers/cloudsigma.py
@@ -25,7 +25,7 @@ import base64
 
 try:
     import simplejson as json
-except:
+except Exception:
     import json
 
 from libcloud.utils.py3 import b

--- a/libcloud/compute/drivers/dimensiondata.py
+++ b/libcloud/compute/drivers/dimensiondata.py
@@ -4366,7 +4366,7 @@ class DimensionDataNodeDriver(NodeDriver):
         location = list(filter(lambda x: x.id == location_id,
                                locations))[0]
         plan = findtext(element, 'type', TYPES_URN)
-        if plan is 'ESSENTIALS':
+        if plan == 'ESSENTIALS':
             plan_type = NetworkDomainServicePlan.ESSENTIALS
         else:
             plan_type = NetworkDomainServicePlan.ADVANCED
@@ -4425,11 +4425,11 @@ class DimensionDataNodeDriver(NodeDriver):
         return locations
 
     def _to_location(self, element):
-        l = NodeLocation(id=element.get('id'),
-                         name=findtext(element, 'displayName', TYPES_URN),
-                         country=findtext(element, 'country', TYPES_URN),
-                         driver=self)
-        return l
+        loc = NodeLocation(id=element.get('id'),
+                           name=findtext(element, 'displayName', TYPES_URN),
+                           country=findtext(element, 'country', TYPES_URN),
+                           driver=self)
+        return loc
 
     def _to_cpu_spec(self, element):
         return DimensionDataServerCpuSpecification(

--- a/libcloud/compute/drivers/dummy.py
+++ b/libcloud/compute/drivers/dummy.py
@@ -312,11 +312,11 @@ class DummyNodeDriver(NodeDriver):
 
         @inherits: :class:`NodeDriver.create_node`
         """
-        l = len(self.nl) + 1
-        n = Node(id=l,
-                 name='dummy-%d' % l,
+        num = len(self.nl) + 1
+        n = Node(id=num,
+                 name='dummy-%d' % (num),
                  state=NodeState.RUNNING,
-                 public_ips=['127.0.0.%d' % l],
+                 public_ips=['127.0.0.%d' % (num)],
                  private_ips=[],
                  driver=self,
                  size=NodeSize(id='s1', name='foo', ram=2048,
@@ -342,6 +342,7 @@ def _ip_to_int(ip):
 
 def _int_to_ip(ip):
     return socket.inet_ntoa(struct.pack('I', socket.ntohl(ip)))
+
 
 if __name__ == "__main__":
     import doctest

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -1208,7 +1208,7 @@ class EC2Response(AWSBaseResponse):
 
         try:
             body = ET.XML(self.body)
-        except:
+        except Exception:
             raise MalformedResponseError("Failed to parse XML",
                                          body=self.body, driver=EC2NodeDriver)
 
@@ -1774,12 +1774,13 @@ class BaseEC2NodeDriver(NodeDriver):
 
     def list_locations(self):
         locations = []
-        for index, availability_zone in \
-                enumerate(self.ex_list_availability_zones()):
-                    locations.append(EC2NodeLocation(
-                        index, availability_zone.name, self.country, self,
-                        availability_zone)
-                    )
+
+        iterator = enumerate(self.ex_list_availability_zones())
+        for index, availability_zone in iterator:
+            locations.append(EC2NodeLocation(
+                index, availability_zone.name, self.country, self,
+                availability_zone)
+            )
         return locations
 
     def list_volumes(self, node=None):

--- a/libcloud/compute/drivers/ecs.py
+++ b/libcloud/compute/drivers/ecs.py
@@ -1357,21 +1357,21 @@ class ECSDriver(NodeDriver):
         return self.get_image(image_id=image_id)
 
     def create_public_ip(self, instance_id):
-            """
-            Create public ip.
+        """
+        Create public ip.
 
-            :keyword instance_id: instance id for allocating public ip.
-            :type    instance_id: ``str``
+        :keyword instance_id: instance id for allocating public ip.
+        :type    instance_id: ``str``
 
-            :return public ip
-            :rtype ``str``
-            """
-            params = {'Action': 'AllocatePublicIpAddress',
-                      'InstanceId': instance_id}
+        :return public ip
+        :rtype ``str``
+        """
+        params = {'Action': 'AllocatePublicIpAddress',
+                  'InstanceId': instance_id}
 
-            resp = self.connection.request(self.path, params=params)
-            return findtext(resp.object, 'IpAddress',
-                            namespace=self.namespace)
+        resp = self.connection.request(self.path, params=params)
+        return findtext(resp.object, 'IpAddress',
+                        namespace=self.namespace)
 
     def _to_nodes(self, object):
         """

--- a/libcloud/compute/drivers/exoscale.py
+++ b/libcloud/compute/drivers/exoscale.py
@@ -24,8 +24,8 @@ __all__ = [
 class ExoscaleNodeDriver(CloudStackNodeDriver):
     type = Provider.EXOSCALE
     name = 'Exoscale'
-    website = 'https://www.exoscale.ch/'
+    website = 'https://www.exoscale.com/'
 
     # API endpoint info
-    host = 'api.exoscale.ch'
+    host = 'api.exoscale.com'
     path = '/compute'

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -333,7 +333,7 @@ class GCELicense(UuidMixin, LazyObject):
             request = '/global/licenses/%s' % self.name
             response = self.driver.connection.request(request,
                                                       method='GET').object
-        except:
+        except Exception:
             raise
         finally:
             # Restore the connection request_path
@@ -2315,7 +2315,7 @@ class GCENodeDriver(NodeDriver):
                 image_list.extend(
                     self.ex_list_project_images(ex_project=img_proj,
                                                 ex_include_deprecated=dep))
-            except:
+            except Exception:
                 # do not break if an OS type is invalid
                 pass
         return image_list
@@ -2360,7 +2360,7 @@ class GCENodeDriver(NodeDriver):
                 try:
                     response = self.connection.request(request,
                                                        method='GET').object
-                except:
+                except Exception:
                     raise
                 finally:
                     # Restore the connection request_path
@@ -6524,7 +6524,7 @@ class GCENodeDriver(NodeDriver):
 
                 try:
                     timestamp_to_datetime(value)
-                except:
+                except Exception:
                     raise ValueError('%s must be an RFC3339 timestamp' %
                                      attribute)
                 image_data[attribute] = value
@@ -8832,7 +8832,7 @@ class GCENodeDriver(NodeDriver):
                                        extra['zone'].name.split("-")[0])
             price = self._get_size_price(size_id=machine_type['name'])
             self.api_name = orig_api_name
-        except:
+        except Exception:
             price = None
 
         return GCENodeSize(id=machine_type['id'], name=machine_type['name'],

--- a/libcloud/compute/drivers/gogrid.py
+++ b/libcloud/compute/drivers/gogrid.py
@@ -112,7 +112,7 @@ class GoGridNodeDriver(BaseGoGridDriver, NodeDriver):
     def _get_state(self, element):
         try:
             return STATE[element['state']['name']]
-        except:
+        except Exception:
             pass
         return NodeState.UNKNOWN
 

--- a/libcloud/compute/drivers/gridspot.py
+++ b/libcloud/compute/drivers/gridspot.py
@@ -90,7 +90,7 @@ class GridspotNodeDriver(NodeDriver):
         if data[field]:
             try:
                 params[field] = int(data[field])
-            except:
+            except Exception:
                 pass
 
     def _to_node(self, data):

--- a/libcloud/compute/drivers/hostvirtual.py
+++ b/libcloud/compute/drivers/hostvirtual.py
@@ -443,7 +443,7 @@ class HostVirtualNodeDriver(NodeDriver):
             return False
         if fqdn[-1] == ".":
             fqdn = fqdn[:-1]
-        valid = re.compile("(?!-)[A-Z\d-]{1,63}(?<!-)$", re.IGNORECASE)
+        valid = re.compile(r"(?!-)[A-Z\d-]{1,63}(?<!-)$", re.IGNORECASE)
         if len(fqdn.split(".")) > 1:
             return all(valid.match(x) for x in fqdn.split("."))
         else:

--- a/libcloud/compute/drivers/joyent.py
+++ b/libcloud/compute/drivers/joyent.py
@@ -21,7 +21,7 @@ import base64
 
 try:
     import simplejson as json
-except:
+except Exception:
     import json
 
 from libcloud.utils.py3 import httplib

--- a/libcloud/compute/drivers/libvirt_driver.py
+++ b/libcloud/compute/drivers/libvirt_driver.py
@@ -403,7 +403,7 @@ class LibvirtNodeDriver(NodeDriver):
         :return: Dictionary from the parsing funtion
         :rtype: ``dict``
         """
-        arp_regex = re.compile('.*?\((.*?)\) at (.*?)\s+')
+        arp_regex = re.compile(r'.*?\((.*?)\) at (.*?)\s+')
         return self._parse_mac_addr_table(arp_output, arp_regex)
 
     def _parse_ip_table_neigh(self, ip_output):
@@ -414,7 +414,7 @@ class LibvirtNodeDriver(NodeDriver):
         :return: Dictionary from the parsing function
         :rtype: ``dict``
         """
-        ip_regex = re.compile('(.*?)\s+.*lladdr\s+(.*?)\s+')
+        ip_regex = re.compile(r'(.*?)\s+.*lladdr\s+(.*?)\s+')
         return self._parse_mac_addr_table(ip_output, ip_regex)
 
     def _parse_mac_addr_table(self, cmd_output, mac_regex):

--- a/libcloud/compute/drivers/linode.py
+++ b/libcloud/compute/drivers/linode.py
@@ -272,7 +272,7 @@ class LinodeNodeDriver(NodeDriver):
         # Swap size
         try:
             swap = 128 if "ex_swap" not in kwargs else int(kwargs["ex_swap"])
-        except:
+        except Exception:
             raise LinodeException(0xFB, "Need an integer swap size")
 
         # Root partition size

--- a/libcloud/compute/drivers/nttcis.py
+++ b/libcloud/compute/drivers/nttcis.py
@@ -5188,7 +5188,7 @@ class NttCisNodeDriver(NodeDriver):
         location = list(filter(lambda x: x.id == location_id,
                                locations))[0]
         plan = findtext(element, 'type', TYPES_URN)
-        if plan is 'ESSENTIALS':
+        if plan == 'ESSENTIALS':
             plan_type = NetworkDomainServicePlan.ESSENTIALS
         else:
             plan_type = NetworkDomainServicePlan.ADVANCED
@@ -5247,11 +5247,11 @@ class NttCisNodeDriver(NodeDriver):
         return locations
 
     def _to_location(self, element):
-        l = NodeLocation(id=element.get('id'),
-                         name=findtext(element, 'displayName', TYPES_URN),
-                         country=findtext(element, 'country', TYPES_URN),
-                         driver=self)
-        return l
+        loc = NodeLocation(id=element.get('id'),
+                           name=findtext(element, 'displayName', TYPES_URN),
+                           country=findtext(element, 'country', TYPES_URN),
+                           driver=self)
+        return loc
 
     def _to_cpu_spec(self, element):
         return NttCisServerCpuSpecification(

--- a/libcloud/compute/drivers/opennebula.py
+++ b/libcloud/compute/drivers/opennebula.py
@@ -1076,13 +1076,13 @@ class OpenNebula_3_2_NodeDriver(OpenNebula_3_0_NodeDriver):
         values = {}
 
         for attribute_name, attribute_type, alias in attributes:
-                key = alias if alias else attribute_name.upper()
-                value = element.findtext(key)
+            key = alias if alias else attribute_name.upper()
+            value = element.findtext(key)
 
-                if value is not None:
-                    value = attribute_type(value)
+            if value is not None:
+                value = attribute_type(value)
 
-                values[attribute_name] = value
+            values[attribute_name] = value
 
         return values
 

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -322,14 +322,19 @@ class OpenStackNodeDriver(NodeDriver, OpenStackDriverMixin):
         # when ex_node is not provided, volume is detached from all nodes
         failed_nodes = []
         for attachment in volume.extra['attachments']:
-            if not ex_node or ex_node.id == attachment['serverId']:
+            if not ex_node or ex_node.id in filter(None, (attachment.get(
+                'serverId'
+            ), attachment.get('server_id'))):
                 response = self.connection.request(
                     '/servers/%s/os-volume_attachments/%s' %
-                    (attachment['serverId'], attachment['id']),
+                    (attachment.get('serverId') or attachment['server_id'],
+                     attachment['id']),
                     method='DELETE')
 
                 if not response.success():
-                    failed_nodes.append(attachment['serverId'])
+                    failed_nodes.append(
+                        attachment.get('serverId') or attachment['server_id']
+                    )
         if failed_nodes:
             raise OpenStackException(
                 'detach_volume failed for nodes with id: %s' %

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -2204,7 +2204,7 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
 
                 try:
                     is_public_ip = is_public_subnet(ip)
-                except:
+                except Exception:
                     # IPv6
 
                     # Openstack Icehouse sets 'OS-EXT-IPS:type' to 'floating'

--- a/libcloud/compute/drivers/vcl.py
+++ b/libcloud/compute/drivers/vcl.py
@@ -300,6 +300,6 @@ class VCLNodeDriver(NodeDriver):
         )
         time = 0
         for i in res['requests']:
-                if i['requestid'] == node.id:
-                        time = i['end']
+            if i['requestid'] == node.id:
+                time = i['end']
         return time

--- a/libcloud/compute/drivers/vcloud.py
+++ b/libcloud/compute/drivers/vcloud.py
@@ -1735,7 +1735,7 @@ class VCloud_1_5_NodeDriver(VCloudNodeDriver):
                 "%s the VM script file does not exist" % vm_script)
         try:
             open(vm_script).read()
-        except:
+        except Exception:
             raise
         return vm_script
 
@@ -1915,7 +1915,7 @@ class VCloud_1_5_NodeDriver(VCloudNodeDriver):
         vms = self._get_vm_elements(vapp_or_vm_id)
         try:
             script = open(vm_script).read()
-        except:
+        except Exception:
             return
 
         # ElementTree escapes script characters automatically. Escape
@@ -1931,7 +1931,7 @@ class VCloud_1_5_NodeDriver(VCloudNodeDriver):
             try:
                 res.object.find(
                     fixxpath(res.object, 'CustomizationScript')).text = script
-            except:
+            except Exception:
                 # CustomizationScript section does not exist, insert it just
                 # before ComputerName
                 for i, e in enumerate(res.object):
@@ -1993,7 +1993,7 @@ class VCloud_1_5_NodeDriver(VCloudNodeDriver):
         try:
             res.object.find(
                 fixxpath(res.object, section)).text = text
-        except:
+        except Exception:
             # "section" section does not exist, insert it just
             # before "prev_section"
             for i, e in enumerate(res.object):
@@ -2334,5 +2334,5 @@ class VCloud_5_5_NodeDriver(VCloud_5_1_NodeDriver):
                 "port": res.object.find(fixxpath(res.object, 'Port')).text,
             }
             return output
-        except:
+        except Exception:
             return None

--- a/libcloud/compute/drivers/voxel.py
+++ b/libcloud/compute/drivers/voxel.py
@@ -99,6 +99,7 @@ class VoxelConnection(ConnectionUserAndKey):
         params['api_sig'] = md5.hexdigest()
         return params
 
+
 VOXEL_INSTANCE_TYPES = {}
 RAM_PER_CPU = 2048
 

--- a/libcloud/container/drivers/docker.py
+++ b/libcloud/container/drivers/docker.py
@@ -21,7 +21,7 @@ import os
 
 try:
     import simplejson as json
-except:
+except Exception:
     import json
 
 from libcloud.utils.py3 import httplib
@@ -308,7 +308,7 @@ class DockerContainerDriver(ContainerDriver):
         for image in result:
             try:
                 name = image.get('RepoTags')[0]
-            except:
+            except Exception:
                 name = image.get('Id')
             images.append(ContainerImage(
                 id=image.get('Id'),
@@ -682,10 +682,10 @@ class DockerContainerDriver(ContainerDriver):
         """
         try:
             name = data.get('Name').strip('/')
-        except:
+        except Exception:
             try:
                 name = data.get('Names')[0].strip('/')
-            except:
+            except Exception:
                 name = data.get('Id')
         state = data.get('State')
         if isinstance(state, dict):

--- a/libcloud/container/drivers/dummy.py
+++ b/libcloud/container/drivers/dummy.py
@@ -41,6 +41,7 @@ class DummyContainerDriver(ContainerDriver):
         :rtype: ``None``
         """
 
+
 if __name__ == "__main__":
     import doctest
     doctest.testmod()

--- a/libcloud/container/drivers/kubernetes.py
+++ b/libcloud/container/drivers/kubernetes.py
@@ -18,7 +18,7 @@ import datetime
 
 try:
     import simplejson as json
-except:
+except Exception:
     import json
 
 from libcloud.utils.py3 import httplib

--- a/libcloud/container/drivers/rancher.py
+++ b/libcloud/container/drivers/rancher.py
@@ -17,7 +17,7 @@ import base64
 
 try:
     import simplejson as json
-except:
+except Exception:
     import json
 
 from libcloud.utils.py3 import httplib, urlparse

--- a/libcloud/dns/drivers/digitalocean.py
+++ b/libcloud/dns/drivers/digitalocean.py
@@ -125,7 +125,7 @@ class DigitalOceanDNSDriver(DigitalOcean_v2_BaseDriver, DNSDriver):
         params = {'name': domain}
         try:
             params['ip_address'] = extra['ip']
-        except:
+        except Exception:
             params['ip_address'] = '127.0.0.1'
 
         res = self.connection.request('/v2/domains', params=params,

--- a/libcloud/dns/drivers/godaddy.py
+++ b/libcloud/dns/drivers/godaddy.py
@@ -18,7 +18,7 @@ __all__ = [
 
 try:
     import simplejson as json
-except:
+except Exception:
     import json
 
 from libcloud.common.base import ConnectionKey, JsonResponse

--- a/libcloud/dns/drivers/hostvirtual.py
+++ b/libcloud/dns/drivers/hostvirtual.py
@@ -20,7 +20,7 @@ import sys
 
 try:
     import simplejson as json
-except:
+except Exception:
     import json
 
 from libcloud.utils.py3 import httplib

--- a/libcloud/dns/drivers/onapp.py
+++ b/libcloud/dns/drivers/onapp.py
@@ -252,7 +252,7 @@ class OnAppDNSDriver(DNSDriver):
     #
 
     def _format_record(self, name, type, data, extra):
-        if name is '':
+        if name == '':
             name = '@'
         if extra is None:
             extra = {}

--- a/libcloud/dns/drivers/rackspace.py
+++ b/libcloud/dns/drivers/rackspace.py
@@ -82,8 +82,8 @@ class RackspaceDNSConnection(OpenStack_1_1_Connection, PollingConnection):
     _auth_version = '2.0'
 
     def __init__(self, *args, **kwargs):
-            self.region = kwargs.pop('region', None)
-            super(RackspaceDNSConnection, self).__init__(*args, **kwargs)
+        self.region = kwargs.pop('region', None)
+        super(RackspaceDNSConnection, self).__init__(*args, **kwargs)
 
     def get_poll_request_kwargs(self, response, context, request_kwargs):
         job_id = response.object['jobId']

--- a/libcloud/dns/drivers/zerigo.py
+++ b/libcloud/dns/drivers/zerigo.py
@@ -81,7 +81,7 @@ class ZerigoDNSResponse(XmlResponse):
         elif status != 503:
             try:
                 body = ET.XML(self.body)
-            except:
+            except Exception:
                 raise MalformedResponseError('Failed to parse XML',
                                              body=self.body)
 

--- a/libcloud/loadbalancer/drivers/gce.py
+++ b/libcloud/loadbalancer/drivers/gce.py
@@ -168,7 +168,7 @@ class GCELBDriver(Driver):
             forwarding_rule = self.gce.ex_create_forwarding_rule(
                 name, targetpool, region=ex_region, protocol=protocol,
                 port_range=port, address=ex_address)
-        except:
+        except Exception:
             targetpool.destroy()
             raise
 

--- a/libcloud/loadbalancer/drivers/softlayer.py
+++ b/libcloud/loadbalancer/drivers/softlayer.py
@@ -355,7 +355,7 @@ class SoftlayerLBDriver(Driver):
     def _to_lb_package(self, pkg):
         try:
             price_id = pkg['prices'][0]['id']
-        except:
+        except Exception:
             price_id = -1
 
         capacity = int(pkg.get('capacity', 0))
@@ -404,7 +404,7 @@ class SoftlayerLBDriver(Driver):
                 try:
                     extra['algorithm'] = self.\
                         _value_to_algorithm(routing_method)
-                except:
+                except Exception:
                     pass
                 extra['protocol'] = routing_type.lower()
 

--- a/libcloud/storage/drivers/atmos.py
+++ b/libcloud/storage/drivers/atmos.py
@@ -91,8 +91,9 @@ class AtmosConnection(ConnectionUserAndKey):
 
     def _calculate_signature(self, params, headers):
         pathstring = urlunquote(self.action)
-        if pathstring.startswith(self.driver.path):
-            pathstring = pathstring[len(self.driver.path):]
+        driver_path = self.driver.path  # pylint: disable=no-member
+        if pathstring.startswith(driver_path):
+            pathstring = pathstring[len(driver_path):]
         if params:
             if type(params) is dict:
                 params = list(params.items())

--- a/libcloud/storage/drivers/cloudfiles.py
+++ b/libcloud/storage/drivers/cloudfiles.py
@@ -83,7 +83,7 @@ class CloudFilesResponse(Response):
         if content_type == 'application/json':
             try:
                 data = json.loads(self.body)
-            except:
+            except Exception:
                 raise MalformedResponseError('Failed to parse JSON',
                                              body=self.body,
                                              driver=CloudFilesStorageDriver)

--- a/libcloud/storage/drivers/dummy.py
+++ b/libcloud/storage/drivers/dummy.py
@@ -492,6 +492,7 @@ class DummyStorageDriver(StorageDriver):
         self._containers[container.name]['objects'][object_name] = obj
         return obj
 
+
 if __name__ == "__main__":
     import doctest
     doctest.testmod()

--- a/libcloud/storage/drivers/local.py
+++ b/libcloud/storage/drivers/local.py
@@ -330,7 +330,7 @@ class LocalStorageDriver(StorageDriver):
             try:
                 obj_file = open(path, 'w')
                 obj_file.close()
-            except:
+            except Exception:
                 return False
 
         return True

--- a/libcloud/storage/drivers/oss.py
+++ b/libcloud/storage/drivers/oss.py
@@ -207,6 +207,8 @@ class OSSConnection(ConnectionUserAndKey):
             path = '/%s%s' % (self._container.name, self.action)
         else:
             path = self.action
+
+        # pylint: disable=no-member
         params['Signature'] = self._get_auth_signature(
             method=self.method, headers=headers, params=params,
             expires=params['Expires'], secret_key=self.key, path=path,

--- a/libcloud/storage/drivers/oss.py
+++ b/libcloud/storage/drivers/oss.py
@@ -91,7 +91,7 @@ class OSSResponse(XmlResponse):
                 body = ET.XML(self.body.encode('utf-8'), parser=parser)
             else:
                 body = ET.XML(self.body)
-        except:
+        except Exception:
             raise MalformedResponseError('Failed to parse XML',
                                          body=self.body,
                                          driver=self.connection.driver)

--- a/libcloud/storage/drivers/s3.py
+++ b/libcloud/storage/drivers/s3.py
@@ -170,6 +170,7 @@ class BaseS3Connection(ConnectionUserAndKey):
         return params
 
     def pre_connect_hook(self, params, headers):
+        # pylint: disable=no-member
         params['Signature'] = self.get_auth_signature(
             method=self.method, headers=headers, params=params,
             expires=params['Expires'], secret_key=self.key, path=self.action,

--- a/libcloud/test/common/test_base.py
+++ b/libcloud/test/common/test_base.py
@@ -71,7 +71,7 @@ class ErrorResponseTest(LibcloudTestCase):
             Response(resp_mock, mock.MagicMock())
         except RateLimitReachedError as e:
             self.assertEqual(e.retry_after, 120)
-        except:
+        except Exception:
             # We should have got a RateLimitReachedError
             self.fail("Catched exception should have been RateLimitReachedError")
         else:

--- a/libcloud/test/common/test_openstack_identity.py
+++ b/libcloud/test/common/test_openstack_identity.py
@@ -93,7 +93,7 @@ class OpenStackIdentityConnectionTestCase(unittest.TestCase):
 
                 try:
                     osa = osa.authenticate()
-                except:
+                except Exception:
                     pass
 
                 if (should_append_default_path == APPEND):

--- a/libcloud/test/compute/fixtures/cloudsigma_2_0/subscriptions.json
+++ b/libcloud/test/compute/fixtures/cloudsigma_2_0/subscriptions.json
@@ -99,6 +99,25 @@
             "status": "active",
             "subscribed_object": null,
             "uuid": "8965ff95-4924-40a9-b923-a58615149732"
+        },
+        {
+            "amount": "32212254720",
+            "auto_renew": true,
+            "descendants": [],
+            "discount_amount": null,
+            "discount_percent": null,
+            "end_time": "",
+            "id": "5555",
+            "last_notification": null,
+            "period": "365 days, 0:00:00",
+            "price": "0E-20",
+            "remaining": "32212254720",
+            "resource": "dssd",
+            "resource_uri": "/api/2.0/subscriptions/3987/",
+            "start_time": null,
+            "status": "active",
+            "subscribed_object": null,
+            "uuid": "8965ff95-4924-40a9-b923-a58615149732"
         }
     ],
     "price": "0E-20"

--- a/libcloud/test/compute/fixtures/openstack_v1.1/_v2_0__volume_abc6a3a1_c4ce_40f6_9b9f_07a61508938d.json
+++ b/libcloud/test/compute/fixtures/openstack_v1.1/_v2_0__volume_abc6a3a1_c4ce_40f6_9b9f_07a61508938d.json
@@ -1,0 +1,22 @@
+{
+    "volume": {
+        "attachments": [
+            {
+                "device": "/dev/vdb",
+                "id": "cd76a3a1-c4ce-40f6-9b9f-07a61508938d",
+                "server_id": "12065",
+                "volume_id": "cd76a3a1-c4ce-40f6-9b9f-07a61508938d"
+            }
+        ],
+        "availability_zone": "nova",
+        "created_at": "2013-06-24T11:20:13.000000",
+        "display_description": "",
+        "display_name": "test_volume_2",
+        "id": "cd76a3a1-c4ce-40f6-9b9f-07a61508938d",
+        "metadata": {},
+        "size": 2,
+        "snapshot_id": null,
+        "status": "in-use",
+        "volume_type": "None"
+    }
+}

--- a/libcloud/test/compute/test_cloudsigma_v2_0.py
+++ b/libcloud/test/compute/test_cloudsigma_v2_0.py
@@ -17,7 +17,7 @@ import sys
 
 try:
     import simplejson as json
-except:
+except Exception:
     import json
 
 from libcloud.utils.py3 import httplib

--- a/libcloud/test/compute/test_cloudsigma_v2_0.py
+++ b/libcloud/test/compute/test_cloudsigma_v2_0.py
@@ -355,14 +355,20 @@ class CloudSigmaAPI20BaseTestCase(object):
     def test_ex_list_subscriptions(self):
         subscriptions = self.driver.ex_list_subscriptions()
 
+        self.assertEqual(len(subscriptions), 6)
+
         subscription = subscriptions[0]
-        self.assertEqual(len(subscriptions), 5)
         self.assertEqual(subscription.id, '7272')
         self.assertEqual(subscription.resource, 'vlan')
         self.assertEqual(subscription.amount, 1)
         self.assertEqual(subscription.period, '345 days, 0:00:00')
         self.assertEqual(subscription.status, 'active')
         self.assertEqual(subscription.price, '0E-20')
+
+        subscription = subscriptions[-1]
+        self.assertEqual(subscription.id, '5555')
+        self.assertEqual(subscription.start_time, None)
+        self.assertEqual(subscription.end_time, None)
 
     def test_ex_create_subscription(self):
         CloudSigmaMockHttp.type = 'CREATE_SUBSCRIPTION'

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -81,7 +81,7 @@ class BaseEC2Tests(LibcloudTestCase):
                 sizes = driver.list_sizes()
                 if no_pricing:
                     self.assertTrue(all([s.price is None for s in sizes]))
-            except:
+            except Exception:
                 unsupported_regions.append(region)
 
         if unsupported_regions:

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -1989,6 +1989,14 @@ class OpenStack_2_Tests(OpenStack_1_1_Tests):
         self.assertFalse("display_name" in kwargs["data"]["snapshot"])
         self.assertFalse("display_description" in kwargs["data"]["snapshot"])
 
+    def test_detach_volume(self):
+        node = self.driver.list_nodes()[0]
+        volume = self.driver.ex_get_volume(
+            'abc6a3a1-c4ce-40f6-9b9f-07a61508938d')
+        self.assertEqual(
+            self.driver.attach_volume(node, volume, '/dev/sdb'), True)
+        self.assertEqual(self.driver.detach_volume(volume), True)
+
 
 class OpenStack_1_1_FactoryMethodTests(OpenStack_1_1_Tests):
     should_list_locations = False
@@ -2511,7 +2519,15 @@ class OpenStack_1_1_MockHttp(MockHttp, unittest.TestCase):
         if method == 'DELETE':
             body = ''
             return (httplib.NO_CONTENT, body, self.json_content_headers, httplib.responses[httplib.OK])
-    
+
+    def _v2_1337_volumes_abc6a3a1_c4ce_40f6_9b9f_07a61508938d(self, method, url, body, headers):
+        if method == 'GET':
+            body = self.fixtures.load('_v2_0__volume_abc6a3a1_c4ce_40f6_9b9f_07a61508938d.json')
+            return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
+        if method == 'DELETE':
+            body = ''
+            return (httplib.NO_CONTENT, body, self.json_content_headers, httplib.responses[httplib.OK])
+
     def _v2_1337_snapshots_detail(self, method, url, body, headers):
         if ('unit_test=paginate' in url and 'marker' not in url) or \
                 'unit_test=pagination_loop' in url:

--- a/libcloud/test/container/test_ecs.py
+++ b/libcloud/test/container/test_ecs.py
@@ -188,9 +188,13 @@ class ECSMockHttp(MockHttp):
         'GetAuthorizationToken': 'getauthorizationtoken.json'
     }
 
-    def root(
-            self, method, url, body, headers):
+    def root(self, method, url, body, headers):
         target = headers['x-amz-target']
+
+        # Workaround for host not being correctly set for the tests
+        if '%s' in self.host:
+            self.host = self.host % ('region')
+
         if target is not None:
             type = target.split('.')[-1]
             if type is None or self.fixture_map.get(type) is None:

--- a/libcloud/test/dns/test_auroradns.py
+++ b/libcloud/test/dns/test_auroradns.py
@@ -167,7 +167,7 @@ class AuroraDNSDriverTests(LibcloudTestCase):
             self.fail('expected a ZoneDoesNotExistError')
         except ZoneDoesNotExistError:
             pass
-        except:
+        except Exception:
             raise
 
     def test_delete_zone_non_exist(self):
@@ -178,7 +178,7 @@ class AuroraDNSDriverTests(LibcloudTestCase):
             self.fail('expected a ZoneDoesNotExistError')
         except ZoneDoesNotExistError:
             pass
-        except:
+        except Exception:
             raise
 
     def test_create_zone_already_exist(self):
@@ -187,7 +187,7 @@ class AuroraDNSDriverTests(LibcloudTestCase):
             self.fail('expected a ZoneAlreadyExistsError')
         except ZoneAlreadyExistsError:
             pass
-        except:
+        except Exception:
             raise
 
     def test_list_records_non_exist(self):
@@ -198,7 +198,7 @@ class AuroraDNSDriverTests(LibcloudTestCase):
             self.fail('expected a ZoneDoesNotExistError')
         except ZoneDoesNotExistError:
             pass
-        except:
+        except Exception:
             raise
 
     def test_get_record_non_exist(self):
@@ -207,7 +207,7 @@ class AuroraDNSDriverTests(LibcloudTestCase):
             self.fail('expected a RecordDoesNotExistError')
         except RecordDoesNotExistError:
             pass
-        except:
+        except Exception:
             raise
 
     def test_create_health_check(self):

--- a/libcloud/test/storage/test_cloudfiles.py
+++ b/libcloud/test/storage/test_cloudfiles.py
@@ -72,7 +72,7 @@ class CloudFilesTests(unittest.TestCase):
 
         try:
             driver.list_containers()
-        except:
+        except Exception:
             e = sys.exc_info()[1]
             self.assertEqual(e.value, 'Could not find specified endpoint')
         else:

--- a/libcloud/test/storage/test_s3.py
+++ b/libcloud/test/storage/test_s3.py
@@ -315,7 +315,7 @@ class S3MockHttp(MockHttp):
             except ValueError:
                 # lxml wants a bytes and tests are basically hard-coded to str
                 body = ET.XML(self.body.encode('utf-8'))
-        except:
+        except Exception:
             raise MalformedResponseError("Failed to parse XML",
                                          body=self.body,
                                          driver=self.connection.driver)

--- a/libcloud/utils/iso8601.py
+++ b/libcloud/utils/iso8601.py
@@ -117,8 +117,9 @@ def parse_date(datestring, default_timezone=UTC):
     default timezone specified in default_timezone is used. This is UTC by
     default.
     """
-    if datestring is None:
-        datestring = "9999-01-01T12:00:00+00:00"
+    if not datestring:
+        raise ValueError('datestring must be valid date string and not None')
+
     m = ISO8601_REGEX.match(datestring)
     if not m:
         raise ParseError("Unable to parse date string %r" % datestring)

--- a/libcloud/utils/iso8601.py
+++ b/libcloud/utils/iso8601.py
@@ -46,6 +46,7 @@ TIMEZONE_REGEX = re.compile("(?P<prefix>[+-])(?P<hours>[0-9]{2}).(?P<minutes>[0-
 class ParseError(Exception):
     """Raised when there is a problem parsing a date string"""
 
+
 # Yoinked from python docs
 ZERO = timedelta(0)
 
@@ -62,6 +63,8 @@ class Utc(tzinfo):
 
     def dst(self, dt):
         return ZERO
+
+
 UTC = Utc()
 
 

--- a/libcloud/utils/iso8601.py
+++ b/libcloud/utils/iso8601.py
@@ -114,6 +114,8 @@ def parse_date(datestring, default_timezone=UTC):
     default timezone specified in default_timezone is used. This is UTC by
     default.
     """
+    if datestring is None:
+        datestring = "9999-01-01T12:00:00+00:00"
     m = ISO8601_REGEX.match(datestring)
     if not m:
         raise ParseError("Unable to parse date string %r" % datestring)

--- a/libcloud/utils/loggingconnection.py
+++ b/libcloud/utils/loggingconnection.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import
 
 try:
     import simplejson as json
-except:
+except Exception:
     import json
 
 from pipes import quote as pquote
@@ -70,7 +70,7 @@ class LoggingConnection(LibcloudConnection):
             try:
                 body = json.loads(body.decode('utf-8'))
                 body = json.dumps(body, sort_keys=True, indent=4)
-            except:
+            except Exception:
                 # Invalid JSON or server is lying about content-type
                 pass
         elif pretty_print and content_type == 'text/xml':

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,6 +1,6 @@
 pep8>=1.7.0,<1.8
 flake8==3.7.7
-astroid==1.6.5
+astroid==1.6.6
 pylint==1.9.4
 mock==3.0.5
 codecov

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,8 +1,8 @@
 pep8>=1.7.0,<1.8
-flake8>=2.5.1,<2.6
-astroid>=1.4.5,<1.5
-pylint>=1.5.5,<1.6
-mock>=1.0.1,<1.1
+flake8==3.7.7
+astroid==1.6.5
+pylint==1.9.4
+mock==3.0.5
 codecov
 coverage<4.0
 requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,4 +13,4 @@ testpaths=libcloud/test
 
 [flake8]
 exclude=libcloud/compute/constants.py,libcloud/test
-ignore=E402
+ignore=E402,W503,W504

--- a/tox.ini
+++ b/tox.ini
@@ -88,8 +88,8 @@ commands = flake8 libcloud/
            flake8 --max-line-length=160 libcloud/test/
            flake8 demos/
            flake8 integration/
-           flake8 --ignore=E402,E902 docs/examples/
-           flake8 --ignore=E402,E902 --max-line-length=160 contrib/
+           flake8 --ignore=E402,E902,W503,W504 docs/examples/
+           flake8 --ignore=E402,E902,W503,W504 --max-line-length=160 contrib/
            python -mjson.tool libcloud/data/pricing.json /dev/null
            rstcheck --report warning README.rst
            rstcheck --report warning CHANGES.rst

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps =
     lockfile
     libvirt-python==4.0.0
     py2.7: paramiko
+    py3.7: setuptools==41.0.1
 commands = cp libcloud/test/secrets.py-dist libcloud/test/secrets.py
            python setup.py test
 basepython =


### PR DESCRIPTION
…_subscription_includes_free_tier_resources

## Title

CloudSigma provider ex_list_subscriptions() fails if your subscription includes free tier resources

### Description

When using driver.ex_list_subscriptions(status='all', resources=None) to list your resources, you'll receive the error:

  File "../libcloud/2.4.0/lib/python3.5/site-packages/libcloud/utils/iso8601.py", line 117, in parse_date
    m = ISO8601_REGEX.match(datestring)
TypeError: expected string or bytes-like object

CloudSigma gave some free resources to their customers a few years ago.

CloudSigmaSubscription id=free_mem, resource=mem, amount=1073741824, period=None, object_uuid=None
CloudSigmaSubscription id=free_dssd, resource=dssd, amount=53687091200, period=None, object_uuid=None

I suspect these are the problem resources with no end time.

I've added to iso8601.py on lines 117 and 118:

    if datestring is None:
        datestring = "9999-01-01T12:00:00+00:00"

Not sure if this is an appropriate fix but seems to fix it.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
