### PR TITLE
openstack: fix project-scoped with project name

### DIFF
--- a/libcloud/common/openstack.py
+++ b/libcloud/common/openstack.py
@@ -109,6 +109,15 @@ class OpenStackBaseConnection(ConnectionUserAndKey):
                            default tenant if none is provided.
     :type ex_tenant_name: ``str``
 
+    :param ex_tenant_domain_id: When authenticating, provide this tenant
+                                domain id to the identity service.
+                                A scoped token will be returned.
+                                Some cloud providers require the tenant
+                                domain id to be provided at authentication
+                                time. Others will use a default tenant
+                                domain id if none is provided.
+    :type ex_tenant_domain_id: ``str``
+
     :param ex_force_service_type: Service type to use when selecting an
                                   service. If not specified, a provider
                                   specific default will be used.
@@ -145,6 +154,7 @@ class OpenStackBaseConnection(ConnectionUserAndKey):
                  ex_token_scope=OpenStackIdentityTokenScope.PROJECT,
                  ex_domain_name='Default',
                  ex_tenant_name=None,
+                 ex_tenant_domain_id='default',
                  ex_force_service_type=None,
                  ex_force_service_name=None,
                  ex_force_service_region=None,
@@ -163,6 +173,7 @@ class OpenStackBaseConnection(ConnectionUserAndKey):
         self._ex_token_scope = ex_token_scope
         self._ex_domain_name = ex_domain_name
         self._ex_tenant_name = ex_tenant_name
+        self._ex_tenant_domain_id = ex_tenant_domain_id
         self._ex_force_service_type = ex_force_service_type
         self._ex_force_service_name = ex_force_service_name
         self._ex_force_service_region = ex_force_service_region
@@ -199,6 +210,7 @@ class OpenStackBaseConnection(ConnectionUserAndKey):
                             user_id=self.user_id,
                             key=self.key,
                             tenant_name=self._ex_tenant_name,
+                            tenant_domain_id=self._ex_tenant_domain_id,
                             domain_name=self._ex_domain_name,
                             token_scope=self._ex_token_scope,
                             timeout=self.timeout,
@@ -420,6 +432,7 @@ class OpenStackDriverMixin(object):
                  ex_token_scope=OpenStackIdentityTokenScope.PROJECT,
                  ex_domain_name='Default',
                  ex_tenant_name=None,
+                 ex_tenant_domain_id='default',
                  ex_force_service_type=None,
                  ex_force_service_name=None,
                  ex_force_service_region=None, *args, **kwargs):
@@ -430,6 +443,7 @@ class OpenStackDriverMixin(object):
         self._ex_token_scope = ex_token_scope
         self._ex_domain_name = ex_domain_name
         self._ex_tenant_name = ex_tenant_name
+        self._ex_tenant_domain_id = ex_tenant_domain_id
         self._ex_force_service_type = ex_force_service_type
         self._ex_force_service_name = ex_force_service_name
         self._ex_force_service_region = ex_force_service_region
@@ -455,6 +469,8 @@ class OpenStackDriverMixin(object):
             rv['ex_domain_name'] = self._ex_domain_name
         if self._ex_tenant_name:
             rv['ex_tenant_name'] = self._ex_tenant_name
+        if self._ex_tenant_domain_id:
+            rv['ex_tenant_domain_id'] = self._ex_tenant_domain_id
         if self._ex_force_service_type:
             rv['ex_force_service_type'] = self._ex_force_service_type
         if self._ex_force_service_name:

--- a/libcloud/common/openstack_identity.py
+++ b/libcloud/common/openstack_identity.py
@@ -576,7 +576,7 @@ class OpenStackIdentityConnection(ConnectionUserAndKey):
     auth_version = None
 
     def __init__(self, auth_url, user_id, key, tenant_name=None,
-                 domain_name='Default',
+                 tenant_domain_id='default', domain_name='Default',
                  token_scope=OpenStackIdentityTokenScope.PROJECT,
                  timeout=None, proxy_url=None, parent_conn=None):
         super(OpenStackIdentityConnection, self).__init__(user_id=user_id,
@@ -931,7 +931,7 @@ class OpenStackIdentity_3_0_Connection(OpenStackIdentityConnection):
     ]
 
     def __init__(self, auth_url, user_id, key, tenant_name=None,
-                 domain_name='Default',
+                 domain_name='Default', tenant_domain_id='default',
                  token_scope=OpenStackIdentityTokenScope.PROJECT,
                  timeout=None, proxy_url=None, parent_conn=None):
         """
@@ -973,6 +973,7 @@ class OpenStackIdentity_3_0_Connection(OpenStackIdentityConnection):
             raise ValueError('Must provide domain_name argument')
 
         self.auth_user_roles = None
+        self.tenant_domain_id = tenant_domain_id
 
     def authenticate(self, force=False):
         """
@@ -1003,7 +1004,7 @@ class OpenStackIdentity_3_0_Connection(OpenStackIdentityConnection):
             data['auth']['scope'] = {
                 'project': {
                     'domain': {
-                        'name': self.domain_name
+                        'id': self.tenant_domain_id
                     },
                     'name': self.tenant_name
                 }

--- a/libcloud/test/common/test_openstack_identity.py
+++ b/libcloud/test/common/test_openstack_identity.py
@@ -312,6 +312,7 @@ class OpenStackIdentity_3_0_ConnectionTests(unittest.TestCase):
                                                 key='test_key',
                                                 token_scope='project',
                                                 tenant_name="test_tenant",
+                                                tenant_domain_id="test_tenant_domain_id",
                                                 domain_name='test_domain',
                                                 proxy_url='http://proxy:8080',
                                                 timeout=10)
@@ -692,7 +693,7 @@ class OpenStackIdentity_3_0_MockHttp(MockHttp):
             data = json.loads(body)
             if 'password' in data['auth']['identity']:
                 if data['auth']['identity']['password']['user']['domain']['name'] != 'test_domain' or \
-                        data['auth']['scope']['project']['domain']['name'] != 'test_domain':
+                        data['auth']['scope']['project']['domain']['id'] != 'test_tenant_domain_id':
                     status = httplib.UNAUTHORIZED
 
             body = ComputeFileFixtures('openstack').load('_v3__auth.json')


### PR DESCRIPTION
## Fix openstack project-scoped with project name token authentication

### Description

The project-scoped with project name should include
project domain id instead user domain name in scope
section according to current openstack API, example:

```
{
    "auth": {
        "identity": {
            "methods": [
                "password"
            ],
            "password": {
                "user": {
                    "id": "ee4dfb6e5540447cb3741905149d9b6e",
                    "password": "devstacker"
                }
            }
        },
        "scope": {
            "project": {
                "domain": {
                    "id": "default"
                },
                "name": "admin"
            }
        }
    }
}
```

### Status

work in progress

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
