### PR TITLE
Various code fixes and improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ install:
   - TOX_ENV=py$TRAVIS_PYTHON_VERSION
 
 script:
-  - tox -vvv -e $TOX_ENV
+  - tox -e $TOX_ENV
 
 cache:
   apt: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ install:
   - TOX_ENV=py$TRAVIS_PYTHON_VERSION
 
 script:
-  - tox -e $TOX_ENV
+  - tox -vvv -e $TOX_ENV
 
 cache:
   apt: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ cache:
   apt: true
   directories:
     - $HOME/.cache/pip # pip cache
+    - .tox
 
 notifications:
   # Disabled until ASF switches to new mailing list software

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -151,6 +151,13 @@ Storage
   code to ``requests``.
   (LIBCLOUD-1039, GITHUB-1283)
   [Matt Seymour]
+- [CloudFiles] Fix a bug with ``ChunkStreamReader`` class and make sure file
+  descriptor is also closed if the iterator isn't fully exhausted or if the
+  iterator is never read from.
+
+  NOTE: This potential open file descriptor leakage only affected code which
+  utilized ``ex_multipart_upload_object`` method.
+  [Tomaz Muraus]
 
 Container
 ~~~~~~~~~

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,14 @@ General
   (GITHUB-1280)
   [Ryan Petrello]
 
+- Fix ``libcloud.enable_debug`` function so it doesn't leak open file handle
+  and closes the open file when the program exits when a debug mode is used.
+  [Tomaz Muraus]
+
+* Update various drivers (CloudFiles, NTT CIS etc.) so they don't leak open
+  file handles in some situations.
+  [Tomaz Muraus]
+
 Common
 ~~~~~~
 

--- a/libcloud/__init__.py
+++ b/libcloud/__init__.py
@@ -18,9 +18,11 @@ libcloud provides a unified interface to the cloud computing resources.
 
 :var __version__: Current version of libcloud
 """
+
 import logging
 import os
 import codecs
+import atexit
 
 from libcloud.base import DriverType  # NOQA
 from libcloud.base import DriverTypeFactoryMap  # NOQA
@@ -53,6 +55,15 @@ def enable_debug(fo):
 
     LoggingConnection.log = fo
     Connection.conn_class = LoggingConnection
+
+    # Ensure the file handle is closed on exit
+    def close_file(fd):
+        try:
+            fd.close()
+        except Exception:
+            pass
+
+    atexit.register(close_file, fo)
 
 
 def _init_once():

--- a/libcloud/common/brightbox.py
+++ b/libcloud/common/brightbox.py
@@ -13,13 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import base64
-
 from libcloud.common.base import ConnectionUserAndKey, JsonResponse
 from libcloud.compute.types import InvalidCredsError
 
 from libcloud.utils.py3 import b
 from libcloud.utils.py3 import httplib
+from libcloud.utils.py3 import base64_encode_string
 
 try:
     import simplejson as json
@@ -62,7 +61,7 @@ class BrightboxConnection(ConnectionUserAndKey):
     def _fetch_oauth_token(self):
         body = json.dumps({'client_id': self.user_id, 'grant_type': 'none'})
 
-        authorization = 'Basic ' + str(base64.encodestring(b('%s:%s' %
+        authorization = 'Basic ' + str(base64_encode_string(b('%s:%s' %
                                        (self.user_id, self.key)))).rstrip()
 
         self.connect()

--- a/libcloud/common/durabledns.py
+++ b/libcloud/common/durabledns.py
@@ -150,12 +150,12 @@ class DurableResponse(XmlResponse):
         xml_obj = self.parse_body()
 
         # pylint: disable=no-member
-        envelop_body = xml_obj.getchildren()[0]
-        method_resp = envelop_body.getchildren()[0]
+        envelop_body = list(xml_obj)[0]
+        method_resp = list(envelop_body)[0]
         # parse the xml_obj
         # handle errors
         if 'Fault' in method_resp.tag:
-            fault = [fault for fault in method_resp.getchildren()
+            fault = [fault for fault in list(method_resp)
                      if fault.tag == 'faultstring'][0]
             error_dict['ERRORMESSAGE'] = fault.text.strip()
             error_dict['ERRORCODE'] = self.status
@@ -163,17 +163,17 @@ class DurableResponse(XmlResponse):
 
         # parsing response from listZonesResponse
         if 'listZonesResponse' in method_resp.tag:
-            answer = method_resp.getchildren()[0]
+            answer = list(method_resp)[0]
             for element in answer:
-                zone_dict['id'] = element.getchildren()[0].text
+                zone_dict['id'] = list(element)[0].text
                 objects.append(zone_dict)
                 # reset the zone_dict
                 zone_dict = {}
         # parse response from listRecordsResponse
         if 'listRecordsResponse' in method_resp.tag:
-            answer = method_resp.getchildren()[0]
+            answer = list(method_resp)[0]
             for element in answer:
-                for child in element.getchildren():
+                for child in list(element):
                     if child.tag == 'id':
                         record_dict['id'] = child.text.strip()
                 objects.append(record_dict)
@@ -181,7 +181,7 @@ class DurableResponse(XmlResponse):
                 record_dict = {}
         # parse response from getZoneResponse
         if 'getZoneResponse' in method_resp.tag:
-            for child in method_resp.getchildren():
+            for child in list(method_resp):
                 if child.tag == 'origin':
                     zone_dict['id'] = child.text.strip()
                     zone_dict['domain'] = child.text.strip()
@@ -202,8 +202,8 @@ class DurableResponse(XmlResponse):
             objects.append(zone_dict)
         # parse response from getRecordResponse
         if 'getRecordResponse' in method_resp.tag:
-            answer = method_resp.getchildren()[0]
-            for child in method_resp.getchildren():
+            answer = list(method_resp)[0]
+            for child in list(method_resp):
                 if child.tag == 'id' and child.text:
                     record_dict['id'] = child.text.strip()
                 elif child.tag == 'name' and child.text:
@@ -223,19 +223,19 @@ class DurableResponse(XmlResponse):
             objects.append(record_dict)
             record_dict = {}
         if 'createZoneResponse' in method_resp.tag:
-            answer = method_resp.getchildren()[0]
+            answer = list(method_resp)[0]
             if answer.tag == 'return' and answer.text:
                 record_dict['id'] = answer.text.strip()
             objects.append(record_dict)
         # catch Record does not exists error when deleting record
         if 'deleteRecordResponse' in method_resp.tag:
-            answer = method_resp.getchildren()[0]
+            answer = list(method_resp)[0]
             if 'Record does not exists' in answer.text.strip():
                 errors.append({'ERRORMESSAGE': answer.text.strip(),
                                'ERRORCODE': self.status})
         # parse response in createRecordResponse
         if 'createRecordResponse' in method_resp.tag:
-            answer = method_resp.getchildren()[0]
+            answer = list(method_resp)[0]
             record_dict['id'] = answer.text.strip()
             objects.append(record_dict)
             record_dict = {}

--- a/libcloud/common/zonomi.py
+++ b/libcloud/common/zonomi.py
@@ -78,15 +78,15 @@ class ZonomiResponse(XmlResponse):
             errors.append(error_dict)
 
         # Data handling
-        childrens = xml_body.getchildren()
+        childrens = list(xml_body)
         if len(childrens) == 3:
             result_counts = childrens[1]
             actions = childrens[2]
 
         if actions is not None:
-            actions_childrens = actions.getchildren()
+            actions_childrens = list(actions)
             action = actions_childrens[0]
-            action_childrens = action.getchildren()
+            action_childrens = list(action)
 
         if action_childrens is not None:
             for child in action_childrens:

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -1213,7 +1213,7 @@ class EC2Response(AWSBaseResponse):
                                          body=self.body, driver=EC2NodeDriver)
 
         for err in body.findall('Errors/Error'):
-            code, message = err.getchildren()
+            code, message = list(err)
             err_list.append('%s: %s' % (code.text, message.text))
             if code.text == 'InvalidClientTokenId':
                 raise InvalidCredsError(err_list[-1])

--- a/libcloud/compute/drivers/ecp.py
+++ b/libcloud/compute/drivers/ecp.py
@@ -17,7 +17,6 @@
 Enomaly ECP driver
 """
 import time
-import base64
 import os
 import socket
 import binascii

--- a/libcloud/compute/drivers/ecp.py
+++ b/libcloud/compute/drivers/ecp.py
@@ -24,6 +24,7 @@ import binascii
 
 from libcloud.utils.py3 import httplib
 from libcloud.utils.py3 import b
+from libcloud.utils.py3 import base64_encode_string
 
 # JSON is included in the standard library starting with Python 2.6.  For 2.5
 # and 2.4, there's a simplejson egg at: http://pypi.python.org/pypi/simplejson
@@ -86,7 +87,7 @@ class ECPConnection(ConnectionUserAndKey):
         # Authentication
         username = self.user_id
         password = self.key
