### PR TITLE
Scaleway driver fixes

### DIFF
--- a/libcloud/compute/drivers/scaleway.py
+++ b/libcloud/compute/drivers/scaleway.py
@@ -104,7 +104,7 @@ class ScalewayConnection(ConnectionUserAndKey):
         while links and 'next' in links:
             next = self.request(links['next']['url'], data=data,
                                 headers=headers, method=method,
-                                raw=raw, stream=stream).object
+                                raw=raw, stream=stream, region=region).object
             links = self.connection.getresponse().links
             merged = {root: child + next[root]
                       for root, child in list(results.items())}
@@ -169,6 +169,8 @@ class ScalewayNodeDriver(NodeDriver):
         :return: list of node size objects
         :rtype: ``list`` of :class:`.NodeSize`
         """
+        if region is None:
+            region = self.region
         response = self.connection._request_paged('/products/servers',
                                                   region=region)
         sizes = response['servers']
@@ -222,6 +224,8 @@ class ScalewayNodeDriver(NodeDriver):
         :return: list of image objects
         :rtype: ``list`` of :class:`.NodeImage`
         """
+        if region is None:
+            region = self.region
         response = self.connection._request_paged('/images', region=region)
         images = response['images']
         return [self._to_image(image) for image in images]
@@ -243,6 +247,8 @@ class ScalewayNodeDriver(NodeDriver):
         :return: the newly created image object
         :rtype: :class:`.NodeImage`
         """
+        if region is None:
+            region = self.region
         data = {
             'organization': self.key,
             'name': name,
@@ -269,6 +275,8 @@ class ScalewayNodeDriver(NodeDriver):
         :return: True if the image was deleted, otherwise False
         :rtype: ``bool``
         """
+        if region is None:
+            region = self.region
         return self.connection.request('/images/%s' % node_image.id,
                                        region=region,
                                        method='DELETE').success()
@@ -287,6 +295,8 @@ class ScalewayNodeDriver(NodeDriver):
         :return: the requested image object
         :rtype: :class:`.NodeImage`
         """
+        if region is None:
+            region = self.region
         response = self.connection.request('/images/%s' % image_id,
                                            region=region)
         image = response.object['image']
@@ -317,6 +327,8 @@ class ScalewayNodeDriver(NodeDriver):
         :return: list of node objects
         :rtype: ``list`` of :class:`.Node`
         """
+        if region is None:
+            region = self.region
         response = self.connection._request_paged('/servers', region=region)
         servers = response['servers']
         return [self._to_node(server) for server in servers]
@@ -403,6 +415,9 @@ class ScalewayNodeDriver(NodeDriver):
                        (size.id, range, allocate_space)),
                 http_code=400, driver=self)
 
+        # no volumes in API
+        data.pop('volumes')
+
         response = self.connection.request('/servers', data=json.dumps(data),
                                            region=region, method='POST')
         server = response.object['server']
@@ -416,6 +431,8 @@ class ScalewayNodeDriver(NodeDriver):
         return node
 
     def _action(self, server_id, action, region=None):
