### PR TITLE
Label support for GCP volumes

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -2056,6 +2056,31 @@ class GCENodeDriver(NodeDriver):
         self.connection.async_request(request, method='POST', data=body)
         return True
 
+    def ex_set_volume_labels(self, volume, labels):
+        """
+        Set labels for the specified volume (disk).
+
+        :keyword  volume: The existing target StorageVolume for the request.
+        :type     volume: ``StorageVolume``
+
+        :keyword  labels: Set (or clear with None) labels for this image.
+        :type     labels: ``dict`` or ``None``
+
+        :return: True if successful
+        :rtype:  ``bool``
+        """
+
+        if not isinstance(volume, StorageVolume):
+            raise ValueError("Must specify a valid libcloud volume object.")
+
+        volume_name = volume.name
+        zone_name = volume.extra['zone'].name
+        current_fp = volume.extra['labelFingerprint']
+        body = {'labels': labels, 'labelFingerprint': current_fp}
+        request = '/zones/%s/disks/%s/setLabels' % (zone_name, volume_name)
+        self.connection.async_request(request, method='POST', data=body)
+        return True
+
     def ex_get_serial_output(self, node):
         """
         Fetch the console/serial port output from the node.
@@ -9049,6 +9074,9 @@ class GCENodeDriver(NodeDriver):
         extra['sourceSnapshot'] = volume.get('sourceSnapshot')
         extra['sourceSnapshotId'] = volume.get('sourceSnapshotId')
         extra['options'] = volume.get('options')
+        extra['labels'] = volume.get('labels', {})
+        extra['labelFingerprint'] = volume.get('labelFingerprint')
+
         if 'licenses' in volume:
             lic_objs = self._licenses_from_urls(licenses=volume['licenses'])
             extra['licenses'] = lic_objs

--- a/libcloud/test/compute/fixtures/gce/aggregated_disks.json
+++ b/libcloud/test/compute/fixtures/gce/aggregated_disks.json
@@ -90,6 +90,12 @@
         "name": "lcdisk",
         "type": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/diskTypes/pd-ssd",
         "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/disks/lcdisk",
+        "labelFingerprint": "42WmSpB8rSM=",
+        "labels": {
+          "one": "1",
+          "two": "2",
+          "three": "3"
+        },
         "sizeGb": "10",
         "sourceImage": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20131120",
         "sourceImageId": "17312518942796567789",

--- a/libcloud/test/compute/fixtures/gce/operations_operation_zones_us-central1-a_disks_lcdisk_setLabels_post.json
+++ b/libcloud/test/compute/fixtures/gce/operations_operation_zones_us-central1-a_disks_lcdisk_setLabels_post.json
@@ -1,7 +1,7 @@
 {
   "kind": "compute#operation",
   "id": "4992266504414588438",
-  "name": "operation-zones_us-central1-a_disks_lcdisk_setLabels",
+  "name": "operation-zones_us-central1-a_disks_lcdisk_setLabels_post",
   "zone": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a",
   "operationType": "setLabels",
   "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/disks/904434546113910404",
@@ -12,5 +12,5 @@
   "insertTime": "2019-07-02T14:47:37.095-07:00",
   "startTime": "2019-07-02T14:47:37.111-07:00",
   "endTime": "2019-07-02T14:47:41.991-07:00",
-  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/operations/operation-zones_us-central1-a_disks_lcdisk_setLabels"
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/operations/operation-zones_us-central1-a_disks_lcdisk_setLabels_post"
 }

--- a/libcloud/test/compute/fixtures/gce/operations_operation_zones_us-central1-a_disks_lcdisk_setLabels_post.json
+++ b/libcloud/test/compute/fixtures/gce/operations_operation_zones_us-central1-a_disks_lcdisk_setLabels_post.json
@@ -1,0 +1,16 @@
+{
+  "kind": "compute#operation",
+  "id": "4992266504414588438",
+  "name": "operation-zones_us-central1-a_disks_lcdisk_setLabels",
+  "zone": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a",
+  "operationType": "setLabels",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/disks/904434546113910404",
+  "targetId": "904434546113910404",
+  "status": "DONE",
+  "user": "487551519631-t6qvu2na6p4u9ptm46bsdujf0ohbdro7@developer.gserviceaccount.com",
+  "progress": 100,
+  "insertTime": "2019-07-02T14:47:37.095-07:00",
+  "startTime": "2019-07-02T14:47:37.111-07:00",
+  "endTime": "2019-07-02T14:47:41.991-07:00",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/operations/operation-zones_us-central1-a_disks_lcdisk_setLabels"
+}

--- a/libcloud/test/compute/fixtures/gce/zones_us-central1-a_disks_lcdisk_setLabel_post.json
+++ b/libcloud/test/compute/fixtures/gce/zones_us-central1-a_disks_lcdisk_setLabel_post.json
@@ -1,6 +1,6 @@
 {
   "id": "0158330665043557584",
-  "name": "operation-1574861021466-59853e7c15164-5cc58767-a7a679d3",
+  "name": "operation-zones_us-central1-a_disks_lcdisk_setLabels",
   "zone": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a",
   "operationType": "setLabels",
   "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/disks/lcdisk",
@@ -11,6 +11,6 @@
   "insertTime": "2019-11-27T05:23:41.870-08:00",
   "startTime": "2019-11-27T05:23:41.873-08:00",
   "endTime": "2019-11-27T05:23:41.873-08:00",
-  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/operations/operation-1574861021466-59853e7c15164-5cc58767-a7a679d3",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/operations/operation-zones_us-central1-a_disks_lcdisk_setLabels",
   "kind": "compute#operation"
 }

--- a/libcloud/test/compute/fixtures/gce/zones_us-central1-a_disks_lcdisk_setLabel_post.json
+++ b/libcloud/test/compute/fixtures/gce/zones_us-central1-a_disks_lcdisk_setLabel_post.json
@@ -1,0 +1,16 @@
+{
+  "id": "0158330665043557584",
+  "name": "operation-1574861021466-59853e7c15164-5cc58767-a7a679d3",
+  "zone": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a",
+  "operationType": "setLabels",
+  "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/disks/lcdisk",
+  "targetId": "6142245483972904501",
+  "status": "DONE",
+  "user": "487551519631-t6qvu2na6p4u9ptm46bsdujf0ohbdro7@developer.gserviceaccount.com",
+  "progress": 100,
+  "insertTime": "2019-11-27T05:23:41.870-08:00",
+  "startTime": "2019-11-27T05:23:41.873-08:00",
+  "endTime": "2019-11-27T05:23:41.873-08:00",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/operations/operation-1574861021466-59853e7c15164-5cc58767-a7a679d3",
+  "kind": "compute#operation"
+}

--- a/libcloud/test/compute/fixtures/gce/zones_us-central1-a_disks_lcdisk_setLabel_post.json
+++ b/libcloud/test/compute/fixtures/gce/zones_us-central1-a_disks_lcdisk_setLabel_post.json
@@ -1,6 +1,6 @@
 {
   "id": "0158330665043557584",
-  "name": "operation-zones_us-central1-a_disks_lcdisk_setLabels",
+  "name": "operation-zones_us-central1-a_disks_lcdisk_setLabels_post",
   "zone": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a",
   "operationType": "setLabels",
   "targetLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/disks/lcdisk",
@@ -11,6 +11,6 @@
   "insertTime": "2019-11-27T05:23:41.870-08:00",
   "startTime": "2019-11-27T05:23:41.873-08:00",
   "endTime": "2019-11-27T05:23:41.873-08:00",
-  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/operations/operation-zones_us-central1-a_disks_lcdisk_setLabels",
+  "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/operations/operation-zones_us-central1-a_disks_lcdisk_setLabels_post",
   "kind": "compute#operation"
 }

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -2980,6 +2980,12 @@ class GCEMockHttp(MockHttp):
             'operations_operation_zones_us-central1-a_disks_lcdisk_resize_post.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
+    def _zones_us_central1_a_operations_operation_zones_us_central1_a_disks_lcdisk_setLabels_post(
+        self, method, url, body, headers):
+        body = self.fixtures.load(
+            'operations_operation_zones_us-central1-a_disks_lcdisk_setLabels_post.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
     def _zones_us_central1_a_operations_operation_zones_us_central1_a_disks_post(
             self, method, url, body, headers):
         body = self.fixtures.load(

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -1543,6 +1543,17 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         self.assertTrue(isinstance(volume, StorageVolume))
         self.assertEqual(volume.name, volume_name)
 
+    def test_ex_set_volume_labels(self):
+        volume_name = 'lcdisk'
+        zone = self.driver.zone
+        volume_labels = {'one': '1', 'two': '2', 'three': '3'}
+        size = 10
+        new_vol = self.driver.create_volume(size, volume_name, location=zone)
+        self.assertTrue(self.driver.ex_set_volume_labels(new_vol,
+                                                         labels=volume_labels))
+        exist_vol = self.driver.ex_get_volume(volume_name, self.driver.zone)
+        self.assertEqual(exist_vol.extra['labels'], volume_labels)
+
     def test_ex_update_healthcheck(self):
         healthcheck_name = 'lchealthcheck'
         healthcheck = self.driver.ex_get_healthcheck(healthcheck_name)

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -3400,6 +3400,12 @@ class GCEMockHttp(MockHttp):
             'zones_us-central1-a_disks_lcdisk_resize_post.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
+    def _zones_us_central1_a_disks_lcdisk_setLabels(self, method, url,
+                                                    body, header):
+        body = self.fixtures.load(
+            'zones_us-central1-a_disks_lcdisk_setLabel_post.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
     def _zones_us_central1_a_disks_node_name(self, method, url, body, headers):
         body = self.fixtures.load('generic_disk.json')
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])


### PR DESCRIPTION
## GCP Volumes - now with labels! 
There was no support in the GCP provider for querying/setting labels on volumes - this adds that!

### Description
In order to set the labels for a disk, the user is required to pass in the last labelFingerprint, which must be fetched first. This is done when building the StorageVolume object from a query, pull out the relevant fields (labels, labelFingerprint) and stuff them in the `extra` dictionary.

In addition, a new method has been added, `ex_set_volume_labels` which sets the labels for a given volume.

For more information on contributing, please see [Contributing](http://libcloud.readthedocs.org/en/latest/development.html#contributing)
section of our documentation.

### Status
- ready for review!

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
