### PR TITLE
Remove code needed for Python 2.5 and Python 2.6 compatibility

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,10 @@ General
   [Miguel Caballer - @micafer]
 - Add new ``extra`` attribute to the base ``NodeLocation`` class. (GITHUB-1282)
   [Dimitris Moraitis - @d-mo]
+- Remove various code patterns which were in place for supporting multiple
+  Python versions, including 2.5 and 2.6. Libcloud hasn't supported Python <
+  2.7 for a while now, so we can remove that code. (GITHUB-1307)
+  [Tomaz Muraus]
 
 Compute
 ~~~~~~~

--- a/demos/compute_demo.py
+++ b/demos/compute_demo.py
@@ -95,8 +95,7 @@ def main(argv):
     """
     try:
         driver = get_demo_driver()
-    except InvalidCredsError:
-        e = sys.exc_info()[1]
+    except InvalidCredsError as e:
         print("Invalid Credentials: " + e.value)
         return 1
 
@@ -109,8 +108,7 @@ def main(argv):
 
         print(">> Loading sizes... (showing up to 10)")
         pprint(driver.list_sizes()[:10])
-    except Exception:
-        e = sys.exc_info()[1]
+    except Exception as e:
         print("A fatal error occurred: " + e)
         return 1
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -376,23 +376,6 @@ Context managers aren't available in Python 2.5 by default. If you want to use
 them make sure to put from ``__future__ import with_statement`` on top of the
 file where you use them.
 
-Exception Handling
-~~~~~~~~~~~~~~~~~~
-
-There is no unified way to handle exceptions and extract the exception object
-in Python 2.5 and Python 3.x. This means you need to use a
-``sys.exc_info()[1]`` approach to extract the raised exception object.
-
-For example:
-
-.. sourcecode:: python
-
-    try:
-        some code
-    except Exception:
-        e = sys.exc_info()[1]
-        print e
-
 Utility functions for cross-version compatibility
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/libcloud/common/base.py
+++ b/libcloud/common/base.py
@@ -15,7 +15,6 @@
 
 import json
 import os
-import sys
 import ssl
 import socket
 import copy
@@ -600,8 +599,7 @@ class Connection(object):
                 else:
                     self.connection.request(method=method, url=url, body=data,
                                             headers=headers, stream=stream)
-        except socket.gaierror:
-            e = sys.exc_info()[1]
+        except socket.gaierror as e:
             message = str(e)
             errno = getattr(e, 'errno', None)
 
@@ -618,8 +616,7 @@ class Connection(object):
                 raise socket.gaierror(msg)
             self.reset_context()
             raise e
-        except ssl.SSLError:
-            e = sys.exc_info()[1]
+        except ssl.SSLError as e:
             self.reset_context()
             raise ssl.SSLError(str(e))
 

--- a/libcloud/common/gandi.py
+++ b/libcloud/common/gandi.py
@@ -18,7 +18,6 @@ Gandi driver base classes
 
 import time
 import hashlib
-import sys
 
 from libcloud.utils.py3 import b
 
@@ -99,8 +98,7 @@ class BaseGandiDriver(object):
                     return False
             except (KeyError, IndexError):
                 pass
-            except Exception:
-                e = sys.exc_info()[1]
+            except Exception as e:
                 raise GandiException(1002, e)
 
             time.sleep(check_interval)

--- a/libcloud/common/google.py
+++ b/libcloud/common/google.py
@@ -698,10 +698,9 @@ class GoogleOAuth2Credential(object):
             with open(filename, 'r') as f:
                 data = f.read()
             token = json.loads(data)
-        except (IOError, ValueError):
+        except (IOError, ValueError) as e:
             # Note: File related errors (IOError) and errors related to json
             # parsing of the data (ValueError) are not fatal.
-            e = sys.exc_info()[1]
             LOG.info('Failed to read cached auth token from file "%s": %s',
                      filename, str(e))
 
@@ -721,11 +720,10 @@ class GoogleOAuth2Credential(object):
             with os.fdopen(os.open(filename, write_flags,
                                    int('600', 8)), 'w') as f:
                 f.write(data)
-        except Exception:
+        except Exception as e:
             # Note: Failure to write (cache) token in a file is not fatal. It
             # simply means degraded performance since we will need to acquire a
             # new token each time script runs.
-            e = sys.exc_info()[1]
             LOG.info('Failed to write auth token to file "%s": %s',
                      filename, str(e))
 
@@ -813,8 +811,7 @@ class GoogleBaseConnection(ConnectionUserAndKey, PollingConnection):
             try:
                 return super(GoogleBaseConnection, self).request(
                     *args, **kwargs)
-            except socket.error:
-                e = sys.exc_info()[1]
+            except socket.error as e:
                 if e.errno == errno.ECONNRESET:
                     tries = tries + 1
                 else:

--- a/libcloud/common/openstack_identity.py
+++ b/libcloud/common/openstack_identity.py
@@ -18,7 +18,6 @@ Common / shared code for handling authentication against OpenStack identity
 service (Keystone).
 """
 
-import sys
 import datetime
 
 from libcloud.utils.py3 import httplib
@@ -817,8 +816,7 @@ class OpenStackIdentity_1_1_Connection(OpenStackIdentityConnection):
         else:
             try:
                 body = json.loads(resp.body)
-            except Exception:
-                e = sys.exc_info()[1]
+            except Exception as e:
                 raise MalformedResponseError('Failed to parse JSON', e)
 
             try:
@@ -828,8 +826,7 @@ class OpenStackIdentity_1_1_Connection(OpenStackIdentityConnection):
                 self.auth_token_expires = parse_date(expires)
                 self.urls = body['auth']['serviceCatalog']
                 self.auth_user_info = None
-            except KeyError:
-                e = sys.exc_info()[1]
+            except KeyError as e:
                 raise MalformedResponseError('Auth JSON response is \
                                              missing required elements', e)
 
@@ -902,8 +899,7 @@ class OpenStackIdentity_2_0_Connection(OpenStackIdentityConnection):
                 self.auth_token_expires = parse_date(expires)
                 self.urls = access['serviceCatalog']
                 self.auth_user_info = access.get('user', {})
-            except KeyError:
-                e = sys.exc_info()[1]
+            except KeyError as e:
                 raise MalformedResponseError('Auth JSON response is \
                                              missing required elements', e)
 
@@ -1036,14 +1032,12 @@ class OpenStackIdentity_3_0_Connection(OpenStackIdentityConnection):
 
             try:
                 body = json.loads(response.body)
-            except Exception:
-                e = sys.exc_info()[1]
+            except Exception as e:
                 raise MalformedResponseError('Failed to parse JSON', e)
 
             try:
                 roles = self._to_roles(body['token']['roles'])
-            except Exception:
-                e = sys.exc_info()[1]
+            except Exception as e:
                 roles = []
 
             try:
@@ -1055,8 +1049,7 @@ class OpenStackIdentity_3_0_Connection(OpenStackIdentityConnection):
                 self.urls = body['token'].get('catalog', None)
                 self.auth_user_info = None
                 self.auth_user_roles = roles
-            except KeyError:
-                e = sys.exc_info()[1]
+            except KeyError as e:
                 raise MalformedResponseError('Auth JSON response is \
                                              missing required elements', e)
             body = 'code: %s body:%s' % (response.status, response.body)
