### PR TITLE
Fix Azure compute driver to allow adding maximum number of disks when LUN is unspecified

### DIFF
--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -959,7 +959,7 @@ class AzureNodeDriver(NodeDriver):
         if ex_lun is None:
             # find the smallest unused logical unit number
             used_luns = [disk['lun'] for disk in disks]
-            free_luns = [lun for lun in range(0, 63) if lun not in used_luns]
+            free_luns = [lun for lun in range(0, 64) if lun not in used_luns]
             if len(free_luns) > 0:
                 ex_lun = free_luns[0]
             else:

--- a/libcloud/test/compute/test_azure_arm.py
+++ b/libcloud/test/compute/test_azure_arm.py
@@ -432,6 +432,15 @@ class AzureNodeDriverTests(LibcloudTestCase):
         self.assertTrue(len(data_disks), len(volumes))
         self.assertTrue(set(luns), {0, 1, 15})
 
+        volumes = self.driver.list_volumes()
+        node = self.driver.list_nodes()[0]
+        for count in range(64):
+            self.driver.attach_volume(node, volumes[0])
+        data_disks = node.extra['properties']['storageProfile']['dataDisks']
+        luns = [disk['lun'] for disk in data_disks]
+        self.assertTrue(len(data_disks), 64)
+        self.assertTrue(set(luns), set(range(64)))
+
     def test_resize_volume(self):
         volume = self.driver.list_volumes()[0]
         original_size = volume.size


### PR DESCRIPTION
## Fix Azure compute driver to allow adding maximum number of disks when LUN is unspecified

### Description

When the LUN is unspecified in the `attach_volume` method, it finds the lowest available number to attach the volume to. The maximum number of data disks on an Azure VM is 64, which means LUNs can range from 0 to 63.

The current logic to figure out the LUN iterates from 0 to 62: `for lun in range(0, 63)`. When you try to add the Nth device where N = maximum number of data disks allowed for that instance size, this code raises `LibcloudError("No LUN available to attach new disk.")`.

This PR fixes this to ensure the last LUN is usable.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
