### PR TITLE
Enable to specify project id in OpenStack OIDC auth

### DIFF
--- a/libcloud/common/openstack_identity.py
+++ b/libcloud/common/openstack_identity.py
@@ -1416,8 +1416,9 @@ class OpenStackIdentity_3_0_Connection_OIDC_access_token(
     The protocol name required to get the full path
     must be set in the self.tenant_name attribute.
 
-    The user must be scoped to the first project accessible with the
-    specified access token (usually there are only one)
+    The self.domain_name attribute can be used either to select the
+    domain name in case of domain scoped token or to select the project
+    name in case of project scoped token
     """
 
     responseCls = OpenStackAuthResponse
@@ -1432,7 +1433,6 @@ class OpenStackIdentity_3_0_Connection_OIDC_access_token(
             return self
 
         subject_token = self._get_unscoped_token_from_oidc_token()
-        project_id = self._get_project_id(token=subject_token)
 
         data = {
             'auth': {
@@ -1447,6 +1447,7 @@ class OpenStackIdentity_3_0_Connection_OIDC_access_token(
 
         if self.token_scope == OpenStackIdentityTokenScope.PROJECT:
             # Scope token to project (tenant)
+            project_id = self._get_project_id(token=subject_token)
             data['auth']['scope'] = {
                 'project': {
                     'id': project_id
@@ -1562,7 +1563,15 @@ class OpenStackIdentity_3_0_Connection_OIDC_access_token(
         elif response.status in [httplib.OK, httplib.CREATED]:
             try:
                 body = json.loads(response.body)
-                return body["projects"][0]["id"]
+                # We use domain_name in both cases of the scoped tokens
+                # as we have used tenant as the protocol
+                if self.domain_name and self.domain_name != 'Default':
+                    for project in body['projects']:
+                        if project['name'] == self.domain_name:
+                            return project['id']
+                    raise ValueError('Project %s not found' % self.domain_name)
+                else:
+                    return body['projects'][0]['id']
             except Exception:
                 e = sys.exc_info()[1]
                 raise MalformedResponseError('Failed to parse JSON', e)

--- a/libcloud/test/common/test_openstack_identity.py
+++ b/libcloud/test/common/test_openstack_identity.py
@@ -24,7 +24,6 @@ except ImportError:
 from mock import Mock
 
 from libcloud.utils.py3 import httplib
-from libcloud.utils.py3 import assertRaisesRegex
 from libcloud.common.openstack import OpenStackBaseConnection
 from libcloud.common.openstack_identity import AUTH_TOKEN_EXPIRES_GRACE_SECONDS
 from libcloud.common.openstack_identity import get_class_for_auth_version
@@ -259,31 +258,31 @@ class OpenStackIdentity_3_0_ConnectionTests(unittest.TestCase):
     def test_token_scope_argument(self):
         # Invalid token_scope value
         expected_msg = 'Invalid value for "token_scope" argument: foo'
-        assertRaisesRegex(self, ValueError, expected_msg,
-                          OpenStackIdentity_3_0_Connection,
-                          auth_url='http://none',
-                          user_id='test',
-                          key='test',
-                          token_scope='foo')
+        self.assertRaisesRegexp(ValueError, expected_msg,
+                                OpenStackIdentity_3_0_Connection,
+                                auth_url='http://none',
+                                user_id='test',
+                                key='test',
+                                token_scope='foo')
 
         # Missing tenant_name
         expected_msg = 'Must provide tenant_name and domain_name argument'
-        assertRaisesRegex(self, ValueError, expected_msg,
-                          OpenStackIdentity_3_0_Connection,
-                          auth_url='http://none',
-                          user_id='test',
-                          key='test',
-                          token_scope='project')
+        self.assertRaisesRegexp(ValueError, expected_msg,
+                                OpenStackIdentity_3_0_Connection,
+                                auth_url='http://none',
+                                user_id='test',
+                                key='test',
+                                token_scope='project')
 
         # Missing domain_name
         expected_msg = 'Must provide domain_name argument'
-        assertRaisesRegex(self, ValueError, expected_msg,
-                          OpenStackIdentity_3_0_Connection,
-                          auth_url='http://none',
-                          user_id='test',
-                          key='test',
-                          token_scope='domain',
-                          domain_name=None)
+        self.assertRaisesRegexp(ValueError, expected_msg,
+                                OpenStackIdentity_3_0_Connection,
+                                auth_url='http://none',
+                                user_id='test',
+                                key='test',
+                                token_scope='domain',
+                                domain_name=None)
 
         # Scope to project all ok
         OpenStackIdentity_3_0_Connection(auth_url='http://none',
@@ -454,8 +453,7 @@ class OpenStackIdentity_3_0_Connection_OIDC_access_token_federation_projectsTest
         self.auth_instance = OpenStackIdentity_3_0_Connection_OIDC_access_token(auth_url='http://none',
                                                                                 user_id='idp',
                                                                                 key='token',
-                                                                                tenant_name='oidc',
-                                                                                domain_name='test_domain')
+                                                                                tenant_name='oidc')
         self.auth_instance.auth_token = 'mock'
 
     def test_authenticate(self):
@@ -463,8 +461,7 @@ class OpenStackIdentity_3_0_Connection_OIDC_access_token_federation_projectsTest
                                                                   user_id='idp',
                                                                   key='token',
                                                                   token_scope='project',
-                                                                  tenant_name="oidc",
-                                                                  domain_name='test_domain')
+                                                                  tenant_name="oidc")
         auth.authenticate()
 
 
@@ -479,7 +476,7 @@ class OpenStackIdentity_3_0_Connection_OIDC_access_tokenTests(
                                                                                 user_id='idp',
                                                                                 key='token',
                                                                                 tenant_name='oidc',
-                                                                                domain_name='test_domain')
+                                                                                domain_name='project_name2')
         self.auth_instance.auth_token = 'mock'
 
     def test_authenticate(self):
@@ -488,7 +485,7 @@ class OpenStackIdentity_3_0_Connection_OIDC_access_tokenTests(
                                                                   key='token',
                                                                   token_scope='project',
                                                                   tenant_name="oidc",
-                                                                  domain_name='test_domain')
+                                                                  domain_name='project_name2')
         auth.authenticate()
 
 
@@ -790,14 +787,16 @@ class OpenStackIdentity_3_0_MockHttp(MockHttp):
     def _v3_OS_FEDERATION_projects(self, method, url, body, headers):
         if method == 'GET':
             # get user projects
-            body = json.dumps({"projects": [{"id": "project_id"}]})
+            body = json.dumps({"projects": [{"id": "project_id", "name": "project_name"},
+                                            {"id": "project_id2", "name": "project_name2"}]})
             return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
         raise NotImplementedError()
 
     def _v3_auth_projects(self, method, url, body, headers):
         if method == 'GET':
             # get user projects
-            body = json.dumps({"projects": [{"id": "project_id"}]})
+            body = json.dumps({"projects": [{"id": "project_id", "name": "project_name"},
+                                            {"id": "project_id2", "name": "project_name2"}]})
             return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
         raise NotImplementedError()
 

--- a/libcloud/test/common/test_openstack_identity.py
+++ b/libcloud/test/common/test_openstack_identity.py
@@ -24,6 +24,7 @@ except ImportError:
 from mock import Mock
 
 from libcloud.utils.py3 import httplib
+from libcloud.utils.py3 import assertRaisesRegex
 from libcloud.common.openstack import OpenStackBaseConnection
 from libcloud.common.openstack_identity import AUTH_TOKEN_EXPIRES_GRACE_SECONDS
 from libcloud.common.openstack_identity import get_class_for_auth_version
@@ -258,31 +259,31 @@ class OpenStackIdentity_3_0_ConnectionTests(unittest.TestCase):
     def test_token_scope_argument(self):
         # Invalid token_scope value
         expected_msg = 'Invalid value for "token_scope" argument: foo'
-        self.assertRaisesRegexp(ValueError, expected_msg,
-                                OpenStackIdentity_3_0_Connection,
-                                auth_url='http://none',
-                                user_id='test',
-                                key='test',
-                                token_scope='foo')
+        assertRaisesRegex(self, ValueError, expected_msg,
+                          OpenStackIdentity_3_0_Connection,
+                          auth_url='http://none',
+                          user_id='test',
+                          key='test',
+                          token_scope='foo')
 
         # Missing tenant_name
         expected_msg = 'Must provide tenant_name and domain_name argument'
-        self.assertRaisesRegexp(ValueError, expected_msg,
-                                OpenStackIdentity_3_0_Connection,
-                                auth_url='http://none',
-                                user_id='test',
-                                key='test',
-                                token_scope='project')
+        assertRaisesRegex(self, ValueError, expected_msg,
+                          OpenStackIdentity_3_0_Connection,
+                          auth_url='http://none',
+                          user_id='test',
+                          key='test',
+                          token_scope='project')
 
         # Missing domain_name
         expected_msg = 'Must provide domain_name argument'
-        self.assertRaisesRegexp(ValueError, expected_msg,
-                                OpenStackIdentity_3_0_Connection,
-                                auth_url='http://none',
-                                user_id='test',
-                                key='test',
-                                token_scope='domain',
-                                domain_name=None)
+        assertRaisesRegex(self, ValueError, expected_msg,
+                          OpenStackIdentity_3_0_Connection,
+                          auth_url='http://none',
+                          user_id='test',
+                          key='test',
+                          token_scope='domain',
+                          domain_name=None)
 
         # Scope to project all ok
         OpenStackIdentity_3_0_Connection(auth_url='http://none',


### PR DESCRIPTION
## Enable to specify project id in OpenStack OIDC auth

### Description

In current implementation the OpenStack OIDC auth the first project available is selected.
This PR enables to specify the project id using the domain_name (as the tenant_name attribute is used to specify the protocol). The domain_name attribute can be used either to select the domain name in case of domain scoped token or to select the project name in case of project scoped token


### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