@@ -1479,14 +1472,12 @@ class OpenStackIdentity_3_0_Connection_OIDC_access_token(
 
             try:
                 body = json.loads(response.body)
-            except Exception:
-                e = sys.exc_info()[1]
+            except Exception as e:
                 raise MalformedResponseError('Failed to parse JSON', e)
 
             try:
                 roles = self._to_roles(body['token']['roles'])
-            except Exception:
-                e = sys.exc_info()[1]
+            except Exception as e:
                 roles = []
 
             try:
@@ -1498,8 +1489,7 @@ class OpenStackIdentity_3_0_Connection_OIDC_access_token(
                 self.urls = body['token'].get('catalog', None)
                 self.auth_user_info = None
                 self.auth_user_roles = roles
-            except KeyError:
-                e = sys.exc_info()[1]
+            except KeyError as e:
                 raise MalformedResponseError('Auth JSON response is \
                                              missing required elements', e)
             body = 'code: %s body:%s' % (response.status, response.body)
@@ -1572,8 +1562,7 @@ class OpenStackIdentity_3_0_Connection_OIDC_access_token(
                     raise ValueError('Project %s not found' % self.domain_name)
                 else:
                     return body['projects'][0]['id']
-            except Exception:
-                e = sys.exc_info()[1]
+            except Exception as e:
                 raise MalformedResponseError('Failed to parse JSON', e)
         else:
             raise MalformedResponseError('Malformed response',
@@ -1653,8 +1642,7 @@ class OpenStackIdentity_2_0_Connection_VOMS(OpenStackIdentityConnection,
             try:
                 body = json.loads(response.body)
                 return body['access']['token']['id']
-            except Exception:
-                e = sys.exc_info()[1]
+            except Exception as e:
                 raise MalformedResponseError('Failed to parse JSON', e)
         else:
             raise MalformedResponseError('Malformed response',
@@ -1677,8 +1665,7 @@ class OpenStackIdentity_2_0_Connection_VOMS(OpenStackIdentityConnection,
             try:
                 body = json.loads(response.body)
                 return body["tenants"][0]["name"]
-            except Exception:
-                e = sys.exc_info()[1]
+            except Exception as e:
                 raise MalformedResponseError('Failed to parse JSON', e)
         else:
             raise MalformedResponseError('Malformed response',
@@ -1708,8 +1695,7 @@ class OpenStackIdentity_2_0_Connection_VOMS(OpenStackIdentityConnection,
                 self.auth_token_expires = parse_date(expires)
                 self.urls = access['serviceCatalog']
                 self.auth_user_info = access.get('user', {})
-            except KeyError:
-                e = sys.exc_info()[1]
+            except KeyError as e:
                 raise MalformedResponseError('Auth JSON response is \
                                              missing required elements', e)
 

--- a/libcloud/common/providers.py
+++ b/libcloud/common/providers.py
@@ -99,8 +99,7 @@ def set_driver(drivers, provider, module, klass):
     # Check if this driver is valid
     try:
         driver = get_driver(drivers, provider)
-    except (ImportError, AttributeError):
-        exp = sys.exc_info()[1]
+    except (ImportError, AttributeError) as e:
         drivers.pop(provider)
         raise exp
 

--- a/libcloud/common/providers.py
+++ b/libcloud/common/providers.py
@@ -17,8 +17,6 @@
 Common methods for obtaining a reference to the provider driver class.
 """
 
-import sys
-
 __all__ = [
     'get_driver',
     'set_driver'
@@ -99,7 +97,7 @@ def set_driver(drivers, provider, module, klass):
     # Check if this driver is valid
     try:
         driver = get_driver(drivers, provider)
-    except (ImportError, AttributeError) as e:
+    except (ImportError, AttributeError) as exp:
         drivers.pop(provider)
         raise exp
 

--- a/libcloud/common/xmlrpc.py
+++ b/libcloud/common/xmlrpc.py
@@ -16,8 +16,6 @@
 Base classes for working with xmlrpc APIs
 """
 
-import sys
-
 from libcloud.utils.py3 import xmlrpclib
 from libcloud.utils.py3 import httplib
 from libcloud.common.base import Response, Connection
@@ -64,8 +62,7 @@ class XMLRPCResponse(ErrorCodeMixin, Response):
             if len(params) == 1:
                 params = params[0]
             return params
-        except xmlrpclib.Fault:
-            e = sys.exc_info()[1]
+        except xmlrpclib.Fault as e:
             self.raise_exception_for_error(e.faultCode, e.faultString)
             error_string = '%s: %s' % (e.faultCode, e.faultString)
             raise self.defaultExceptionCls(error_string)

--- a/libcloud/compute/base.py
+++ b/libcloud/compute/base.py
@@ -19,7 +19,6 @@ Provides base classes for working with drivers
 
 from __future__ import with_statement
 
-import sys
 import time
 import hashlib
 import os
@@ -973,8 +972,7 @@ class NodeDriver(BaseDriver):
                 wait_period=3,
                 timeout=kwargs.get('timeout', NODE_ONLINE_WAIT_TIMEOUT),
                 ssh_interface=ssh_interface)[0]
-        except Exception:
-            e = sys.exc_info()[1]
+        except Exception as e:
             raise DeploymentError(node=node, original_exception=e, driver=self)
 
         ssh_username = kwargs.get('ssh_username', 'root')
@@ -994,11 +992,10 @@ class NodeDriver(BaseDriver):
                     ssh_username=username, ssh_password=password,
                     ssh_key_file=ssh_key_file, ssh_timeout=ssh_timeout,
                     timeout=timeout, max_tries=max_tries)
-            except Exception:
+            except Exception as e:
                 # Try alternate username
                 # Todo: Need to fix paramiko so we can catch a more specific
                 # exception
-                e = sys.exc_info()[1]
                 deploy_error = e
             else:
                 # Script successfully executed, don't try alternate username
@@ -1494,8 +1491,7 @@ class NodeDriver(BaseDriver):
         while time.time() < end:
             try:
                 ssh_client.connect()
-            except SSH_TIMEOUT_EXCEPTION_CLASSES:
-                e = sys.exc_info()[1]
+            except SSH_TIMEOUT_EXCEPTION_CLASSES as e:
                 message = str(e).lower()
                 expected_msg = 'no such file or directory'
 
@@ -1566,11 +1562,10 @@ class NodeDriver(BaseDriver):
         while tries < max_tries:
             try:
                 node = task.run(node, ssh_client)
-            except Exception:
+            except Exception as e:
                 tries += 1
 
                 if tries >= max_tries:
-                    e = sys.exc_info()[1]
                     raise LibcloudError(value='Failed after %d tries: %s'
                                         % (max_tries, str(e)), driver=self)
             else:

--- a/libcloud/compute/drivers/azure.py
+++ b/libcloud/compute/drivers/azure.py
@@ -1478,8 +1478,7 @@ class AzureNodeDriver(NodeDriver):
                 headers=request.headers,
                 method=request.method
             )
-        except AzureRedirectException:
-            e = sys.exc_info()[1]
+        except AzureRedirectException as e:
             parsed_url = urlparse.urlparse(e.location)
             request.host = parsed_url.netloc
             return self._perform_request(request)

--- a/libcloud/compute/drivers/cloudstack.py
+++ b/libcloud/compute/drivers/cloudstack.py
@@ -15,7 +15,6 @@
 
 from __future__ import with_statement
 
-import sys
 import base64
 import warnings
 
@@ -36,8 +35,7 @@ from libcloud.utils.networking import is_private_subnet
 def transform_int_or_unlimited(value):
     try:
         return int(value)
-    except ValueError:
-        e = sys.exc_info()[1]
+    except ValueError as e:
 
         if str(value).lower() == 'unlimited':
             return -1

--- a/libcloud/compute/drivers/cloudwatt.py
+++ b/libcloud/compute/drivers/cloudwatt.py
@@ -16,7 +16,6 @@
 """
 Cloudwatt driver.
 """
-import sys
 try:
     import simplejson as json
 except ImportError:
@@ -70,8 +69,7 @@ class CloudwattAuthConnection(OpenStackIdentityConnection):
         else:
             try:
                 body = json.loads(resp.body)
-            except Exception:
-                e = sys.exc_info()[1]
+            except Exception as e:
                 raise MalformedResponseError('Failed to parse JSON', e)
 
             try:
@@ -81,8 +79,7 @@ class CloudwattAuthConnection(OpenStackIdentityConnection):
                 self.auth_token_expires = parse_date(expires)
                 self.urls = body['access']['serviceCatalog']
                 self.auth_user_info = None
-            except KeyError:
-                e = sys.exc_info()[1]
+            except KeyError as e:
                 raise MalformedResponseError('Auth JSON response is \
                                              missing required elements', e)
 

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -18,7 +18,6 @@ Amazon EC2, Eucalyptus, Nimbus and Outscale drivers.
 """
 
 import re
-import sys
 import base64
 import copy
 import warnings
@@ -3001,8 +3000,7 @@ class BaseEC2NodeDriver(NodeDriver):
             res = self.connection.request(
                 self.path, params=params.copy()).object
             return self._get_boolean(res)
-        except Exception:
-            e = sys.exc_info()[1]
+        except Exception as e:
             if e.args[0].find('InvalidPermission.Duplicate') == -1:
                 raise e
 
@@ -3245,8 +3243,7 @@ class BaseEC2NodeDriver(NodeDriver):
             results.append(
                 self.connection.request(self.path, params=params.copy()).object
             )
-        except Exception:
-            e = sys.exc_info()[1]
+        except Exception as e:
             if e.args[0].find("InvalidPermission.Duplicate") == -1:
                 raise e
         params['IpProtocol'] = 'udp'
@@ -3255,8 +3252,7 @@ class BaseEC2NodeDriver(NodeDriver):
             results.append(
                 self.connection.request(self.path, params=params.copy()).object
             )
-        except Exception:
-            e = sys.exc_info()[1]
+        except Exception as e:
             if e.args[0].find("InvalidPermission.Duplicate") == -1:
                 raise e
 
@@ -3266,8 +3262,7 @@ class BaseEC2NodeDriver(NodeDriver):
             results.append(
                 self.connection.request(self.path, params=params.copy()).object
             )
-        except Exception:
-            e = sys.exc_info()[1]
+        except Exception as e:
 
             if e.args[0].find("InvalidPermission.Duplicate") == -1:
                 raise e

--- a/libcloud/compute/drivers/gandi.py
+++ b/libcloud/compute/drivers/gandi.py
@@ -15,7 +15,6 @@
 """
 Gandi driver for compute
 """
-import sys
 from datetime import datetime
 
 from libcloud.common.gandi import BaseGandiDriver, GandiException,\
@@ -99,8 +98,7 @@ class GandiNodeDriver(BaseGandiDriver, NodeDriver):
         try:
             obj = self.connection.request('hosting.%s.info' % type, int(id))
             return obj.object
-        except Exception:
-            e = sys.exc_info()[1]
+        except Exception as e:
             raise GandiException(1003, e)
 
     def _node_info(self, id):
@@ -360,8 +358,7 @@ class GandiNodeDriver(BaseGandiDriver, NodeDriver):
                 filtering = {}
             images = self.connection.request('hosting.image.list', filtering)
             return [self._to_image(i) for i in images.object]
-        except Exception:
-            e = sys.exc_info()[1]
+        except Exception as e:
             raise GandiException(1011, e)
 
     def _to_size(self, id, size):

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -3519,8 +3519,7 @@ class GCENodeDriver(NodeDriver):
                 self.connection.request(request, method='POST',
                                         data=image_data)
 
-        except ResourceExistsError:
-            e = sys.exc_info()[1]
+        except ResourceExistsError as e:
             if not use_existing:
                 raise e
 
@@ -5410,8 +5409,7 @@ class GCENodeDriver(NodeDriver):
         try:
             self.connection.async_request(request, method='POST',
                                           data=volume_data, params=params)
-        except ResourceExistsError:
-            e = sys.exc_info()[1]
+        except ResourceExistsError as e:
             if not use_existing:
                 raise e
 

--- a/libcloud/compute/drivers/nephoscale.py
+++ b/libcloud/compute/drivers/nephoscale.py
@@ -20,7 +20,6 @@ Created by Markos Gogoulos (https://mist.io)
 """
 
 import base64
-import sys
 import time
 import os
 import binascii
@@ -378,8 +377,7 @@ get all keys call with no arguments')
         try:
             node = self.connection.request('/server/cloud/', data=params,
                                            method='POST')
-        except Exception:
-            e = sys.exc_info()[1]
+        except Exception as e:
             raise Exception("Failed to create node %s" % e)
         node = Node(id='', name=name, state=NodeState.UNKNOWN, public_ips=[],
                     private_ips=[], driver=self)

--- a/libcloud/compute/drivers/packet.py
+++ b/libcloud/compute/drivers/packet.py
@@ -174,7 +174,7 @@ class PacketNodeDriver(NodeDriver):
                 ex_project_id=self.project_id)
 
         # In case of Python2 perform requests serially
-        if use_asyncio():
+        if not use_asyncio():
             nodes = []
             for project in self.projects:
                 nodes.extend(
@@ -625,7 +625,7 @@ def _list_async(driver):
                 ex_project_id=self.project_id)
 
         # In case of Python2 perform requests serially
-        if use_asyncio():
+        if not use_asyncio():
             nodes = []
             for project in self.projects:
                 nodes.extend(

--- a/libcloud/compute/drivers/packet.py
+++ b/libcloud/compute/drivers/packet.py
@@ -15,11 +15,11 @@
 """
 Packet Driver
 """
+
 try:  # Try to use asyncio to perform requests in parallel across projects
     import asyncio
 except ImportError:  # If not available will do things serially
     asyncio = None
-
 
 import datetime
 import json
@@ -34,6 +34,13 @@ from libcloud.compute.base import KeyPair
 from libcloud.compute.base import StorageVolume, VolumeSnapshot
 
 PACKET_ENDPOINT = "api.packet.net"
+
+# True to use async io if available (aka running under Python 3)
+USE_ASYNC_IO_IF_AVAILABLE = True
+
+
+def use_asyncio():
+    return asyncio is not None and USE_ASYNC_IO_IF_AVAILABLE
 
 
 class PacketResponse(JsonResponse):
@@ -167,7 +174,7 @@ class PacketNodeDriver(NodeDriver):
                 ex_project_id=self.project_id)
 
         # In case of Python2 perform requests serially
-        if asyncio is None:
+        if use_asyncio():
             nodes = []
             for project in self.projects:
                 nodes.extend(
@@ -618,7 +625,7 @@ def _list_async(driver):
                 ex_project_id=self.project_id)
 
         # In case of Python2 perform requests serially
-        if asyncio is None:
+        if use_asyncio():
             nodes = []
             for project in self.projects:
                 nodes.extend(

--- a/libcloud/compute/drivers/vcloud.py
+++ b/libcloud/compute/drivers/vcloud.py
@@ -16,7 +16,6 @@
 VMware vCloud driver.
 """
 import copy
-import sys
 import re
 import base64
 import os
@@ -590,10 +589,9 @@ class VCloudNodeDriver(NodeDriver):
                                  'application/vnd.vmware.vcloud.vApp+xml'}
                     )
                     nodes.append(self._to_node(res.object))
-                except Exception:
+                except Exception as e:
                     # The vApp was probably removed since the previous vDC
                     # query, ignore
-                    e = sys.exc_info()[1]
                     if not (e.args[0].tag.endswith('Error') and
                             e.args[0].get('minorErrorCode') ==
                             'ACCESS_TO_RESOURCE_IS_FORBIDDEN'):

--- a/libcloud/compute/drivers/vsphere.py
+++ b/libcloud/compute/drivers/vsphere.py
@@ -22,7 +22,6 @@ more information, please refer to the official documentation.
 """
 
 import os
-import sys
 import atexit
 
 try:
@@ -90,8 +89,7 @@ class VSphereConnection(ConnectionUserAndKey):
                                 password=self.key,
                                 sock_timeout=DEFAULT_CONNECTION_TIMEOUT,
                                 trace_file=trace_file)
-        except Exception:
-            e = sys.exc_info()[1]
+        except Exception as e:
             message = e.message
             if hasattr(e, 'strerror'):
                 message = e.strerror

--- a/libcloud/dns/drivers/buddyns.py
+++ b/libcloud/dns/drivers/buddyns.py
@@ -16,8 +16,6 @@
 BuddyNS DNS Driver
 """
 
-import sys
-
 try:
     import simplejson as json
 except ImportError:
@@ -63,8 +61,7 @@ class BuddyNSDNSDriver(DNSDriver):
         action = '/api/v2/zone/%s' % zone_id
         try:
             response = self.connection.request(action=action, method='GET')
-        except BuddyNSException:
-            e = sys.exc_info()[1]
+        except BuddyNSException as e:
             if e.message == 'Not found':
                 raise ZoneDoesNotExistError(value=e.message, driver=self,
                                             zone_id=zone_id)
@@ -102,8 +99,7 @@ class BuddyNSDNSDriver(DNSDriver):
         try:
             response = self.connection.request(action=action, method='POST',
                                                data=post_data)
-        except BuddyNSException:
-            e = sys.exc_info()[1]
+        except BuddyNSException as e:
             if e.message == 'Invalid zone submitted for addition.':
                 raise ZoneAlreadyExistsError(value=e.message, driver=self,
                                              zone_id=domain)
@@ -124,8 +120,7 @@ class BuddyNSDNSDriver(DNSDriver):
         action = '/api/v2/zone/%s' % zone.domain
         try:
             self.connection.request(action=action, method='DELETE')
-        except BuddyNSException:
-            e = sys.exc_info()[1]
+        except BuddyNSException as e:
             if e.message == 'Not found':
                 raise ZoneDoesNotExistError(value=e.message, driver=self,
                                             zone_id=zone.id)

--- a/libcloud/dns/drivers/dnspod.py
+++ b/libcloud/dns/drivers/dnspod.py
@@ -12,8 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import sys
-
 
 from libcloud.dns.types import Provider, ZoneDoesNotExistError, \
     ZoneAlreadyExistsError, RecordDoesNotExistError, RecordAlreadyExistsError
@@ -77,8 +75,7 @@ class DNSPodDNSDriver(DNSDriver):
         try:
             response = self._make_request(action=action,
                                           method='POST')
-        except DNSPodException:
-            e = sys.exc_info()[1]
+        except DNSPodException as e:
             if e.message == 'No domains':
                 return []
         zones = self._to_zones(items=response.object['domains'])
@@ -97,8 +94,7 @@ class DNSPodDNSDriver(DNSDriver):
         try:
             self._make_request(action=action, method='POST',
                                data=data)
-        except DNSPodException:
-            e = sys.exc_info()[1]
+        except DNSPodException as e:
             if e.message in ZONE_DOES_NOT_EXIST_ERROR_MSGS:
                 raise ZoneDoesNotExistError(value=e.message, driver=self,
                                             zone_id=zone.id)
@@ -117,8 +113,7 @@ class DNSPodDNSDriver(DNSDriver):
         try:
             response = self._make_request(action=action, method='POST',
                                           data=data)
-        except DNSPodException:
-            e = sys.exc_info()[1]
+        except DNSPodException as e:
             if e.message in ZONE_DOES_NOT_EXIST_ERROR_MSGS:
                 raise ZoneDoesNotExistError(value=e.message, driver=self,
                                             zone_id=zone_id)
@@ -153,8 +148,7 @@ class DNSPodDNSDriver(DNSDriver):
         try:
             response = self._make_request(action=action, method='POST',
                                           data=data)
-        except DNSPodException:
-            e = sys.exc_info()[1]
+        except DNSPodException as e:
             if e.message in ZONE_ALREADY_EXISTS_ERROR_MSGS:
                 raise ZoneAlreadyExistsError(value=e.message, driver=self,
                                              zone_id=domain)
@@ -179,8 +173,7 @@ class DNSPodDNSDriver(DNSDriver):
         try:
             response = self._make_request(action=action, data=data,
                                           method='POST')
-        except DNSPodException:
-            e = sys.exc_info()[1]
+        except DNSPodException as e:
             if e.message in ZONE_DOES_NOT_EXIST_ERROR_MSGS:
                 raise ZoneDoesNotExistError(value='', driver=self,
                                             zone_id=zone.id)
@@ -205,8 +198,7 @@ class DNSPodDNSDriver(DNSDriver):
         try:
             self._make_request(action=action, method='POST',
                                data=data)
-        except DNSPodException:
-            e = sys.exc_info()[1]
+        except DNSPodException as e:
             if e.message in RECORD_DOES_NOT_EXIST_ERRORS_MSGS:
                 raise RecordDoesNotExistError(record_id=record.id, driver=self,
                                               value='')
@@ -236,8 +228,7 @@ class DNSPodDNSDriver(DNSDriver):
         try:
             response = self._make_request(action=action, method='POST',
                                           data=data)
-        except DNSPodException:
-            e = sys.exc_info()[1]
+        except DNSPodException as e:
             if e.message in RECORD_DOES_NOT_EXIST_ERRORS_MSGS:
                 raise RecordDoesNotExistError(record_id=record_id, driver=self,
                                               value='')
@@ -292,8 +283,7 @@ class DNSPodDNSDriver(DNSDriver):
             response = self._make_request(action=action,
                                           method='POST',
                                           data=data)
-        except DNSPodException:
-            e = sys.exc_info()[1]
+        except DNSPodException as e:
             if e.message == ('Record impacted, same record exists '
                              'or CNAME/URL impacted'):
                 raise RecordAlreadyExistsError(record_id='', driver=self,

--- a/libcloud/dns/drivers/durabledns.py
+++ b/libcloud/dns/drivers/durabledns.py
@@ -15,8 +15,6 @@
 """
 DurableDNS Driver
 """
-import sys
-
 from libcloud.utils.py3 import httplib
 from libcloud.utils.py3 import ensure_string
 from libcloud.dns.types import Provider, RecordType
@@ -141,8 +139,7 @@ class DurableDNSDriver(DNSDriver):
             response = self.connection.request(action=action, params=params,
                                                data=req_data, method="POST",
                                                headers=headers)
-        except DurableDNSException:
-            e = sys.exc_info()[1]
+        except DurableDNSException as e:
             if 'Zone does not exist' in e.message:
                 raise ZoneDoesNotExistError(zone_id=zone.id, driver=self,
                                             value=e.message)
@@ -186,8 +183,7 @@ class DurableDNSDriver(DNSDriver):
             response = self.connection.request(action=action, params=params,
                                                data=req_data, method="POST",
                                                headers=headers)
-        except DurableDNSException:
-            e = sys.exc_info()[1]
+        except DurableDNSException as e:
             if 'Zone does not exist' in e.message:
                 raise ZoneDoesNotExistError(zone_id=zone_id, driver=self,
                                             value=e.message)
@@ -229,8 +225,7 @@ class DurableDNSDriver(DNSDriver):
             response = self.connection.request(action=action, params=params,
                                                data=req_data, method="POST",
                                                headers=headers)
-        except DurableDNSException:
-            e = sys.exc_info()[1]
+        except DurableDNSException as e:
             if 'Zone does not exist' in e.message:
                 raise ZoneDoesNotExistError(zone_id=zone_id, driver=self,
                                             value=e.message)
@@ -302,8 +297,7 @@ class DurableDNSDriver(DNSDriver):
             self.connection.request(action=action, params=params,
                                     data=req_data, method="POST",
                                     headers=headers)
-        except DurableDNSException:
-            e = sys.exc_info()[1]
+        except DurableDNSException as e:
             if 'Zone Already Exist' in e.message:
                 raise ZoneAlreadyExistsError(zone_id=domain, driver=self,
                                              value=e.message)
@@ -374,8 +368,7 @@ class DurableDNSDriver(DNSDriver):
             response = self.connection.request(action=action, data=req_data,
                                                method="POST", headers=headers)
             objects = response.objects
-        except DurableDNSException:
-            e = sys.exc_info()[1]
+        except DurableDNSException as e:
             # In DurableDNS is possible to create records with same data.
             # Their ID's will be different but the API does not implement
             # the RecordAlreadyExist exception. Only ZoneDoesNotExist will
@@ -457,8 +450,7 @@ class DurableDNSDriver(DNSDriver):
                                     data=req_data,
                                     method="POST",
                                     headers=headers)
-        except DurableDNSException:
-            e = sys.exc_info()[1]
+        except DurableDNSException as e:
             if 'Zone does not exist' in e.message:
                 raise ZoneDoesNotExistError(zone_id=zone.id, driver=self,
                                             value=e.message)
@@ -533,8 +525,7 @@ class DurableDNSDriver(DNSDriver):
                                     data=req_data,
                                     method="POST",
                                     headers=headers)
-        except DurableDNSException:
-            e = sys.exc_info()[1]
+        except DurableDNSException as e:
             if 'Zone does not exist' in e.message:
                 raise ZoneDoesNotExistError(zone_id=zone.id, driver=self,
                                             value=e.message)
@@ -580,8 +571,7 @@ class DurableDNSDriver(DNSDriver):
             response = self.connection.request(action=action,
                                                data=req_data, method="POST",
                                                headers=headers)
-        except DurableDNSException:
-            e = sys.exc_info()[1]
+        except DurableDNSException as e:
             if 'Zone does not exist' in e.message:
                 raise ZoneDoesNotExistError(zone_id=zone.id, driver=self,
                                             value=e.message)
@@ -616,8 +606,7 @@ class DurableDNSDriver(DNSDriver):
         try:
             response = self.connection.request(action=action, data=req_data,
                                                headers=headers, method="POST")
-        except DurableDNSException:
-            e = sys.exc_info()[1]
+        except DurableDNSException as e:
             if 'Record does not exists' in e.message:
                 raise RecordDoesNotExistError(record_id=record.id, driver=self,
                                               value=e.message)

--- a/libcloud/dns/drivers/hostvirtual.py
+++ b/libcloud/dns/drivers/hostvirtual.py
@@ -16,8 +16,6 @@ __all__ = [
     'HostVirtualDNSDriver'
 ]
 
-import sys
-
 try:
     import simplejson as json
 except Exception:
@@ -124,8 +122,7 @@ class HostVirtualDNSDriver(DNSDriver):
         try:
             result = self.connection.request(
                 API_ROOT + '/dns/records/', params=params).object
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             if 'Not Found: No Records Found' in e.value:
                 return []
             raise e

--- a/libcloud/dns/drivers/liquidweb.py
+++ b/libcloud/dns/drivers/liquidweb.py
@@ -16,8 +16,6 @@
 Liquid Web DNS Driver
 """
 
-import sys
-
 try:
     import simplejson as json
 except ImportError:
@@ -111,8 +109,7 @@ class LiquidWebDNSDriver(DNSDriver):
             response = self.connection.request(action=action,
                                                method='POST',
                                                data=data)
-        except APIException:
-            e = sys.exc_info()[1]
+        except APIException as e:
             if e.error_class == 'LW::Exception::RecordNotFound':
                 raise ZoneDoesNotExistError(zone_id=zone_id,
                                             value=e.value, driver=self)
@@ -141,8 +138,7 @@ class LiquidWebDNSDriver(DNSDriver):
             response = self.connection.request(action=action,
                                                method='POST',
                                                data=data)
-        except APIException:
-            e = sys.exc_info()[1]
+        except APIException as e:
             if e.error_class == 'LW::Exception::RecordNotFound':
                 raise RecordDoesNotExistError(record_id=record_id, driver=self,
                                               value=e.value)
@@ -185,8 +181,7 @@ class LiquidWebDNSDriver(DNSDriver):
             response = self.connection.request(action=action,
                                                method='POST',
                                                data=data)
-        except APIException:
-            e = sys.exc_info()[1]
+        except APIException as e:
             if e.error_class == 'LW::Exception::DuplicateRecord':
                 raise ZoneAlreadyExistsError(zone_id=domain,
                                              value=e.value,
@@ -238,8 +233,7 @@ class LiquidWebDNSDriver(DNSDriver):
             response = self.connection.request(action=action,
                                                method='POST',
                                                data=data)
-        except APIException:
-            e = sys.exc_info()[1]
+        except APIException as e:
             if e.error_class == 'LW::Exception::DuplicateRecord':
                 raise RecordAlreadyExistsError(record_id=name,
                                                value=e.value,
@@ -288,8 +282,7 @@ class LiquidWebDNSDriver(DNSDriver):
             response = self.connection.request(action=action,
                                                method='PUT',
                                                data=j_data)
-        except APIException:
-            e = sys.exc_info()[1]
+        except APIException as e:
             if e.error_class == 'LW::Exception::RecordNotFound':
                 raise RecordDoesNotExistError(record_id=record.id, driver=self,
                                               value=e.value)
@@ -316,8 +309,7 @@ class LiquidWebDNSDriver(DNSDriver):
             response = self.connection.request(action=action,
                                                method='POST',
                                                data=data)
-        except APIException:
-            e = sys.exc_info()[1]
+        except APIException as e:
             if e.error_class == 'LW::Exception::RecordNotFound':
                 raise ZoneDoesNotExistError(zone_id=zone.id,
                                             value=e.value, driver=self)
@@ -341,8 +333,7 @@ class LiquidWebDNSDriver(DNSDriver):
             response = self.connection.request(action=action,
                                                method='POST',
                                                data=data)
-        except APIException:
-            e = sys.exc_info()[1]
+        except APIException as e:
             if e.error_class == 'LW::Exception::RecordNotFound':
                 raise RecordDoesNotExistError(record_id=record.id, driver=self,
                                               value=e.value)

--- a/libcloud/dns/drivers/luadns.py
+++ b/libcloud/dns/drivers/luadns.py
@@ -1,5 +1,3 @@
-import sys
-
 try:
     import simplejson as json
 except ImportError:
@@ -69,8 +67,7 @@ class LuadnsDNSDriver(DNSDriver):
         action = '/v1/zones/%s' % zone_id
         try:
             response = self.connection.request(action=action)
-        except LuadnsException:
-            e = sys.exc_info()[1]
+        except LuadnsException as e:
             if e.message in ['Zone not found.', 'Resource not found.']:
                 raise ZoneDoesNotExistError(zone_id=zone_id,
                                             value='', driver=self)
@@ -96,8 +93,7 @@ class LuadnsDNSDriver(DNSDriver):
         try:
             response = self.connection.request(action=action,
                                                method='DELETE')
-        except LuadnsException:
-            e = sys.exc_info()[1]
+        except LuadnsException as e:
             if e.message in ['Resource not found.', 'Zone not found.']:
                 raise ZoneDoesNotExistError(zone_id=zone.id,
                                             value='', driver=self)
@@ -132,8 +128,7 @@ class LuadnsDNSDriver(DNSDriver):
             response = self.connection.request(action=action,
                                                method='POST',
                                                data=data)
-        except LuadnsException:
-            e = sys.exc_info()[1]
+        except LuadnsException as e:
             if e.message == "Zone '%s' is taken already." % domain:
                 raise ZoneAlreadyExistsError(zone_id=domain,
                                              value='',
@@ -175,8 +170,7 @@ class LuadnsDNSDriver(DNSDriver):
         action = '/v1/zones/%s/records/%s' % (zone_id, record_id)
         try:
             response = self.connection.request(action=action)
-        except LuadnsException:
-            e = sys.exc_info()[1]
+        except LuadnsException as e:
             if e.message == 'Record not found.':
                 raise RecordDoesNotExistError(record_id=record_id, driver=self,
                                               value='')
@@ -200,8 +194,7 @@ class LuadnsDNSDriver(DNSDriver):
         try:
             response = self.connection.request(action=action,
                                                method='DELETE')
-        except LuadnsException:
-            e = sys.exc_info()[1]
+        except LuadnsException as e:
             if e.message == 'Record not found.':
                 raise RecordDoesNotExistError(record_id=record.id, driver=self,
                                               value='')
@@ -247,8 +240,7 @@ class LuadnsDNSDriver(DNSDriver):
             response = self.connection.request(action=action,
                                                method='POST',
                                                data=data)
-        except LuadnsException:
-            e = sys.exc_info()[1]
+        except LuadnsException as e:
             raise e
 
         record = self._to_record(response.parse_body(), zone=zone)

--- a/libcloud/dns/drivers/nfsn.py
+++ b/libcloud/dns/drivers/nfsn.py
@@ -15,7 +15,6 @@
 NFSN DNS Driver
 """
 import re
-import sys
 
 from libcloud.common.exceptions import BaseHTTPError
 from libcloud.common.nfsn import NFSNConnection
@@ -83,8 +82,7 @@ class NFSNDNSDriver(DNSDriver):
         # then the zone exists.
         try:
             self.connection.request(action='/dns/%s/serial' % zone_id)
-        except BaseHTTPError:
-            e = sys.exc_info()[1]
+        except BaseHTTPError as e:
             if e.code == httplib.NOT_FOUND:
                 raise ZoneDoesNotExistError(zone_id=None, driver=self,
                                             value=e.message)
@@ -153,8 +151,7 @@ class NFSNDNSDriver(DNSDriver):
             payload['ttl'] = extra['ttl']
         try:
             self.connection.request(action=action, data=payload, method='POST')
-        except BaseHTTPError:
-            e = sys.exc_info()[1]
+        except BaseHTTPError as e:
             exists_re = re.compile(r'That RR already exists on the domain')
             if e.code == httplib.BAD_REQUEST and \
                re.search(exists_re, e.message) is not None:
@@ -178,8 +175,7 @@ class NFSNDNSDriver(DNSDriver):
                    'type': record.type}
         try:
             self.connection.request(action=action, data=payload, method='POST')
-        except BaseHTTPError:
-            e = sys.exc_info()[1]
+        except BaseHTTPError as e:
             if e.code == httplib.NOT_FOUND:
                 raise RecordDoesNotExistError(value=e.message, driver=self,
                                               record_id=None)

--- a/libcloud/dns/drivers/nsone.py
+++ b/libcloud/dns/drivers/nsone.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 try:
     import simplejson as json
 except ImportError:
@@ -72,8 +71,7 @@ class NsOneDNSDriver(DNSDriver):
         action = '/v1/zones/%s' % zone_id
         try:
             response = self.connection.request(action=action, method='GET')
-        except NsOneException:
-            e = sys.exc_info()[1]
+        except NsOneException as e:
             if e.message == 'zone not found':
                 raise ZoneDoesNotExistError(value=e.message, driver=self,
                                             zone_id=zone_id)
@@ -109,8 +107,7 @@ class NsOneDNSDriver(DNSDriver):
         try:
             response = self.connection.request(action=action, method='PUT',
                                                data=post_data)
-        except NsOneException:
-            e = sys.exc_info()[1]
+        except NsOneException as e:
             if e.message == 'zone already exists':
                 raise ZoneAlreadyExistsError(value=e.message, driver=self,
                                              zone_id=domain)
@@ -135,8 +132,7 @@ class NsOneDNSDriver(DNSDriver):
         """
         try:
             response = self.connection.request(action=action, method='DELETE')
-        except NsOneException:
-            e = sys.exc_info()[1]
+        except NsOneException as e:
             if e.message == 'zone not found':
                 raise ZoneDoesNotExistError(value=e.message, driver=self,
                                             zone_id=zone.id)
@@ -155,8 +151,7 @@ class NsOneDNSDriver(DNSDriver):
         action = '/v1/zones/%s' % zone.domain
         try:
             response = self.connection.request(action=action, method='GET')
-        except NsOneException:
-            e = sys.exc_info()[1]
+        except NsOneException as e:
             if e.message == 'zone not found':
                 raise ZoneDoesNotExistError(value=e.message, driver=self,
                                             zone_id=zone.id)
@@ -180,8 +175,7 @@ class NsOneDNSDriver(DNSDriver):
         action = '/v1/zones/%s/%s/%s' % (zone_id, zone_id, record_id)
         try:
             response = self.connection.request(action=action, method='GET')
-        except NsOneException:
-            e = sys.exc_info()[1]
+        except NsOneException as e:
             if e.message == 'record not found':
                 raise RecordDoesNotExistError(value=e.message, driver=self,
                                               record_id=record_id)
@@ -203,8 +197,7 @@ class NsOneDNSDriver(DNSDriver):
                                          record.type)
         try:
             response = self.connection.request(action=action, method='DELETE')
-        except NsOneException:
-            e = sys.exc_info()[1]
+        except NsOneException as e:
             if e.message == 'record not found':
                 raise RecordDoesNotExistError(value=e.message, driver=self,
                                               record_id=record.id)
@@ -246,8 +239,7 @@ class NsOneDNSDriver(DNSDriver):
         try:
             response = self.connection.request(action=action, method='PUT',
                                                data=post_data)
-        except NsOneException:
-            e = sys.exc_info()[1]
+        except NsOneException as e:
             if e.message == 'record already exists':
                 raise RecordAlreadyExistsError(value=e.message, driver=self,
                                                record_id='')
@@ -288,8 +280,7 @@ class NsOneDNSDriver(DNSDriver):
         try:
             response = self.connection.request(action=action, data=post_data,
                                                method='POST')
-        except NsOneException:
-            e = sys.exc_info()[1]
+        except NsOneException as e:
             if e.message == 'record does not exist':
                 raise RecordDoesNotExistError(value=e.message, driver=self,
                                               record_id=record.id)

--- a/libcloud/dns/drivers/pointdns.py
+++ b/libcloud/dns/drivers/pointdns.py
@@ -23,8 +23,6 @@ __all__ = [
     'PointDNSDriver'
 ]
 
-import sys
-
 try:
     import simplejson as json
 except ImportError:
@@ -199,8 +197,7 @@ class PointDNSDriver(DNSDriver):
         """
         try:
             response = self.connection.request('/zones/%s' % zone_id)
-        except MalformedResponseError:
-            e = sys.exc_info()[1]
+        except MalformedResponseError as e:
             if e.body == 'Not found':
                 raise ZoneDoesNotExistError(driver=self,
                                             value="The zone doesn't exists",
@@ -225,8 +222,7 @@ class PointDNSDriver(DNSDriver):
         try:
             response = self.connection.request('/zones/%s/records/%s' %
                                                (zone_id, record_id))
-        except MalformedResponseError:
-            e = sys.exc_info()[1]
+        except MalformedResponseError as e:
             if e.body == 'Not found':
                 raise RecordDoesNotExistError(value="Record doesn't exists",
                                               driver=self,
@@ -263,8 +259,7 @@ class PointDNSDriver(DNSDriver):
         try:
             response = self.connection.request('/zones', method='POST',
                                                data=r_data)
-        except BaseHTTPError:
-            e = sys.exc_info()[1]
+        except BaseHTTPError as e:
             raise PointDNSException(value=e.message, http_code=e.code,
                                     driver=self)
         zone = self._to_zone(response.object)
@@ -301,8 +296,7 @@ class PointDNSDriver(DNSDriver):
         try:
             response = self.connection.request('/zones/%s/records' % zone.id,
                                                method='POST', data=r_data)
-        except BaseHTTPError:
-            e = sys.exc_info()[1]
+        except BaseHTTPError as e:
             raise PointDNSException(value=e.message, http_code=e.code,
                                     driver=self)
         record = self._to_record(response.object, zone=zone)
@@ -336,8 +330,7 @@ class PointDNSDriver(DNSDriver):
         try:
             response = self.connection.request('/zones/%s' % zone.id,
                                                method='PUT', data=r_data)
-        except (BaseHTTPError, MalformedResponseError):
-            e = sys.exc_info()[1]
+        except (BaseHTTPError, MalformedResponseError) as e:
             if isinstance(e, MalformedResponseError) and e.body == 'Not found':
                 raise ZoneDoesNotExistError(value="Zone doesn't exists",
                                             driver=self,
@@ -380,8 +373,7 @@ class PointDNSDriver(DNSDriver):
             response = self.connection.request('/zones/%s/records/%s' %
                                                (zone.id, record.id),
                                                method='PUT', data=r_data)
-        except (BaseHTTPError, MalformedResponseError):
-            e = sys.exc_info()[1]
+        except (BaseHTTPError, MalformedResponseError) as e:
             if isinstance(e, MalformedResponseError) and e.body == 'Not found':
                 raise RecordDoesNotExistError(value="Record doesn't exists",
                                               driver=self,
@@ -404,8 +396,7 @@ class PointDNSDriver(DNSDriver):
         """
         try:
             self.connection.request('/zones/%s' % zone.id, method='DELETE')
-        except MalformedResponseError:
-            e = sys.exc_info()[1]
+        except MalformedResponseError as e:
             if e.body == 'Not found':
                 raise ZoneDoesNotExistError(driver=self,
                                             value="The zone doesn't exists",
@@ -428,8 +419,7 @@ class PointDNSDriver(DNSDriver):
             self.connection.request('/zones/%s/records/%s' % (zone_id,
                                                               record_id),
                                     method='DELETE')
-        except MalformedResponseError:
-            e = sys.exc_info()[1]
+        except MalformedResponseError as e:
             if e.body == 'Not found':
                 raise RecordDoesNotExistError(value="Record doesn't exists",
                                               driver=self,
@@ -495,8 +485,7 @@ class PointDNSDriver(DNSDriver):
         try:
             response = self.connection.request('/zones/%s/redirects' % zone.id,
                                                method='POST', data=r_data)
-        except (BaseHTTPError, MalformedResponseError):
-            e = sys.exc_info()[1]
+        except (BaseHTTPError, MalformedResponseError) as e:
             raise PointDNSException(value=e.message, http_code=e.code,
                                     driver=self)
         redirect = self._to_redirect(response.object, zone=zone)
@@ -521,8 +510,7 @@ class PointDNSDriver(DNSDriver):
             response = self.connection.request('/zones/%s/mail_redirects' %
                                                zone.id, method='POST',
                                                data=r_data)
-        except (BaseHTTPError, MalformedResponseError):
-            e = sys.exc_info()[1]
+        except (BaseHTTPError, MalformedResponseError) as e:
             raise PointDNSException(value=e.message, http_code=e.code,
                                     driver=self)
         mail_redirect = self._to_mail_redirect(response.object, zone=zone)
@@ -541,8 +529,7 @@ class PointDNSDriver(DNSDriver):
         try:
             response = self.connection.request('/zones/%s/redirects/%s' %
                                                (zone_id, redirect_id))
-        except (BaseHTTPError, MalformedResponseError):
-            e = sys.exc_info()[1]
+        except (BaseHTTPError, MalformedResponseError) as e:
             if isinstance(e, MalformedResponseError) and e.body == 'Not found':
                 raise PointDNSException(value='Couldn\'t found redirect',
                                         http_code=httplib.NOT_FOUND,
@@ -565,8 +552,7 @@ class PointDNSDriver(DNSDriver):
         try:
             response = self.connection.request('/zones/%s/mail_redirects/%s' %
                                                (zone_id, mail_r_id))
-        except (BaseHTTPError, MalformedResponseError):
-            e = sys.exc_info()[1]
+        except (BaseHTTPError, MalformedResponseError) as e:
             if isinstance(e, MalformedResponseError) and e.body == 'Not found':
                 raise PointDNSException(value='Couldn\'t found mail redirect',
                                         http_code=httplib.NOT_FOUND,
@@ -619,8 +605,7 @@ class PointDNSDriver(DNSDriver):
             response = self.connection.request('/zones/%s/redirects/%s' %
                                                (zone_id, redirect.id),
                                                method='PUT', data=r_data)
-        except (BaseHTTPError, MalformedResponseError):
-            e = sys.exc_info()[1]
+        except (BaseHTTPError, MalformedResponseError) as e:
             if isinstance(e, MalformedResponseError) and e.body == 'Not found':
                 raise PointDNSException(value='Couldn\'t found redirect',
                                         http_code=httplib.NOT_FOUND,
@@ -652,8 +637,7 @@ class PointDNSDriver(DNSDriver):
             response = self.connection.request('/zones/%s/mail_redirects/%s' %
                                                (zone_id, mail_r.id),
                                                method='PUT', data=r_data)
-        except (BaseHTTPError, MalformedResponseError):
-            e = sys.exc_info()[1]
+        except (BaseHTTPError, MalformedResponseError) as e:
             if isinstance(e, MalformedResponseError) and e.body == 'Not found':
                 raise PointDNSException(value='Couldn\'t found mail redirect',
                                         http_code=httplib.NOT_FOUND,
@@ -676,8 +660,7 @@ class PointDNSDriver(DNSDriver):
         try:
             self.connection.request('/zones/%s/redirects/%s' % (zone_id,
                                     redirect_id), method='DELETE')
-        except (BaseHTTPError, MalformedResponseError):
-            e = sys.exc_info()[1]
+        except (BaseHTTPError, MalformedResponseError) as e:
             if isinstance(e, MalformedResponseError) and e.body == 'Not found':
                 raise PointDNSException(value='Couldn\'t found redirect',
                                         http_code=httplib.NOT_FOUND,
@@ -698,8 +681,7 @@ class PointDNSDriver(DNSDriver):
         try:
             self.connection.request('/zones/%s/mail_redirects/%s' % (zone_id,
                                     mail_r_id), method='DELETE')
-        except (BaseHTTPError, MalformedResponseError):
-            e = sys.exc_info()[1]
+        except (BaseHTTPError, MalformedResponseError) as e:
             if isinstance(e, MalformedResponseError) and e.body == 'Not found':
                 raise PointDNSException(value='Couldn\'t found mail redirect',
                                         http_code=httplib.NOT_FOUND,

--- a/libcloud/dns/drivers/powerdns.py
+++ b/libcloud/dns/drivers/powerdns.py
@@ -15,7 +15,6 @@
 PowerDNS Driver
 """
 import json
-import sys
 
 from libcloud.common.base import ConnectionKey, JsonResponse
 from libcloud.common.exceptions import BaseHTTPError
@@ -42,8 +41,7 @@ class PowerDNSResponse(JsonResponse):
 
         try:
             body = self.parse_body()
-        except MalformedResponseError:
-            e = sys.exc_info()[1]
+        except MalformedResponseError as e:
             body = '%s: %s' % (e.value, e.body)
         try:
             errors = [body['error']]
@@ -198,8 +196,7 @@ class PowerDNSDriver(DNSDriver):
         try:
             self.connection.request(action=action, data=json.dumps(payload),
                                     method='PATCH')
-        except BaseHTTPError:
-            e = sys.exc_info()[1]
+        except BaseHTTPError as e:
             if e.code == httplib.UNPROCESSABLE_ENTITY and \
                e.message.startswith('Could not find domain'):
                 raise ZoneDoesNotExistError(zone_id=zone.id, driver=self,
@@ -250,8 +247,7 @@ class PowerDNSDriver(DNSDriver):
         try:
             self.connection.request(action=action, data=json.dumps(payload),
                                     method='POST')
-        except BaseHTTPError:
-            e = sys.exc_info()[1]
+        except BaseHTTPError as e:
             if e.code == httplib.UNPROCESSABLE_ENTITY and \
                e.message.startswith("Domain '%s' already exists" % domain):
                 raise ZoneAlreadyExistsError(zone_id=zone_id, driver=self,
@@ -283,7 +279,6 @@ class PowerDNSDriver(DNSDriver):
             # I'm not sure if we should raise a ZoneDoesNotExistError here. The
             # base DNS API only specifies that we should return a bool. So,
             # let's ignore this code for now.
-            # e = sys.exc_info()[1]
             # if e.code == httplib.UNPROCESSABLE_ENTITY and \
             #     e.message.startswith('Could not find domain'):
             #     raise ZoneDoesNotExistError(zone_id=zone.id, driver=self,
@@ -309,7 +304,6 @@ class PowerDNSDriver(DNSDriver):
             # I'm not sure if we should raise a ZoneDoesNotExistError here. The
             # base DNS API only specifies that we should return a bool. So,
             # let's ignore this code for now.
-            # e = sys.exc_info()[1]
             # if e.code == httplib.UNPROCESSABLE_ENTITY and \
             #     e.message.startswith('Could not find domain'):
             #     raise ZoneDoesNotExistError(zone_id=zone.id, driver=self,
@@ -336,8 +330,7 @@ class PowerDNSDriver(DNSDriver):
                                              zone_id)
         try:
             response = self.connection.request(action=action, method='GET')
-        except BaseHTTPError:
-            e = sys.exc_info()[1]
+        except BaseHTTPError as e:
             if e.code == httplib.UNPROCESSABLE_ENTITY:
                 raise ZoneDoesNotExistError(zone_id=zone_id, driver=self,
                                             value=e.message)
@@ -357,8 +350,7 @@ class PowerDNSDriver(DNSDriver):
                                              zone.id)
         try:
             response = self.connection.request(action=action, method='GET')
-        except BaseHTTPError:
-            e = sys.exc_info()[1]
+        except BaseHTTPError as e:
             if e.code == httplib.UNPROCESSABLE_ENTITY and \
                e.message.startswith('Could not find domain'):
                 raise ZoneDoesNotExistError(zone_id=zone.id, driver=self,
@@ -421,8 +413,7 @@ class PowerDNSDriver(DNSDriver):
         try:
             self.connection.request(action=action, data=json.dumps(payload),
                                     method='PATCH')
-        except BaseHTTPError:
-            e = sys.exc_info()[1]
+        except BaseHTTPError as e:
             if e.code == httplib.UNPROCESSABLE_ENTITY and \
                e.message.startswith('Could not find domain'):
                 raise ZoneDoesNotExistError(zone_id=record.zone.id,

--- a/libcloud/dns/drivers/rcodezero.py
+++ b/libcloud/dns/drivers/rcodezero.py
@@ -15,7 +15,6 @@
     RcodeZero DNS Driver
 """
 import json
-import sys
 import hashlib
 import re
 
@@ -48,8 +47,7 @@ class RcodeZeroResponse(JsonResponse):
         errors = []
         try:
             body = self.parse_body()
-        except MalformedResponseError:
-            e = sys.exc_info()[1]
+        except MalformedResponseError as e:
             body = '%s: %s' % (e.value, e.body)
         try:
             errors = [body['message']]
@@ -174,8 +172,7 @@ class RcodeZeroDNSDriver(DNSDriver):
         try:
             self.connection.request(action=action, data=json.dumps(payload),
                                     method='PATCH')
-        except BaseHTTPError:
-            e = sys.exc_info()[1]
+        except BaseHTTPError as e:
             if e.code == httplib.UNPROCESSABLE_ENTITY and \
                e.message.startswith('Could not find domain'):
                 raise ZoneDoesNotExistError(zone_id=zone.id, driver=self,
@@ -221,8 +218,7 @@ class RcodeZeroDNSDriver(DNSDriver):
         try:
             self.connection.request(action=action, data=json.dumps(payload),
                                     method='POST')
-        except BaseHTTPError:
-            e = sys.exc_info()[1]
+        except BaseHTTPError as e:
             if e.code == httplib.UNPROCESSABLE_ENTITY and \
                e.message.find("Zone '%s' already configured for your account"
                               % domain):
@@ -269,8 +265,7 @@ class RcodeZeroDNSDriver(DNSDriver):
         try:
             self.connection.request(action=action, data=json.dumps(payload),
                                     method='PUT')
-        except BaseHTTPError:
-            e = sys.exc_info()[1]
+        except BaseHTTPError as e:
             if e.code == httplib.UNPROCESSABLE_ENTITY and \
                e.message.startswith("Domain '%s' update failed" % domain):
                 raise ZoneAlreadyExistsError(zone_id=zone.id, driver=self,
@@ -299,8 +294,7 @@ class RcodeZeroDNSDriver(DNSDriver):
             self.connection.request(action=action, data=json.dumps(payload),
                                     method='PATCH')
 
-        except BaseHTTPError:
-            e = sys.exc_info()[1]
+        except BaseHTTPError as e:
             if e.code == httplib.UNPROCESSABLE_ENTITY and \
                e.message.startswith('Could not find domain'):
                 raise ZoneDoesNotExistError(zone_id=record.zone.id,
@@ -340,8 +334,7 @@ class RcodeZeroDNSDriver(DNSDriver):
         action = '%s/zones/%s' % (self.api_root, zone_id)
         try:
             response = self.connection.request(action=action, method='GET')
-        except BaseHTTPError:
-            e = sys.exc_info()[1]
+        except BaseHTTPError as e:
             if e.code == httplib.NOT_FOUND:
                 raise ZoneDoesNotExistError(zone_id=zone_id, driver=self,
                                             value=e.message)
@@ -384,8 +377,7 @@ class RcodeZeroDNSDriver(DNSDriver):
         action = '%s/zones/%s/rrsets?page_size=-1' % (self.api_root, zone.id)
         try:
             response = self.connection.request(action=action, method='GET')
-        except BaseHTTPError:
-            e = sys.exc_info()[1]
+        except BaseHTTPError as e:
             if e.code == httplib.UNPROCESSABLE_ENTITY and \
                e.message.startswith('Could not find domain'):
                 raise ZoneDoesNotExistError(zone_id=zone.id, driver=self,
@@ -434,8 +426,7 @@ class RcodeZeroDNSDriver(DNSDriver):
             self.connection.request(action=action, data=json.dumps(payload),
                                     method='PATCH')
 
-        except BaseHTTPError:
-            e = sys.exc_info()[1]
+        except BaseHTTPError as e:
             if e.code == httplib.UNPROCESSABLE_ENTITY and \
                e.message.startswith('Could not find domain'):
                 raise ZoneDoesNotExistError(zone_id=record.zone.id,

--- a/libcloud/dns/drivers/zonomi.py
+++ b/libcloud/dns/drivers/zonomi.py
@@ -14,7 +14,6 @@
 """
 Zonomi DNS Driver
 """
-import sys
 
 from libcloud.common.zonomi import ZonomiConnection, ZonomiResponse
 from libcloud.common.zonomi import ZonomiException
@@ -77,8 +76,7 @@ class ZonomiDNSDriver(DNSDriver):
         params = {'action': 'QUERY', 'name': '**.' + zone.id}
         try:
             response = self.connection.request(action=action, params=params)
-        except ZonomiException:
-            e = sys.exc_info()[1]
+        except ZonomiException as e:
             if e.code == '404':
                 raise ZoneDoesNotExistError(zone_id=zone.id, driver=self,
                                             value=e.message)
@@ -147,8 +145,7 @@ class ZonomiDNSDriver(DNSDriver):
         params = {'name': domain}
         try:
             self.connection.request(action=action, params=params)
-        except ZonomiException:
-            e = sys.exc_info()[1]
+        except ZonomiException as e:
             if e.message == 'ERROR: This zone is already in your zone list.':
                 raise ZoneAlreadyExistsError(zone_id=domain, driver=self,
                                              value=e.message)
@@ -195,8 +192,7 @@ class ZonomiDNSDriver(DNSDriver):
             params['prio'] = extra.get('prio')
         try:
             response = self.connection.request(action=action, params=params)
-        except ZonomiException:
-            e = sys.exc_info()[1]
+        except ZonomiException as e:
             if ('ERROR: No zone found for %s' % record_name) in e.message:
                 raise ZoneDoesNotExistError(zone_id=zone.id, driver=self,
                                             value=e.message)
@@ -233,8 +229,7 @@ class ZonomiDNSDriver(DNSDriver):
         params = {'action': 'DELETEZONE', 'name': zone.id}
         try:
             response = self.connection.request(action=action, params=params)
-        except ZonomiException:
-            e = sys.exc_info()[1]
+        except ZonomiException as e:
             if e.code == '404':
                 raise ZoneDoesNotExistError(zone_id=zone.id, driver=self,
                                             value=e.message)
@@ -255,8 +250,7 @@ class ZonomiDNSDriver(DNSDriver):
         params = {'action': 'DELETE', 'name': record.name, 'type': record.type}
         try:
             response = self.connection.request(action=action, params=params)
-        except ZonomiException:
-            e = sys.exc_info()[1]
+        except ZonomiException as e:
             if e.message == 'Record not deleted.':
                 raise RecordDoesNotExistError(record_id=record.id, driver=self,
                                               value=e.message)
@@ -280,8 +274,7 @@ class ZonomiDNSDriver(DNSDriver):
         params = {'name': zone.domain, 'master': master}
         try:
             self.connection.request(action=action, params=params)
-        except ZonomiException:
-            e = sys.exc_info()[1]
+        except ZonomiException as e:
             if 'ERROR: Could not find' in e.message:
                 raise ZoneDoesNotExistError(zone_id=zone.id, driver=self,
                                             value=e.message)
@@ -300,8 +293,7 @@ class ZonomiDNSDriver(DNSDriver):
         params = {'name': zone.domain}
         try:
             self.connection.request(action=action, params=params)
-        except ZonomiException:
-            e = sys.exc_info()[1]
+        except ZonomiException as e:
             if 'ERROR: Could not find' in e.message:
                 raise ZoneDoesNotExistError(zone_id=zone.id, driver=self,
                                             value=e.message)

--- a/libcloud/loadbalancer/drivers/gogrid.py
+++ b/libcloud/loadbalancer/drivers/gogrid.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import time
 
 from libcloud.utils.py3 import httplib
@@ -130,8 +129,7 @@ class GoGridLBDriver(BaseGoGridDriver, Driver):
             resp = self.connection.request(
                 '/api/grid/loadbalancer/delete', method='POST',
                 params={'id': balancer.id})
-        except Exception:
-            e = sys.exc_info()[1]
+        except Exception as e:
             if "Update request for LoadBalancer" in str(e):
                 raise LibcloudLBImmutableError(
                     "Cannot delete immutable object", GoGridLBDriver)
@@ -190,13 +188,12 @@ class GoGridLBDriver(BaseGoGridDriver, Driver):
             return self.connection.request('/api/grid/loadbalancer/edit',
                                            method='POST',
                                            params=params)
-        except Exception:
-            e = sys.exc_info()[1]
+        except Exception as e:
             if "Update already pending" in str(e):
                 raise LibcloudLBImmutableError(
                     "Balancer is immutable", GoGridLBDriver)
 
-        raise LibcloudError(value='Exception: %s' % str(e), driver=self)
+            raise LibcloudError(value='Exception: %s' % str(e), driver=self)
 
     def _members_to_params(self, members):
         """

--- a/libcloud/loadbalancer/drivers/slb.py
+++ b/libcloud/loadbalancer/drivers/slb.py
@@ -18,8 +18,6 @@ __all__ = [
     'SLBDriver'
 ]
 
-import sys
-
 try:
     import simplejson as json
 except ImportError:
@@ -453,8 +451,7 @@ class SLBDriver(Driver):
                                     algorithm, bandwidth, **kwargs)
             self.ex_start_listener(balancer, port)
             return balancer
-        except Exception:
-            e = sys.exc_info()[1]
+        except Exception as e:
             if balancer is not None:
                 try:
                     self.destroy_balancer(balancer)

--- a/libcloud/storage/drivers/atmos.py
+++ b/libcloud/storage/drivers/atmos.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import base64
 import hashlib
 import hmac
@@ -147,8 +146,7 @@ class AtmosDriver(StorageDriver):
         path = self._namespace_path(container_name) + '/?metadata/system'
         try:
             result = self.connection.request(path)
-        except AtmosError:
-            e = sys.exc_info()[1]
+        except AtmosError as e:
             if e.code != 1003:
                 raise
             raise ContainerDoesNotExistError(e, self, container_name)
@@ -162,8 +160,7 @@ class AtmosDriver(StorageDriver):
         path = self._namespace_path(container_name) + '/'
         try:
             self.connection.request(path, method='POST')
-        except AtmosError:
-            e = sys.exc_info()[1]
+        except AtmosError as e:
             if e.code != 1016:
                 raise
             raise ContainerAlreadyExistsError(e, self, container_name)
@@ -173,8 +170,7 @@ class AtmosDriver(StorageDriver):
         try:
             self.connection.request(self._namespace_path(container.name) + '/',
                                     method='DELETE')
-        except AtmosError:
-            e = sys.exc_info()[1]
+        except AtmosError as e:
             if e.code == 1003:
                 raise ContainerDoesNotExistError(e, self, container.name)
             elif e.code == 1023:
@@ -192,8 +188,7 @@ class AtmosDriver(StorageDriver):
 
             result = self.connection.request(path + '?metadata/user')
             user_meta = self._emc_meta(result)
-        except AtmosError:
-            e = sys.exc_info()[1]
+        except AtmosError as e:
             if e.code != 1003:
                 raise
             raise ObjectDoesNotExistError(e, self, object_name)
@@ -222,8 +217,7 @@ class AtmosDriver(StorageDriver):
 
         try:
             self.connection.request(request_path + '?metadata/system')
-        except AtmosError:
-            e = sys.exc_info()[1]
+        except AtmosError as e:
             if e.code != 1003:
                 raise
             method = 'POST'
@@ -287,8 +281,7 @@ class AtmosDriver(StorageDriver):
 
         try:
             self.connection.request(path + '?metadata/system')
-        except AtmosError:
-            e = sys.exc_info()[1]
+        except AtmosError as e:
             if e.code != 1003:
                 raise
             method = 'POST'
@@ -372,8 +365,7 @@ class AtmosDriver(StorageDriver):
             self._clean_object_name(obj.name)
         try:
             self.connection.request(path, method='DELETE')
-        except AtmosError:
-            e = sys.exc_info()[1]
+        except AtmosError as e:
             if e.code != 1003:
                 raise
             raise ObjectDoesNotExistError(e, self, obj.name)

--- a/libcloud/storage/drivers/local.py
+++ b/libcloud/storage/drivers/local.py
@@ -101,8 +101,7 @@ class LocalStorageDriver(StorageDriver):
 
         try:
             os.makedirs(path)
-        except OSError:
-            exp = sys.exc_info()[1]
+        except OSError as e:
             if exp.errno == errno.EEXIST and not ignore_existing:
                 raise exp
 
@@ -520,8 +519,7 @@ class LocalStorageDriver(StorageDriver):
         while path != container_url:
             try:
                 os.rmdir(path)
-            except OSError:
-                exp = sys.exc_info()[1]
+            except OSError as e:
                 if exp.errno == errno.ENOTEMPTY:
                     break
                 raise exp
@@ -547,8 +545,7 @@ class LocalStorageDriver(StorageDriver):
 
         try:
             self._make_path(path, ignore_existing=False)
-        except OSError:
-            exp = sys.exc_info()[1]
+        except OSError as e:
             if exp.errno == errno.EEXIST:
                 raise ContainerAlreadyExistsError(
                     value='Container with this name already exists. The name '

--- a/libcloud/storage/drivers/local.py
+++ b/libcloud/storage/drivers/local.py
@@ -22,7 +22,6 @@ from __future__ import with_statement
 import errno
 import os
 import shutil
-import sys
 
 try:
     import lockfile
@@ -101,7 +100,7 @@ class LocalStorageDriver(StorageDriver):
 
         try:
             os.makedirs(path)
-        except OSError as e:
+        except OSError as exp:
             if exp.errno == errno.EEXIST and not ignore_existing:
                 raise exp
 
@@ -519,7 +518,7 @@ class LocalStorageDriver(StorageDriver):
         while path != container_url:
             try:
                 os.rmdir(path)
-            except OSError as e:
+            except OSError as exp:
                 if exp.errno == errno.ENOTEMPTY:
                     break
                 raise exp
@@ -545,7 +544,7 @@ class LocalStorageDriver(StorageDriver):
 
         try:
             self._make_path(path, ignore_existing=False)
-        except OSError as e:
+        except OSError as exp:
             if exp.errno == errno.EEXIST:
                 raise ContainerAlreadyExistsError(
                     value='Container with this name already exists. The name '

--- a/libcloud/storage/drivers/oss.py
+++ b/libcloud/storage/drivers/oss.py
@@ -19,7 +19,6 @@ import base64
 import codecs
 import hmac
 import time
-import sys
 from hashlib import sha1
 
 from libcloud.utils.py3 import ET
@@ -687,11 +686,10 @@ class OSSStorageDriver(StorageDriver):
             # Commit the chunk info and complete the upload
             etag = self._commit_multipart(object_path, upload_id, chunks,
                                           container=container)
-        except Exception:
-            exc = sys.exc_info()[1]
+        except Exception as e:
             # Amazon provides a mechanism for aborting an upload.
             self._abort_multipart(object_path, upload_id, container=container)
-            raise exc
+            raise e
 
         # Modify the response header of the first request. This is used
         # by other functions once the callback is done

--- a/libcloud/test/common/test_cloudstack.py
+++ b/libcloud/test/common/test_cloudstack.py
@@ -57,8 +57,7 @@ class CloudStackCommonTest(unittest.TestCase):
         self.driver.path = '/bad/response'
         try:
             self.connection._sync_request('fake')
-        except Exception:
-            e = sys.exc_info()[1]
+        except Exception as e:
             self.assertTrue(isinstance(e, MalformedResponseError))
             return
         self.assertTrue(False)
@@ -76,8 +75,7 @@ class CloudStackCommonTest(unittest.TestCase):
         self.driver.path = '/async/fail'
         try:
             self.connection._async_request('fake')
-        except Exception:
-            e = sys.exc_info()[1]
+        except Exception as e:
             self.assertEqual(CloudStackMockHttp.ERROR_TEXT, str(e))
             return
         self.assertFalse(True)

--- a/libcloud/test/compute/test_deployment.py
+++ b/libcloud/test/compute/test_deployment.py
@@ -231,8 +231,7 @@ class DeploymentTests(unittest.TestCase):
             node2, ips = self.driver.wait_until_running(
                 nodes=[self.node], wait_period=0.1,
                 timeout=0.2)[0]
-        except LibcloudError:
-            e = sys.exc_info()[1]
+        except LibcloudError as e:
             self.assertTrue(e.value.find('Timed out after 0.2 second') != -1)
         else:
             self.fail('Exception was not thrown')
@@ -244,8 +243,7 @@ class DeploymentTests(unittest.TestCase):
             node2, ips = self.driver.wait_until_running(
                 nodes=[self.node], wait_period=0.1,
                 timeout=0.2)[0]
-        except LibcloudError:
-            e = sys.exc_info()[1]
+        except LibcloudError as e:
             self.assertTrue(e.value.find('Timed out after 0.2 second') != -1)
         else:
             self.fail('Exception was not thrown')
@@ -289,8 +287,7 @@ class DeploymentTests(unittest.TestCase):
         try:
             self.driver.wait_until_running(nodes=[self.node], wait_period=0.1,
                                            timeout=0.2)
-        except LibcloudError:
-            e = sys.exc_info()[1]
+        except LibcloudError as e:
             self.assertTrue(e.value.find('Timed out') != -1)
         else:
             self.fail('Exception was not thrown')
@@ -301,8 +298,7 @@ class DeploymentTests(unittest.TestCase):
         try:
             self.driver.wait_until_running(nodes=[self.node], wait_period=0.1,
                                            timeout=0.2)
-        except LibcloudError:
-            e = sys.exc_info()[1]
+        except LibcloudError as e:
             self.assertTrue(e.value.find('Timed out after 0.2 second') != -1)
         else:
             self.fail('Exception was not thrown')
@@ -313,8 +309,7 @@ class DeploymentTests(unittest.TestCase):
         try:
             self.driver.wait_until_running(nodes=[self.node], wait_period=0.1,
                                            timeout=0.2)
-        except LibcloudError:
-            e = sys.exc_info()[1]
+        except LibcloudError as e:
             self.assertTrue(
                 e.value.find('Unable to match specified uuids') != -1)
         else:
@@ -349,8 +344,7 @@ class DeploymentTests(unittest.TestCase):
             self.driver._ssh_client_connect(ssh_client=mock_ssh_client,
                                             wait_period=0.1,
                                             timeout=0.2)
-        except LibcloudError:
-            e = sys.exc_info()[1]
+        except LibcloudError as e:
             self.assertTrue(e.value.find('Giving up') != -1)
         else:
             self.fail('Exception was not thrown')
@@ -376,8 +370,7 @@ class DeploymentTests(unittest.TestCase):
                                                node=self.node,
                                                ssh_client=ssh_client,
                                                max_tries=2)
-        except LibcloudError:
-            e = sys.exc_info()[1]
+        except LibcloudError as e:
             self.assertTrue(e.value.find('Failed after 2 tries') != -1)
         else:
             self.fail('Exception was not thrown')
@@ -408,8 +401,7 @@ class DeploymentTests(unittest.TestCase):
 
         try:
             self.driver.deploy_node(deploy=deploy)
-        except DeploymentError:
-            e = sys.exc_info()[1]
+        except DeploymentError as e:
             self.assertTrue(e.node.id, self.node.id)
         else:
             self.fail('Exception was not thrown')
@@ -428,8 +420,7 @@ class DeploymentTests(unittest.TestCase):
 
         try:
             self.driver.deploy_node(deploy=deploy)
-        except DeploymentError:
-            e = sys.exc_info()[1]
+        except DeploymentError as e:
             self.assertTrue(e.node.id, self.node.id)
         else:
             self.fail('Exception was not thrown')
@@ -480,8 +471,7 @@ class DeploymentTests(unittest.TestCase):
 
         try:
             self.driver.deploy_node(deploy=Mock())
-        except RuntimeError:
-            e = sys.exc_info()[1]
+        except RuntimeError as e:
             self.assertTrue(str(e).find('paramiko is not installed') != -1)
         else:
             self.fail('Exception was not thrown')

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -216,8 +216,7 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
             self.driver.create_node(name='foo', image=image, size=size,
                                     ex_mincount='2', ex_maxcount='2',
                                     ex_clienttoken=token)
-        except IdempotentParamError:
-            e = sys.exc_info()[1]
+        except IdempotentParamError as e:
             idem_error = e
         self.assertTrue(idem_error is not None)
 

--- a/libcloud/test/compute/test_elasticstack.py
+++ b/libcloud/test/compute/test_elasticstack.py
@@ -45,8 +45,7 @@ class ElasticStackTestCase(object):
         self.mockHttp.type = 'UNAUTHORIZED'
         try:
             self.driver.list_nodes()
-        except InvalidCredsError:
-            e = sys.exc_info()[1]
+        except InvalidCredsError as e:
             self.assertEqual(True, isinstance(e, InvalidCredsError))
         else:
             self.fail('test should have thrown')
@@ -64,8 +63,7 @@ class ElasticStackTestCase(object):
         self.mockHttp.type = 'PARSE_ERROR'
         try:
             self.driver.list_nodes()
-        except Exception:
-            e = sys.exc_info()[1]
+        except Exception as e:
             self.assertTrue(str(e).find('X-Elastic-Error') != -1)
         else:
             self.fail('test should have thrown')

--- a/libcloud/test/compute/test_gogrid.py
+++ b/libcloud/test/compute/test_gogrid.py
@@ -105,8 +105,7 @@ class GoGridTests(unittest.TestCase, TestCaseMixin):
         GoGridMockHttp.type = 'FAIL'
         try:
             self.driver.list_images()
-        except LibcloudError:
-            e = sys.exc_info()[1]
+        except LibcloudError as e:
             self.assertTrue(isinstance(e, LibcloudError))
         else:
             self.fail("test should have thrown")
@@ -115,8 +114,7 @@ class GoGridTests(unittest.TestCase, TestCaseMixin):
         GoGridMockHttp.type = 'FAIL'
         try:
             self.driver.list_nodes()
-        except InvalidCredsError:
-            e = sys.exc_info()[1]
+        except InvalidCredsError as e:
             self.assertTrue(e.driver is not None)
             self.assertEqual(e.driver.name, self.driver.name)
         else:
@@ -130,8 +128,7 @@ class GoGridTests(unittest.TestCase, TestCaseMixin):
                 name='test1',
                 image=image,
                 size=self._get_test_512Mb_node_size())
-        except LibcloudError:
-            e = sys.exc_info()[1]
+        except LibcloudError as e:
             self.assertTrue(isinstance(e, LibcloudError))
             self.assertTrue(e.driver is not None)
             self.assertEqual(e.driver.name, self.driver.name)

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -188,8 +188,7 @@ class OpenStack_1_0_Tests(TestCaseMixin, unittest.TestCase):
         try:
             self.driver = self.create_driver()
             self.driver.list_nodes()
-        except InvalidCredsError:
-            e = sys.exc_info()[1]
+        except InvalidCredsError as e:
             self.assertEqual(True, isinstance(e, InvalidCredsError))
         else:
             self.fail('test should have thrown')
@@ -202,8 +201,7 @@ class OpenStack_1_0_Tests(TestCaseMixin, unittest.TestCase):
         try:
             self.driver = self.create_driver()
             self.driver.list_nodes()
-        except MalformedResponseError:
-            e = sys.exc_info()[1]
+        except MalformedResponseError as e:
             self.assertEqual(True, isinstance(e, MalformedResponseError))
         else:
             self.fail('test should have thrown')
@@ -216,8 +214,7 @@ class OpenStack_1_0_Tests(TestCaseMixin, unittest.TestCase):
         try:
             self.driver = self.create_driver()
             self.driver.list_nodes()
-        except MalformedResponseError:
-            e = sys.exc_info()[1]
+        except MalformedResponseError as e:
             self.assertEqual(True, isinstance(e, MalformedResponseError))
         else:
             self.fail('test should have thrown')
@@ -226,8 +223,7 @@ class OpenStack_1_0_Tests(TestCaseMixin, unittest.TestCase):
         OpenStackMockHttp.type = 'NO_MESSAGE_IN_ERROR_BODY'
         try:
             self.driver.list_images()
-        except Exception:
-            e = sys.exc_info()[1]
+        except Exception as e:
             self.assertEqual(True, isinstance(e, Exception))
         else:
             self.fail('test should have thrown')
@@ -1070,22 +1066,19 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
                         driver=self.driver)
         try:
             self.driver.ex_resize(self.node, size)
-        except Exception:
-            e = sys.exc_info()[1]
+        except Exception as e:
             self.fail('An error was raised: ' + repr(e))
 
     def test_ex_confirm_resize(self):
         try:
             self.driver.ex_confirm_resize(self.node)
-        except Exception:
-            e = sys.exc_info()[1]
+        except Exception as e:
             self.fail('An error was raised: ' + repr(e))
 
     def test_ex_revert_resize(self):
         try:
             self.driver.ex_revert_resize(self.node)
-        except Exception:
-            e = sys.exc_info()[1]
+        except Exception as e:
             self.fail('An error was raised: ' + repr(e))
 
     def test_create_image(self):

--- a/libcloud/test/compute/test_packet.py
+++ b/libcloud/test/compute/test_packet.py
@@ -36,6 +36,9 @@ from libcloud.test.file_fixtures import ComputeFileFixtures
 import libcloud.compute.drivers.packet
 libcloud.compute.drivers.packet.USE_ASYNC_IO_IF_AVAILABLE = False
 
+__all__ = [
+    'PacketTest'
+]
 
 
 class PacketTest(unittest.TestCase, TestCaseMixin):
@@ -170,7 +173,6 @@ g5ZW2BiJzvqz5PebGS70y/ySCNW1qQmJURK/Wc1bt9en root@libcloud")
         self.assertEqual(session['status'], 'unknown')
 
     def test_ex_get_bgp_session(self):
-        node = self.driver.list_nodes('project-id')[0]
         session = self.driver.ex_get_bgp_session(self.driver.ex_list_bgp_sessions()[0]['id'])
         self.assertEqual(session['status'], 'down')
 
@@ -231,7 +233,7 @@ g5ZW2BiJzvqz5PebGS70y/ySCNW1qQmJURK/Wc1bt9en root@libcloud")
         assignments = self.driver.ex_list_ip_assignments_for_node(node)
         for ip_assignment in assignments['ip_addresses']:
             if ip_assignment['gateway'] == '147.75.40.2':
-                response = self.driver.ex_disassociate_address(
+                self.driver.ex_disassociate_address(
                     ip_assignment['id'])
                 break
 
@@ -246,7 +248,7 @@ g5ZW2BiJzvqz5PebGS70y/ySCNW1qQmJURK/Wc1bt9en root@libcloud")
             10, location, description="test volume", plan="storage_1",
             ex_project_id='3d27fd13-0466-4878-be22-9a4b5595a3df')
         assert len(volume.extra['attachments']) == 0
-        assert volume.extra['locked'] == False
+        assert not volume.extra['locked']
 
     def test_attach_volume(self):
         attached = False
@@ -309,7 +311,7 @@ class PacketMockHttp(MockHttp):
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
     def _projects_3d27fd13_0466_4878_be22_9a4b5595a3df_ips(self, method, url, body, headers):
-        if method =='POST':
+        if method == 'POST':
             body = self.fixtures.load('reserve_ip.json')
             return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
@@ -357,7 +359,7 @@ class PacketMockHttp(MockHttp):
 
     def _devices_1e52437e_bbbb_cccc_dddd_74a9dfd3d3bb_actions(
             self, method, url, body, headers):
-            return (httplib.OK, '', {}, httplib.responses[httplib.OK])
+        return (httplib.OK, '', {}, httplib.responses[httplib.OK])
 
     def _devices_1e52437e_bbbb_cccc_dddd_74a9dfd3d3bb_bgp_sessions(self,
             method, url, body, headers):
@@ -387,7 +389,6 @@ class PacketMockHttp(MockHttp):
         if method == 'GET':
             body = self.fixtures.load('bgp_sessions.json')
             return (httplib.OK, body, {}, httplib.responses[httplib.OK])
-
 
     def _projects_3d27fd13_0466_4878_be22_9a4b5595a3df_bgp_sessions(self,
             method, url, body, headers):
@@ -471,6 +472,7 @@ class PacketMockHttp(MockHttp):
             method, url, body, headers):
         if method == 'DELETE':
             return (httplib.NO_CONTENT, '', {}, httplib.responses[httplib.NO_CONTENT])
+
 
 if __name__ == '__main__':
     sys.exit(unittest.main())

--- a/libcloud/test/compute/test_packet.py
+++ b/libcloud/test/compute/test_packet.py
@@ -32,6 +32,11 @@ from libcloud.test import MockHttp
 from libcloud.test.compute import TestCaseMixin
 from libcloud.test.file_fixtures import ComputeFileFixtures
 
+# This is causing test failures inder Python 3.5
+import libcloud.compute.drivers.packet
+libcloud.compute.drivers.packet.USE_ASYNC_IO_IF_AVAILABLE = False
+
+
 
 class PacketTest(unittest.TestCase, TestCaseMixin):
     def setUp(self):

--- a/libcloud/test/compute/test_rackspace.py
+++ b/libcloud/test/compute/test_rackspace.py
@@ -49,8 +49,7 @@ class RackspaceusFirstGenUsTests(OpenStack_1_0_Tests):
         for provider in DEPRECATED_RACKSPACE_PROVIDERS:
             try:
                 get_driver(provider)
-            except Exception:
-                e = sys.exc_info()[1]
+            except Exception as e:
                 self.assertTrue(str(e).find('has been removed') != -1)
             else:
                 self.fail('Exception was not thrown')

--- a/libcloud/test/compute/test_ssh_client.py
+++ b/libcloud/test/compute/test_ssh_client.py
@@ -348,8 +348,7 @@ class ShellOutSSHClientTests(LibcloudTestCase):
         try:
             ShellOutSSHClient(hostname='localhost', username='foo',
                               password='bar')
-        except ValueError:
-            e = sys.exc_info()[1]
+        except ValueError as e:
             msg = str(e)
             self.assertTrue('ShellOutSSHClient only supports key auth' in msg)
         else:
@@ -368,8 +367,7 @@ class ShellOutSSHClientTests(LibcloudTestCase):
         with patch('subprocess.Popen', mock_popen):
             try:
                 ShellOutSSHClient(hostname='localhost', username='foo')
-            except ValueError:
-                e = sys.exc_info()[1]
+            except ValueError as e:
                 msg = str(e)
                 self.assertTrue('ssh client is not available' in msg)
             else:

--- a/libcloud/test/compute/test_voxel.py
+++ b/libcloud/test/compute/test_voxel.py
@@ -38,8 +38,7 @@ class VoxelTest(unittest.TestCase):
         VoxelMockHttp.type = 'UNAUTHORIZED'
         try:
             self.driver.list_nodes()
-        except Exception:
-            e = sys.exc_info()[1]
+        except Exception as e:
             self.assertTrue(isinstance(e, InvalidCredsError))
         else:
             self.fail('test should have thrown')

--- a/libcloud/test/dns/test_buddyns.py
+++ b/libcloud/test/dns/test_buddyns.py
@@ -47,8 +47,7 @@ class BuddyNSDNSTests(unittest.TestCase):
 
         try:
             self.driver.delete_zone(zone=self.test_zone)
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, self.test_zone.id)
         else:
             self.fail('Exception was not thrown')
@@ -63,8 +62,7 @@ class BuddyNSDNSTests(unittest.TestCase):
         BuddyNSMockHttp.type = 'GET_ZONE_ZONE_DOES_NOT_EXIST'
         try:
             self.driver.get_zone(zone_id='zonedoesnotexist.com')
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, 'zonedoesnotexist.com')
         else:
             self.fail('Exception was not thrown')
@@ -94,8 +92,7 @@ class BuddyNSDNSTests(unittest.TestCase):
         try:
             self.driver.create_zone(domain='newzone.com',
                                     extra={'master': '13.0.0.1'})
-        except ZoneAlreadyExistsError:
-            e = sys.exc_info()[1]
+        except ZoneAlreadyExistsError as e:
             self.assertEqual(e.zone_id, 'newzone.com')
         else:
             self.fail('Exception was not thrown')

--- a/libcloud/test/dns/test_dnspod.py
+++ b/libcloud/test/dns/test_dnspod.py
@@ -49,8 +49,7 @@ class DNSPodDNSTests(unittest.TestCase):
         DNSPodMockHttp.type = 'ZONE_DOES_NOT_EXIST'
         try:
             self.driver.get_zone(zone_id='13')
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, '13')
         else:
             self.fail('Exception was not thrown')
@@ -77,8 +76,7 @@ class DNSPodDNSTests(unittest.TestCase):
         zone = self.test_zone
         try:
             self.driver.delete_zone(zone=zone)
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, '11')
         else:
             self.fail('Exception was not thrown')
@@ -97,8 +95,7 @@ class DNSPodDNSTests(unittest.TestCase):
         DNSPodMockHttp.type = 'CREATE_ZONE_ZONE_ALREADY_EXISTS'
         try:
             self.driver.create_zone(domain='test.com')
-        except ZoneAlreadyExistsError:
-            e = sys.exc_info()[1]
+        except ZoneAlreadyExistsError as e:
             self.assertEqual(e.zone_id, 'test.com')
         else:
             self.fail('Exception was not thrown')
@@ -136,8 +133,7 @@ class DNSPodDNSTests(unittest.TestCase):
         record = self.test_record
         try:
             self.driver.delete_record(record=record)
-        except RecordDoesNotExistError:
-            e = sys.exc_info()[1]
+        except RecordDoesNotExistError as e:
             self.assertEqual(e.record_id, '13')
         else:
             self.fail('Exception was not thrown')
@@ -160,8 +156,7 @@ class DNSPodDNSTests(unittest.TestCase):
                                       type='A', data='92.126.115.73',
                                       extra={'ttl': 13,
                                              'record_line': 'default'})
-        except RecordAlreadyExistsError:
-            e = sys.exc_info()[1]
+        except RecordAlreadyExistsError as e:
             self.assertEqual(e.value, '@')
         else:
             self.fail('Exception was not thrown')

--- a/libcloud/test/dns/test_durabledns.py
+++ b/libcloud/test/dns/test_durabledns.py
@@ -114,8 +114,7 @@ class DurableDNSTests(LibcloudTestCase):
         DurableDNSMockHttp.type = 'ZONE_DOES_NOT_EXIST'
         try:
             self.driver.list_records(zone=zone)
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, zone.id)
         else:
             self.fail('Exception was not thrown')
@@ -141,8 +140,7 @@ class DurableDNSTests(LibcloudTestCase):
         DurableDNSMockHttp.type = 'ZONE_DOES_NOT_EXIST'
         try:
             self.driver.get_zone(zone_id='nonexistentzone.com.')
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, 'nonexistentzone.com.')
         else:
             self.fail('Exception was not thrown')

--- a/libcloud/test/dns/test_gandi.py
+++ b/libcloud/test/dns/test_gandi.py
@@ -85,8 +85,7 @@ class GandiTests(unittest.TestCase):
 
         try:
             self.driver.list_records(zone=zone)
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, zone.id)
         else:
             self.fail('Exception was not thrown')
@@ -96,8 +95,7 @@ class GandiTests(unittest.TestCase):
 
         try:
             self.driver.get_zone(zone_id='47234')
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, '47234')
         else:
             self.fail('Exception was not thrown')
@@ -182,8 +180,7 @@ class GandiTests(unittest.TestCase):
 
         try:
             self.driver.delete_zone(zone=zone)
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, zone.id)
         else:
             self.fail('Exception was not thrown')
@@ -200,8 +197,7 @@ class GandiTests(unittest.TestCase):
         GandiMockHttp.type = 'RECORD_DOES_NOT_EXIST'
         try:
             self.driver.delete_record(record=record)
-        except RecordDoesNotExistError:
-            e = sys.exc_info()[1]
+        except RecordDoesNotExistError as e:
             self.assertEqual(e.record_id, record.id)
         else:
             self.fail('Exception was not thrown')

--- a/libcloud/test/dns/test_google.py
+++ b/libcloud/test/dns/test_google.py
@@ -61,8 +61,7 @@ class GoogleTests(GoogleTestCase):
 
         try:
             self.driver.get_zone('example-com')
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, 'example-com')
         else:
             self.fail('Exception not thrown')
@@ -81,8 +80,7 @@ class GoogleTests(GoogleTestCase):
 
         try:
             self.driver.get_record('example-com', 'a:a')
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, 'example-com')
         else:
             self.fail('Exception not thrown')
@@ -91,8 +89,7 @@ class GoogleTests(GoogleTestCase):
         GoogleDNSMockHttp.type = 'RECORD_DOES_NOT_EXIST'
         try:
             self.driver.get_record('example-com', "A:foo")
-        except RecordDoesNotExistError:
-            e = sys.exc_info()[1]
+        except RecordDoesNotExistError as e:
             self.assertEqual(e.record_id, 'A:foo')
         else:
             self.fail('Exception not thrown')

--- a/libcloud/test/dns/test_hostvirtual.py
+++ b/libcloud/test/dns/test_hostvirtual.py
@@ -87,8 +87,7 @@ class HostVirtualTests(unittest.TestCase):
 
         try:
             self.driver.list_records(zone=zone)
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, zone.id)
         else:
             self.fail('Exception was not thrown')
@@ -98,8 +97,7 @@ class HostVirtualTests(unittest.TestCase):
 
         try:
             self.driver.get_zone(zone_id='4444')
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, '4444')
         else:
             self.fail('Exception was not thrown')
@@ -191,8 +189,7 @@ class HostVirtualTests(unittest.TestCase):
 
         try:
             self.driver.delete_zone(zone=zone)
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, zone.id)
         else:
             self.fail('Exception was not thrown')
@@ -209,8 +206,7 @@ class HostVirtualTests(unittest.TestCase):
         HostVirtualMockHttp.type = 'RECORD_DOES_NOT_EXIST'
         try:
             self.driver.delete_record(record=record)
-        except RecordDoesNotExistError:
-            e = sys.exc_info()[1]
+        except RecordDoesNotExistError as e:
             self.assertEqual(e.record_id, record.id)
         else:
             self.fail('Exception was not thrown')

--- a/libcloud/test/dns/test_linode.py
+++ b/libcloud/test/dns/test_linode.py
@@ -82,8 +82,7 @@ class LinodeTests(unittest.TestCase):
         LinodeMockHttp.type = 'ZONE_DOES_NOT_EXIST'
         try:
             self.driver.list_records(zone=zone)
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, zone.id)
         else:
             self.fail('Exception was not thrown')
@@ -103,8 +102,7 @@ class LinodeTests(unittest.TestCase):
 
         try:
             self.driver.get_zone(zone_id='4444')
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, '4444')
         else:
             self.fail('Exception was not thrown')
@@ -213,8 +211,7 @@ class LinodeTests(unittest.TestCase):
 
         try:
             self.driver.delete_zone(zone=zone)
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, zone.id)
         else:
             self.fail('Exception was not thrown')
@@ -233,8 +230,7 @@ class LinodeTests(unittest.TestCase):
 
         try:
             self.driver.delete_record(record=record)
-        except RecordDoesNotExistError:
-            e = sys.exc_info()[1]
+        except RecordDoesNotExistError as e:
             self.assertEqual(e.record_id, record.id)
         else:
             self.fail('Exception was not thrown')

--- a/libcloud/test/dns/test_liquidweb.py
+++ b/libcloud/test/dns/test_liquidweb.py
@@ -81,8 +81,7 @@ class LiquidWebTests(unittest.TestCase):
         LiquidWebMockHttp.type = 'ZONE_DOES_NOT_EXIST'
         try:
             self.driver.get_zone(zone_id='13')
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, '13')
         else:
             self.fail('Exception was not thrown')
@@ -109,8 +108,7 @@ class LiquidWebTests(unittest.TestCase):
         zone = self.test_zone
         try:
             self.driver.delete_zone(zone=zone)
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, '11')
         else:
             self.fail('Exception was not thrown')
@@ -129,8 +127,7 @@ class LiquidWebTests(unittest.TestCase):
         LiquidWebMockHttp.type = 'CREATE_ZONE_ZONE_ALREADY_EXISTS'
         try:
             self.driver.create_zone(domain='test.com')
-        except ZoneAlreadyExistsError:
-            e = sys.exc_info()[1]
+        except ZoneAlreadyExistsError as e:
             self.assertEqual(e.zone_id, 'test.com')
         else:
             self.fail('Exception was not thrown')
@@ -175,8 +172,7 @@ class LiquidWebTests(unittest.TestCase):
         LiquidWebMockHttp.type = 'GET_RECORD_RECORD_DOES_NOT_EXIST'
         try:
             self.driver.get_record(zone_id='13', record_id='13')
-        except RecordDoesNotExistError:
-            e = sys.exc_info()[1]
+        except RecordDoesNotExistError as e:
             self.assertEqual(e.record_id, '13')
         else:
             self.fail('Exception was not thrown')
@@ -221,8 +217,7 @@ class LiquidWebTests(unittest.TestCase):
         record = self.test_record
         try:
             self.driver.delete_record(record=record)
-        except RecordDoesNotExistError:
-            e = sys.exc_info()[1]
+        except RecordDoesNotExistError as e:
             self.assertEqual(e.record_id, '13')
         else:
             self.fail('Exception was not thrown')

--- a/libcloud/test/dns/test_luadns.py
+++ b/libcloud/test/dns/test_luadns.py
@@ -59,8 +59,7 @@ class LuadnsTests(unittest.TestCase):
         LuadnsMockHttp.type = 'ZONE_DOES_NOT_EXIST'
         try:
             self.driver.get_zone(zone_id='13')
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, '13')
         else:
             self.fail('Exception was not thrown')
@@ -87,8 +86,7 @@ class LuadnsTests(unittest.TestCase):
         zone = self.test_zone
         try:
             self.driver.delete_zone(zone=zone)
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, '11')
         else:
             self.fail('Exception was not thrown')
@@ -107,8 +105,7 @@ class LuadnsTests(unittest.TestCase):
         LuadnsMockHttp.type = 'CREATE_ZONE_ZONE_ALREADY_EXISTS'
         try:
             self.driver.create_zone(domain='test.com')
-        except ZoneAlreadyExistsError:
-            e = sys.exc_info()[1]
+        except ZoneAlreadyExistsError as e:
             self.assertEqual(e.zone_id, 'test.com')
         else:
             self.fail('Exception was not thrown')
@@ -146,8 +143,7 @@ class LuadnsTests(unittest.TestCase):
         LuadnsMockHttp.type = 'GET_RECORD_RECORD_DOES_NOT_EXIST'
         try:
             self.driver.get_record(zone_id='31', record_id='31')
-        except RecordDoesNotExistError:
-            e = sys.exc_info()[1]
+        except RecordDoesNotExistError as e:
             self.assertEqual(e.record_id, '31')
         else:
             self.fail('Exception was not thrown')
@@ -173,8 +169,7 @@ class LuadnsTests(unittest.TestCase):
         record = self.test_record
         try:
             self.driver.delete_record(record=record)
-        except RecordDoesNotExistError:
-            e = sys.exc_info()[1]
+        except RecordDoesNotExistError as e:
             self.assertEqual(e.record_id, '13')
         else:
             self.fail('Exception was not thrown')

--- a/libcloud/test/dns/test_nsone.py
+++ b/libcloud/test/dns/test_nsone.py
@@ -50,8 +50,7 @@ class NsOneTests(unittest.TestCase):
 
         try:
             self.driver.delete_zone(zone=self.test_zone)
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, self.test_zone.id)
         else:
             self.fail('Exception was not thrown')
@@ -66,8 +65,7 @@ class NsOneTests(unittest.TestCase):
         NsOneMockHttp.type = 'GET_ZONE_ZONE_DOES_NOT_EXIST'
         try:
             self.driver.get_zone(zone_id='zonedoesnotexist.com')
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, 'zonedoesnotexist.com')
         else:
             self.fail('Exception was not thrown')
@@ -86,8 +84,7 @@ class NsOneTests(unittest.TestCase):
 
         try:
             self.driver.create_zone(domain='newzone.com')
-        except ZoneAlreadyExistsError:
-            e = sys.exc_info()[1]
+        except ZoneAlreadyExistsError as e:
             self.assertEqual(e.zone_id, 'newzone.com')
         else:
             self.fail('Exception was not thrown')
@@ -97,8 +94,7 @@ class NsOneTests(unittest.TestCase):
 
         try:
             self.driver.get_record(zone_id='getrecord.com', record_id='A')
-        except RecordDoesNotExistError:
-            e = sys.exc_info()[1]
+        except RecordDoesNotExistError as e:
             self.assertEqual(e.record_id, 'A')
         else:
             self.fail('Exception was not thrown')
@@ -117,8 +113,7 @@ class NsOneTests(unittest.TestCase):
 
         try:
             self.driver.list_records(zone=self.test_zone)
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, self.test_zone.id)
         else:
             self.fail('Exception was not thrown')
@@ -145,8 +140,7 @@ class NsOneTests(unittest.TestCase):
 
         try:
             self.driver.delete_record(record=self.test_record)
-        except RecordDoesNotExistError:
-            e = sys.exc_info()[1]
+        except RecordDoesNotExistError as e:
             self.assertEqual(e.record_id, self.test_record.id)
         else:
             self.fail('Exception was not thrown')

--- a/libcloud/test/dns/test_pointdns.py
+++ b/libcloud/test/dns/test_pointdns.py
@@ -335,8 +335,7 @@ class PointDNSTests(unittest.TestCase):
             self.driver.ex_create_redirect('http://other.com', 'redirect2',
                                            '302', zone, iframe='An Iframe',
                                            query=True)
-        except PointDNSException:
-            e = sys.exc_info()[1]
+        except PointDNSException as e:
             # The API actually responds with httplib.UNPROCESSABLE_ENTITY code,
             # but httplib.responses doesn't have it.
             self.assertEqual(e.http_code, httplib.METHOD_NOT_ALLOWED)
@@ -361,8 +360,7 @@ class PointDNSTests(unittest.TestCase):
         try:
             self.driver.ex_create_mail_redirect('user@example-site.com',
                                                 'admin', zone)
-        except PointDNSException:
-            e = sys.exc_info()[1]
+        except PointDNSException as e:
             # The API actually responds with httplib.UNPROCESSABLE_ENTITY code,
             # but httplib.responses doesn't have it.
             self.assertEqual(e.http_code, httplib.METHOD_NOT_ALLOWED)
@@ -387,8 +385,7 @@ class PointDNSTests(unittest.TestCase):
         PointDNSMockHttp.type = 'GET_WITH_ERROR'
         try:
             self.driver.ex_get_redirect(zone.id, '36843229')
-        except PointDNSException:
-            e = sys.exc_info()[1]
+        except PointDNSException as e:
             # The API actually responds with httplib.UNPROCESSABLE_ENTITY code,
             # but httplib.responses doesn't have it.
             self.assertEqual(e.http_code, httplib.METHOD_NOT_ALLOWED)
@@ -401,8 +398,7 @@ class PointDNSTests(unittest.TestCase):
         PointDNSMockHttp.type = 'GET_NOT_FOUND'
         try:
             self.driver.ex_get_redirect(zone.id, '36843229')
-        except PointDNSException:
-            e = sys.exc_info()[1]
+        except PointDNSException as e:
             self.assertEqual(e.http_code, httplib.NOT_FOUND)
             self.assertEqual(e.value, "Couldn't found redirect")
         else:
@@ -423,8 +419,7 @@ class PointDNSTests(unittest.TestCase):
         PointDNSMockHttp.type = 'GET_WITH_ERROR'
         try:
             self.driver.ex_get_mail_redirects(zone.id, '5')
-        except PointDNSException:
-            e = sys.exc_info()[1]
+        except PointDNSException as e:
             # The API actually responds with httplib.UNPROCESSABLE_ENTITY code,
             # but httplib.responses doesn't have it.
             self.assertEqual(e.http_code, httplib.METHOD_NOT_ALLOWED)
@@ -454,8 +449,7 @@ class PointDNSTests(unittest.TestCase):
         try:
             self.driver.ex_update_redirect(
                 redirect, 'http://updatedother.com', 'redirect3', '302')
-        except PointDNSException:
-            e = sys.exc_info()[1]
+        except PointDNSException as e:
             # The API actually responds with httplib.UNPROCESSABLE_ENTITY code,
             # but httplib.responses doesn't have it.
             self.assertEqual(e.http_code, httplib.METHOD_NOT_ALLOWED)
@@ -483,8 +477,7 @@ class PointDNSTests(unittest.TestCase):
         try:
             self.driver.ex_update_mail_redirect(
                 mailredirect, 'new_user@example-site.com', 'new_admin')
-        except PointDNSException:
-            e = sys.exc_info()[1]
+        except PointDNSException as e:
             # The API actually responds with httplib.UNPROCESSABLE_ENTITY code,
             # but httplib.responses doesn't have it.
             self.assertEqual(e.http_code, httplib.METHOD_NOT_ALLOWED)
@@ -506,8 +499,7 @@ class PointDNSTests(unittest.TestCase):
         PointDNSMockHttp.type = 'DELETE_WITH_ERROR'
         try:
             self.driver.ex_delete_redirect(redirect)
-        except PointDNSException:
-            e = sys.exc_info()[1]
+        except PointDNSException as e:
             # The API actually responds with httplib.UNPROCESSABLE_ENTITY code,
             # but httplib.responses doesn't have it.
             self.assertEqual(e.http_code, httplib.METHOD_NOT_ALLOWED)
@@ -521,8 +513,7 @@ class PointDNSTests(unittest.TestCase):
         PointDNSMockHttp.type = 'DELETE_NOT_FOUND'
         try:
             self.driver.ex_delete_redirect(redirect)
-        except PointDNSException:
-            e = sys.exc_info()[1]
+        except PointDNSException as e:
             self.assertEqual(e.http_code, httplib.NOT_FOUND)
             self.assertEqual(e.value, "Couldn't found redirect")
         else:
@@ -543,8 +534,7 @@ class PointDNSTests(unittest.TestCase):
         PointDNSMockHttp.type = 'DELETE_WITH_ERROR'
         try:
             self.driver.ex_delete_mail_redirect(mailredirect)
-        except PointDNSException:
-            e = sys.exc_info()[1]
+        except PointDNSException as e:
             # The API actually responds with httplib.UNPROCESSABLE_ENTITY code,
             # but httplib.responses doesn't have it.
             self.assertEqual(e.http_code, httplib.METHOD_NOT_ALLOWED)
@@ -558,8 +548,7 @@ class PointDNSTests(unittest.TestCase):
         PointDNSMockHttp.type = 'DELETE_NOT_FOUND'
         try:
             self.driver.ex_delete_mail_redirect(mailredirect)
-        except PointDNSException:
-            e = sys.exc_info()[1]
+        except PointDNSException as e:
             self.assertEqual(e.http_code, httplib.NOT_FOUND)
             self.assertEqual(e.value, "Couldn't found mail redirect")
         else:

--- a/libcloud/test/dns/test_rackspace.py
+++ b/libcloud/test/dns/test_rackspace.py
@@ -144,8 +144,7 @@ class RackspaceUSTests(unittest.TestCase):
         RackspaceMockHttp.type = 'ZONE_DOES_NOT_EXIST'
         try:
             self.driver.list_records(zone=zone)
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, zone.id)
         else:
             self.fail('Exception was not thrown')
@@ -164,8 +163,7 @@ class RackspaceUSTests(unittest.TestCase):
 
         try:
             self.driver.get_zone(zone_id='4444')
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, '4444')
         else:
             self.fail('Exception was not thrown')
@@ -217,8 +215,7 @@ class RackspaceUSTests(unittest.TestCase):
             self.driver.create_zone(domain='foo.bar.com', type='master',
                                     ttl=10,
                                     extra={'email': 'test@test.com'})
-        except Exception:
-            e = sys.exc_info()[1]
+        except Exception as e:
             self.assertEqual(str(e), 'Validation errors: Domain TTL is ' +
                                      'required and must be greater than ' +
                                      'or equal to 300')
@@ -290,8 +287,7 @@ class RackspaceUSTests(unittest.TestCase):
 
         try:
             self.driver.delete_zone(zone=zone)
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, zone.id)
         else:
             self.fail('Exception was not thrown')
@@ -310,8 +306,7 @@ class RackspaceUSTests(unittest.TestCase):
 
         try:
             self.driver.delete_record(record=record)
-        except RecordDoesNotExistError:
-            e = sys.exc_info()[1]
+        except RecordDoesNotExistError as e:
             self.assertEqual(e.record_id, record.id)
         else:
             self.fail('Exception was not thrown')

--- a/libcloud/test/dns/test_route53.py
+++ b/libcloud/test/dns/test_route53.py
@@ -95,8 +95,7 @@ class Route53Tests(unittest.TestCase):
 
         try:
             self.driver.list_records(zone=zone)
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, zone.id)
         else:
             self.fail('Exception was not thrown')
@@ -106,8 +105,7 @@ class Route53Tests(unittest.TestCase):
 
         try:
             self.driver.get_zone(zone_id='47234')
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, '47234')
         else:
             self.fail('Exception was not thrown')
@@ -295,8 +293,7 @@ class Route53Tests(unittest.TestCase):
 
         try:
             self.driver.delete_zone(zone=zone)
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, zone.id)
         else:
             self.fail('Exception was not thrown')
@@ -313,8 +310,7 @@ class Route53Tests(unittest.TestCase):
         Route53MockHttp.type = 'RECORD_DOES_NOT_EXIST'
         try:
             self.driver.delete_record(record=record)
-        except RecordDoesNotExistError:
-            e = sys.exc_info()[1]
+        except RecordDoesNotExistError as e:
             self.assertEqual(e.record_id, record.id)
         else:
             self.fail('Exception was not thrown')

--- a/libcloud/test/dns/test_vultr.py
+++ b/libcloud/test/dns/test_vultr.py
@@ -77,8 +77,7 @@ class VultrTests(unittest.TestCase):
         VultrMockHttp.type = 'GET_ZONE_ZONE_DOES_NOT_EXIST'
         try:
             self.driver.get_zone(zone_id='test.com')
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, 'test.com')
         else:
             self.fail('Exception was not thrown')
@@ -97,8 +96,7 @@ class VultrTests(unittest.TestCase):
 
         try:
             self.driver.delete_zone(zone=self.test_zone)
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, self.test_zone.id)
         else:
             self.fail('Exception was not thrown')
@@ -124,8 +122,7 @@ class VultrTests(unittest.TestCase):
         try:
             self.driver.create_zone(domain='example.com',
                                     extra={'serverip': '127.0.0.1'})
-        except ZoneAlreadyExistsError:
-            e = sys.exc_info()[1]
+        except ZoneAlreadyExistsError as e:
             self.assertEqual(e.zone_id, 'example.com')
         else:
             self.fail('Exception was not thrown')
@@ -135,8 +132,7 @@ class VultrTests(unittest.TestCase):
 
         try:
             self.driver.get_record(zone_id='zupo.com', record_id='1300')
-        except RecordDoesNotExistError:
-            e = sys.exc_info()[1]
+        except RecordDoesNotExistError as e:
             self.assertEqual(e.record_id, '1300')
         else:
             self.fail('Exception was not thrown')
@@ -146,8 +142,7 @@ class VultrTests(unittest.TestCase):
 
         try:
             self.driver.list_records(zone=self.test_zone)
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, self.test_zone.id)
         else:
             self.fail('Exception was not thrown')
@@ -184,8 +179,7 @@ class VultrTests(unittest.TestCase):
 
         try:
             self.driver.delete_record(record=self.test_record)
-        except RecordDoesNotExistError:
-            e = sys.exc_info()[1]
+        except RecordDoesNotExistError as e:
             self.assertEqual(e.record_id, self.test_record.id)
         else:
             self.fail('Exception was not thrown')

--- a/libcloud/test/dns/test_worldwidedns.py
+++ b/libcloud/test/dns/test_worldwidedns.py
@@ -80,8 +80,7 @@ class WorldWideDNSTests(unittest.TestCase):
         try:
             zone = self.driver.list_zones()[0]
             self.driver.list_records(zone=zone)
-        except NonExistentDomain:
-            e = sys.exc_info()[1]
+        except NonExistentDomain as e:
             self.assertEqual(e.code, 405)
         else:
             self.fail('Exception was not thrown')
@@ -100,8 +99,7 @@ class WorldWideDNSTests(unittest.TestCase):
         WorldWideDNSMockHttp.type = 'GET_ZONE_DOES_NOT_EXIST'
         try:
             self.driver.get_zone(zone_id='unexistentzone')
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, 'unexistentzone')
         else:
             self.fail('Exception was not thrown')
@@ -119,8 +117,7 @@ class WorldWideDNSTests(unittest.TestCase):
         try:
             self.driver.get_record(zone_id='unexistentzone',
                                    record_id='3585100')
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, 'unexistentzone')
         else:
             self.fail('Exception was not thrown')
@@ -129,8 +126,7 @@ class WorldWideDNSTests(unittest.TestCase):
         try:
             self.driver.get_record(zone_id='niteowebsponsoredthisone.com',
                                    record_id='3585100')
-        except RecordDoesNotExistError:
-            e = sys.exc_info()[1]
+        except RecordDoesNotExistError as e:
             self.assertEqual(e.record_id, '3585100')
         else:
             self.fail('Exception was not thrown')
@@ -149,8 +145,7 @@ class WorldWideDNSTests(unittest.TestCase):
         try:
             self.driver.create_zone(domain='foo.%.com', type='master',
                                     ttl=None, extra=None)
-        except InvalidDomainName:
-            e = sys.exc_info()[1]
+        except InvalidDomainName as e:
             self.assertEqual(e.code, 410)
         else:
             self.fail('Exception was not thrown')
@@ -223,8 +218,7 @@ class WorldWideDNSTests(unittest.TestCase):
         try:
             self.driver.create_record(
                 name='domain41', zone=zone, type=RecordType.A, data='0.0.0.41')
-        except WorldWideDNSError:
-            e = sys.exc_info()[1]
+        except WorldWideDNSError as e:
             self.assertEqual(e.value, 'All record entries are full')
         else:
             self.fail('Exception was not thrown')
@@ -277,8 +271,7 @@ class WorldWideDNSTests(unittest.TestCase):
 
         try:
             self.driver.delete_zone(zone=zone)
-        except NonExistentDomain:
-            e = sys.exc_info()[1]
+        except NonExistentDomain as e:
             self.assertEqual(e.code, 405)
         else:
             self.fail('Exception was not thrown')

--- a/libcloud/test/dns/test_zerigo.py
+++ b/libcloud/test/dns/test_zerigo.py
@@ -95,8 +95,7 @@ class ZerigoTests(unittest.TestCase):
         ZerigoMockHttp.type = 'ZONE_DOES_NOT_EXIST'
         try:
             list(self.driver.list_records(zone=zone))
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, zone.id)
         else:
             self.fail('Exception was not thrown')
@@ -115,8 +114,7 @@ class ZerigoTests(unittest.TestCase):
 
         try:
             self.driver.get_zone(zone_id='4444')
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, '4444')
         else:
             self.fail('Exception was not thrown')
@@ -163,8 +161,7 @@ class ZerigoTests(unittest.TestCase):
         try:
             self.driver.create_zone(domain='foo.bar.com', type='master',
                                     ttl=10, extra=None)
-        except ZerigoError:
-            e = sys.exc_info()[1]
+        except ZerigoError as e:
             self.assertEqual(len(e.errors), 2)
         else:
             self.fail('Exception was not thrown')
@@ -234,8 +231,7 @@ class ZerigoTests(unittest.TestCase):
 
         try:
             self.driver.delete_zone(zone=zone)
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, zone.id)
         else:
             self.fail('Exception was not thrown')
@@ -254,8 +250,7 @@ class ZerigoTests(unittest.TestCase):
 
         try:
             self.driver.delete_record(record=record)
-        except RecordDoesNotExistError:
-            e = sys.exc_info()[1]
+        except RecordDoesNotExistError as e:
             self.assertEqual(e.record_id, record.id)
         else:
             self.fail('Exception was not thrown')

--- a/libcloud/test/dns/test_zonomi.py
+++ b/libcloud/test/dns/test_zonomi.py
@@ -85,8 +85,7 @@ class ZonomiTests(unittest.TestCase):
         ZonomiMockHttp.type = 'GET_ZONE_DOES_NOT_EXIST'
         try:
             self.driver.get_zone('testzone.com')
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, 'testzone.com')
         else:
             self.fail('Exception was not thrown.')
@@ -105,8 +104,7 @@ class ZonomiTests(unittest.TestCase):
         ZonomiMockHttp.type = 'DELETE_ZONE_DOES_NOT_EXIST'
         try:
             self.driver.delete_zone(zone=self.test_zone)
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, self.test_zone.id)
         else:
             self.fail('Exception was not thrown.')
@@ -121,8 +119,7 @@ class ZonomiTests(unittest.TestCase):
         ZonomiMockHttp.type = 'CREATE_ZONE_ALREADY_EXISTS'
         try:
             self.driver.create_zone(domain='gamertest.com')
-        except ZoneAlreadyExistsError:
-            e = sys.exc_info()[1]
+        except ZoneAlreadyExistsError as e:
             self.assertEqual(e.zone_id, 'gamertest.com')
         else:
             self.fail('Exception was not thrown.')
@@ -185,8 +182,7 @@ class ZonomiTests(unittest.TestCase):
         try:
             self.driver.get_record(record_id=record_id,
                                    zone_id='zone.com')
-        except RecordDoesNotExistError:
-            e = sys.exc_info()[1]
+        except RecordDoesNotExistError as e:
             self.assertEqual(e.record_id, record_id)
         else:
             self.fail('Exception was not thrown.')
@@ -209,8 +205,7 @@ class ZonomiTests(unittest.TestCase):
         record = self.test_record
         try:
             self.driver.delete_record(record=record)
-        except RecordDoesNotExistError:
-            e = sys.exc_info()[1]
+        except RecordDoesNotExistError as e:
             self.assertEqual(e.record_id, record.id)
         else:
             self.fail('Exception was not thrown.')
@@ -228,8 +223,7 @@ class ZonomiTests(unittest.TestCase):
         try:
             self.driver.create_record(name='createrecord', type='A',
                                       data='127.0.0.1', zone=zone, extra={})
-        except RecordAlreadyExistsError:
-            e = sys.exc_info()[1]
+        except RecordAlreadyExistsError as e:
             self.assertEqual(e.record_id, 'createrecord')
         else:
             self.fail('Exception was not thrown.')
@@ -257,8 +251,7 @@ class ZonomiTests(unittest.TestCase):
         ZonomiMockHttp.type = 'COULDNT_CONVERT'
         try:
             self.driver.ex_convert_to_secondary(zone, '1.2.3.4')
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, 'zone.com')
         else:
             self.fail('Exception was not thrown.')
@@ -273,8 +266,7 @@ class ZonomiTests(unittest.TestCase):
         ZonomiMockHttp.type = 'COULDNT_CONVERT'
         try:
             self.driver.ex_convert_to_master(zone)
-        except ZoneDoesNotExistError:
-            e = sys.exc_info()[1]
+        except ZoneDoesNotExistError as e:
             self.assertEqual(e.zone_id, 'zone.com')
         else:
             self.fail('Exception was not thrown.')

--- a/libcloud/test/loadbalancer/test_gogrid.py
+++ b/libcloud/test/loadbalancer/test_gogrid.py
@@ -84,8 +84,7 @@ class GoGridTests(unittest.TestCase):
                                         members=(Member(None, '10.1.0.10', 80),
                                                  Member(None, '10.1.0.11', 80))
                                         )
-        except LibcloudError:
-            e = sys.exc_info()[1]
+        except LibcloudError as e:
             self.assertTrue(
                 str(e).find('tried to add a member with an IP address not assigned to your account') != -1)
         else:

--- a/libcloud/test/storage/test_azure_blobs.py
+++ b/libcloud/test/storage/test_azure_blobs.py
@@ -395,8 +395,7 @@ class AzureBlobsTests(unittest.TestCase):
         self.mock_response_klass.type = 'UNAUTHORIZED'
         try:
             self.driver.list_containers()
-        except InvalidCredsError:
-            e = sys.exc_info()[1]
+        except InvalidCredsError as e:
             self.assertEqual(True, isinstance(e, InvalidCredsError))
         else:
             self.fail('Exception was not thrown')
@@ -663,8 +662,7 @@ class AzureBlobsTests(unittest.TestCase):
                                       object_name=object_name,
                                       verify_hash=True,
                                       ex_blob_type='invalid-blob')
-        except LibcloudError:
-            e = sys.exc_info()[1]
+        except LibcloudError as e:
             self.assertTrue(str(e).lower().find('invalid blob type') != -1)
         else:
             self.fail('Exception was not thrown')
@@ -774,8 +772,7 @@ class AzureBlobsTests(unittest.TestCase):
                                       extra=extra,
                                       verify_hash=False,
                                       ex_blob_type='PageBlob')
-        except LibcloudError:
-            e = sys.exc_info()[1]
+        except LibcloudError as e:
             self.assertTrue(str(e).lower().find('not aligned') != -1)
 
         os.remove(file_path)

--- a/libcloud/test/storage/test_cloudfiles.py
+++ b/libcloud/test/storage/test_cloudfiles.py
@@ -79,8 +79,7 @@ class CloudFilesTests(unittest.TestCase):
 
         try:
             driver.list_containers()
-        except Exception:
-            e = sys.exc_info()[1]
+        except Exception as e:
             self.assertEqual(e.value, 'Could not find specified endpoint')
         else:
             self.fail('Exception was not thrown')

--- a/libcloud/test/storage/test_s3.py
+++ b/libcloud/test/storage/test_s3.py
@@ -409,8 +409,7 @@ class S3Tests(unittest.TestCase):
         self.mock_response_klass.type = 'UNAUTHORIZED'
         try:
             self.driver.list_containers()
-        except InvalidCredsError:
-            e = sys.exc_info()[1]
+        except InvalidCredsError as e:
             self.assertEqual(True, isinstance(e, InvalidCredsError))
         else:
             self.fail('Exception was not thrown')
@@ -767,8 +766,7 @@ class S3Tests(unittest.TestCase):
                                       object_name=object_name,
                                       verify_hash=True,
                                       ex_storage_class='invalid-class')
-        except ValueError:
-            e = sys.exc_info()[1]
+        except ValueError as e:
             self.assertTrue(str(e).lower().find('invalid storage class') != -1)
         else:
             self.fail('Exception was not thrown')

--- a/libcloud/test/test_http.py
+++ b/libcloud/test/test_http.py
@@ -41,8 +41,7 @@ class TestHttpLibSSLTests(unittest.TestCase):
 
         try:
             reload(libcloud.security)
-        except ValueError:
-            e = sys.exc_info()[1]
+        except ValueError as e:
             msg = 'Certificate file /foo/doesnt/exist doesn\'t exist'
             self.assertEqual(str(e), msg)
         else:

--- a/libcloud/utils/decorators.py
+++ b/libcloud/utils/decorators.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 from functools import wraps
 
 from libcloud.common.types import LibcloudError
@@ -35,8 +34,7 @@ def wrap_non_libcloud_exceptions(func):
     def decorated_function(*args, **kwargs):
         try:
             return func(*args, **kwargs)
-        except Exception:
-            e = sys.exc_info()[1]
+        except Exception as e:
 
             if isinstance(e, LibcloudError):
                 raise e

--- a/libcloud/utils/misc.py
+++ b/libcloud/utils/misc.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import os
-import sys
 import binascii
 import socket
 import time
@@ -302,9 +301,7 @@ def retry(retry_exceptions=RETRY_EXCEPTIONS, retry_delay=DEFAULT_DELAY,
     def transform_ssl_error(func, *args, **kwargs):
         try:
             return func(*args, **kwargs)
-        except ssl.SSLError:
-            exc = sys.exc_info()[1]
-
+        except ssl.SSLError as exc:
             if TRANSIENT_SSL_ERROR in str(exc):
                 raise TransientSSLError(*exc.args)
 
@@ -319,9 +316,7 @@ def retry(retry_exceptions=RETRY_EXCEPTIONS, retry_delay=DEFAULT_DELAY,
             while True:
                 try:
                     return transform_ssl_error(func, *args, **kwargs)
-                except retry_exceptions:
-                    exc = sys.exc_info()[1]
-
+                except retry_exceptions as exc:
                     if isinstance(exc, RateLimitReachedError):
                         time.sleep(exc.retry_after)
 


### PR DESCRIPTION
This pull request removes or amends various code patterns which are not needed anymore.

We used to support Python 2.5 and Python 2.6, but that's not the case anymore. We now only support Python >= 2.7 and next year we will likely also drop support for Python 2.7 when it reaches official EOL.

As such, various code patterns for compatibility with older Python versions are not needed anymore.