-        base64string = base64.encodestring(
+        base64string = base64_encode_string(
             b('%s:%s' % (username, password)))[:-1]
         authheader = "Basic %s" % base64string
         headers['Authorization'] = authheader

--- a/libcloud/compute/drivers/vcloud.py
+++ b/libcloud/compute/drivers/vcloud.py
@@ -2292,7 +2292,7 @@ class VCloud_5_5_NodeDriver(VCloud_5_1_NodeDriver):
     def _perform_snapshot_operation(self, node, operation, xml_data, headers):
         res = self.connection.request(
             '%s/action/%s' % (get_url_path(node.id), operation),
-            data=ET.tostring(xml_data) if xml_data else None,
+            data=ET.tostring(xml_data) if xml_data is not None else None,
             method='POST',
             headers=headers)
         self._wait_for_task_completion(res.object.get('href'))

--- a/libcloud/compute/drivers/voxel.py
+++ b/libcloud/compute/drivers/voxel.py
@@ -40,7 +40,7 @@ class VoxelResponse(XmlResponse):
     def parse_body(self):
         if not self.body:
             return None
-        if not self.parsed:
+        if self.parsed is None:
             self.parsed = super(VoxelResponse, self).parse_body()
         return self.parsed
 
@@ -48,7 +48,7 @@ class VoxelResponse(XmlResponse):
         err_list = []
         if not self.body:
             return None
-        if not self.parsed:
+        if self.parsed is None:
             self.parsed = super(VoxelResponse, self).parse_body()
         for err in self.parsed.findall('err'):
             code = err.get('code')

--- a/libcloud/compute/drivers/vultr.py
+++ b/libcloud/compute/drivers/vultr.py
@@ -39,7 +39,7 @@ class rate_limited:
     :param int retries: Number of retries.
     """
 
-    def __init__(self, sleep=1, retries=1):
+    def __init__(self, sleep=0.5, retries=1):
         self.sleep = sleep
         self.retries = retries
 

--- a/libcloud/dns/drivers/durabledns.py
+++ b/libcloud/dns/drivers/durabledns.py
@@ -92,7 +92,7 @@ class DurableDNSDriver(DNSDriver):
                                     schema_params.get('method'),
                                     attributes)
         params = {'apiuser': self.key, 'apikey': self.secret}
-        urn = schema.getchildren()[0]
+        urn = list(schema)[0]
         for child in urn:
             key = child.tag.split(':')[2]
             if key in attributes:
@@ -128,7 +128,7 @@ class DurableDNSDriver(DNSDriver):
                                     attributes)
         params = {'apiuser': self.key, 'apikey': self.secret,
                   'zonename': zone.id}
-        urn = schema.getchildren()[0]
+        urn = list(schema)[0]
         for child in urn:
             key = child.tag.split(':')[2]
             if key in attributes:
@@ -173,7 +173,7 @@ class DurableDNSDriver(DNSDriver):
                                     attributes)
         params = {'apiuser': self.key, 'apikey': self.secret,
                   'zonename': zone_id}
-        urn = schema.getchildren()[0]
+        urn = list(schema)[0]
         for child in urn:
             key = child.tag.split(':')[2]
             if key in attributes:
@@ -216,7 +216,7 @@ class DurableDNSDriver(DNSDriver):
                                     attributes)
         params = {'apiuser': self.key, 'apikey': self.secret,
                   'zonename': zone_id, 'recordid': record_id}
-        urn = schema.getchildren()[0]
+        urn = list(schema)[0]
         for child in urn:
             key = child.tag.split(':')[2]
             if key in attributes:
@@ -278,7 +278,7 @@ class DurableDNSDriver(DNSDriver):
         params = {'apiuser': self.key, 'apikey': self.secret,
                   'zonename': domain, 'ttl': ttl or DEFAULT_TTL}
         params.update(extra)
-        urn = schema.getchildren()[0]
+        urn = list(schema)[0]
         for child in urn:
             key = child.tag.split(':')[2]
             if key in attributes:
@@ -353,7 +353,7 @@ class DurableDNSDriver(DNSDriver):
                   'zonename': zone.id, 'name': name, 'type': type,
                   'data': data}
         params.update(extra)
-        urn = schema.getchildren()[0]
+        urn = list(schema)[0]
         for child in urn:
             key = child.tag.split(':')[2]
             if key in attributes:
@@ -434,7 +434,7 @@ class DurableDNSDriver(DNSDriver):
         params = {'apiuser': self.key, 'apikey': self.secret,
                   'zonename': domain, 'ttl': ttl}
         params.update(extra)
-        urn = schema.getchildren()[0]
+        urn = list(schema)[0]
         for child in urn:
             key = child.tag.split(':')[2]
             if key in attributes:
@@ -511,7 +511,7 @@ class DurableDNSDriver(DNSDriver):
                   'zonename': zone.id, 'id': record.id, 'name': name,
                   'data': data}
         params.update(extra)
-        urn = schema.getchildren()[0]
+        urn = list(schema)[0]
         for child in urn:
             key = child.tag.split(':')[2]
             if key in attributes:
@@ -568,7 +568,7 @@ class DurableDNSDriver(DNSDriver):
                                     attributes)
         params = {'apiuser': self.key, 'apikey': self.secret,
                   'zonename': zone.id}
-        urn = schema.getchildren()[0]
+        urn = list(schema)[0]
         for child in urn:
             key = child.tag.split(':')[2]
             if key in attributes:
@@ -605,7 +605,7 @@ class DurableDNSDriver(DNSDriver):
                                     attributes)
         params = {'apiuser': self.key, 'apikey': self.secret,
                   'zonename': record.zone.id, 'id': record.id}
-        urn = schema.getchildren()[0]
+        urn = list(schema)[0]
         for child in urn:
             key = child.tag.split(':')[2]
             if key in attributes:

--- a/libcloud/loadbalancer/drivers/nttcis.py
+++ b/libcloud/loadbalancer/drivers/nttcis.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 try:
     import OpenSSL
     OpenSSL
@@ -782,12 +783,18 @@ class NttCisLBDriver(Driver):
         :type `description: `str``
         :return: ``bool``
         """
-        c = OpenSSL.crypto.load_certificate(
-            OpenSSL.crypto.FILETYPE_PEM, open(crt_file).read())
+
+        with open(crt_file) as fp:
+            c = OpenSSL.crypto.load_certificate(
+                OpenSSL.crypto.FILETYPE_PEM, fp.read())
+
         cert = OpenSSL.crypto.dump_certificate(
             OpenSSL.crypto.FILETYPE_PEM, c).decode(encoding='utf-8')
-        k = OpenSSL.crypto.load_privatekey(
-            OpenSSL.crypto.FILETYPE_PEM, open(key_file).read())
+
+        with open(key_file) as fp:
+            k = OpenSSL.crypto.load_privatekey(
+                OpenSSL.crypto.FILETYPE_PEM, fp.read())
+
         key = OpenSSL.crypto.dump_privatekey(OpenSSL.crypto.FILETYPE_PEM, k) \
             .decode(encoding='utf-8')
         cert_elem = ET.Element("importSslDomainCertificate",

--- a/libcloud/storage/drivers/azure_blobs.py
+++ b/libcloud/storage/drivers/azure_blobs.py
@@ -214,7 +214,7 @@ class AzureBlobsStorageDriver(StorageDriver):
             'meta_data': {}
         }
 
-        for meta in metadata.getchildren():
+        for meta in list(metadata):
             extra['meta_data'][meta.tag] = meta.text
 
         return Container(name=name, extra=extra, driver=self)
@@ -299,7 +299,7 @@ class AzureBlobsStorageDriver(StorageDriver):
             extra['md5_hash'] = value
 
         meta_data = {}
-        for meta in metadata.getchildren():
+        for meta in list(metadata):
             meta_data[meta.tag] = meta.text
 
         return Object(name=name, size=size, hash=etag, meta_data=meta_data,

--- a/libcloud/storage/drivers/cloudfiles.py
+++ b/libcloud/storage/drivers/cloudfiles.py
@@ -13,10 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from hashlib import sha1
+import atexit
 import hmac
 import os
 from time import time
+from hashlib import sha1
 
 from libcloud.utils.py3 import httplib
 from libcloud.utils.py3 import urlencode
@@ -943,6 +944,16 @@ class ChunkStreamReader(object):
         self.chunk_size = chunk_size
         self.bytes_read = 0
         self.stop_iteration = False
+
+        # Work around to make sure file description is closed even if the
+        # iterator is never read from or if it's not fully exhausted
+        def close_file(fd):
+            try:
+                fd.close()
+            except Exception:
+                pass
+
+        atexit.register(close_file, self.fd)
 
     def __iter__(self):
         return self

--- a/libcloud/test/common/test_openstack_identity.py
+++ b/libcloud/test/common/test_openstack_identity.py
@@ -24,6 +24,7 @@ except ImportError:
 from mock import Mock
 
 from libcloud.utils.py3 import httplib
+from libcloud.utils.py3 import assertRaisesRegex
 from libcloud.common.openstack import OpenStackBaseConnection
 from libcloud.common.openstack_identity import AUTH_TOKEN_EXPIRES_GRACE_SECONDS
 from libcloud.common.openstack_identity import get_class_for_auth_version
@@ -258,31 +259,31 @@ class OpenStackIdentity_3_0_ConnectionTests(unittest.TestCase):
     def test_token_scope_argument(self):
         # Invalid token_scope value
         expected_msg = 'Invalid value for "token_scope" argument: foo'
-        self.assertRaisesRegexp(ValueError, expected_msg,
-                                OpenStackIdentity_3_0_Connection,
-                                auth_url='http://none',
-                                user_id='test',
-                                key='test',
-                                token_scope='foo')
+        assertRaisesRegex(self, ValueError, expected_msg,
+                          OpenStackIdentity_3_0_Connection,
+                          auth_url='http://none',
+                          user_id='test',
+                          key='test',
+                          token_scope='foo')
 
         # Missing tenant_name
         expected_msg = 'Must provide tenant_name and domain_name argument'
-        self.assertRaisesRegexp(ValueError, expected_msg,
-                                OpenStackIdentity_3_0_Connection,
-                                auth_url='http://none',
-                                user_id='test',
-                                key='test',
-                                token_scope='project')
+        assertRaisesRegex(self, ValueError, expected_msg,
+                          OpenStackIdentity_3_0_Connection,
+                          auth_url='http://none',
+                          user_id='test',
+                          key='test',
+                          token_scope='project')
 
         # Missing domain_name
         expected_msg = 'Must provide domain_name argument'
-        self.assertRaisesRegexp(ValueError, expected_msg,
-                                OpenStackIdentity_3_0_Connection,
-                                auth_url='http://none',
-                                user_id='test',
-                                key='test',
-                                token_scope='domain',
-                                domain_name=None)
+        assertRaisesRegex(self, ValueError, expected_msg,
+                          OpenStackIdentity_3_0_Connection,
+                          auth_url='http://none',
+                          user_id='test',
+                          key='test',
+                          token_scope='domain',
+                          domain_name=None)
 
         # Scope to project all ok
         OpenStackIdentity_3_0_Connection(auth_url='http://none',

--- a/libcloud/test/common/test_retry_limit.py
+++ b/libcloud/test/common/test_retry_limit.py
@@ -33,7 +33,7 @@ SIMPLE_RESPONSE_STATUS = ('HTTP/1.1', 429, 'CONFLICT')
 class FailedRequestRetryTestCase(unittest.TestCase):
 
     def test_retry_connection(self):
-        con = Connection(timeout=1, retry_delay=0.1)
+        con = Connection(timeout=0.2, retry_delay=0.1)
         con.connection = Mock()
         connect_method = 'libcloud.common.base.Connection.request'
 
@@ -45,7 +45,7 @@ class FailedRequestRetryTestCase(unittest.TestCase):
                 pass
 
     def test_retry_connection_ssl_error(self):
-        conn = Connection(timeout=1, retry_delay=0.1)
+        conn = Connection(timeout=0.2, retry_delay=0.1)
 
         with patch.object(conn, 'connect', Mock()):
             with patch.object(conn, 'connection') as connection:

--- a/libcloud/test/common/test_upcloud.py
+++ b/libcloud/test/common/test_upcloud.py
@@ -179,14 +179,14 @@ class TestStorageDevice(unittest.TestCase):
         storagedevice = _StorageDevice(self.image, self.size)
         d = storagedevice.to_dict()
 
-        self.assertEquals(d['storage_device'][0]['tier'], 'maxiops')
+        self.assertEqual(d['storage_device'][0]['tier'], 'maxiops')
 
     def test_storage_tier_given(self):
         self.size.extra['storage_tier'] = 'hdd'
         storagedevice = _StorageDevice(self.image, self.size)
         d = storagedevice.to_dict()
 
-        self.assertEquals(d['storage_device'][0]['tier'], 'hdd')
+        self.assertEqual(d['storage_device'][0]['tier'], 'hdd')
 
 
 class TestUpcloudNodeDestroyer(unittest.TestCase):
@@ -246,8 +246,8 @@ class TestUpcloudNodeDestroyer(unittest.TestCase):
         self.assertTrue(self.destroyer.destroy_node(1))
         self.assertTrue(self.destroyer.destroy_node(1))
 
-        self.assertEquals(self.mock_sleep.call_count, 0)
-        self.assertEquals(self.mock_operations.stop_node.call_count, 2)
+        self.assertEqual(self.mock_sleep.call_count, 0)
+        self.assertEqual(self.mock_operations.stop_node.call_count, 2)
 
     def test_timeout(self):
         self.mock_operations.get_node_state.side_effect = ['maintenance'] * 50

--- a/libcloud/test/compute/test_cloudsigma_v2_0.py
+++ b/libcloud/test/compute/test_cloudsigma_v2_0.py
@@ -21,6 +21,7 @@ except Exception:
     import json
 
 from libcloud.utils.py3 import httplib
+from libcloud.utils.py3 import assertRaisesRegex
 
 from libcloud.common.types import InvalidCredsError
 from libcloud.compute.drivers.cloudsigma import CloudSigmaNodeDriver
@@ -48,9 +49,9 @@ class CloudSigmaAPI20BaseTestCase(object):
 
     def test_invalid_api_versions(self):
         expected_msg = 'Unsupported API version: invalid'
-        self.assertRaisesRegexp(NotImplementedError, expected_msg,
-                                CloudSigmaNodeDriver, 'username', 'password',
-                                api_version='invalid')
+        assertRaisesRegex(self, NotImplementedError, expected_msg,
+                          CloudSigmaNodeDriver, 'username', 'password',
+                          api_version='invalid')
 
     def test_invalid_credentials(self):
         CloudSigmaMockHttp.type = 'INVALID_CREDS'
@@ -58,9 +59,9 @@ class CloudSigmaAPI20BaseTestCase(object):
 
     def test_invalid_region(self):
         expected_msg = 'Invalid region:'
-        self.assertRaisesRegexp(ValueError, expected_msg,
-                                CloudSigma_2_0_NodeDriver, 'foo', 'bar',
-                                region='invalid')
+        assertRaisesRegex(self, ValueError, expected_msg,
+                          CloudSigma_2_0_NodeDriver, 'foo', 'bar',
+                          region='invalid')
 
     def test_list_sizes(self):
         sizes = self.driver.list_sizes()
@@ -133,8 +134,8 @@ class CloudSigmaAPI20BaseTestCase(object):
         expected_msg = 'Cannot start guest in state "started". Guest should ' \
                        'be in state "stopped'
 
-        self.assertRaisesRegexp(CloudSigmaError, expected_msg,
-                                self.driver.ex_start_node, node=self.node)
+        assertRaisesRegex(self, CloudSigmaError, expected_msg,
+                          self.driver.ex_start_node, node=self.node)
 
     def test_ex_stop_node(self):
         status = self.driver.ex_stop_node(node=self.node)
@@ -144,8 +145,8 @@ class CloudSigmaAPI20BaseTestCase(object):
         CloudSigmaMockHttp.type = 'ALREADY_STOPPED'
 
         expected_msg = 'Cannot stop guest in state "stopped"'
-        self.assertRaisesRegexp(CloudSigmaError, expected_msg,
-                                self.driver.ex_stop_node, node=self.node)
+        assertRaisesRegex(self, CloudSigmaError, expected_msg,
+                          self.driver.ex_stop_node, node=self.node)
 
     def test_ex_clone_node(self):
         node_to_clone = self.driver.list_nodes()[0]
@@ -271,11 +272,11 @@ class CloudSigmaAPI20BaseTestCase(object):
 
         nic_mac = 'inexistent'
         expected_msg = 'Cannot find the NIC interface to attach a policy to'
-        self.assertRaisesRegexp(ValueError, expected_msg,
-                                self.driver.ex_attach_firewall_policy,
-                                policy=policy,
-                                node=node,
-                                nic_mac=nic_mac)
+        assertRaisesRegex(self, ValueError, expected_msg,
+                          self.driver.ex_attach_firewall_policy,
+                          policy=policy,
+                          node=node,
+                          nic_mac=nic_mac)
 
     def test_ex_delete_firewall_policy(self):
         policy = self.driver.ex_list_firewall_policies()[0]
@@ -325,9 +326,9 @@ class CloudSigmaAPI20BaseTestCase(object):
         tag = self.driver.ex_list_tags()[0]
 
         expected_msg = 'Resource doesn\'t have id attribute'
-        self.assertRaisesRegexp(ValueError, expected_msg,
-                                self.driver.ex_tag_resource, tag=tag,
-                                resource={})
+        assertRaisesRegex(self, ValueError, expected_msg,
+                          self.driver.ex_tag_resource, tag=tag,
+                          resource={})
 
     def test_ex_delete_tag(self):
         tag = self.driver.ex_list_tags()[0]
@@ -417,10 +418,10 @@ class CloudSigmaAPI20BaseTestCase(object):
         state = 'timeout'
 
         expected_msg = 'Timed out while waiting for drive transition'
-        self.assertRaisesRegexp(Exception, expected_msg,
-                                self.driver._wait_for_drive_state_transition,
-                                drive=drive, state=state,
-                                timeout=0.5)
+        assertRaisesRegex(self, Exception, expected_msg,
+                          self.driver._wait_for_drive_state_transition,
+                          drive=drive, state=state,
+                          timeout=0.5)
 
     def test_wait_for_drive_state_transition_success(self):
         drive = self.driver.ex_list_user_drives()[0]

--- a/libcloud/test/compute/test_cloudstack.py
+++ b/libcloud/test/compute/test_cloudstack.py
@@ -33,6 +33,7 @@ from libcloud.compute.types import LibcloudError, Provider, InvalidCredsError
 from libcloud.compute.types import KeyPairDoesNotExistError
 from libcloud.compute.types import NodeState
 from libcloud.compute.providers import get_driver
+from libcloud.utils.py3 import assertRaisesRegex
 
 from libcloud.test import unittest
 from libcloud.test import MockHttp
@@ -67,9 +68,9 @@ class CloudStackCommonTestCase(TestCaseMixin):
         key_material = ''
 
         expected_msg = 'Public key is invalid'
-        self.assertRaisesRegexp(ProviderError, expected_msg,
-                                self.driver.import_key_pair_from_string,
-                                name=name, key_material=key_material)
+        assertRaisesRegex(self, ProviderError, expected_msg,
+                          self.driver.import_key_pair_from_string,
+                          name=name, key_material=key_material)
 
     def test_create_node_immediate_failure(self):
         size = self.driver.list_sizes()[0]
@@ -1263,8 +1264,8 @@ class CloudStackTestCase(CloudStackCommonTestCase, unittest.TestCase):
                         'argument')
         cls = get_driver(Provider.CLOUDSTACK)
 
-        self.assertRaisesRegexp(Exception, expected_msg, cls,
-                                'key', 'secret')
+        assertRaisesRegex(self, Exception, expected_msg, cls,
+                          'key', 'secret')
 
         try:
             cls('key', 'secret', True, 'localhost', '/path')

--- a/libcloud/test/compute/test_deployment.py
+++ b/libcloud/test/compute/test_deployment.py
@@ -219,7 +219,7 @@ class DeploymentTests(unittest.TestCase):
 
     def test_wait_until_running_running_instantly(self):
         node2, ips = self.driver.wait_until_running(
-            nodes=[self.node], wait_period=1,
+            nodes=[self.node], wait_period=0.1,
             timeout=0.5)[0]
         self.assertEqual(self.node.uuid, node2.uuid)
         self.assertEqual(['67.23.21.33'], ips)
@@ -229,11 +229,11 @@ class DeploymentTests(unittest.TestCase):
 
         try:
             node2, ips = self.driver.wait_until_running(
-                nodes=[self.node], wait_period=1,
-                timeout=0.5)[0]
+                nodes=[self.node], wait_period=0.1,
+                timeout=0.2)[0]
         except LibcloudError:
             e = sys.exc_info()[1]
-            self.assertTrue(e.value.find('Timed out after 0.5 second') != -1)
+            self.assertTrue(e.value.find('Timed out after 0.2 second') != -1)
         else:
             self.fail('Exception was not thrown')
 
@@ -242,11 +242,11 @@ class DeploymentTests(unittest.TestCase):
 
         try:
             node2, ips = self.driver.wait_until_running(
-                nodes=[self.node], wait_period=1,
-                timeout=0.5)[0]
+                nodes=[self.node], wait_period=0.1,
+                timeout=0.2)[0]
         except LibcloudError:
             e = sys.exc_info()[1]
