### PR TITLE
Specify minimum requests version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -178,6 +178,11 @@ Storage
   ``2012-02-12`` to ``2014-02-14'``. (LIBCLOUD-851, GITHUB-1202, GITHUB-1294)
   [Clemens Wolff - @c-w, Davis Kirkendall - @daviskirk]
 
+- [Azure Blobs] Set the minimum required version of requests to ``2.5.0`` since
+  requests ``2.4.0`` and earlier exhibit XML parsing errors of Azure Storage
+  responses. (GITHUB-1325, GITHUB-1322)
+  [Clemens Wolff - @c-w]
+
 - [Common, CloudFiles] Fix ``upload_object_via_stream`` and ensure we start
   from the beginning when calculating hash for the provided iterator. This way
   we avoid hash mismatch errors in scenario where provided iterator is already

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ DOC_TEST_MODULES = ['libcloud.compute.drivers.dummy',
 
 SUPPORTED_VERSIONS = ['2.7', 'PyPy', '3.3+']
 
-INSTALL_REQUIREMENTS = ['requests']
+INSTALL_REQUIREMENTS = ['requests>=2.5.0']
 
 TEST_REQUIREMENTS = [
     'mock',

--- a/setup.py
+++ b/setup.py
@@ -54,13 +54,14 @@ DOC_TEST_MODULES = ['libcloud.compute.drivers.dummy',
 
 SUPPORTED_VERSIONS = ['2.7', 'PyPy', '3.3+']
 
+INSTALL_REQUIREMENTS = ['requests']
+
 TEST_REQUIREMENTS = [
     'mock',
-    'requests',
     'requests_mock',
     'pytest',
     'pytest-runner'
-]
+] + INSTALL_REQUIREMENTS
 
 if PY2_pre_279:
     TEST_REQUIREMENTS.append('backports.ssl_match_hostname')
@@ -119,10 +120,8 @@ class ApiDocsCommand(Command):
 
 forbid_publish()
 
-install_requires = ['requests']
-
 if PY2_pre_279:
-    install_requires.append('backports.ssl_match_hostname')
+    INSTALL_REQUIREMENTS.append('backports.ssl_match_hostname')
 
 needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
 pytest_runner = ['pytest-runner'] if needs_pytest else []
@@ -136,7 +135,7 @@ setup(
     long_description=open('README.rst').read(),
     author='Apache Software Foundation',
     author_email='dev@libcloud.apache.org',
-    install_requires=install_requires,
+    install_requires=INSTALL_REQUIREMENTS,
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4",
     packages=get_packages('libcloud'),
     package_dir={


### PR DESCRIPTION
## Specify minimum requests version

### Description

The investigation in https://github.com/apache/libcloud/issues/1322, has led to the discovery that there are errors in the libcloud Azure Storage driver with any requests version below `2.5.0`. As such, this pull request updates `setup.py` to ensure that the requests dependency is at least that version.

- [Failed integration tests with requests==2.4.0](https://clewolff.visualstudio.com/libcloud-tests/_build/results?buildId=299)
- [Passed integration tests with requests==2.5.0](https://clewolff.visualstudio.com/libcloud-tests/_build/results?buildId=298)

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) ([build passed](https://travis-ci.org/CatalystCode/libcloud/builds/564186773))
- [x] Documentation (changelog updated)
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html) (covered by existing tests)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes)