+        if region is None:
+            region = self.region
         return self.connection.request('/servers/%s/action' % server_id,
                                        region=region,
                                        data=json.dumps({'action': action}),
@@ -456,6 +473,8 @@ class ScalewayNodeDriver(NodeDriver):
         :return: A list of volume objects.
         :rtype: ``list`` of :class:`StorageVolume`
         """
+        if region is None:
+            region = self.region
         response = self.connection._request_paged('/volumes', region=region)
         volumes = response['volumes']
         return [self._to_volume(volume) for volume in volumes]
@@ -483,6 +502,8 @@ class ScalewayNodeDriver(NodeDriver):
         (if None, use default region specified in __init__)
         :type region: :class:`.NodeLocation`
         """
+        if region is None:
+            region = self.region
         response = self.connection._request_paged('/snapshots', region=region)
         snapshots = filter(lambda s: s['base_volume']['id'] == volume.id,
                            response['snapshots'])
@@ -519,6 +540,8 @@ class ScalewayNodeDriver(NodeDriver):
         :return: The newly created volume.
         :rtype: :class:`StorageVolume`
         """
+        if region is None:
+            region = self.region
         data = {
             'name': name,
             'organization': self.key,
@@ -549,6 +572,8 @@ class ScalewayNodeDriver(NodeDriver):
         :return: The newly created snapshot.
         :rtype: :class:`VolumeSnapshot`
         """
+        if region is None:
+            region = self.region
         data = {
             'name': name,
             'organization': self.key,
@@ -575,6 +600,8 @@ class ScalewayNodeDriver(NodeDriver):
         :return: True if the destroy was successful, otherwise False
         :rtype: ``bool``
         """
+        if region is None:
+            region = self.region
         return self.connection.request('/volumes/%s' % volume.id,
                                        region=region,
                                        method='DELETE').success()
@@ -593,6 +620,8 @@ class ScalewayNodeDriver(NodeDriver):
         :return: True if the destroy was successful, otherwise False
         :rtype: ``bool``
         """
+        if region is None:
+            region = self.region
         return self.connection.request('/snapshots/%s' % snapshot.id,
                                        region=region,
                                        method='DELETE').success()

--- a/libcloud/compute/drivers/scaleway.py
+++ b/libcloud/compute/drivers/scaleway.py
@@ -322,7 +322,7 @@ class ScalewayNodeDriver(NodeDriver):
         extra = {
             'arch': image['arch'],
             'size': _to_lib_size(image.get('root_volume', {})
-                                      .get('size', 0)) or 50,
+                                 .get('size', 0)) or 50,
             'creation_date': parse_date(image['creation_date']),
             'modification_date': parse_date(image['modification_date']),
             'organization': image['organization'],
@@ -367,7 +367,7 @@ class ScalewayNodeDriver(NodeDriver):
                     created_at=parse_date(server['creation_date']))
 
     def create_node(self, name, size, image, ex_volumes=None, ex_tags=None,
-                    region=None):
+                    region=None, **kwargs):
         """
         Create a new node.
 
@@ -659,6 +659,17 @@ class ScalewayNodeDriver(NodeDriver):
                         public_key=' '.join(key['key'].split(' ')[:2]),
                         fingerprint=key['fingerprint'],
                         driver=self) for key in keys]
+
+    def get_key_pair(self, name):
+        """
+        Retrieve a single key pair.
+
+        :param name: Name of the key pair to retrieve.
+        :type name: ``str``
+
+        :rtype: :class:`.KeyPair`
+        """
+        return [k for k in self.list_key_pairs() if k.name == name][0]
 
     def import_key_pair_from_string(self, name, key_material):
         """

--- a/libcloud/compute/drivers/scaleway.py
+++ b/libcloud/compute/drivers/scaleway.py
@@ -74,14 +74,15 @@ class ScalewayConnection(ConnectionUserAndKey):
 
     def request(self, action, params=None, data=None, headers=None,
                 method='GET', raw=False, stream=False, region=None):
-        if region:
-            old_host = self.host
+        old_host = self.host
+        if region is None:
+            self.host = SCALEWAY_API_HOSTS['default']
+        else:
             self.host = SCALEWAY_API_HOSTS[region.id
                                            if isinstance(region, NodeLocation)
                                            else region]
-            if not self.host == old_host:
-                self.connect()
-
+        if not self.host == old_host:
+            self.connect()
         return super(ScalewayConnection, self).request(action, params, data,
                                                        headers, method, raw,
                                                        stream)


### PR DESCRIPTION
## Scaleway driver fixes

### Description

This PR fixes several problems that blocked Scaleway driver from using in the wild, namely:
1. Rewritten Request logic in such a way that it reconnects after host is changed. In present, if host variable changes to None, connection is not re-established, leading to crash after the following code:
```
driver = ScalewayNodeDriver(key=XXX, secret=XXX)
keys = driver.list_key_pairs()
servers = driver.list_servers()  
```
2. Implemented the code to get the organization from the API, as organization and key are two different entities
3. Implemented region choice at Driver level
4. Implemeted get_key_pair method
 
### Status

- done, ready for review

### Checklist (tick everything that applies)

- [X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
