### PR TITLE
Fix hash validation with stream uploads

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -164,6 +164,11 @@ Storage
   ``2012-02-12`` to ``2014-02-14'``. (LIBCLOUD-851, GITHUB-1202, GITHUB-1294)
   [Clemens Wolff - @c-w, Davis Kirkendall - @daviskirk]
 
+- [Common, CloudFiles] Fix ``upload_object_via_stream`` via stream method and
+  ensure we rewind to the beginning of the provided iterator in case iterator
+  has already been iterated or is not positioned at the begining. (GITHUB-1326)
+  [Gabe Van Engel - @gvengel, Tomaz Muraus]
+
 DNS
 ~~~
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -164,9 +164,10 @@ Storage
   ``2012-02-12`` to ``2014-02-14'``. (LIBCLOUD-851, GITHUB-1202, GITHUB-1294)
   [Clemens Wolff - @c-w, Davis Kirkendall - @daviskirk]
 
-- [Common, CloudFiles] Fix ``upload_object_via_stream`` via stream method and
-  ensure we rewind to the beginning of the provided iterator in case iterator
-  has already been iterated or is not positioned at the begining. (GITHUB-1326)
+- [Common, CloudFiles] Fix ``upload_object_via_stream`` and ensure we start
+  from the beginning when calculating hash for the provided iterator. This way
+  we avoid hash mismatch errors in scenario where provided iterator is already
+  iterated / seeked upon before calculating the hash. (GITHUB-1326)
   [Gabe Van Engel - @gvengel, Tomaz Muraus]
 
 DNS

--- a/libcloud/storage/base.py
+++ b/libcloud/storage/base.py
@@ -647,8 +647,11 @@ class StorageDriver(BaseDriver):
         total_len = 0
 
         if hasattr(stream, '__next__') or hasattr(stream, 'next'):
+            # Ensure we start from the begining of a stream in case stream is
+            # not at the beginning
             if hasattr(stream, 'seek'):
                 stream.seek(0)
+
             for chunk in libcloud.utils.files.read_in_chunks(iterator=stream):
                 hasher.update(b(chunk))
                 total_len += len(chunk)

--- a/libcloud/storage/base.py
+++ b/libcloud/storage/base.py
@@ -647,6 +647,8 @@ class StorageDriver(BaseDriver):
         total_len = 0
 
         if hasattr(stream, '__next__') or hasattr(stream, 'next'):
+            if hasattr(stream, 'seek'):
+                stream.seek(0)
             for chunk in libcloud.utils.files.read_in_chunks(iterator=stream):
                 hasher.update(b(chunk))
                 total_len += len(chunk)


### PR DESCRIPTION
## Fix hash validation with stream uploads

### Description

Bug fix for cloudfiles upload_object_via_stream() erroneously throwing a hash mismatch when using a file handle as the iterator. Example:

```python
from libcloud.storage.providers import get_driver
from libcloud.storage.types import ObjectDoesNotExistError

driver = get_driver('cloudfiles')
driver = driver('user', 'key')
container = driver.get_container(container_name='test')
with open('/tmp/test.file', 'w') as fh:
    fh.write('test')
with open('/tmp/test.file') as fh:
    driver.upload_object_via_stream(iterator=fh, container=container, object_name='test.file')
```

This would result in the exception:

```
libcloud.storage.types.ObjectHashMismatchError: <ObjectHashMismatchError in <libcloud.storage.drivers.cloudfiles.CloudFilesStorageDriver object at 0x103f43d68>, value=MD5 hash checksum does not match (expected=d41d8cd98f00b204e9800998ecf8427e, actual=098f6bcd4621d373cade4e832627b4f6), object = test.file>
```

d41d8cd98f00b204e9800998ecf8427e is the hash for an empty file. The problem is the upload happens before the hash is calculated and the file handle is read to the EOF. The fix is to seek the file handle to the beginning before feeding it into the hash function.


### Status

done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
