### PR TITLE
Change issues link from GitHub issues to JIRA

### DIFF
--- a/docs/developer_information.rst
+++ b/docs/developer_information.rst
@@ -39,8 +39,8 @@ IRC
 Issue Tracker
 -------------
 
-For bug and issue tracking we use Github issues located at
-https://github.com/apache/libcloud/issues.
+For bug and issue tracking we use Apache Libcloud JIRA located at
+https://issues.apache.org/jira/projects/LIBCLOUD/issues.
 
 Testing
 -------


### PR DESCRIPTION
## Change issues link from GitHub issues to JIRA

### Description
Contributor [document](https://libcloud.readthedocs.io/en/latest/developer_information.html#issue-tracker) refers to GitHub issues as the issue tracker while it looks like Apache JIRA is being used for the purpose.

### Status

done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
