### PR TITLE
Add Gandi LiveDNS driver to list in types and providers

### DIFF
--- a/libcloud/dns/providers.py
+++ b/libcloud/dns/providers.py
@@ -40,6 +40,8 @@ DRIVERS = {
     ('libcloud.dns.drivers.route53', 'Route53DNSDriver'),
     Provider.GANDI:
     ('libcloud.dns.drivers.gandi', 'GandiDNSDriver'),
+    Provider.GANDI_LIVE:
+    ('libcloud.dns.drivers.gandi_live', 'GandiLiveDNSDriver'),
     Provider.GOOGLE: ('libcloud.dns.drivers.google', 'GoogleDNSDriver'),
     Provider.SOFTLAYER:
     ('libcloud.dns.drivers.softlayer', 'SoftLayerDNSDriver'),

--- a/libcloud/dns/types.py
+++ b/libcloud/dns/types.py
@@ -44,6 +44,7 @@ class Provider(object):
     DNSIMPLE = 'dnsimple'
     DURABLEDNS = 'durabledns'
     GANDI = 'gandi'
+    GANDI_LIVE = 'gandi_live'
     GODADDY = 'godaddy'
     GOOGLE = 'google'
     HOSTVIRTUAL = 'hostvirtual'


### PR DESCRIPTION
## Add Gandi LiveDNS driver to list in types and providers

### Description

While #1323 was accepted, it didn't do the last inch of adding the driver to the DNS list of providers and types.  This adds it to those lists.

### Status

Nearly trivial change - done, ready for review.

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
