### PR TITLE
Add support for Vultr Object Storage

### DIFF
--- a/libcloud/storage/drivers/vultr.py
+++ b/libcloud/storage/drivers/vultr.py
@@ -82,3 +82,15 @@ class VultrObjectStorageDriver(BaseVultrObjectStorageDriver):
                                           driver=self)
 
         raise LibcloudError('Unexpected status code: %s' % (response.status))
+
+    def _headers_to_object(self, object_name, container, headers):
+        normalized_headers = headers.copy()
+
+        # Vultr doesn't return this header for objects >1K that are compressed
+        if 'content-length' not in normalized_headers:
+            normalized_headers['content-length'] = 0
+
+        return super(VultrObjectStorageDriver, self)._headers_to_object(
+            object_name=object_name,
+            container=container,
+            headers=normalized_headers)

--- a/libcloud/storage/drivers/vultr.py
+++ b/libcloud/storage/drivers/vultr.py
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from libcloud.storage.providers import Provider
+from libcloud.storage.drivers.s3 import BaseS3StorageDriver, BaseS3Connection
+
+__all__ = [
+    'VultrObjectStorageDriver'
+]
+
+VULTR_OBJECT_STORAGE_US_HOST = 'ewr1.vultrobjects.com'
+
+
+class BaseVultrObjectConnection(BaseS3Connection):
+    host = VULTR_OBJECT_STORAGE_US_HOST
+
+
+class BaseVultrObjectStorageDriver(BaseS3StorageDriver):
+    type = Provider.VULTR
+    name = 'Vultr Object Storage'
+    website = 'https://www.vultr.com/products/object-storage/'
+    supports_s3_multipart_upload = False
+
+
+class VultrObjectStorageDriver(BaseVultrObjectStorageDriver):
+    connectionCls = BaseVultrObjectConnection

--- a/libcloud/storage/providers.py
+++ b/libcloud/storage/providers.py
@@ -86,6 +86,8 @@ DRIVERS = {
     Provider.DIGITALOCEAN_SPACES:
     ('libcloud.storage.drivers.digitalocean_spaces',
      'DigitalOceanSpacesStorageDriver'),
+    Provider.VULTR:
+    ('libcloud.storage.drivers.vultr', 'VultrObjectStorageDriver'),
 }
 
 

--- a/libcloud/storage/types.py
+++ b/libcloud/storage/types.py
@@ -69,6 +69,7 @@ class Provider(object):
     :cvar S3_US_GOV_WEST: Amazon S3 GovCloud (US)
     :cvar S3_RGW: S3 RGW
     :cvar S3_RGW_OUTSCALE: OUTSCALE S3 RGW
+    :cvar VULTR: Vultr Object Storage driver
     """
     DUMMY = 'dummy'
     ALIYUN_OSS = 'aliyun_oss'
@@ -103,6 +104,7 @@ class Provider(object):
     S3_US_GOV_WEST = 's3_us_gov_west'
     S3_RGW = 's3_rgw'
     S3_RGW_OUTSCALE = 's3_rgw_outscale'
+    VULTR = 'vultr'
 
     # Deperecated
     CLOUDFILES_US = 'cloudfiles_us'

--- a/libcloud/test/storage/test_vultr.py
+++ b/libcloud/test/storage/test_vultr.py
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import unittest
+
+from libcloud.storage.drivers.vultr import VultrObjectStorageDriver
+from libcloud.test.storage.test_s3 import S3MockHttp, S3Tests
+
+
+class VultrObjectTests(S3Tests, unittest.TestCase):
+    driver_type = VultrObjectStorageDriver
+
+    def setUp(self):
+        super(VultrObjectTests, self).setUp()
+
+        VultrObjectStorageDriver.connectionCls.conn_class = S3MockHttp
+        S3MockHttp.type = None
+        self.driver = self.create_driver()
+
+
+if __name__ == '__main__':
+    sys.exit(unittest.main())


### PR DESCRIPTION
## Support for Vultr Object Storage

### Description

This adds preliminary support for recently released [Vultr Object Storage](https://www.vultr.com/products/object-storage/). According to [documentation](https://www.vultr.com/docs/vultr-object-storage), it has close S3 compatibility.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)