### PR TITLE
[LIBCLOUD-1043] Fix Azure upload_object_via_stream used with iter

### DIFF
--- a/libcloud/storage/drivers/azure_blobs.py
+++ b/libcloud/storage/drivers/azure_blobs.py
@@ -18,6 +18,7 @@ from __future__ import with_statement
 import base64
 import os
 import binascii
+from io import BytesIO
 
 from libcloud.utils.py3 import ET
 from libcloud.utils.py3 import httplib
@@ -799,6 +800,9 @@ class AzureBlobsStorageDriver(StorageDriver):
         """
         @inherits: :class:`StorageDriver.upload_object_via_stream`
 
+        Note that if ``iterator`` does not support ``seek``, the
+        entire generator will be buffered in memory.
+
         :param ex_blob_type: Storage class
         :type ex_blob_type: ``str``
 
@@ -825,7 +829,12 @@ class AzureBlobsStorageDriver(StorageDriver):
         """
         self._check_values(ex_blob_type, ex_page_blob_size)
         if ex_blob_type == "BlockBlob":
-            iterator.seek(0, os.SEEK_END)
+            try:
+                iterator.seek(0, os.SEEK_END)
+            except AttributeError:
+                buffer = BytesIO()
+                buffer.writelines(iterator)
+                iterator = buffer
             blob_size = iterator.tell()
             iterator.seek(0)
         else:

--- a/libcloud/test/storage/test_azure_blobs.py
+++ b/libcloud/test/storage/test_azure_blobs.py
@@ -874,6 +874,24 @@ class AzureBlobsTests(unittest.TestCase):
         self.assertEqual(obj.size, 3)
         self.mock_response_klass.use_param = None
 
+    def test_upload_blob_object_via_stream_from_iterable(self):
+        self.mock_response_klass.use_param = 'comp'
+        container = Container(name='foo_bar_container', extra={},
+                              driver=self.driver)
+
+        object_name = 'foo_test_upload'
+        iterator = iter([b('34'), b('5')])
+        extra = {'content_type': 'text/plain'}
+        obj = self.driver.upload_object_via_stream(container=container,
+                                                   object_name=object_name,
+                                                   iterator=iterator,
+                                                   extra=extra,
+                                                   ex_blob_type='BlockBlob')
+
+        self.assertEqual(obj.name, object_name)
+        self.assertEqual(obj.size, 3)
+        self.mock_response_klass.use_param = None
+
     def test_upload_blob_object_via_stream_with_lease(self):
         self.mock_response_klass.use_param = 'comp'
         container = Container(name='foo_bar_container', extra={},


### PR DESCRIPTION
## Fix Azure upload_object_via_stream used with iter

### Description

As described in [LIBCLOUD-1043](https://issues.apache.org/jira/browse/LIBCLOUD-1043), the Azure Blob Storage driver currently doesn't support use-cases like this:

```py
driver.upload_object_via_stream(iter(something), ...)
```

This is due to the fact that the current implementation of `upload_object_via_stream` assumes that the passed-in iterator always implements `seek`. This pull request adds a fallback for iterators where this is not the case.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide)
- [x] Documentation **Bugfix only**
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html) **Added new unit test**
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes) **Code change is small**
