### PR TITLE
Fix error getting floating ip instance_id

### DIFF
--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -3556,7 +3556,7 @@ class OpenStack_2_FloatingIpPool(object):
 
         if 'port_details' in obj and obj['port_details']:
             if obj['port_details']['device_owner'] in ['compute:nova',
-                                                       'compute:Nona']:
+                                                       'compute:None']:
                 instance_id = obj['port_details']['device_id']
 
         ip_address = obj['floating_ip_address']

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -3555,7 +3555,8 @@ class OpenStack_2_FloatingIpPool(object):
                                            port.extra["mac_address"]}
 
         if 'port_details' in obj and obj['port_details']:
-            if obj['port_details']['device_owner'] == 'compute:nova':
+            if obj['port_details']['device_owner'] in ['compute:nova',
+                                                       'compute:Nona']:
                 instance_id = obj['port_details']['device_id']
 
         ip_address = obj['floating_ip_address']


### PR DESCRIPTION
## Fix error getting floating ip instance_id

### Description

In some cases the `device_owner` of the port can be `compute:None`. In this cases the float ip does not return the correct instace_id where the float ip is attached.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
