### PR TITLE
Reuse TCP connections when uploading files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -217,6 +217,9 @@ Storage
   iterated / seeked upon before calculating the hash. (GITHUB-1326)
   [Gabe Van Engel - @gvengel, Tomaz Muraus]
 
+- [Common, S3, GCS] Reuse TCP connections when uploading files (GITHUB-1353)
+  [Quentin Pradet]
+
 - [Backblaze B2] Fix a bug with driver not working correctly due to a
   regression which was inadvertently introduced in one of the previous
   releases. (GITHUB-1338, GITHUB-1339)

--- a/libcloud/http.py
+++ b/libcloud/http.py
@@ -244,7 +244,7 @@ class LibcloudConnection(LibcloudBaseConnection):
 
         self.response = self.session.send(
             prepped,
-            stream=raw,
+            stream=stream,
             verify=self.ca_cert if self.ca_cert is not None else self.verify)
 
     def getresponse(self):

--- a/libcloud/test/storage/test_base.py
+++ b/libcloud/test/storage/test_base.py
@@ -86,6 +86,17 @@ class BaseStorageTests(unittest.TestCase):
             else:
                 self.fail('Exception was not thrown')
 
+    def test__upload_object_does_not_stream_response(self):
+        resp = self.driver1._upload_object(
+            object_name='foo',
+            content_type='foo/bar',
+            request_path='/',
+            stream=iter(b'foo'))
+        mock_response = resp["response"].response._response
+        response_streamed = mock_response.request.stream
+        assert response_streamed is False
+
+
     def test__get_hash_function(self):
         self.driver1.hash_type = 'md5'
         func = self.driver1._get_hash_function()


### PR DESCRIPTION
## Reuse TCP connections when uploading files

### Description

It's easy to break connection reuse when using the requests API: just use `stream=True` and never read the response. The connection used to make the request will never be reused, and will be dropped when the urllib3's connection pool is full.

It turns out uploading objects using the S3 API goes through `prepared_request`, which incorrectly sets `stream` to the value of `raw`, `True` in our case. And since we don't read the response data, the connection are never reused, and each upload requires its own connection.

This is particularly wasteful when uploading many small objects, which can easily happen with JSON or Parquet files generated by Apache Spark, where setting up the connection takes significant time compared to uploading a few bytes.

Setting `stream=stream` in the `prepared_request` method matches the code in the `request` method and fixes the bug.

### Status

- work in progress

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)

cc @Kami @tonybaloney 