### PR TITLE
[GH-1322] Detect broken `yum install python-requests`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -202,6 +202,11 @@ Storage
   responses. (GITHUB-1325, GITHUB-1322)
   [Clemens Wolff - @c-w]
 
+- [Azure Blobs] Detect bad version of requests that leads to errors in parsing
+  Azure Storage responses. This scenario is known to happen on RHEL 7.6 when
+  requests was installed via yum. (GITHUB-1332, GITHUB-1322)
+  [Clemens Wolff - @c-w]
+
 - [Common, CloudFiles] Fix ``upload_object_via_stream`` and ensure we start
   from the beginning when calculating hash for the provided iterator. This way
   we avoid hash mismatch errors in scenario where provided iterator is already

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -178,6 +178,10 @@ Compute
   ``False``. (GITHUB-1334, GITHUB-1335)
   [@r2ronoha]
 
+- [GCE] Add optional ``cpuPlatform`` and ``minCpuPlatform`` attributes to the
+  ``node.extra`` dictionary. (GITHUB-1342, GITHUB-1343)
+  [@yairshemla]
+
 Storage
 ~~~~~~~
 

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -8849,6 +8849,8 @@ class GCENodeDriver(NodeDriver):
         extra['zone'] = self.ex_get_zone(node['zone'])
         extra['image'] = node.get('image')
         extra['machineType'] = node.get('machineType')
+        extra['cpuPlatform'] = node.get('cpuPlatform')
+        extra['minCpuPlatform'] = node.get('minCpuPlatform')
         extra['disks'] = node.get('disks', [])
         extra['networkInterfaces'] = node.get('networkInterfaces')
         extra['id'] = node['id']

--- a/libcloud/test/compute/fixtures/gce/zones_us-central1-a_instances.json
+++ b/libcloud/test/compute/fixtures/gce/zones_us-central1-a_instances.json
@@ -44,6 +44,8 @@
       },
       "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/instances/node-name",
       "status": "RUNNING",
+      "cpuPlatform": "Intel Skylake",
+      "minCpuPlatform": "Intel Skylake",
       "tags": {
         "fingerprint": "42WmSpB8rSM="
       },

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -640,6 +640,8 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         self.assertEqual(len(nodes_uc1a), 1)
         self.assertEqual(nodes[0].name, 'node-name')
         self.assertEqual(nodes_uc1a[0].name, 'node-name')
+        self.assertEqual(nodes_uc1a[0].extra['cpuPlatform'], 'Intel Skylake')
+        self.assertEqual(nodes_uc1a[0].extra['minCpuPlatform'], 'Intel Skylake')
 
         names = [n.name for n in nodes_all]
         self.assertTrue('node-name' in names)

--- a/libcloud/test/test_init.py
+++ b/libcloud/test/test_init.py
@@ -68,9 +68,15 @@ class TestUtils(unittest.TestCase):
 
     @patch.object(libcloud.requests, '__version__', '2.6.0')
     @patch.object(libcloud.requests.packages.chardet, '__version__', '2.2.1')
-    def test_detects_bad_yum_install_requests(self, *args):
-        with self.assertRaises(AssertionError):
+    def test_init_once_detects_bad_yum_install_requests(self, *args):
+        expected_msg = 'Known bad version of requests detected'
+        with self.assertRaisesRegexp(AssertionError, expected_msg):
             _init_once()
+
+    @patch.object(libcloud.requests, '__version__', '2.6.0')
+    @patch.object(libcloud.requests.packages.chardet, '__version__', '2.3.0')
+    def test_init_once_correct_chardet_version(self, *args):
+        _init_once()
 
 
 if __name__ == '__main__':

--- a/libcloud/test/test_init.py
+++ b/libcloud/test/test_init.py
@@ -24,6 +24,8 @@ try:
 except ImportError:
     have_paramiko = False
 
+from mock import patch
+
 import libcloud
 from libcloud import _init_once
 from libcloud.utils.loggingconnection import LoggingConnection
@@ -63,6 +65,12 @@ class TestUtils(unittest.TestCase):
     def test_raises_error(self):
         with self.assertRaises(DriverTypeNotFoundError):
             libcloud.get_driver('potato', 'potato')
+
+    @patch.object(libcloud.requests, '__version__', '2.6.0')
+    @patch.object(libcloud.requests.packages.chardet, '__version__', '2.2.1')
+    def test_detects_bad_yum_install_requests(self, *args):
+        with self.assertRaises(AssertionError):
+            _init_once()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Detect issues with libcloud and python-requests on RHEL 7

### Description

As discussed in https://github.com/apache/libcloud/issues/1322, libcloud breaks when used on RHEL 7.6 with requests installed from yum instead of PyPI. In order to prevent user confusion, this pull request introduces a check for this environment state and provides guidance for the user on how to correctly set up their system for libcloud to function.

Resolves https://github.com/apache/libcloud/issues/1322

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) ([build passed](https://travis-ci.org/CatalystCode/libcloud/builds/567156431))
- [x] Documentation (updated changelog)
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html) (added unit test)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
