### PR TITLE
Throw more user-friendly exception in EC2 driver on invalid request parameter type

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -57,7 +57,7 @@ General
 - Update Paramiko SSH client to throw a more user-friendly error if a private
   key file in an unsupported format is used. (GITHUB-1314)
   [Tomaz Muraus]
-  
+
 - Fix HTTP(s) proxy support in the OpenStack drivers. (GITHUB-1324)
   [Gabe Van Engel - @gvengel]
 
@@ -149,6 +149,16 @@ Compute
 - [Azure ARM] Add ``ex_delete_public_ip`` method to the Azure ARM driver.
   (GITHUB-1318)
   [Reza Shahriari - redha1419]
+
+- [EC2] Update EC2 driver to throw a more user-friendly exception if a user /
+  developer tries to provide an invalid value type for an item value in the
+  request ``params`` dictionary.
+
+  Request parameters are sent via query parameters and not via request body,
+  as such, only string values are supported. (GITHUB-1329, GITHUB-1321)
+
+  Reported by James Bednell.
+  [Tomaz Muraus]
 
 Storage
 ~~~~~~~

--- a/libcloud/common/aws.py
+++ b/libcloud/common/aws.py
@@ -62,6 +62,9 @@ one:
 
 params['TagSpecification.1.Tag.Value'] = 'foo'
 params['TagSpecification.2.Tag.Value'] = 'bar'
+
+See https://docs.aws.amazon.com/AWSEC2/latest/APIReference/Query-Requests.html
+for details.
 """.strip()
 
 

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -3866,7 +3866,8 @@ class BaseEC2NodeDriver(NodeDriver):
                                  'the current one')
 
         attributes = {'InstanceType.Value': new_size.id}
-        return self.ex_modify_instance_attribute(node, attributes)
+        return self.ex_modify_instance_attribute(node=node,
+                                                 attributes=attributes)
 
     def ex_start_node(self, node):
         """
@@ -6023,7 +6024,7 @@ class OutscaleNodeDriver(BaseEC2NodeDriver):
     def ex_modify_instance_attribute(self, node, disable_api_termination=None,
                                      ebs_optimized=None, group_id=None,
                                      source_dest_check=None, user_data=None,
-                                     instance_type=None):
+                                     instance_type=None, attributes=None):
         """
         Modifies node attributes.
         Ouscale supports the following attributes:
@@ -6040,7 +6041,7 @@ class OutscaleNodeDriver(BaseEC2NodeDriver):
         :return: True on success, False otherwise.
         :rtype: ``bool``
         """
-        attributes = {}
+        attributes = attributes or {}
 
         if disable_api_termination is not None:
             attributes['DisableApiTermination.Value'] = disable_api_termination

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -1313,6 +1313,23 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
         self.assertEqual('io1', modifications[1].target_volume_type)
         self.assertEqual('vol-bEXAMPLE', modifications[1].volume_id)
 
+    def test_params_is_not_simple_type_exception_is_thrown(self):
+        params = {
+            'not': {'not': ['simple']}
+        }
+
+        expected_msg = 'dictionary contains an attribute "not" which value'
+        self.assertRaisesRegexp(ValueError, expected_msg,
+                               self.driver.connection.request, '/', params=params)
+
+        params = {
+            'invalid': [1, 2, 3]
+        }
+
+        expected_msg = 'dictionary contains an attribute "invalid" which value'
+        self.assertRaisesRegexp(ValueError, expected_msg,
+                               self.driver.connection.request, '/', params=params)
+
 
 class EC2USWest1Tests(EC2Tests):
     region = 'us-west-1'


### PR DESCRIPTION
EC2 driver uses ``GET`` and not ``POST`` method for all the outgoing HTTP requests. This means all the action parameters are sent via query parameters and not as a request body.

This means all the parameter values needs to be of a simple type (string), otherwise it won't work as expected.

This pull request updates the code to fail loudly and throw a user-friendly exception in case invalid type is provided for ``params`` dictionary item value. Previously a very cryptic error was throw so it was hard to figure out why it's failing.

As a bonus, this change already uncovered a small bug in the Outscale driver - 3dadc47c03a2cb71887b13ed247e98562b9db39a.

Resolves #1321.