### PR TITLE
add more new gce image families

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -1781,10 +1781,18 @@ class GCENodeDriver(NodeDriver):
     }
 
     IMAGE_PROJECTS = {
-        "centos-cloud": ["centos-6", "centos-7"],
+        "centos-cloud": [
+            "centos-6",
+            "centos-7",
+            "centos-8",
+        ],
         "cos-cloud": ["cos-beta", "cos-dev", "cos-stable"],
         "coreos-cloud": ["coreos-alpha", "coreos-beta", "coreos-stable"],
-        "debian-cloud": ["debian-8", "debian-9"],
+        "debian-cloud": [
+            "debian-8",
+            "debian-9",
+            "debian-10",
+        ],
         "opensuse-cloud": ["opensuse-leap"],
         "rhel-cloud": [
             "rhel-6",


### PR DESCRIPTION
## add more new gce image families

### Description

similar to #1304 we add new image families for `centos-8` and `debian-10` from https://cloud.google.com/compute/docs/images#unshielded-images to prevent similar errors as in #1303

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
