### PR TITLE
Add ability to resize volume in GCE

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -6417,6 +6417,28 @@ class GCENodeDriver(NodeDriver):
         self.connection.async_request(request, method='POST', data=volume_data)
         return True
 
+    def ex_resize_volume(self, volume, size):
+        """
+        Resize a volume to the specified size.
+
+        :param volume: Volume object to resize
+        :type  volume: :class:`StorageVolume`
+
+        :param size: The size in GB of the volume to resize to.
+        :type size: ``int``
+
+        :return:  True if successful
+        :rtype:   ``bool``
+        """
+        request = '/zones/%s/disks/%s/resize' % (
+            volume.extra['zone'].name, volume.name)
+        request_data = {'sizeGb': int(size)}
+
+        self.connection.async_request(
+            request, method='POST', data=request_data
+        )
+        return True
+
     def detach_volume(self, volume, ex_node=None):
         """
         Detach a volume from a node.

--- a/libcloud/test/compute/fixtures/gce/operations_operation_zones_us-central1-a_disks_lcdisk_resize_post.json
+++ b/libcloud/test/compute/fixtures/gce/operations_operation_zones_us-central1-a_disks_lcdisk_resize_post.json
@@ -1,0 +1,16 @@
+{
+  "kind": "compute#operation",
+  "id": "4992266504414588438",
+  "name": "operation-1562104056794-58cb9b1684c7e-8109138e-848683f7",
+  "zone": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a",
+  "operationType": "resizeDisk",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/disks/904434546113910404",
+  "targetId": "904434546113910404",
+  "status": "DONE",
+  "user": "487551519631-t6qvu2na6p4u9ptm46bsdujf0ohbdro7@developer.gserviceaccount.com",
+  "progress": 100,
+  "insertTime": "2019-07-02T14:47:37.095-07:00",
+  "startTime": "2019-07-02T14:47:37.111-07:00",
+  "endTime": "2019-07-02T14:47:41.991-07:00",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/operations/operation-1562104056794-58cb9b1684c7e-8109138e-848683f7"
+}

--- a/libcloud/test/compute/fixtures/gce/zones_us-central1-a_disks_lcdisk_resize_post.json
+++ b/libcloud/test/compute/fixtures/gce/zones_us-central1-a_disks_lcdisk_resize_post.json
@@ -1,0 +1,15 @@
+{
+  "id": "4992266504414588438",
+  "insertTime": "2019-07-02T14:47:37.095-07:00",
+  "kind": "compute#operation",
+  "name": "operation-zones_us-central1-a_disks_lcdisk_resize_post",
+  "operationType": "resizeDisk",
+  "progress": 0,
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/operations/operation-zones_us-central1-a_disks_lcdisk_resize_post",
+  "startTime": "2019-07-02T14:47:37.111-07:00",
+  "status": "PENDING",
+  "targetId": "904434546113910404",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/disks/lcdisk",
+  "user": "487551519631-t6qvu2na6p4u9ptm46bsdujf0ohbdro7@developer.gserviceaccount.com",
+  "zone": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a"
+}

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -1640,6 +1640,12 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         attach = volume.attach(node)
         self.assertTrue(attach)
 
+    def test_ex_resize_volume(self):
+        volume = self.driver.ex_get_volume('lcdisk')
+        desired_size = int(volume.size) + 8
+        resize = self.driver.ex_resize_volume(volume, desired_size)
+        self.assertTrue(resize)
+
     def test_detach_volume(self):
         volume = self.driver.ex_get_volume('lcdisk')
         node = self.driver.ex_get_node('node-name')
@@ -2946,6 +2952,12 @@ class GCEMockHttp(MockHttp):
             'operations_operation_zones_us-central1-a_disks_lcdisk_createSnapshot_post.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
+    def _zones_us_central1_a_operations_operation_zones_us_central1_a_disks_lcdisk_resize_post(
+        self, method, url, body, headers):
+        body = self.fixtures.load(
+            'operations_operation_zones_us-central1-a_disks_lcdisk_resize_post.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
     def _zones_us_central1_a_operations_operation_zones_us_central1_a_disks_post(
             self, method, url, body, headers):
         body = self.fixtures.load(
@@ -3358,6 +3370,12 @@ class GCEMockHttp(MockHttp):
                                                          body, headers):
         body = self.fixtures.load(
             'zones_us-central1-a_disks_lcdisk_createSnapshot_post.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _zones_us_central1_a_disks_lcdisk_resize(self, method, url,
+                                                 body, headers):
+        body = self.fixtures.load(
+            'zones_us-central1-a_disks_lcdisk_resize_post.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
     def _zones_us_central1_a_disks_node_name(self, method, url, body, headers):


### PR DESCRIPTION
## Add ability to resize volume in GCE

### Description

This change adds a new method to the GCE driver to support resizing a volume in Google Cloud. See this [API reference](https://cloud.google.com/compute/docs/reference/rest/v1/disks/resize) for more information.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)