-            self.assertTrue(e.value.find('Timed out after 0.5 second') != -1)
+            self.assertTrue(e.value.find('Timed out after 0.2 second') != -1)
         else:
             self.fail('Exception was not thrown')
 
@@ -258,19 +258,19 @@ class DeploymentTests(unittest.TestCase):
         self.assertEqual(self.node.uuid, node2.uuid)
         self.assertEqual(['2001:DB8::1'], ips)
 
-    def test_wait_until_running_running_after_1_second(self):
+    def test_wait_until_running_running_after_0_2_second(self):
         RackspaceMockHttp.type = '05_SECOND_DELAY'
         node2, ips = self.driver.wait_until_running(
-            nodes=[self.node], wait_period=1,
-            timeout=0.5)[0]
+            nodes=[self.node], wait_period=0.2,
+            timeout=0.1)[0]
         self.assertEqual(self.node.uuid, node2.uuid)
         self.assertEqual(['67.23.21.33'], ips)
 
-    def test_wait_until_running_running_after_1_second_private_ips(self):
+    def test_wait_until_running_running_after_0_2_second_private_ips(self):
         RackspaceMockHttp.type = '05_SECOND_DELAY'
         node2, ips = self.driver.wait_until_running(
-            nodes=[self.node], wait_period=1,
-            timeout=0.5, ssh_interface='private_ips')[0]
+            nodes=[self.node], wait_period=0.2,
+            timeout=0.1, ssh_interface='private_ips')[0]
         self.assertEqual(self.node.uuid, node2.uuid)
         self.assertEqual(['10.176.168.218'], ips)
 
