### PR TITLE
Fix list_sizes on Packet when using project API tokens

### DIFF
--- a/libcloud/compute/drivers/packet.py
+++ b/libcloud/compute/drivers/packet.py
@@ -225,8 +225,14 @@ def _list_async(driver):
             .object['operating_systems']
         return list(map(self._to_image, data))
 
-    def list_sizes(self):
-        data = self.connection.request('/plans').object['plans']
+    def list_sizes(self, ex_project_id=None):
+        project_id = ex_project_id or self.project_id or (
+            len(self.projects) and self.projects[0].id)
+        if project_id:
+            data = self.connection.request('/projects/%s/plans' %
+                                           project_id).object['plans']
+        else:  # This only works with personal tokens
+            data = self.connection.request('/plans' ).object['plans']
         return [self._to_size(size) for size in data if
                 size.get('line') == 'baremetal']
 


### PR DESCRIPTION
## Fix list_sizes on Packet when using project API tokens
### Description

The `list_sizes` method of the Packet driver was invoking the `/plans` API endpoint, which is only available when using personal API tokens. Project specific API tokens should invoke `/project/<project_id>/plans` instead. This PR uses the latter endpoint when `project_id` is set.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
