### PR TITLE
Fix GCE driver so it also supports "SUSPENDED" node state

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,22 @@
 ﻿Changelog
 =========
 
+Changes in Apache Libcloud in development
+-----------------------------------------
+
+Compute
+~~~~~~~
+
+- [Google Compute Engine] Fix the driver so ``list_nodes()`` method doesn't
+  throw if there is a node in a ``SUSPENDED`` state.
+
+  Also update the code so it doesn't crash if an unknown node state which is
+  not defined locally is returned by the API when listing nodes. Such states
+  are now mapped to ``UNKNOWN``. (GITHUB-1296, LIBCLOUD-1045)
+
+  Reported by rafa alistair.
+  [Tomaz Muraus]
+
 Changes in Apache Libcloud 2.5.0
 --------------------------------
 

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -1730,6 +1730,7 @@ class GCENodeDriver(NodeDriver):
         "STAGING": NodeState.PENDING,
         "RUNNING": NodeState.RUNNING,
         "STOPPING": NodeState.PENDING,
+        "SUSPENDED": NodeState.SUSPENDED,
         "TERMINATED": NodeState.STOPPED,
         "UNKNOWN": NodeState.UNKNOWN
     }
@@ -8805,8 +8806,10 @@ class GCENodeDriver(NodeDriver):
             extra['image'] = image
         size = self._get_components_from_path(node['machineType'])['name']
 
+        state = self.NODE_STATE_MAP.get(node['status'], NodeState.UNKNOWN)
+
         return Node(id=node['id'], name=node['name'],
-                    state=self.NODE_STATE_MAP[node['status']],
+                    state=state,
                     public_ips=public_ips, private_ips=private_ips,
                     driver=self, size=size, image=image, extra=extra)
 

--- a/libcloud/test/compute/fixtures/gce/aggregated_instances.json
+++ b/libcloud/test/compute/fixtures/gce/aggregated_instances.json
@@ -449,7 +449,7 @@
             "onHostMaintenance": "MIGRATE"
           },
           "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central2-a/instances/libcloud-demo-multiple-nodes-001",
-          "status": "RUNNING",
+          "status": "SUSPENDED",
           "tags": {
             "fingerprint": "W7t6ZyTyIrc=",
             "items": [

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -617,9 +617,12 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         self.assertEqual(len(nodes_uc1a), 1)
         self.assertEqual(nodes[0].name, 'node-name')
         self.assertEqual(nodes_uc1a[0].name, 'node-name')
+
         names = [n.name for n in nodes_all]
         self.assertTrue('node-name' in names)
-        self.assertEqual(nodes_all[-1].state, NodeState.SUSPENDED)
+
+        states = [n.state for n in nodes_all]
+        self.assertTrue(NodeState.SUSPENDED in states)
 
     def test_ex_list_regions(self):
         regions = self.driver.ex_list_regions()

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -32,6 +32,7 @@ from libcloud.common.google import (GoogleBaseAuthConnection,
                                     GoogleBaseError)
 from libcloud.test.common.test_google import GoogleAuthMockHttp, GoogleTestCase
 from libcloud.compute.base import Node, StorageVolume
+from libcloud.compute.types import NodeState
 
 from libcloud.test import MockHttp
 from libcloud.test.compute import TestCaseMixin
@@ -618,6 +619,7 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         self.assertEqual(nodes_uc1a[0].name, 'node-name')
         names = [n.name for n in nodes_all]
         self.assertTrue('node-name' in names)
+        self.assertEqual(nodes_all[-1].state, NodeState.SUSPENDED)
 
     def test_ex_list_regions(self):
         regions = self.driver.ex_list_regions()


### PR DESCRIPTION
This pull request fixes issue reported in https://issues.apache.org/jira/browse/LIBCLOUD-1045.

Interestingly enough, official documentation doesn't seem to list ``SUSPENDED`` state under Instance Life Cycle page (https://cloud.google.com/compute/docs/instances/instance-life-cycle), but it does look like it's supported and used when node is suspended.

As an additional safe-guard to prevent similar issues crashing the driver code in the future, I made a change which maps any unknown server side node status to ``UNKNOWN``.

 Thanks to rafa alistair for reporting this issue.