@@ -288,7 +288,7 @@ class DeploymentTests(unittest.TestCase):
 
         try:
             self.driver.wait_until_running(nodes=[self.node], wait_period=0.1,
-                                           timeout=0.5)
+                                           timeout=0.2)
         except LibcloudError:
             e = sys.exc_info()[1]
             self.assertTrue(e.value.find('Timed out') != -1)
@@ -300,10 +300,10 @@ class DeploymentTests(unittest.TestCase):
 
         try:
             self.driver.wait_until_running(nodes=[self.node], wait_period=0.1,
-                                           timeout=0.5)
+                                           timeout=0.2)
         except LibcloudError:
             e = sys.exc_info()[1]
-            self.assertTrue(e.value.find('Timed out after 0.5 second') != -1)
+            self.assertTrue(e.value.find('Timed out after 0.2 second') != -1)
         else:
             self.fail('Exception was not thrown')
 
@@ -312,7 +312,7 @@ class DeploymentTests(unittest.TestCase):
 
         try:
             self.driver.wait_until_running(nodes=[self.node], wait_period=0.1,
-                                           timeout=0.5)
+                                           timeout=0.2)
         except LibcloudError:
             e = sys.exc_info()[1]
             self.assertTrue(
@@ -347,7 +347,8 @@ class DeploymentTests(unittest.TestCase):
 
         try:
             self.driver._ssh_client_connect(ssh_client=mock_ssh_client,
-                                            timeout=0.5)
+                                            wait_period=0.1,
+                                            timeout=0.2)
         except LibcloudError:
             e = sys.exc_info()[1]
             self.assertTrue(e.value.find('Giving up') != -1)

--- a/libcloud/test/compute/test_digitalocean_v2.py
+++ b/libcloud/test/compute/test_digitalocean_v2.py
@@ -24,6 +24,7 @@ except ImportError:
     import json  # NOQA
 
 from libcloud.utils.py3 import httplib
+from libcloud.utils.py3 import assertRaisesRegex
 
 from libcloud.common.types import InvalidCredsError
 from libcloud.common.digitalocean import DigitalOcean_v1_Error
@@ -108,10 +109,10 @@ class DigitalOcean_v2_Tests(LibcloudTestCase):
         DigitalOceanMockHttp.type = 'INVALID_IMAGE'
         expected_msg = \
             r'You specified an invalid image for Droplet creation. \(code: (404|HTTPStatus.NOT_FOUND)\)'
-        self.assertRaisesRegexp(Exception, expected_msg,
-                                self.driver.create_node,
-                                name='test', size=size, image=image,
-                                location=location)
+        assertRaisesRegex(self, Exception, expected_msg,
+                          self.driver.create_node,
+                          name='test', size=size, image=image,
+                          location=location)
 
     def test_reboot_node_success(self):
         node = self.driver.list_nodes()[0]

--- a/libcloud/test/compute/test_dimensiondata_v2_3.py
+++ b/libcloud/test/compute/test_dimensiondata_v2_3.py
@@ -929,19 +929,22 @@ class DimensionData_v2_3_Tests(unittest.TestCase, TestCaseMixin):
     def test_ex_wait_for_state(self):
         self.driver.ex_wait_for_state('NORMAL',
                                       self.driver.ex_get_vlan,
-                                      vlan_id='0e56433f-d808-4669-821d-812769517ff8')
+                                      vlan_id='0e56433f-d808-4669-821d-812769517ff8',
+                                      poll_interval=0.1)
 
     def test_ex_wait_for_state_NODE(self):
         self.driver.ex_wait_for_state('running',
                                       self.driver.ex_get_node_by_id,
-                                      id='e75ead52-692f-4314-8725-c8a4f4d13a87')
+                                      id='e75ead52-692f-4314-8725-c8a4f4d13a87',
+                                      poll_interval=0.1)
 
     def test_ex_wait_for_state_FAIL(self):
         with self.assertRaises(DimensionDataAPIException) as context:
             self.driver.ex_wait_for_state('starting',
                                           self.driver.ex_get_node_by_id,
                                           id='e75ead52-692f-4314-8725-c8a4f4d13a87',
-                                          timeout=2
+                                          poll_interval=0.1,
+                                          timeout=0.1
                                           )
         self.assertEqual(context.exception.code, 'running')
         self.assertTrue('timed out' in context.exception.msg)

--- a/libcloud/test/compute/test_dimensiondata_v2_4.py
+++ b/libcloud/test/compute/test_dimensiondata_v2_4.py
@@ -927,19 +927,22 @@ class DimensionData_v2_4_Tests(unittest.TestCase):
     def test_ex_wait_for_state(self):
         self.driver.ex_wait_for_state('NORMAL',
                                       self.driver.ex_get_vlan,
-                                      vlan_id='0e56433f-d808-4669-821d-812769517ff8')
+                                      vlan_id='0e56433f-d808-4669-821d-812769517ff8',
+                                      poll_interval=0.1)
 
     def test_ex_wait_for_state_NODE(self):
         self.driver.ex_wait_for_state('running',
                                       self.driver.ex_get_node_by_id,
-                                      id='e75ead52-692f-4314-8725-c8a4f4d13a87')
+                                      id='e75ead52-692f-4314-8725-c8a4f4d13a87',
+                                      poll_interval=0.1)
 
     def test_ex_wait_for_state_FAIL(self):
         with self.assertRaises(DimensionDataAPIException) as context:
             self.driver.ex_wait_for_state('starting',
                                           self.driver.ex_get_node_by_id,
                                           id='e75ead52-692f-4314-8725-c8a4f4d13a87',
-                                          timeout=2
+                                          poll_interval=0.1,
+                                          timeout=0.1
                                           )
         self.assertEqual(context.exception.code, 'running')
         self.assertTrue('timed out' in context.exception.msg)

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -105,14 +105,14 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
         token = 'temporary_credentials_token'
         driver = EC2NodeDriver(*EC2_PARAMS, **{'region': self.region, 'token': token})
         self.assertTrue(hasattr(driver, 'token'), 'Driver has no attribute token')
-        self.assertEquals(token, driver.token, "Driver token does not match with provided token")
+        self.assertEqual(token, driver.token, "Driver token does not match with provided token")
 
     def test_driver_with_token_signature_version(self):
         token = 'temporary_credentials_token'
         driver = EC2NodeDriver(*EC2_PARAMS, **{'region': self.region, 'token': token})
         kwargs = driver._ex_connection_class_kwargs()
         self.assertIn('signature_version', kwargs)
-        self.assertEquals('4', kwargs['signature_version'], 'Signature version is not 4 with temporary credentials')
+        self.assertEqual('4', kwargs['signature_version'], 'Signature version is not 4 with temporary credentials')
 
     def test_create_node(self):
         image = NodeImage(id='ami-be3adfd7',

--- a/libcloud/test/compute/test_elasticstack.py
+++ b/libcloud/test/compute/test_elasticstack.py
@@ -15,6 +15,7 @@
 
 import sys
 from libcloud.utils.py3 import httplib
+from libcloud.utils.py3 import assertRaisesRegex
 
 from libcloud.compute.base import Node
 from libcloud.compute.drivers.elasticstack import ElasticStackException
@@ -173,8 +174,8 @@ class ElasticHostsTestCase(ElasticStackTestCase, unittest.TestCase):
 
     def test_invalid_region(self):
         expected_msg = r'Invalid region.+'
-        self.assertRaisesRegexp(ValueError, expected_msg, ElasticHosts,
-                                'foo', 'bar', region='invalid')
+        assertRaisesRegex(self, ValueError, expected_msg, ElasticHosts,
+                          'foo', 'bar', region='invalid')
 
 
 class SkaliCloudTestCase(ElasticStackTestCase, unittest.TestCase):

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -1385,8 +1385,11 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         size = self.driver.ex_get_size('n1-standard-1')
         number = 2
         disk_size = "25"
+        # NOTE: We use small poll_interval to speed up the tests
         nodes = self.driver.ex_create_multiple_nodes(base_name, size, image,
-                                                     number, ex_disk_size=disk_size)
+                                                     number,
+                                                     ex_disk_size=disk_size,
+                                                     poll_interval=0.1)
         self.assertEqual(len(nodes), 2)
         self.assertTrue(isinstance(nodes[0], Node))
         self.assertTrue(isinstance(nodes[1], Node))
@@ -1400,8 +1403,10 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         image = None
         size = self.driver.ex_get_size('n1-standard-1')
         number = 2
