### PR TITLE
adding a sync/async flag for destroy_node

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -6831,7 +6831,7 @@ class GCENodeDriver(NodeDriver):
         self.connection.async_request(request, method='DELETE')
         return True
 
-    def destroy_node(self, node, destroy_boot_disk=False, sync=True):
+    def destroy_node(self, node, destroy_boot_disk=False, ex_sync=True):
         """
         Destroy a node.
 
@@ -6844,8 +6844,8 @@ class GCENodeDriver(NodeDriver):
                                      method.)
         :type     destroy_boot_disk: ``bool``
 
-        :keyword  sync: If true, do not return until destroyed or timeout
-        :type     sync: ``bool``
+        :keyword  ex_sync: If true, do not return until destroyed or timeout
+        :type     ex_sync: ``bool``
 
         :return:  True if successful
         :rtype:   ``bool``

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -6852,7 +6852,7 @@ class GCENodeDriver(NodeDriver):
         """
         request = '/zones/%s/instances/%s' % (node.extra['zone'].name,
                                               node.name)
-        if sync:
+        if ex_sync:
             self.connection.async_request(request, method='DELETE')
         else:
             self.connection.request(request, method='DELETE')

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -6726,34 +6726,49 @@ class GCENodeDriver(NodeDriver):
         self.connection.async_request(request, method='POST', data=body)
         return True
 
-    def ex_start_node(self, node):
+    def ex_start_node(self, node, sync=True):
         """
         Start a node that is stopped and in TERMINATED state.
 
         :param  node: Node object to start
         :type   node: :class:`Node`
 
+        :keyword  sync: If true, do not return until destroyed or timeout
+        :type     sync: ``bool``
+
         :return:  True if successful
         :rtype:   ``bool``
         """
         request = '/zones/%s/instances/%s/start' % (node.extra['zone'].name,
                                                     node.name)
-        self.connection.async_request(request, method='POST')
+
+        if sync:
+            self.connection.async_request(request, method='POST')
+        else:
+            self.connection.request(request, method='POST')
+
         return True
 
-    def ex_stop_node(self, node):
+    def ex_stop_node(self, node, sync=True):
         """
         Stop a running node.
 
         :param  node: Node object to stop
         :type   node: :class:`Node`
 
+        :keyword  sync: If true, do not return until destroyed or timeout
+        :type     sync: ``bool``
+
         :return:  True if successful
         :rtype:   ``bool``
         """
         request = '/zones/%s/instances/%s/stop' % (node.extra['zone'].name,
                                                    node.name)
-        self.connection.async_request(request, method='POST')
+        if sync:
+            self.connection.async_request(request, method='POST')
+        else:
+            self.connection.request(request, method='POST')
+
         return True
 
     def ex_destroy_instancegroupmanager(self, manager):

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -6816,7 +6816,7 @@ class GCENodeDriver(NodeDriver):
         self.connection.async_request(request, method='DELETE')
         return True
 
-    def destroy_node(self, node, destroy_boot_disk=False):
+    def destroy_node(self, node, destroy_boot_disk=False, sync=True):
         """
         Destroy a node.
 
@@ -6829,12 +6829,19 @@ class GCENodeDriver(NodeDriver):
                                      method.)
         :type     destroy_boot_disk: ``bool``
 
+        :keyword  sync: If true, do not return until destroyed or timeout
+        :type     sync: ``bool``
+
         :return:  True if successful
         :rtype:   ``bool``
         """
         request = '/zones/%s/instances/%s' % (node.extra['zone'].name,
                                               node.name)
-        self.connection.async_request(request, method='DELETE')
+        if sync:
+            self.connection.async_request(request, method='DELETE')
+        else:
+            self.connection.request(request, method='DELETE')
+
         if destroy_boot_disk and node.extra['boot_disk']:
             node.extra['boot_disk'].destroy()
         return True


### PR DESCRIPTION
## Changes GCE node deletion to allow async issuance
Adds the ability for GCE provider to perform node deletion in an async manner. 


### Description

See issue #1356 for full back-story. 
tldr; even the most basic node deletions in GCP will time out when using the `destroy_node()` function as it works today. 


### Status
Covers issue #1356 
- work in progress


### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
