### PR TITLE
Various fixes for the Backblaze B2 driver

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,6 +61,10 @@ General
 - Fix HTTP(s) proxy support in the OpenStack drivers. (GITHUB-1324)
   [Gabe Van Engel - @gvengel]
 
+- Fix logging connection class so it also works when data type is ``bytearray``
+  or ``bytes``. (GITHUB-1339)
+  [Tomaz Muraus]
+
 Compute
 ~~~~~~~
 
@@ -198,6 +202,13 @@ Storage
   we avoid hash mismatch errors in scenario where provided iterator is already
   iterated / seeked upon before calculating the hash. (GITHUB-1326)
   [Gabe Van Engel - @gvengel, Tomaz Muraus]
+
+- [Backblaze B2] Fix a bug with driver not working correctly due to a
+  regression which was inadvertently introduced in one of the previous
+  releases. (GITHUB-1338, GITHUB-1339)
+
+  Reported by Shawn Nock - @nocko.
+  [Tomaz Muraus]
 
 DNS
 ~~~

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -210,6 +210,9 @@ Storage
   Reported by Shawn Nock - @nocko.
   [Tomaz Muraus]
 
+- [Backblaze B2] Fix ``upload_object_via_stream`` method. (GITHUB-1339)
+  [Tomaz Muraus]
+
 DNS
 ~~~
 

--- a/docs/examples/storage/backblaze_b2/instantiate.py
+++ b/docs/examples/storage/backblaze_b2/instantiate.py
@@ -1,8 +1,8 @@
 from libcloud.storage.types import Provider
 from libcloud.storage.providers import get_driver
 
-account_id = 'XXXXXX'
+key_id = 'XXXXXX'
 application_key = 'YYYYYY'
 
 cls = get_driver(Provider.BACKBLAZE_B2)
-driver = cls(account_id, application_key)
+driver = cls(key_id, application_key)

--- a/docs/storage/drivers/backblaze_b2.rst
+++ b/docs/storage/drivers/backblaze_b2.rst
@@ -12,19 +12,18 @@ other object storage services.
     :width: 300
     :target: https://www.backblaze.com/b2/cloud-storage.html
 
-Keep in mind that the service is currently in public beta and only users who
-have signed up and received beta access can use it. To sign up for the beta
-access, visit their website mentioned above.
-
 Instantiating a driver
 ----------------------
 
-To instantiate the driver you need to pass your account id and application key
-to the driver constructor as shown below.
+To instantiate the driver you need to pass your key id and application key to
+the driver constructor as shown below.
 
-To access the account id, once we have admitted you into the beta you can login
-to https://secure.backblaze.com/user_signin.htm, then click "buckets" and
-"show account id and application key".
+To access the credentials, you can login to
+https://secure.backblaze.com/user_signin.htm, then click "App Keys" or go
+to https://secure.backblaze.com/app_keys.htm directly.
+
+``keyID`` serves as the first and ``applicationKey`` as the second argument to
+the driver constructor.
 
 .. literalinclude:: /examples/storage/backblaze_b2/instantiate.py
    :language: python

--- a/libcloud/storage/drivers/backblaze_b2.py
+++ b/libcloud/storage/drivers/backblaze_b2.py
@@ -328,8 +328,11 @@ class BackblazeB2StorageDriver(StorageDriver):
 
         return self._get_object(obj=obj, callback=read_in_chunks,
                                 response=response,
-                                callback_kwargs={'iterator': response.response,
-                                                 'chunk_size': chunk_size},
+                                callback_kwargs={
+                                    'iterator': response.iter_content(
+                                        chunk_size
+                                    ),
+                                    'chunk_size': chunk_size},
                                 success_status_code=httplib.OK)
 
     def upload_object(self, file_path, container, object_name, extra=None,

--- a/libcloud/storage/drivers/backblaze_b2.py
+++ b/libcloud/storage/drivers/backblaze_b2.py
@@ -225,10 +225,11 @@ class BackblazeB2Connection(ConnectionUserAndKey):
 
     def _set_host(self, host):
         """
-        Dynamically set host which will be used for the following HTTP requests.
-
-        NOTE: This is needed because Backblaze uses different hosts for API, download and upload
+        Dynamically set host which will be used for the following HTTP
         requests.
+
+        NOTE: This is needed because Backblaze uses different hosts for API,
+        download and upload requests.
         """
         self.host = host
         self.connection.host = 'https://%s' % (host)

--- a/libcloud/storage/drivers/backblaze_b2.py
+++ b/libcloud/storage/drivers/backblaze_b2.py
@@ -147,7 +147,7 @@ class BackblazeB2Connection(ConnectionUserAndKey):
         auth_conn = self._auth_conn.authenticate()
 
         # Set host to the download server
-        self.host = auth_conn.download_host
+        self._set_host(auth_conn.download_host)
 
         action = '/file/' + action
         method = 'GET'
@@ -162,7 +162,7 @@ class BackblazeB2Connection(ConnectionUserAndKey):
         auth_conn = self._auth_conn.authenticate()
 
         # Upload host is dynamically retrieved for each upload request
-        self.host = upload_host
+        self._set_host(host=upload_host)
 
         method = 'POST'
         raw = False
@@ -181,7 +181,7 @@ class BackblazeB2Connection(ConnectionUserAndKey):
         auth_conn = self._auth_conn.authenticate()
 
         # Set host
-        self.host = auth_conn.api_host
+        self._set_host(host=auth_conn.api_host)
 
         # Include Content-Type
         if not raw and data:
@@ -222,6 +222,16 @@ class BackblazeB2Connection(ConnectionUserAndKey):
                                                               headers=headers,
                                                               raw=raw)
         return response
