### PR TITLE
[LIBCLOUD-851] Fix azure_blobs driver with BlobStorage account

### DIFF
--- a/libcloud/common/azure.py
+++ b/libcloud/common/azure.py
@@ -31,9 +31,6 @@ from libcloud.common.base import ConnectionUserAndKey, RawResponse
 from libcloud.common.base import CertificateConnection
 from libcloud.common.base import XmlResponse
 
-# Azure API version
-API_VERSION = '2012-02-12'
-
 # The time format for headers in Azure requests
 AZURE_TIME_FORMAT = '%a, %d %b %Y %H:%M:%S GMT'
 
@@ -109,6 +106,8 @@ class AzureConnection(ConnectionUserAndKey):
     responseCls = AzureResponse
     rawResponseCls = AzureRawResponse
 
+    API_VERSION = '2012-02-12'
+
     def add_default_params(self, params):
         return params
 
@@ -117,7 +116,7 @@ class AzureConnection(ConnectionUserAndKey):
 
         # We have to add a date header in GMT
         headers['x-ms-date'] = time.strftime(AZURE_TIME_FORMAT, time.gmtime())
-        headers['x-ms-version'] = API_VERSION
+        headers['x-ms-version'] = self.API_VERSION
 
         # Add the authorization header
         headers['Authorization'] = self._get_azure_auth_signature(

--- a/libcloud/storage/drivers/azure_blobs.py
+++ b/libcloud/storage/drivers/azure_blobs.py
@@ -157,6 +157,10 @@ class AzureBlobsConnection(AzureConnection):
     Represents a single connection to Azure Blobs
     """
 
+    # this is the minimum api version supported by storage accounts of kinds
+    # StorageV2, Storage and BlobStorage
+    API_VERSION = '2014-02-14'
+
 
 class AzureBlobsStorageDriver(StorageDriver):
     name = 'Microsoft Azure (blobs)'

--- a/libcloud/test/storage/fixtures/azure_blobs/list_containers_1.xml
+++ b/libcloud/test/storage/fixtures/azure_blobs/list_containers_1.xml
@@ -1,10 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<EnumerationResults AccountName="https://account.blob.core.windows.net/">
+<EnumerationResults ServiceEndpoint="https://account.blob.core.windows.net/">
     <MaxResults>2</MaxResults>
     <Containers>
         <Container>
             <Name>container1</Name>
-            <Url>https://account.blob.core.windows.net/container1</Url>
             <Properties>
                 <Last-Modified>Mon, 07 Jan 2013 06:31:06 GMT</Last-Modified>
                 <Etag>"0x8CFBAB7B4F23346"</Etag>
@@ -15,7 +14,6 @@
         </Container>
         <Container>
             <Name>container2</Name>
-            <Url>https://account.blob.core.windows.net/container2</Url>
             <Properties>
                 <Last-Modified>Mon, 07 Jan 2013 06:31:07 GMT</Last-Modified>
                 <Etag>"0x8CFBAB7B5B82D8E"</Etag>

--- a/libcloud/test/storage/fixtures/azure_blobs/list_containers_2.xml
+++ b/libcloud/test/storage/fixtures/azure_blobs/list_containers_2.xml
@@ -1,11 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<EnumerationResults AccountName="https://account.blob.core.windows.net/">
+<EnumerationResults ServiceEndpoint="https://account.blob.core.windows.net/">
     <Marker>/account/container3</Marker>
     <MaxResults>2</MaxResults>
     <Containers>
         <Container>
             <Name>container3</Name>
-            <Url>https://account.blob.core.windows.net/container3</Url>
             <Properties>
                 <Last-Modified>Mon, 07 Jan 2013 06:31:08 GMT</Last-Modified>
                 <Etag>"0x8CFBAB7B6452A71"</Etag>
@@ -16,7 +15,6 @@
         </Container>
         <Container>
             <Name>container4</Name>
-            <Url>https://account.blob.core.windows.net/container4</Url>
             <Properties>
                 <Last-Modified>Fri, 04 Jan 2013 08:32:41 GMT</Last-Modified>
                 <Etag>"0x8CFB86D32305484"</Etag>

--- a/libcloud/test/storage/fixtures/azure_blobs/list_containers_empty.xml
+++ b/libcloud/test/storage/fixtures/azure_blobs/list_containers_empty.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<EnumerationResults AccountName="http://account.blob.core.windows.net">
+<EnumerationResults ServiceEndpoint="http://account.blob.core.windows.net">
   <Prefix></Prefix>
   <Marker></Marker>
   <MaxResults>100</MaxResults>

--- a/libcloud/test/storage/fixtures/azure_blobs/list_objects_1.xml
+++ b/libcloud/test/storage/fixtures/azure_blobs/list_objects_1.xml
@@ -1,10 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<EnumerationResults ContainerName="https://account.blob.core.windows.net/test_container">
+<EnumerationResults ServiceEndpoint="https://account.blob.core.windows.net/" ContainerName="test_container">
     <MaxResults>2</MaxResults>
     <Blobs>
         <Blob>
             <Name>object1.txt</Name>
-            <Url>https://account.blob.core.windows.net/test_container/object1.txt</Url>
             <Properties>
                 <Last-Modified>Fri, 04 Jan 2013 09:48:06 GMT</Last-Modified>
                 <Etag>0x8CFB877BB56A6FB</Etag>
@@ -25,7 +24,6 @@
         </Blob>
         <Blob>
             <Name>object2.txt</Name>
-            <Url>https://account.blob.core.windows.net/test_container/object2.txt</Url>
             <Properties>
                 <Last-Modified>Sat, 05 Jan 2013 03:51:42 GMT</Last-Modified>
                 <Etag>0x8CFB90F1BA8CD8F</Etag>

--- a/libcloud/test/storage/fixtures/azure_blobs/list_objects_2.xml
+++ b/libcloud/test/storage/fixtures/azure_blobs/list_objects_2.xml
@@ -1,11 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<EnumerationResults ContainerName="https://account.blob.core.windows.net/test_container">
+<EnumerationResults ServiceEndpoint="https://account.blob.core.windows.net/" ContainerName="test_container">
     <Marker>object3.txt</Marker>
     <MaxResults>2</MaxResults>
     <Blobs>
         <Blob>
             <Name>object3.txt</Name>
-            <Url>https://account.blob.core.windows.net/test_container/object3.txt</Url>
             <Properties>
                 <Last-Modified>Sat, 05 Jan 2013 03:52:08 GMT</Last-Modified>
                 <Etag>0x8CFB90F2B6FC022</Etag>
@@ -23,7 +22,6 @@
         </Blob>
         <Blob>
             <Name>object4.txt</Name>
-            <Url>https://account.blob.core.windows.net/test_container/object4.txt</Url>
             <Properties>
                 <Last-Modified>Fri, 04 Jan 2013 10:20:14 GMT</Last-Modified>
                 <Etag>0x8CFB87C38717450</Etag>

--- a/libcloud/test/storage/fixtures/azure_blobs/list_objects_empty.xml
+++ b/libcloud/test/storage/fixtures/azure_blobs/list_objects_empty.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<EnumerationResults ContainerName="https://account.blob.core.windows.net/test_container">
+<EnumerationResults ServiceEndpoint="https://account.blob.core.windows.net/" ContainerName="test_container">
     <MaxResults>2</MaxResults>
     <Blobs />
     <NextMarker />


### PR DESCRIPTION
## Fix azure_blobs driver with BlobStorage account

### Description

As discussed in [LIBCLOUD-851](https://issues.apache.org/jira/browse/LIBCLOUD-851), the Azure Storage driver currently doesn't work when used against a storage account that was created using `kind=BlobStorage` ([see failed integration test](https://clewolff.visualstudio.com/libcloud-tests/_build/results?buildId=71)). This is because BlobStorage accounts only work with API version `2014-02-14` or newer ([see docs](https://docs.microsoft.com/en-us/rest/api/storageservices/versioning-for-the-azure-storage-services)). Updating the API version fixes the problem and doesn't affect the other types of storage accounts ([see passed integration test](https://clewolff.visualstudio.com/libcloud-tests/_build/results?buildId=76)).

Note that this pull request is based on the work of @daviskirk in https://github.com/apache/libcloud/pull/1202.

### Status

- done, ready for review
- [CI passed](https://travis-ci.org/CatalystCode/libcloud/builds/539805150)

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide)
- [ ] Documentation *(bugfix)*
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) *(bugfix)*