+        # NOTE: We use small poll_interval to speed up the tests
         nodes = self.driver.ex_create_multiple_nodes(
-            base_name, size, image, number, ex_image_family='coreos-stable')
+            base_name, size, image, number, ex_image_family='coreos-stable',
+            poll_interval=0.1)
         self.assertEqual(len(nodes), 2)
         self.assertTrue(isinstance(nodes[0], Node))
         self.assertTrue(isinstance(nodes[1], Node))

--- a/libcloud/test/compute/test_joyent.py
+++ b/libcloud/test/compute/test_joyent.py
@@ -16,6 +16,7 @@
 import sys
 
 from libcloud.utils.py3 import httplib
+from libcloud.utils.py3 import assertRaisesRegex
 from libcloud.common.types import LibcloudError
 from libcloud.compute.base import NodeState
 from libcloud.compute.drivers.joyent import JoyentNodeDriver
@@ -55,10 +56,10 @@ class JoyentTestCase(unittest.TestCase):
     def test_instantiate_invalid_region(self):
         expected_msg = 'Invalid region.+'
 
-        self.assertRaisesRegexp(LibcloudError, expected_msg, JoyentNodeDriver,
-                                'user', 'key', location='invalid')
-        self.assertRaisesRegexp(LibcloudError, expected_msg, JoyentNodeDriver,
-                                'user', 'key', region='invalid')
+        assertRaisesRegex(self, LibcloudError, expected_msg, JoyentNodeDriver,
+                          'user', 'key', location='invalid')
+        assertRaisesRegex(self, LibcloudError, expected_msg, JoyentNodeDriver,
+                          'user', 'key', region='invalid')
 
     def test_list_sizes(self):
         sizes = self.driver.list_sizes()

--- a/libcloud/test/compute/test_nttcis.py
+++ b/libcloud/test/compute/test_nttcis.py
@@ -1003,13 +1003,15 @@ def test_ex_get_vlan(driver):
 def test_ex_wait_for_state(driver):
     driver.ex_wait_for_state('NORMAL',
                              driver.ex_get_vlan,
-                             vlan_id='0e56433f-d808-4669-821d-812769517ff8')
+                             vlan_id='0e56433f-d808-4669-821d-812769517ff8',
+                             poll_interval=0.1)
 
 
 def test_ex_wait_for_state_NODE(driver):
     driver.ex_wait_for_state('running',
                              driver.ex_get_node_by_id,
-                             id='e75ead52-692f-4314-8725-c8a4f4d13a87')
+                             id='e75ead52-692f-4314-8725-c8a4f4d13a87',
+                             poll_interval=0.1)
 
 
 def test_ex_wait_for_state_FAIL(driver):
@@ -1017,7 +1019,8 @@ def test_ex_wait_for_state_FAIL(driver):
         driver.ex_wait_for_state('starting',
                                  driver.ex_get_node_by_id,
                                  id='e75ead52-692f-4314-8725-c8a4f4d13a87',
-                                 timeout=2
+                                 poll_interval=0.1,
+                                 timeout=0.1
                                  )
     assert context.value.code == 'running'
     assert 'timed out' in context.value.msg

--- a/libcloud/test/compute/test_oneandone.py
+++ b/libcloud/test/compute/test_oneandone.py
@@ -283,7 +283,7 @@ class OneAndOneTests(unittest.TestCase):
 
     def test_ex_list_shared_storages(self):
         storages = self.driver.ex_list_shared_storages()
-        self.assertEquals(len(storages), 3)
+        self.assertEqual(len(storages), 3)
 
     def test_ex_get_shared_storage(self):
         storage = self.driver.ex_get_shared_storage('storage_1')

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -19,6 +19,7 @@ import os
 import sys
 import unittest
 import datetime
+import mock
 import pytest
 
 from libcloud.utils.iso8601 import UTC
@@ -1655,6 +1656,8 @@ class OpenStack_2_Tests(OpenStack_1_1_Tests):
         self.assertEqual(snapshots[0]['name'], 'snap-101')
         self.assertEqual(snapshots[3]['name'], 'snap-001')
 
+    # NOTE: We use a smaller limit to speed tests up.
+    @mock.patch('libcloud.compute.drivers.openstack.PAGINATION_LIMIT', 10)
     def test__paginated_request_raises_if_stuck_in_a_loop(self):
         with pytest.raises(OpenStackException):
             self.driver._paginated_request(

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -1299,7 +1299,10 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
         name = 'key3'
         path = os.path.join(
             os.path.dirname(__file__), 'fixtures', 'misc', 'dummy_rsa.pub')
-        pub_key = open(path, 'r').read()
+
+        with open(path, 'r') as fp:
+            pub_key = fp.read()
+
         keypair = self.driver.import_key_pair_from_file(name=name,
                                                         key_file_path=path)
         self.assertEqual(keypair.name, name)
@@ -1312,7 +1315,10 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
         name = 'key3'
         path = os.path.join(
             os.path.dirname(__file__), 'fixtures', 'misc', 'dummy_rsa.pub')
-        pub_key = open(path, 'r').read()
+
+        with open(path, 'r') as fp:
+            pub_key = fp.read()
+
         keypair = self.driver.import_key_pair_from_string(name=name,
                                                           key_material=pub_key)
         self.assertEqual(keypair.name, name)

--- a/libcloud/test/compute/test_scaleway.py
+++ b/libcloud/test/compute/test_scaleway.py
@@ -24,6 +24,7 @@ except ImportError:
     import json  # NOQA
 
 from libcloud.utils.py3 import httplib
+from libcloud.utils.py3 import assertRaisesRegex
 
 from libcloud.common.exceptions import BaseHTTPError
 from libcloud.compute.base import NodeImage
@@ -44,8 +45,8 @@ class Scaleway_Tests(LibcloudTestCase):
 
     def test_authentication(self):
         ScalewayMockHttp.type = 'UNAUTHORIZED'
-        self.assertRaisesRegexp(BaseHTTPError, 'Authentication error',
-                                self.driver.list_nodes)
+        assertRaisesRegex(self, BaseHTTPError, 'Authentication error',
+                          self.driver.list_nodes)
 
     def test_list_locations_success(self):
         locations = self.driver.list_locations()
@@ -136,10 +137,10 @@ class Scaleway_Tests(LibcloudTestCase):
 
         ScalewayMockHttp.type = 'INVALID_IMAGE'
         expected_msg = '" not found'
-        self.assertRaisesRegexp(Exception, expected_msg,
-                                self.driver.create_node,
-                                name='test', size=size, image=image,
-                                region=location)
+        assertRaisesRegex(self, Exception, expected_msg,
+                          self.driver.create_node,
+                          name='test', size=size, image=image,
+                          region=location)
 
     def test_reboot_node_success(self):
         node = self.driver.list_nodes()[0]

--- a/libcloud/test/compute/test_ssh_client.py
+++ b/libcloud/test/compute/test_ssh_client.py
@@ -30,6 +30,7 @@ from libcloud.compute.ssh import have_paramiko
 
 from libcloud.utils.py3 import StringIO
 from libcloud.utils.py3 import u
+from libcloud.utils.py3 import assertRaisesRegex
 
 from mock import patch, Mock, MagicMock
 
@@ -99,8 +100,8 @@ class ParamikoSSHClientTests(LibcloudTestCase):
 
         expected_msg = ('key_files and key_material arguments are mutually '
                         'exclusive')
-        self.assertRaisesRegexp(ValueError, expected_msg,
-                                ParamikoSSHClient, **conn_params)
+        assertRaisesRegex(self, ValueError, expected_msg,
+                          ParamikoSSHClient, **conn_params)
 
     @patch('paramiko.SSHClient', Mock)
     def test_key_material_argument(self):
@@ -135,8 +136,8 @@ class ParamikoSSHClientTests(LibcloudTestCase):
         mock = ParamikoSSHClient(**conn_params)
 
         expected_msg = 'Invalid or unsupported key type'
-        self.assertRaisesRegexp(paramiko.ssh_exception.SSHException,
-                                expected_msg, mock.connect)
+        assertRaisesRegex(self, paramiko.ssh_exception.SSHException,
+                          expected_msg, mock.connect)
 
     @patch('paramiko.SSHClient', Mock)
     def test_create_with_key(self):

--- a/libcloud/test/compute/test_upcloud.py
+++ b/libcloud/test/compute/test_upcloud.py
@@ -120,11 +120,11 @@ class UpcloudDriverTests(LibcloudTestCase):
         node = self.driver.create_node(name='test_server', size=size, image=image, location=location, ex_hostname='myhost.somewhere')
 
         self.assertTrue(re.match('^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}$', node.id))
-        self.assertEquals(node.name, 'test_server')
-        self.assertEquals(node.state, NodeState.STARTING)
+        self.assertEqual(node.name, 'test_server')
+        self.assertEqual(node.state, NodeState.STARTING)
         self.assertTrue(len(node.public_ips) > 0)
         self.assertTrue(len(node.private_ips) > 0)
-        self.assertEquals(node.driver, self.driver)
+        self.assertEqual(node.driver, self.driver)
         self.assertTrue(len(node.extra['password']) > 0)
         self.assertTrue(len(node.extra['vnc_password']) > 0)
 
@@ -140,22 +140,22 @@ class UpcloudDriverTests(LibcloudTestCase):
         auth = NodeAuthSSHKey('publikey')
         node = self.driver.create_node(name='test_server', size=size, image=image, location=location, auth=auth)
         self.assertTrue(re.match('^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}$', node.id))
-        self.assertEquals(node.name, 'test_server')
-        self.assertEquals(node.state, NodeState.STARTING)
+        self.assertEqual(node.name, 'test_server')
+        self.assertEqual(node.state, NodeState.STARTING)
         self.assertTrue(len(node.public_ips) > 0)
         self.assertTrue(len(node.private_ips) > 0)
-        self.assertEquals(node.driver, self.driver)
+        self.assertEqual(node.driver, self.driver)
 
     def test_list_nodes(self):
         nodes = self.driver.list_nodes()
 
         self.assertTrue(len(nodes) >= 1)
         node = nodes[0]
-        self.assertEquals(node.name, 'test_server')
-        self.assertEquals(node.state, NodeState.RUNNING)
+        self.assertEqual(node.name, 'test_server')
+        self.assertEqual(node.state, NodeState.RUNNING)
         self.assertTrue(len(node.public_ips) > 0)
         self.assertTrue(len(node.private_ips) > 0)
-        self.assertEquals(node.driver, self.driver)
+        self.assertEqual(node.driver, self.driver)
 
     def test_reboot_node(self):
         nodes = self.driver.list_nodes()

--- a/libcloud/test/dns/test_auroradns.py
+++ b/libcloud/test/dns/test_auroradns.py
@@ -110,12 +110,12 @@ class AuroraDNSDriverTests(LibcloudTestCase):
 
     def test_create_zone(self):
         zone = self.driver.create_zone('example.com')
-        self.assertEquals(zone.domain, 'example.com')
+        self.assertEqual(zone.domain, 'example.com')
 
     def test_get_zone(self):
         zone = self.driver.get_zone('example.com')
-        self.assertEquals(zone.domain, 'example.com')
-        self.assertEquals(zone.id, 'ffb62570-8414-4578-a346-526b44e320b7')
+        self.assertEqual(zone.domain, 'example.com')
+        self.assertEqual(zone.id, 'ffb62570-8414-4578-a346-526b44e320b7')
 
     def test_delete_zone(self):
         zone = self.driver.get_zone('example.com')
@@ -127,28 +127,28 @@ class AuroraDNSDriverTests(LibcloudTestCase):
                                     type=RecordType.A,
                                     data='127.0.0.1',
                                     extra={'ttl': 900})
