### PR TITLE
Fix proxy url

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,7 +36,7 @@ General
 
   For more information, please refer to the documentation -
   https://libcloud.readthedocs.io/en/latest/other/using-http-proxy.html
-  (GITHUB-1314)
+  (GITHUB-1314, GITHUB-1324)
   [Jim Liu - @hldh214, Tomaz Muraus]
 
 - Fix paramiko debug logging which didn't work when using ``LIBCLOUD_DEBUG``
@@ -57,6 +57,9 @@ General
 - Update Paramiko SSH client to throw a more user-friendly error if a private
   key file in an unsupported format is used. (GITHUB-1314)
   [Tomaz Muraus]
+  
+- Fix HTTP(s) proxy support in the OpenStack drivers. (GITHUB-1324)
+  [Gabe Van Engel - @gvengel]
 
 Compute
 ~~~~~~~

--- a/docs/examples/http_proxy/constructor_argument.py
+++ b/docs/examples/http_proxy/constructor_argument.py
@@ -8,8 +8,8 @@ cls = get_driver(Provider.RACKSPACE)
 
 # 1. Use http proxy
 driver = cls('username', 'api key', region='ord',
-             http_proxy=HTTP_PROXY_URL_NO_AUTH_1)
+             proxy_url=HTTP_PROXY_URL_NO_AUTH_1)
 
 # 2. Use https proxy
 driver = cls('username', 'api key', region='ord',
-             http_proxy=HTTPS_PROXY_URL_NO_AUTH_1)
+             proxy_url=HTTPS_PROXY_URL_NO_AUTH_1)

--- a/docs/other/using-http-proxy.rst
+++ b/docs/other/using-http-proxy.rst
@@ -73,10 +73,10 @@ With basic auth authentication (http proxy):
 
     http_proxy=http://<username>:<password>@<proxy hostname>:<proxy port> python my_script.py
 
-2. Passing ``http_proxy`` argument to the connection class constructor
+2. Passing ``proxy_url`` argument to the connection class constructor
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By passing ``http_proxy`` argument to the
+By passing ``proxy_url`` argument to the
 :class:`libcloud.common.base.Connection` class constructor, you can specify
 which proxy to use for a particular connection.
 

--- a/docs/other/using-http-proxy.rst
+++ b/docs/other/using-http-proxy.rst
@@ -76,6 +76,18 @@ With basic auth authentication (http proxy):
 2. Passing ``proxy_url`` argument to the connection class constructor
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+. note::
+
+  Some drivers don't correctly pass ``proxy_url`` argument to the connection
+  class and don't support ``proxy_url`` constructor argument.
+  
+  If you pass this argument to the driver constructor, but it doesn't appear
+  to be working, it's likely the driver doesn't support this method.
+  
+  In such scenarios, you are advised to use some other method of setting a
+  proxy (e.g. by setting an environment variable or by using
+  :meth:`libcloud.common.base.LibcloudConnection.set_http_proxy` method).
+
 By passing ``proxy_url`` argument to the
 :class:`libcloud.common.base.Connection` class constructor, you can specify
 which proxy to use for a particular connection.

--- a/libcloud/common/openstack.py
+++ b/libcloud/common/openstack.py
@@ -202,6 +202,7 @@ class OpenStackBaseConnection(ConnectionUserAndKey):
                             domain_name=self._ex_domain_name,
                             token_scope=self._ex_token_scope,
                             timeout=self.timeout,
+                            proxy_url=self.proxy_url,
                             parent_conn=self)
 
         return self._osa

--- a/libcloud/common/openstack_identity.py
+++ b/libcloud/common/openstack_identity.py
@@ -578,11 +578,12 @@ class OpenStackIdentityConnection(ConnectionUserAndKey):
     def __init__(self, auth_url, user_id, key, tenant_name=None,
                  domain_name='Default',
                  token_scope=OpenStackIdentityTokenScope.PROJECT,
-                 timeout=None, parent_conn=None):
+                 timeout=None, proxy_url=None, parent_conn=None):
         super(OpenStackIdentityConnection, self).__init__(user_id=user_id,
                                                           key=key,
                                                           url=auth_url,
-                                                          timeout=timeout)
+                                                          timeout=timeout,
+                                                          proxy_url=proxy_url)
 
         self.parent_conn = parent_conn
 

