### PR TITLE
OpenStack v2 create_volume can create bootable vol

### DIFF
--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -3320,7 +3320,7 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
             self.volumev2_connection.request('/volumes/%s' % volumeId).object)
 
     def create_volume(self, size, name, location=None, snapshot=None,
-                      ex_volume_type=None):
+                      ex_volume_type=None, ex_image_ref=None):
         """
         Create a new volume.
 
@@ -3343,6 +3343,10 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
                             (optional)
         :type ex_volume_type: ``str``
 
+        :param ex_image_ref: The image to create the volume from
+                             when creating a bootable volume (optional)
+        :type ex_image_ref: ``str``
+
         :return: The newly created volume.
         :rtype: :class:`StorageVolume`
         """
@@ -3357,6 +3361,9 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
 
         if ex_volume_type:
             volume['volume_type'] = ex_volume_type
+
+        if ex_image_ref:
+            volume['imageRef'] = ex_image_ref
 
         if location:
             volume['availability_zone'] = location

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -1998,6 +1998,21 @@ class OpenStack_2_Tests(OpenStack_1_1_Tests):
             name, args, kwargs = mock_request.mock_calls[0]
             self.assertFalse("volume_type" in kwargs["data"]["volume"])
 
+    def test_create_volume_passes_image_ref_to_request_only_if_not_none(self):
+        with patch.object(self.driver.volumev2_connection, 'request') as mock_request:
+            self.driver.create_volume(
+                1, 'test', ex_image_ref='353c4bd2-b28f-4857-9b7b-808db4397d03')
+            name, args, kwargs = mock_request.mock_calls[0]
+            self.assertEqual(
+                kwargs["data"]["volume"]["imageRef"],
+                "353c4bd2-b28f-4857-9b7b-808db4397d03")
+
+    def test_create_volume_does_not_pass_image_ref_to_request_if_none(self):
+        with patch.object(self.driver.volumev2_connection, 'request') as mock_request:
+            self.driver.create_volume(1, 'test')
+            name, args, kwargs = mock_request.mock_calls[0]
+            self.assertFalse("imageRef" in kwargs["data"]["volume"])
+
     def test_ex_create_snapshot_does_not_post_optional_parameters_if_none(self):
         volume = self.driver.list_volumes()[0]
         with patch.object(self.driver, '_to_snapshot'):


### PR DESCRIPTION
This PR adds `ex_image_ref` to create_volume for the
OpenStack_2_NodeDriver. This allows the user to create
bootable volumes based on machine images. When the UUID
of an image is passed as ImageRef it will create a bootable
volume from which later an instance can be launched. This is
helpful because for older versions of OpenStack it is not
possible to create an instance with a block device mapping
where the newly created volume has to be put in a availability
zone that is not the default.

More info about bootable volumes at https://docs.openstack.org/api-ref/block-storage/v2/index.html?expanded=create-volume-detail#volumes-volumes

> To create a bootable volume, include the UUID of the image from which
> you want to create the volume in the imageRef attribute in the request
> body.