-        self.assertEquals(record.id, '5592f1ff')
-        self.assertEquals(record.name, 'localhost')
-        self.assertEquals(record.data, '127.0.0.1')
-        self.assertEquals(record.type, RecordType.A)
-        self.assertEquals(record.extra['ttl'], 900)
+        self.assertEqual(record.id, '5592f1ff')
+        self.assertEqual(record.name, 'localhost')
+        self.assertEqual(record.data, '127.0.0.1')
+        self.assertEqual(record.type, RecordType.A)
+        self.assertEqual(record.extra['ttl'], 900)
 
     def test_get_record(self):
         zone = self.driver.get_zone('example.com')
         record = self.driver.get_record(zone.id, '5592f1ff')
-        self.assertEquals(record.id, '5592f1ff')
-        self.assertEquals(record.name, 'localhost')
-        self.assertEquals(record.data, '127.0.0.1')
-        self.assertEquals(record.type, RecordType.A)
-        self.assertEquals(record.extra['ttl'], 900)
-        self.assertEquals(record.extra['priority'], None)
+        self.assertEqual(record.id, '5592f1ff')
+        self.assertEqual(record.name, 'localhost')
+        self.assertEqual(record.data, '127.0.0.1')
+        self.assertEqual(record.type, RecordType.A)
+        self.assertEqual(record.extra['ttl'], 900)
+        self.assertEqual(record.extra['priority'], None)
 
     def test_update_record(self):
         ttl = 900
         zone = self.driver.get_zone('example.com')
         record = self.driver.get_record(zone.id, '5592f1ff')
         record = record.update(extra={'ttl': ttl})
-        self.assertEquals(record.extra['ttl'], ttl)
+        self.assertEqual(record.extra['ttl'], ttl)
 
     def test_delete_record(self):
         zone = self.driver.get_zone('example.com')

--- a/libcloud/test/dns/test_base.py
+++ b/libcloud/test/dns/test_base.py
@@ -23,6 +23,8 @@ from libcloud.test import unittest
 from libcloud.dns.base import DNSDriver, Zone, Record
 from libcloud.dns.types import RecordType
 
+from libcloud.utils.py3 import assertRegex
+
 
 MOCK_RECORDS_VALUES = [
     {'id': 1, 'name': 'www', 'type': RecordType.A, 'data': '127.0.0.1'},
@@ -91,17 +93,17 @@ class BaseTestCase(unittest.TestCase):
 
         for lines in [lines1, lines2]:
             self.assertEqual(len(lines), 2 + 1 + 9)
-            self.assertRegexpMatches(lines[1], r'\$ORIGIN example\.com\.')
-            self.assertRegexpMatches(lines[2], r'\$TTL 900')
+            assertRegex(self, lines[1], r'\$ORIGIN example\.com\.')
+            assertRegex(self, lines[2], r'\$TTL 900')
 
-            self.assertRegexpMatches(lines[4], r'www.example.com\.\s+900\s+IN\s+A\s+127\.0\.0\.1')
-            self.assertRegexpMatches(lines[5], r'www.example.com\.\s+900\s+IN\s+AAAA\s+2a01:4f8:121:3121::2')
-            self.assertRegexpMatches(lines[6], r'www.example.com\.\s+123\s+IN\s+A\s+127\.0\.0\.1')
-            self.assertRegexpMatches(lines[7], r'example.com\.\s+900\s+IN\s+A\s+127\.0\.0\.1')
-            self.assertRegexpMatches(lines[8], r'test1.example.com\.\s+900\s+IN\s+TXT\s+"test foo bar"')
-            self.assertRegexpMatches(lines[9], r'test2.example.com\.\s+900\s+IN\s+TXT\s+"test \\"foo\\" \\"bar\\""')
-            self.assertRegexpMatches(lines[10], r'example.com\.\s+900\s+IN\s+MX\s+10\s+mx.example.com')
-            self.assertRegexpMatches(lines[11], r'example.com\.\s+900\s+IN\s+SRV\s+20\s+10 3333 example.com')
+            assertRegex(self, lines[4], r'www.example.com\.\s+900\s+IN\s+A\s+127\.0\.0\.1')
+            assertRegex(self, lines[5], r'www.example.com\.\s+900\s+IN\s+AAAA\s+2a01:4f8:121:3121::2')
+            assertRegex(self, lines[6], r'www.example.com\.\s+123\s+IN\s+A\s+127\.0\.0\.1')
+            assertRegex(self, lines[7], r'example.com\.\s+900\s+IN\s+A\s+127\.0\.0\.1')
+            assertRegex(self, lines[8], r'test1.example.com\.\s+900\s+IN\s+TXT\s+"test foo bar"')
+            assertRegex(self, lines[9], r'test2.example.com\.\s+900\s+IN\s+TXT\s+"test \\"foo\\" \\"bar\\""')
+            assertRegex(self, lines[10], r'example.com\.\s+900\s+IN\s+MX\s+10\s+mx.example.com')
+            assertRegex(self, lines[11], r'example.com\.\s+900\s+IN\s+SRV\s+20\s+10 3333 example.com')
 
 
 if __name__ == '__main__':

--- a/libcloud/test/dns/test_linode.py
+++ b/libcloud/test/dns/test_linode.py
@@ -69,10 +69,10 @@ class LinodeTests(unittest.TestCase):
                                            'weight'])
 
         srvrecord = records[1]
-        self.assertEquals(srvrecord.id, '3585141')
-        self.assertEquals(srvrecord.name, '_minecraft._udp')
-        self.assertEquals(srvrecord.type, RecordType.SRV)
-        self.assertEquals(srvrecord.data, 'mc.linode.com')
+        self.assertEqual(srvrecord.id, '3585141')
+        self.assertEqual(srvrecord.name, '_minecraft._udp')
+        self.assertEqual(srvrecord.type, RecordType.SRV)
+        self.assertEqual(srvrecord.data, 'mc.linode.com')
         self.assertHasKeys(srvrecord.extra, ['protocol', 'ttl_sec', 'port',
                                              'priority', 'weight'])
 

--- a/libcloud/test/dns/test_nfsn.py
+++ b/libcloud/test/dns/test_nfsn.py
@@ -50,8 +50,8 @@ class NFSNTestCase(LibcloudTestCase):
 
     def test_get_zone(self):
         zone = self.driver.get_zone('example.com')
-        self.assertEquals(zone.id, None)
-        self.assertEquals(zone.domain, 'example.com')
+        self.assertEqual(zone.id, None)
+        self.assertEqual(zone.domain, 'example.com')
 
     def test_delete_zone(self):
         with self.assertRaises(NotImplementedError):
@@ -63,11 +63,11 @@ class NFSNTestCase(LibcloudTestCase):
                                               type=RecordType.A,
                                               data='127.0.0.1',
                                               extra={'ttl': 900})
-        self.assertEquals(record.id, None)
-        self.assertEquals(record.name, 'newrecord')
-        self.assertEquals(record.data, '127.0.0.1')
-        self.assertEquals(record.type, RecordType.A)
-        self.assertEquals(record.ttl, 900)
+        self.assertEqual(record.id, None)
+        self.assertEqual(record.name, 'newrecord')
+        self.assertEqual(record.data, '127.0.0.1')
+        self.assertEqual(record.type, RecordType.A)
+        self.assertEqual(record.ttl, 900)
 
     def test_get_record(self):
         with self.assertRaises(NotImplementedError):
@@ -86,10 +86,10 @@ class NFSNTestCase(LibcloudTestCase):
                                                 type=RecordType.A)
         self.assertEqual(len(records), 1)
         record = records[0]
-        self.assertEquals(record.name, '')
-        self.assertEquals(record.data, '192.0.2.1')
-        self.assertEquals(record.type, RecordType.A)
-        self.assertEquals(record.ttl, 3600)
+        self.assertEqual(record.name, '')
+        self.assertEqual(record.data, '192.0.2.1')
+        self.assertEqual(record.type, RecordType.A)
+        self.assertEqual(record.ttl, 3600)
 
     def test_get_zone_not_found(self):
         NFSNMockHttp.type = 'NOT_FOUND'

--- a/libcloud/test/loadbalancer/test_alb.py
+++ b/libcloud/test/loadbalancer/test_alb.py
@@ -37,14 +37,14 @@ class ApplicationLBTests(unittest.TestCase):
         token = 'temporary_credentials_token'
         driver = ApplicationLBDriver(*LB_ALB_PARAMS, **{'token': token})
         self.assertTrue(hasattr(driver, 'token'), 'Driver has no attribute token')