--- a/libcloud/http.py
+++ b/libcloud/http.py
@@ -102,7 +102,8 @@ class LibcloudBaseConnection(object):
         self.http_proxy_used = True
 
         self.session.proxies = {
-            self.proxy_scheme: proxy_url
+            'http': proxy_url,
+            'https': proxy_url,
         }
 
     def _parse_proxy_url(self, proxy_url):

--- a/libcloud/test/test_connection.py
+++ b/libcloud/test/test_connection.py
@@ -102,7 +102,8 @@ class BaseConnectionClassTestCase(unittest.TestCase):
         self.assertEqual(conn.proxy_host, '127.0.0.2')
         self.assertEqual(conn.proxy_port, 3128)
         self.assertEqual(conn.session.proxies, {
-            'http': 'http://127.0.0.2:3128'
+            'http': 'http://127.0.0.2:3128',
+            'https': 'http://127.0.0.2:3128',
         })
 
         _ = os.environ.pop('http_proxy', None)
@@ -117,7 +118,8 @@ class BaseConnectionClassTestCase(unittest.TestCase):
         self.assertEqual(conn.proxy_host, '127.0.0.3')
         self.assertEqual(conn.proxy_port, 3128)
         self.assertEqual(conn.session.proxies, {
-            'http': 'http://127.0.0.3:3128'
+            'http': 'http://127.0.0.3:3128',
+            'https': 'http://127.0.0.3:3128',
         })
 
         proxy_url = 'http://127.0.0.4:3128'
@@ -127,7 +129,8 @@ class BaseConnectionClassTestCase(unittest.TestCase):
         self.assertEqual(conn.proxy_host, '127.0.0.4')
         self.assertEqual(conn.proxy_port, 3128)
         self.assertEqual(conn.session.proxies, {
-            'http': 'http://127.0.0.4:3128'
+            'http': 'http://127.0.0.4:3128',
+            'https': 'http://127.0.0.4:3128',
         })
 
         os.environ['http_proxy'] = proxy_url
@@ -138,7 +141,8 @@ class BaseConnectionClassTestCase(unittest.TestCase):
         self.assertEqual(conn.proxy_host, '127.0.0.5')
         self.assertEqual(conn.proxy_port, 3128)
         self.assertEqual(conn.session.proxies, {
-            'http': 'http://127.0.0.5:3128'
+            'http': 'http://127.0.0.5:3128',
+            'https': 'http://127.0.0.5:3128',
         })
 
         os.environ['http_proxy'] = proxy_url
@@ -149,7 +153,8 @@ class BaseConnectionClassTestCase(unittest.TestCase):
         self.assertEqual(conn.proxy_host, '127.0.0.6')
         self.assertEqual(conn.proxy_port, 3129)
         self.assertEqual(conn.session.proxies, {
-            'https': 'https://127.0.0.6:3129'
+            'http': 'https://127.0.0.6:3129',
+            'https': 'https://127.0.0.6:3129',
         })
 
     def test_connection_to_unusual_port(self):


### PR DESCRIPTION
## Fix proxy_url support in CloudFiles

### Description

I ran into a couple issues when trying to use the cloudfiles driver behind an HTTP proxy. 

* libcloud was not configuring the requests library proxy settings correctly.
* The cloudfiles driver was not passing the proxy into the identity connection.
* The proxy documentation was referencing the wrong argument name.

This PR closes these issues, but there may be other related issues in other drivers.

### Status

Done, ready for review. This could probably use some additional tests, and a review of other code for similar bugs. It looks like 2.5.1 has other proxy changes, so I wanted to get the PR in sooner rather than later and kept it simple.

### Checklist

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
