### PR TITLE
Add missing cpu platform field to GCE driver

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -8849,6 +8849,8 @@ class GCENodeDriver(NodeDriver):
         extra['zone'] = self.ex_get_zone(node['zone'])
         extra['image'] = node.get('image')
         extra['machineType'] = node.get('machineType')
+        extra['cpuPlatform'] = node.get('cpuPlatform')
+        extra['minCpuPlatform'] = node.get('minCpuPlatform')
         extra['disks'] = node.get('disks', [])
         extra['networkInterfaces'] = node.get('networkInterfaces')
         extra['id'] = node['id']


### PR DESCRIPTION
## Add missing cpu platform field to GCE driver

### Description

Added to 'extra' dict missing fields - cpuPlatform and minCpuPlatform.
Those fields already coming from the "list_nodes()" methods and was just ignored.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
