### PR TITLE
ec2 list_volumes should accept more filters

### DIFF
--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -1783,13 +1783,29 @@ class BaseEC2NodeDriver(NodeDriver):
             )
         return locations
 
-    def list_volumes(self, node=None):
+    def list_volumes(self, node=None, ex_filters=None):
+        """
+        List volumes that are attached to a node, if specified and those that
+        satisfy the filters, if specified.
+
+        :param node: The node to which the volumes are attached.
+        :type node: :class:`Node`
+
+        :param ex_filters: The dictionary of additional filters.
+        :type ex_filters: ``dict``
+
+        :return: The list of volumes that match the criteria.
+        :rtype: ``list`` of :class:`StorageVolume`
+        """
         params = {
             'Action': 'DescribeVolumes',
         }
+        if not ex_filters:
+            ex_filters = {}
         if node:
-            filters = {'attachment.instance-id': node.id}
-            params.update(self._build_filters(filters))
+            ex_filters['attachment.instance-id'] = node.id
+        if node or ex_filters:
+            params.update(self._build_filters(ex_filters))
 
         response = self.connection.request(self.path, params=params).object
         volumes = [self._to_volume(el) for el in response.findall(


### PR DESCRIPTION
## ec2 list_volumes should accept more filters

### Description

EC2 API requests are throttled which sometimes requires the API requests to be more fine tuned to avoid having to get back large amounts of responses. For more information, see this [the AWS API reference](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/query-api-troubleshooting.html#api-request-rate).

This change adds the ability to pass more filters to the EC2 DescribeVolumes call, the filter needs to be a dictionary of filter name and value pairs as described [here](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeVolumes.html).

I had 2 options here:
1. Remove the `node` parameter from this call and ensure that the caller passes in the node ID as part of the `filters` dict.
2. Add a new parameter `filters` and leave the `node` parameter as it is in order to preserve the original method signature.

I chose the latter only for the reason that it preserves the original method signature.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
