### PR TITLE
[Bug fix] GCE Error setting/adding project metadata

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -899,7 +899,7 @@ class GCEProject(UuidMixin):
         :return: True if successful
         :rtype:  ``bool``
         """
-        return self.driver.ex_set_common_instance_metadata(self, metadata)
+        return self.driver.ex_set_common_instance_metadata(metadata, force)
 
     def set_usage_export_bucket(self, bucket, prefix=None):
         """


### PR DESCRIPTION
## [Bug fix] GCE provider validation error when setting project scope metadata

### Description
A bug was detected when setting new metadata values into GCE project while using the GCE provider from libcloud "trunk" branch. Browsing through the code I noticed that arguments are not passed correctly to the gce driver (set common metadata), causing gce driver to return an error when setting metadata into a GCE project.

Error:
- ValueError: Unsupported metadata format.
Solution:
- Removed unnecessary "self" argument to ex_set_common_instance_metadata and included force argument, which was currently missing.

### Status
- done, ready for review

### Checklist (tick everything that applies)

- [X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [X] Documentation
- [X] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
