### PR TITLE
Update documentation, describe new Github development workflow, remove references to JIRA

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ Feedback
 ========
 
 Please send feedback to the mailing list at <dev@libcloud.apache.org>,
-or the JIRA at <https://issues.apache.org/jira/browse/LIBCLOUD>.
+or Github repo at <https://github.com/apache/libcloud/issues>.
 
 Contributing
 ============

--- a/docs/committer_guide.rst
+++ b/docs/committer_guide.rst
@@ -18,8 +18,7 @@ First congratulations and welcome to the team!
 
 If you haven't yet, subscribe to {dev,users,notifications}@libcloud.apache.org
 mailing lists. Notifications mailing list is especially important because all of
-the JIRA notification, Github Pull Request notifications and build notifications
-are sent there.
+Github Issue, Pull Request and build notifications are sent there.
 
 2. Subscribe to the private mailing list
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -42,48 +41,17 @@ After you have registered go to
 "`Your details <https://pypi.python.org/pypi?%3Aaction=user_form>`_" page and
 populate `PGP Key ID` field with your PGP key ID.
 
-Applying a patch
-----------------
+Merging user contributions
+--------------------------
 
-When applying a third-party patch created using ``git format-patch`` or
-``git diff`` command, use the following command:
+When a pull request with user contribution / changes has been reviewed and
+all the criteria for merging has been meet (tests and code coverage, Travis
+build is passing, user signed an ICLA, etc.), you can directly merge those
+changes into trunk either by using Github web interface or doing it on the
+command line.
 
-.. sourcecode:: bash
-
-    git am --signoff < patch_name.patch
-
-``--signoff`` argument signs the patch and lets others know that you have
-reviewed and merged a patch.
-
-If you are working with a Github pull request, you can obtain a patch file
-by appending ``.patch`` to the end of the pull request URL. For example:
-
-.. sourcecode:: bash
-
-    wget https://github.com/apache/libcloud/pull/<pr number>.patch
-    git am --signoff < <pr number>.patch
-    # rebase to squash commits / ammend
-    ...
-
-When working with a Github pull request, also don't forget to
-update the commit message during rebase (or use ``git commit --amend`` if the
-rebase was not necessary) to include the "Closes #prnumber" message. This way,
-the corresponding Github pull request will get automatically closed once the
-Github mirror is updated.
-
-For example::
-
-    ...
-    Original message
-    ...
-
-    Closes #prnumber
-
-If the original patch author didn't squash all of the commits into one and you
-think this is needed, you should squash all the commits yourself using
-``git rebase`` after you have merged / applied the patch.
-
-After the patch has been applied, make sure to update ``CHANGES.rst`` file.
+It's also important that you update changelog in ``CHANGES.rst`` file after
+you have merged the changes.
 
 Making a release (for release managers)
 ---------------------------------------
@@ -107,14 +75,13 @@ preparing a release.
 * Remove the _secrets_ file with ``rm libcloud/test/secrets.py``
 * Remove leftover builds from previous releases. ``rm -f dist/apache* ; rm -rf apache_libcloud.egg-info``
 
-2. Update JIRA
-~~~~~~~~~~~~~~
+2. Update Github
+~~~~~~~~~~~~~~~~~
 