+
+    def _set_host(self, host):
+        """
+        Dynamically set host which will be used for the following HTTP requests.
+
+        NOTE: This is needed because Backblaze uses different hosts for API, download and upload
+        requests.
+        """
+        self.host = host
+        self.connection.host = 'https://%s' % (host)
 
 
 class BackblazeB2StorageDriver(StorageDriver):

--- a/libcloud/test/storage/test_backblaze_b2.py
+++ b/libcloud/test/storage/test_backblaze_b2.py
@@ -162,8 +162,8 @@ class BackblazeB2MockHttp(MockHttp):
         if method == 'GET':
             body = json.dumps({
                 'accountId': 'test',
-                'apiUrl': 'test',
-                'downloadUrl': 'test',
+                'apiUrl': 'https://apiNNN.backblazeb2.com',
+                'downloadUrl': 'https://f002.backblazeb2.com',
                 'authorizationToken': 'test'
             })
         else:

--- a/libcloud/test/storage/test_backblaze_b2.py
+++ b/libcloud/test/storage/test_backblaze_b2.py
@@ -19,8 +19,10 @@ import tempfile
 
 import mock
 import json
+
 from libcloud.storage.drivers.backblaze_b2 import BackblazeB2StorageDriver
 from libcloud.utils.py3 import httplib
+from libcloud.utils.files import exhaust_iterator
 from libcloud.test import unittest
 from libcloud.test import MockHttp
 from libcloud.test.file_fixtures import StorageFileFixtures
@@ -90,12 +92,13 @@ class BackblazeB2StorageDriverTestCase(unittest.TestCase):
                                              overwrite_existing=True)
         self.assertTrue(result)
 
-    @unittest.skip(reason='The API for backblaze download object as stream is wrong')
     def test_download_object_as_stream(self):
         container = self.driver.list_containers()[0]
         obj = self.driver.list_container_objects(container=container)[0]
-        result = self.driver.download_object_as_stream(obj=obj)
-        self.assertEqual(result, 'ab')
+
+        stream = self.driver.download_object_as_stream(obj=obj, chunk_size=1024)
+        self.assertTrue(hasattr(stream, '__iter__'))
+        self.assertEqual(exhaust_iterator(stream), 'ab')
 
     def test_upload_object(self):
         file_path = os.path.abspath(__file__)

--- a/libcloud/test/storage/test_backblaze_b2.py
+++ b/libcloud/test/storage/test_backblaze_b2.py
@@ -22,6 +22,7 @@ import json
 
 from libcloud.storage.drivers.backblaze_b2 import BackblazeB2StorageDriver
 from libcloud.utils.py3 import httplib
+from libcloud.utils.py3 import b
 from libcloud.utils.files import exhaust_iterator
 from libcloud.test import unittest
 from libcloud.test import MockHttp
@@ -98,7 +99,7 @@ class BackblazeB2StorageDriverTestCase(unittest.TestCase):
 
         stream = self.driver.download_object_as_stream(obj=obj, chunk_size=1024)
         self.assertTrue(hasattr(stream, '__iter__'))
-        self.assertEqual(exhaust_iterator(stream), 'ab')
+        self.assertEqual(exhaust_iterator(stream), b('ab'))
 
     def test_upload_object(self):
         file_path = os.path.abspath(__file__)

--- a/libcloud/utils/loggingconnection.py
+++ b/libcloud/utils/loggingconnection.py
@@ -124,6 +124,9 @@ class LoggingConnection(LibcloudConnection):
 
         # TODO: in python 2.6, body can be a file-like object.
         if body is not None and len(body) > 0:
+            if isinstance(body, (bytearray, bytes)):
+                body = body.decode('utf-8')
+
             cmd.extend(["--data-binary", pquote(body)])
 
         cmd.extend(["--compress"])


### PR DESCRIPTION
This pull request fixes an issue in the Backblaze B2 driver as reported in #1338.

While working on this, I noticed ``download_object_as_stream`` is also broken, so I fixed that as well.

It looks like both of those regressions were inadvertently introduced when we moved to the ``requests`` library.

It's likely that there are more issues similar to this one hiding in other drivers. Sadly our functional tests didn't catch those issues.

Resolves #1338.