### PR TITLE
added azure_arm ex_delete_public_ip

### DIFF
--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -1873,7 +1873,7 @@ class AzureNodeDriver(NodeDriver):
         :param public_ip: Public ip address resource to delete
         :type public_ip: `.AzureIPAddress`
         """
-        resource = resource.id
+        resource = public_ip.id
         self.connection.request(
             resource,
             method='DELETE',

--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -1866,6 +1866,22 @@ class AzureNodeDriver(NodeDriver):
                                     method='PUT')
         return self._to_ip_address(r.object)
 
+    def ex_delete_public_ip(self, public_ip):
+        """
+        Delete a public ip address resource.
+
+        :param public_ip: Public ip address resource to delete
+        :type public_ip: `.AzureIPAddress`
+        """
+        resource = resource.id
+        self.connection.request(
+            resource,
+            method='DELETE',
+            params={
+                'api-version': "2019-06-01"
+            },
+        )
+
     def ex_create_network_interface(self, name, subnet, resource_group,
                                     location=None, public_ip=None):
         """

--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -1874,13 +1874,15 @@ class AzureNodeDriver(NodeDriver):
         :type public_ip: `.AzureIPAddress`
         """
         resource = public_ip.id
-        self.connection.request(
+        r = self.connection.request(
             resource,
             method='DELETE',
             params={
                 'api-version': "2019-06-01"
             },
         )
+
+        return r.object
 
     def ex_create_network_interface(self, name, subnet, resource_group,
                                     location=None, public_ip=None):

--- a/libcloud/test/compute/test_azure_arm.py
+++ b/libcloud/test/compute/test_azure_arm.py
@@ -566,7 +566,8 @@ class AzureNodeDriverTests(LibcloudTestCase):
         self.assertTrue(res_value)
     
     def test_delete_public_ip(self):
-        public_ip = self.driver.ex_create_public_ip(name='test_public_ip', resource_group='111111')
+        location = self.driver.list_locations()[0]
+        public_ip = self.driver.ex_create_public_ip(name='test_public_ip', resource_group='111111', location=location)
         res_value = self.driver.ex_delete_public_ip(public_ip)
         self.assertTrue(res_value)
 

--- a/libcloud/test/compute/test_azure_arm.py
+++ b/libcloud/test/compute/test_azure_arm.py
@@ -567,7 +567,7 @@ class AzureNodeDriverTests(LibcloudTestCase):
     
     def test_delete_public_ip(self):
         location = self.driver.list_locations()[0]
-        public_ip = self.driver.ex_create_public_ip(name='test_public_ip', resource_group='111111', location=location)
+        public_ip = self.driver.ex_create_public_ip(name='test_public_ip', resource_group='000000', location=location)
         res_value = self.driver.ex_delete_public_ip(public_ip)
         self.assertTrue(res_value)
 

--- a/libcloud/test/compute/test_azure_arm.py
+++ b/libcloud/test/compute/test_azure_arm.py
@@ -564,6 +564,11 @@ class AzureNodeDriverTests(LibcloudTestCase):
         snapshot = self.driver.list_snapshots()[0]
         res_value = snapshot.destroy()
         self.assertTrue(res_value)
+    
+    def test_delete_public_ip(self):
+        public_ip = self.driver.ex_create_public_ip(name='test_public_ip', resource_group='111111')
+        res_value = self.driver.ex_delete_public_ip(public_ip)
+        self.assertTrue(res_value)
 
     def test_update_network_profile(self):
         nics = self.driver.ex_list_nics()

--- a/libcloud/test/compute/test_azure_arm.py
+++ b/libcloud/test/compute/test_azure_arm.py
@@ -567,7 +567,7 @@ class AzureNodeDriverTests(LibcloudTestCase):
     
     def test_delete_public_ip(self):
         location = self.driver.list_locations()[0]
-        public_ip = self.driver.ex_create_public_ip(name='test_public_ip', resource_group='000000', location=location)
+        public_ip = self.driver.ex_create_public_ip(name='test_public_ip', resource_group='REVIZOR', location=location)
         res_value = self.driver.ex_delete_public_ip(public_ip)
         self.assertTrue(res_value)
 


### PR DESCRIPTION
## added azure_arm ex_delete_public_ip

### Description

This feature is just a function with in the azure_arm driver. Lib cloud users can now delete Azure ARM public ip address resources. the ex_delete_resource() method could not be used as RESOURCE_API_VERSION is too old to support the publicIpAddress resource.

### Status
- testing
- done, ready for review

### Checklist

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
