### PR TITLE
Add a workaround for Python 3.7 build failure on Travis

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps =
     lockfile
     libvirt-python==4.0.0
     py2.7: paramiko
+    py3.7: setuptools==41.0.1
 commands = cp libcloud/test/secrets.py-dist libcloud/test/secrets.py
            python setup.py test
 basepython =


### PR DESCRIPTION
It looks like Python 3.7 build fails on Travis because an old version of setuptools library is used.

This pull request should fix the build failure.