### PR TITLE
Re-enable PyPy builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ matrix:
     - python: 3.7
       dist: xenial
       sudo: required
-    - pypy
-    - pypy3
+    - python: pypy
+    - python: pypy3
     - env: ENV=checks
       python: 2.7
       before_script: TOX_ENV=checks

--- a/tox.ini
+++ b/tox.ini
@@ -25,10 +25,6 @@ whitelist_externals = cp
                       bash
                       scripts/*.sh
 
-[testenv:pypypy3]
-commands = cp libcloud/test/secrets.py-dist libcloud/test/secrets.py
-           python -m unittest discover libcloud/test
-
 [testenv:docs]
 deps = pysphere
        pyopenssl


### PR DESCRIPTION
This pull request will try to re-enable builds under PyPy. It looks like they were disabled at some point.