### PR TITLE
Set Softlayer create_node hourly value as boolean to pass to SL API

### DIFF
--- a/libcloud/compute/drivers/softlayer.py
+++ b/libcloud/compute/drivers/softlayer.py
@@ -299,7 +299,7 @@ class SoftLayerNodeDriver(NodeDriver):
         ram = kwargs.get('ex_ram') or ex_size_data.get('ram') or \
             DEFAULT_RAM_SIZE
         bandwidth = kwargs.get('ex_bandwidth') or size.bandwidth or 10
-        hourly = 'true' if kwargs.get('ex_hourly', True) else 'false'
+        hourly = kwargs.get('ex_hourly', True)
 
         local_disk = 'true'
         if ex_size_data.get('local_disk') is False:


### PR DESCRIPTION
## Changes Title (replace this with a logical title for your changes)

### Description

Set hourly in compute/drivers/softlayer.py to boolean to pass to the SL API

### Status

Done, ready for review

### Checklist (tick everything that applies)

- [X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [X] Documentation
- [X] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)

```
libcloud anoha$ PYTHONPATH=. python libcloud/test/compute/test_softlayer.py
......................
----------------------------------------------------------------------
Ran 22 tests in 2.574s

OK
libcloud anoha$
```