-        self.assertEquals(token, driver.token, "Driver token does not match with provided token")
+        self.assertEqual(token, driver.token, "Driver token does not match with provided token")
 
     def test_driver_with_token_signature_version(self):
         token = 'temporary_credentials_token'
         driver = ApplicationLBDriver(*LB_ALB_PARAMS, **{'token': token})
         kwargs = driver._ex_connection_class_kwargs()
         self.assertTrue(('signature_version' in kwargs), 'Driver has no attribute signature_version')
-        self.assertEquals('4', kwargs['signature_version'], 'Signature version is not 4 with temporary credentials')
+        self.assertEqual('4', kwargs['signature_version'], 'Signature version is not 4 with temporary credentials')
 
     def test_list_protocols(self):
         protocols = self.driver.list_protocols()

--- a/libcloud/test/loadbalancer/test_cloudstack.py
+++ b/libcloud/test/loadbalancer/test_cloudstack.py
@@ -8,6 +8,7 @@ except ImportError:
 from libcloud.utils.py3 import httplib
 from libcloud.utils.py3 import urlparse
 from libcloud.utils.py3 import parse_qsl
+from libcloud.utils.py3 import assertRaisesRegex
 
 from libcloud.loadbalancer.types import Provider
 from libcloud.loadbalancer.providers import get_driver
@@ -38,8 +39,8 @@ class CloudStackLBTests(unittest.TestCase):
                        'you also need to provide host and path argument'
         cls = get_driver(Provider.CLOUDSTACK)
 
-        self.assertRaisesRegexp(Exception, expected_msg, cls,
-                                'key', 'secret')
+        assertRaisesRegex(self, Exception, expected_msg, cls,
+                          'key', 'secret')
 
         try:
             cls('key', 'secret', True, 'localhost', '/path')

--- a/libcloud/test/loadbalancer/test_elb.py
+++ b/libcloud/test/loadbalancer/test_elb.py
@@ -39,14 +39,14 @@ class ElasticLBTests(unittest.TestCase):
         token = 'temporary_credentials_token'
         driver = ElasticLBDriver(*LB_ELB_PARAMS, **{'token': token})
         self.assertTrue(hasattr(driver, 'token'), 'Driver has no attribute token')
-        self.assertEquals(token, driver.token, "Driver token does not match with provided token")
+        self.assertEqual(token, driver.token, "Driver token does not match with provided token")
 
     def test_driver_with_token_signature_version(self):
         token = 'temporary_credentials_token'
         driver = ElasticLBDriver(*LB_ELB_PARAMS, **{'token': token})
         kwargs = driver._ex_connection_class_kwargs()
         self.assertTrue(('signature_version' in kwargs), 'Driver has no attribute signature_version')
-        self.assertEquals('4', kwargs['signature_version'], 'Signature version is not 4 with temporary credentials')
+        self.assertEqual('4', kwargs['signature_version'], 'Signature version is not 4 with temporary credentials')
 
     def test_list_protocols(self):
         protocols = self.driver.list_protocols()

--- a/libcloud/test/storage/test_backblaze_b2.py
+++ b/libcloud/test/storage/test_backblaze_b2.py
@@ -109,11 +109,14 @@ class BackblazeB2StorageDriverTestCase(unittest.TestCase):
     def test_upload_object_via_stream(self):
         container = self.driver.list_containers()[0]
         file_path = os.path.abspath(__file__)
-        file = open(file_path, 'rb')
-        iterator = iter(file)
-        obj = self.driver.upload_object_via_stream(iterator=iterator,
-                                                   container=container,
-                                                   object_name='test0007.txt')
+
+        with open(file_path, 'rb') as fp:
+            iterator = iter(fp)
+
+            obj = self.driver.upload_object_via_stream(iterator=iterator,
+                                                       container=container,
+                                                       object_name='test0007.txt')
+
         self.assertEqual(obj.name, 'test0007.txt')
         self.assertEqual(obj.size, 24)
         self.assertEqual(obj.extra['fileId'], 'abcde')

--- a/libcloud/test/storage/test_base.py
+++ b/libcloud/test/storage/test_base.py
@@ -25,6 +25,7 @@ from mock import Mock
 from libcloud.utils.py3 import StringIO
 from libcloud.utils.py3 import b
 from libcloud.utils.py3 import PY2
+from libcloud.utils.py3 import assertRaisesRegex
 
 from libcloud.storage.base import StorageDriver
 from libcloud.storage.base import DEFAULT_CONTENT_TYPE
@@ -126,14 +127,14 @@ class BaseStorageTests(unittest.TestCase):
         self.driver1.strict_mode = True
         expected_msg = ('File content-type could not be guessed and no'
                         ' content_type value is provided')
-        self.assertRaisesRegexp(AttributeError, expected_msg,
-                                self.driver1._upload_object,
-                                object_name='test',
-                                content_type=None,
-                                upload_func=upload_func,
-                                upload_func_kwargs={},
-                                request_path='/',
-                                stream=iterator)
+        assertRaisesRegex(self, AttributeError, expected_msg,
+                          self.driver1._upload_object,
+                          object_name='test',
+                          content_type=None,
+                          upload_func=upload_func,
+                          upload_func_kwargs={},
+                          request_path='/',
+                          stream=iterator)
 
     @mock.patch('libcloud.utils.files.exhaust_iterator')
     @mock.patch('libcloud.utils.files.read_in_chunks')

--- a/libcloud/test/test_connection.py
+++ b/libcloud/test/test_connection.py
@@ -29,6 +29,7 @@ from libcloud.http import LibcloudBaseConnection
 from libcloud.http import LibcloudConnection
 from libcloud.http import SignedHTTPSAdapter
 from libcloud.utils.misc import retry
+from libcloud.utils.py3 import assertRaisesRegex
 
 
 class BaseConnectionClassTestCase(unittest.TestCase):
@@ -61,27 +62,27 @@ class BaseConnectionClassTestCase(unittest.TestCase):
 
         proxy_url = 'https://127.0.0.1:3128'
         expected_msg = 'Only http proxies are supported'
-        self.assertRaisesRegexp(ValueError, expected_msg,
-                                conn._parse_proxy_url,
-                                proxy_url=proxy_url)
+        assertRaisesRegex(self, ValueError, expected_msg,
+                          conn._parse_proxy_url,
+                          proxy_url=proxy_url)
 
         proxy_url = 'http://127.0.0.1'
         expected_msg = 'proxy_url must be in the following format'
-        self.assertRaisesRegexp(ValueError, expected_msg,
-                                conn._parse_proxy_url,
-                                proxy_url=proxy_url)
+        assertRaisesRegex(self, ValueError, expected_msg,
+                          conn._parse_proxy_url,
+                          proxy_url=proxy_url)
 
         proxy_url = 'http://@127.0.0.1:3128'
         expected_msg = 'URL is in an invalid format'
-        self.assertRaisesRegexp(ValueError, expected_msg,
-                                conn._parse_proxy_url,
-                                proxy_url=proxy_url)
+        assertRaisesRegex(self, ValueError, expected_msg,
+                          conn._parse_proxy_url,
+                          proxy_url=proxy_url)
 
         proxy_url = 'http://user@127.0.0.1:3128'
         expected_msg = 'URL is in an invalid format'
-        self.assertRaisesRegexp(ValueError, expected_msg,
-                                conn._parse_proxy_url,
-                                proxy_url=proxy_url)
+        assertRaisesRegex(self, ValueError, expected_msg,
+                          conn._parse_proxy_url,
+                          proxy_url=proxy_url)
 
     def test_constructor(self):
         proxy_url = 'http://127.0.0.2:3128'
@@ -246,9 +247,9 @@ class ConnectionClassTestCase(unittest.TestCase):
         Connection.allow_insecure = False
 
         expected_msg = (r'Non https connections are not allowed \(use '
-                        'secure=True\)')
-        self.assertRaisesRegexp(ValueError, expected_msg, Connection,
-                                secure=False)
+                        r'secure=True\)')
+        assertRaisesRegex(self, ValueError, expected_msg, Connection,
+                          secure=False)
 
     def test_cache_busting(self):
         params1 = {'foo1': 'bar1', 'foo2': 'bar2'}

--- a/libcloud/test/test_connection.py
+++ b/libcloud/test/test_connection.py
@@ -342,7 +342,7 @@ class ConnectionClassTestCase(unittest.TestCase):
             mock_connect.__name__ = 'mock_connect'
             with self.assertRaises(socket.gaierror):
                 mock_connect.side_effect = socket.gaierror('')