-* Create a new JIRA version for the release in question (if one doesn't exist
+* Create a new Github milestone for the release in question (if one doesn't exist
   yet)
-* Close all the corresponding JIRA tickets and set ``Fix Version/s`` field
-  to the current version
-* Release the JIRA version
+* Update affected issues and pull requests and add the corresponding release
+  milestone
 
 3. Creating release artifacts
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -395,7 +362,7 @@ Body::
     Bugs / Issues
 
     If you find any bug or issue, please report it on our issue tracker
-    <https://issues.apache.org/jira/browse/LIBCLOUD>.
+    <https://github.com/apache/libcloud/issues>.
     Don't forget to attach an example and / or test which reproduces your problem.
 
     Thanks
@@ -456,7 +423,7 @@ Body::
     Bugs / Issues
 
     If you find any bug or issue, please report it on our issue tracker
-    <https://issues.apache.org/jira/browse/LIBCLOUD>.
+    <https://github.com/apache/libcloud/issues>.
     Don't forget to attach an example and / or test which reproduces your problem.
 
     Thanks

--- a/docs/committer_guide.rst
+++ b/docs/committer_guide.rst
@@ -44,14 +44,14 @@ populate `PGP Key ID` field with your PGP key ID.
 Merging user contributions
 --------------------------
 
-When a pull request with user contribution / changes has been reviewed and
-all the criteria for merging has been meet (tests and code coverage, Travis
+When a pull request with user contribution (changes) has been reviewed and
+all the criteria for merging has been met (tests and code coverage, Travis
 build is passing, user signed an ICLA, etc.), you can directly merge those
-changes into trunk either by using Github web interface or doing it on the
-command line.
+changes into trunk either by using Github web interface or doing it manually
+on the command line.
 
 It's also important that you update changelog in ``CHANGES.rst`` file after
-you have merged the changes.
+you merged the changes.
 
 Making a release (for release managers)
 ---------------------------------------
@@ -81,7 +81,7 @@ preparing a release.
 * Create a new Github milestone for the release in question (if one doesn't exist
   yet)
 * Update affected issues and pull requests and add the corresponding release
-  milestone
+  milestone to them
 
 3. Creating release artifacts
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/developer_information.rst
+++ b/docs/developer_information.rst
@@ -39,8 +39,8 @@ IRC
 Issue Tracker
 -------------
 
-For bug and issue tracking we use JIRA located at
-https://issues.apache.org/jira/browse/LIBCLOUD.
+For bug and issue tracking we use Github issues located at
+https://github.com/apache/libcloud/issues.
 
 Testing
 -------
@@ -48,13 +48,14 @@ Testing
 For information how to run the tests and how to generate the test coverage
 report, please see the :doc:`Testing page </testing>`.
 
+.. _ci-cd:
+
 Continuous Integration
 ----------------------
 
-For continuous integration we use Apache buildbot instance and Travis-CI. You
-can find build reports on the following two links:
+For continuous integration we use Travis-CI. You can find build reports on the
+following links:
 
-* https://ci.apache.org/waterfall?builder=libcloud-trunk-tox&builder=libcloud-site-staging
 * https://travis-ci.org/apache/libcloud
 
 Travis-CI builder is also integrated with Github which means that if you open a
@@ -63,11 +64,13 @@ pull request there, Travis-CI will automatically build it.
 If you want to validate the build before raising the PR, Travis-CI can be enabled for personal
 accounts and branches separately.
 
+.. _code-coverage:
+
 Test Coverage
 -------------
 
 Test coverage report is automatically generated after every push and can be
-found at http://ci.apache.org/projects/libcloud/coverage.
+found at https://codecov.io/github/apache/libcloud?branch=trunk.
 
 .. _`announce@libcloud.apache.org`: mailto:announce-subscribe@libcloud.apache.org
 .. _`users@libcloud.apache.org`: mailto:users-subscribe@libcloud.apache.org

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -282,10 +282,11 @@ For more information and examples, please refer to the following links:
 Contribution workflow
 ---------------------
 
-1. Start a discussion on the mailing list
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+1. Start a discussion on our Github repository or on the mailing list
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you are implementing a big feature or a change, start a discussion on the
+:ref:`issue tracker <issue-tracker>` or the
 :ref:`mailing list <mailing-lists>` first.
 
 2. Open a new issue on our issue tracker
@@ -307,7 +308,7 @@ For example:
 
 .. sourcecode:: bash
 
-    git checkout -b <jira_issue_id>_<change_name>
+    git checkout -b <change_name>
 
 5. Make your changes
 ~~~~~~~~~~~~~~~~~~~~
@@ -327,14 +328,13 @@ For more information on how to write and run tests, please see
 7. Commit your changes
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Make a single commit for your changes. If a corresponding JIRA ticket exists,
-make sure the commit message contains the ticket number.
+Commit your changes.
 
 For example:
 
 .. sourcecode:: bash
 
-    git commit -a -m "[LIBCLOUD-123] Add a new compute driver for CloudStack based providers."
+    git commit -m "Add a new compute driver for CloudStack based providers."
 
 8. Open a pull request with your changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -342,105 +342,10 @@ For example:
 Go to https://github.com/apache/libcloud/ and open a new pull request with your
 changes. Your pull request will appear at https://github.com/apache/libcloud/pulls.
 
-Make sure the pull request name is prefixed with a JIRA ticket number, e.g.
-``[LIBCLOUD-436] Improvements to DigitalOcean compute driver`` and that the
-pull request description contains link to the JIRA ticket.
-
 9. Wait for the review
 ~~~~~~~~~~~~~~~~~~~~~~
 
 Wait for your changes to be reviewed and address any outstanding comments.
-
-10. Squash the commits and generate the patch
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Once the changes has been reviewed, all the outstanding issues have been
-addressed and the pull request has been +1'ed, close the pull request, squash
-the commits (if necessary) and generate a patch.
-
-.. sourcecode:: bash
-
-    git format-patch --stdout trunk > patch_name.patch
-
-Make sure to use ``git format-patch`` and not ``git diff`` so we can preserve
-the commit authorship.
-
-Note #1: Before you generate the patch and squash the commits, make sure to
-synchronize your branch with the latest trunk (run ``git pull upstream trunk``
-in your branch), otherwise we might have problems applying it cleanly.
-
-Note #2: If you have never used rebase and squashed the commits before, you can
-find instructions on how to do that in the following guide:
-`squashing commits with rebase`_.
-
-11. Attach a final patch with your changes to the corresponding JIRA ticket
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Attach the generated patch to the JIRA issue you have created earlier.
-
-Note about Github
-~~~~~~~~~~~~~~~~~
-
-Github repository is a read-only mirror of the official Apache git repository
-(``https://git-wip-us.apache.org/repos/asf/libcloud.git``). This mirror script
-runs only a couple of times per day which means this mirror can be slightly out
-of date.
-
-You are advised to add a separate remote for the official upstream repository:
-
-.. sourcecode:: bash
-
-    git remote add upstream https://git-wip-us.apache.org/repos/asf/libcloud.git
-
-Github read-only mirror is used only for pull requests and code review. Once a
-pull request has been reviewed, all the comments have been addresses and it's
-ready to be merged, user who submitted the pull request must close the pull
-request, create a patch and attach it to the original JIRA ticket.
-
-Syncing your git(hub) repository with an official upstream git repository
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-This section describes how to synchronize your git clone / Github fork with
-an official upstream repository.
-
-It's important that your repository is in-sync with the upstream one when you
-start working on a new branch and before you generate a final patch. If the
-repository is not in-sync, generated patch will be out of sync and we won't be
-able to cleanly merge it into trunk.
-
-To synchronize it, follow the steps below in your git clone:
-
-1. Add upstream remote if you haven't added it yet
-
-.. sourcecode:: bash
-
-    git remote add upstream https://git-wip-us.apache.org/repos/asf/libcloud.git
-
-2. Synchronize your ``trunk`` branch with an upstream one
-
-.. sourcecode:: bash
-
-    git checkout trunk
-    git pull upstream trunk
-
-3. Create a branch for your changes and start working on it
-
-.. sourcecode:: bash
-
-    git checkout -b my_new_branch
-
-4. Before generating a final patch which is to be attached to the JIRA ticket,
-   make sure your repository and branch is still in-sync
-
-.. sourcecode:: bash
-
-    git pull upstream trunk
-
-5. Generate a patch which can be attached to the JIRA ticket
-
-.. sourcecode:: bash
-
-    git format-patch --stdout remotes/upstream/trunk > patch_name.patch
 
 Contributing Bigger Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -499,7 +404,7 @@ code work with multiple versions on the following link -
 `Lessons learned while porting Libcloud to Python 3`_
 
 .. _`PEP8 Python Style Guide`: http://www.python.org/dev/peps/pep-0008/
-.. _`Issue tracker`: https://issues.apache.org/jira/browse/LIBCLOUD
+.. _`Issue tracker`: https://github.com/apache/libcloud/issues
 .. _`Github git repository`: https://github.com/apache/libcloud
 .. _`Apache website`: https://www.apache.org/licenses/#clas
 .. _`Lessons learned while porting Libcloud to Python 3`: http://www.tomaz.me/2011/12/03/lessons-learned-while-porting-libcloud-to-python-3.html

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -8,7 +8,7 @@ Reporting a vulnerability
 
 .. note::
 
-    Please do **not** report security issues using our public JIRA instance. Use
+    Please do **not** report security issues using our public Github instance. Use
     the private mailing list described below.
 
 If you believe you've found a security issue or a vulnerability, please send a


### PR DESCRIPTION
Apache projects can now finally utilize all the Github functionality in a write manner (issues, milestone, pullre quests, etc.).

On the mailing list we agreed to move all the project development to Github to reduce the barrier to entry for new contributors and also to make life easier for the committers.

This means we will utilize Github issues and milestones functionality going forward.

This pull request updates documentation, replaces mentions of JIRA with Github and removes any section which is not relevant anymore due to the new and much simpler Github development workflow.

I already made corresponding changes on the website.