-                retry_request = retry(timeout=1, retry_delay=.1,
+                retry_request = retry(timeout=0.5, retry_delay=.1,
                                       backoff=1)
                 retry_request(con.request)(action='/')
 
@@ -358,7 +358,7 @@ class ConnectionClassTestCase(unittest.TestCase):
             mock_connect.__name__ = 'mock_connect'
             with self.assertRaises(socket.gaierror):
                 mock_connect.side_effect = socket.gaierror('')
-                retry_request = retry(timeout=2, retry_delay=.1,
+                retry_request = retry(timeout=0.5, retry_delay=.1,
                                       backoff=1)
                 retry_request(con.request)(action='/')
 
@@ -374,7 +374,7 @@ class ConnectionClassTestCase(unittest.TestCase):
             mock_connect.__name__ = 'mock_connect'
             with self.assertRaises(socket.gaierror):
                 mock_connect.side_effect = socket.gaierror('')
-                retry_request = retry(timeout=2, retry_delay=.1,
+                retry_request = retry(timeout=0.5, retry_delay=.1,
                                       backoff=1)
                 retry_request(con.request)(action='/')
 

--- a/libcloud/test/test_connection.py
+++ b/libcloud/test/test_connection.py
@@ -342,7 +342,7 @@ class ConnectionClassTestCase(unittest.TestCase):
             mock_connect.__name__ = 'mock_connect'
             with self.assertRaises(socket.gaierror):
                 mock_connect.side_effect = socket.gaierror('')
-                retry_request = retry(timeout=0.5, retry_delay=.1,
+                retry_request = retry(timeout=0.2, retry_delay=0.1,
                                       backoff=1)
                 retry_request(con.request)(action='/')
 
@@ -358,7 +358,7 @@ class ConnectionClassTestCase(unittest.TestCase):
             mock_connect.__name__ = 'mock_connect'
             with self.assertRaises(socket.gaierror):
                 mock_connect.side_effect = socket.gaierror('')
-                retry_request = retry(timeout=0.5, retry_delay=.1,
+                retry_request = retry(timeout=0.2, retry_delay=0.1,
                                       backoff=1)
                 retry_request(con.request)(action='/')
 
@@ -374,7 +374,7 @@ class ConnectionClassTestCase(unittest.TestCase):
             mock_connect.__name__ = 'mock_connect'
             with self.assertRaises(socket.gaierror):
                 mock_connect.side_effect = socket.gaierror('')
-                retry_request = retry(timeout=0.5, retry_delay=.1,
+                retry_request = retry(timeout=0.2, retry_delay=0.1,
                                       backoff=1)
                 retry_request(con.request)(action='/')
 

--- a/libcloud/test/test_http.py
+++ b/libcloud/test/test_http.py
@@ -21,6 +21,7 @@ import warnings
 import libcloud.security
 
 from libcloud.utils.py3 import reload
+from libcloud.utils.py3 import assertRaisesRegex
 from libcloud.http import LibcloudConnection
 
 from libcloud.test import unittest
@@ -52,8 +53,8 @@ class TestHttpLibSSLTests(unittest.TestCase):
         os.environ['SSL_CERT_FILE'] = file_path
 
         expected_msg = 'Certificate file can\'t be a directory'
-        self.assertRaisesRegexp(ValueError, expected_msg,
-                                reload, libcloud.security)
+        assertRaisesRegex(self, ValueError, expected_msg,
+                          reload, libcloud.security)
 
     def test_custom_ca_path_using_env_var_exist(self):
         # When setting a path we don't actually check that a valid CA file is

--- a/libcloud/utils/publickey.py
+++ b/libcloud/utils/publickey.py
@@ -13,11 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import base64
 import hashlib
 
 from libcloud.utils.py3 import hexadigits
 from libcloud.utils.py3 import b
+from libcloud.utils.py3 import base64_decode_string
 
 __all__ = [
     'get_pubkey_openssh_fingerprint',
@@ -50,7 +50,7 @@ def get_pubkey_openssh_fingerprint(pubkey):
         encoding=serialization.Encoding.OpenSSH,
         format=serialization.PublicFormat.OpenSSH,
     )[7:]  # strip ssh-rsa prefix
-    return _to_md5_fingerprint(base64.decodestring(pub_openssh))
+    return _to_md5_fingerprint(base64_decode_string(pub_openssh))
 
 
 def get_pubkey_ssh2_fingerprint(pubkey):

--- a/libcloud/utils/py3.py
+++ b/libcloud/utils/py3.py
@@ -18,7 +18,7 @@
 # clause BSD license
 # https://bitbucket.org/loewis/django-3k
 
-# pylint: disable=import-error
+# pylint: disable=import-error,no-member
 
 from __future__ import absolute_import
 

--- a/libcloud/utils/py3.py
+++ b/libcloud/utils/py3.py
@@ -136,10 +136,10 @@ if PY3:
     if sys.version_info >= (3, 1, 0):
         # encodestring and decodestring has been deprecated since 3.1.0
         def base64_encode_string(*args, **kwargs):
-            return base64.encodebytes(*args, **kwargs)
+            return base64.encodebytes(*args, **kwargs)  # NOQA
 
         def base64_decode_string(*args, **kwargs):
-            return base64.decodebytes(*args, **kwargs)
+            return base64.decodebytes(*args, **kwargs)  # NOQA
     else:
         def base64_encode_string(*args, **kwargs):
             return base64.encodestring(*args, **kwargs)

--- a/libcloud/utils/py3.py
+++ b/libcloud/utils/py3.py
@@ -24,6 +24,7 @@ from __future__ import absolute_import
 
 import sys
 import types
+import unittest
 
 DEFAULT_LXML = False
 
@@ -128,6 +129,18 @@ if PY3:
         # s needs to be a byte string.
         return [format(x, "02x") for x in s]
 
+    def assertRaisesRegex(self, *args, **kwargs):
+        if not isinstance(self, unittest.TestCase):
+            raise ValueError('First argument "self" needs to be an instance '
+                             'of unittest.TestCase')
+        return getattr(self, 'assertRaisesRegex')(*args, **kwargs)
+
+    def assertRegex(self, *args, **kwargs):
+        if not isinstance(self, unittest.TestCase):
+            raise ValueError('First argument "self" needs to be an instance '
+                             'of unittest.TestCase')
+
+        return getattr(self, 'assertRegex')(*args, **kwargs)
 else:
     import httplib  # NOQA
     from StringIO import StringIO  # NOQA
@@ -188,3 +201,17 @@ else:
     def hexadigits(s):
         # s needs to be a string.
         return [x.encode("hex") for x in s]
+
+    def assertRaisesRegex(self, *args, **kwargs):
+        if not isinstance(self, unittest.TestCase):
+            raise ValueError('First argument "self" needs to be an instance '
+                             'of unittest.TestCase')
+
+        return getattr(self, 'assertRaisesRegexp')(*args, **kwargs)
+
+    def assertRegex(self, *args, **kwargs):
+        if not isinstance(self, unittest.TestCase):
+            raise ValueError('First argument "self" needs to be an instance '
+                             'of unittest.TestCase')
+
+        return getattr(self, 'assertRegexpMatches')(*args, **kwargs)

--- a/libcloud/utils/py3.py
+++ b/libcloud/utils/py3.py
@@ -68,6 +68,7 @@ if PY3:
     from io import StringIO
     import urllib
     import urllib as urllib2
+    import base64
     # pylint: disable=no-name-in-module
     import urllib.parse as urlparse
     import xmlrpc.client as xmlrpclib
@@ -132,6 +133,20 @@ if PY3:
         # s needs to be a byte string.
         return [format(x, "02x") for x in s]
 
+    if sys.version_info >= (3, 1, 0):
+        # encodestring and decodestring has been deprecated since 3.1.0
+        def base64_encode_string(*args, **kwargs):
+            return base64.encodebytes(*args, **kwargs)
+
+        def base64_decode_string(*args, **kwargs):
+            return base64.decodebytes(*args, **kwargs)
+    else:
+        def base64_encode_string(*args, **kwargs):
+            return base64.encodestring(*args, **kwargs)
+
+        def base64_decode_string(*args, **kwargs):
+            return base64.decodestring(*args, **kwargs)
+
     def assertRaisesRegex(self, *args, **kwargs):
         if not isinstance(self, unittest.TestCase):
             raise ValueError('First argument "self" needs to be an instance '
@@ -151,6 +166,7 @@ else:
     import urllib2  # NOQA
     import urlparse  # NOQA
     import xmlrpclib  # NOQA
+    import base64  # NOQA
     from urllib import quote as _urlquote  # NOQA
     from urllib import unquote as urlunquote  # NOQA
     from urllib import urlencode as urlencode  # NOQA
@@ -204,6 +220,12 @@ else:
     def hexadigits(s):
         # s needs to be a string.
         return [x.encode("hex") for x in s]
+
+    def base64_encode_string(*args, **kwargs):
+        return base64.encodestring(*args, **kwargs)
+
+    def base64_decode_string(*args, **kwargs):
+        return base64.decodestring(*args, **kwargs)
 
     def assertRaisesRegex(self, *args, **kwargs):
         if not isinstance(self, unittest.TestCase):

--- a/libcloud/utils/py3.py
+++ b/libcloud/utils/py3.py
@@ -77,7 +77,10 @@ if PY3:
     from urllib.parse import urlencode as urlencode
     from os.path import relpath
 
-    from imp import reload
+    if sys.version_info >= (3, 5, 0):
+        from importlib import reload
+    else:
+        from imp import reload
 
     from builtins import bytes
     from builtins import next

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,8 @@
 [pytest]
 python_classes=*Test
 testpaths=libcloud/test
+# Show slowest 10 tests in the output
+addopts = --durations=10
 # Ignore UserWarning's
 filterwarnings =
     ignore::UserWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,6 @@
 [pytest]
 python_classes=*Test
 testpaths=libcloud/test
+# Ignore UserWarning's
+filterwarnings =
+    ignore::UserWarning

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,9 +10,8 @@ test=pytest
 [tool:pytest]
 python_classes=*Test
 testpaths=libcloud/test
-# Ignore UserWarning's and treat any other warnings as an error
+# Ignore UserWarning's
 filterwarnings =
-    error
     ignore::UserWarning
 
 [flake8]

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,10 @@ test=pytest
 [tool:pytest]
 python_classes=*Test
 testpaths=libcloud/test
+# Ignore UserWarning's and treat any other warnings as an error
+filterwarnings =
+    error
+    ignore::UserWarning
 
 [flake8]
 exclude=libcloud/compute/constants.py,libcloud/test

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = py{2.7,pypy,pypy3,3.4,3.5,3.6,3.7},checks,lint,pylint,integration,cove
 
 [testenv]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
+setenv = PYTHONWARNINGS = "ignore::UserWarning"
 deps =
     -r{toxinidir}/requirements-tests.txt
     pyopenssl

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ envlist = py{2.7,pypy,pypy3,3.4,3.5,3.6,3.7},checks,lint,pylint,integration,cove
 
 [testenv]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
-setenv = PYTHONWARNINGS = "ignore::UserWarning"
 deps =
     -r{toxinidir}/requirements-tests.txt
     pyopenssl


### PR DESCRIPTION
This pull request fixes various issues in the code which were mostly identified when running tests under newer versions of Python 3 (newer versions print various deprecation warning and also report open file handle leakage, etc.).

1. Fix various tests and drivers which didn't correctly cleanup and close open files
2. Fix ``libcloud.enable_debug`` debug function so it correctly closes the file handle on exit
3. Update test code to use non-deprecated assertion methods on newer versions of Python 3
4. Various other deprecation errors
5. Ignore user warnings when running tests using tox (this way we silence non-important warnings)
6. Update various tests to use smaller sleep / poll intervals to speed tests up (tests now finish ~40 seconds or so faster)
7. Update py.test config so it prints 10 slowest tests at the end of the test run report. This will allow us to identify and fix slow tests in the future.