### PR TITLE
Fix DeprecationWarning in unescaped literal and SyntaxWarning over literal is comparison.

### DIFF
--- a/libcloud/compute/drivers/vcloud.py
+++ b/libcloud/compute/drivers/vcloud.py
@@ -1691,7 +1691,7 @@ class VCloud_1_5_NodeDriver(VCloudNodeDriver):
         if names is None:
             return
         hname_re = re.compile(
-            '^(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9]*)[\-])*([A-Za-z]|[A-Za-z][A-Za-z0-9]*[A-Za-z0-9])$')  # NOQA
+            r'^(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9]*)[\-])*([A-Za-z]|[A-Za-z][A-Za-z0-9]*[A-Za-z0-9])$')  # NOQA
         for name in names:
             if len(name) > 15:
                 raise ValueError(

--- a/libcloud/test/compute/test_cloudsigma_v1_0.py
+++ b/libcloud/test/compute/test_cloudsigma_v1_0.py
@@ -114,7 +114,7 @@ class CloudSigmaAPI10BaseTestCase(object):
         self.assertTrue(result)
 
     def test_str2dicts(self):
-        string = 'mem 1024\ncpu 2200\n\nmem2048\cpu 1100'
+        string = 'mem 1024\ncpu 2200\n\nmem2048\\cpu 1100'
         result = str2dicts(string)
         self.assertEqual(len(result), 2)
 

--- a/libcloud/test/compute/test_dimensiondata_v2_3.py
+++ b/libcloud/test/compute/test_dimensiondata_v2_3.py
@@ -2145,7 +2145,7 @@ class DimensionDataMockHttp(MockHttp):
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
     def _oec_0_9_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_networkWithLocation(self, method, url, body, headers):
-        if method is "POST":
+        if method == "POST":
             request = ET.fromstring(body)
             if request.tag != "{http://oec.api.opsource.net/schemas/network}NewNetworkWithLocation":
                 raise InvalidRequestError(request.tag)

--- a/libcloud/test/compute/test_dimensiondata_v2_4.py
+++ b/libcloud/test/compute/test_dimensiondata_v2_4.py
@@ -2234,7 +2234,7 @@ class DimensionDataMockHttp(MockHttp):
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
     def _oec_0_9_8a8f6abc_2745_4d8a_9cbc_8dabe5a7d0e4_networkWithLocation(self, method, url, body, headers):
-        if method is "POST":
+        if method == "POST":
             request = ET.fromstring(body)
             if request.tag != "{http://oec.api.opsource.net/schemas/network}NewNetworkWithLocation":
                 raise InvalidRequestError(request.tag)


### PR DESCRIPTION
## Fix DeprecationWarning and SyntaxWarning in CI

### Description

This PR fixes `DeprecationWarning` and `SyntaxWarning` raised in Python 3.8 in CI. Reference : https://travis-ci.org/apache/libcloud/jobs/619055704#L587

### Status

Replace this: describe the PR status. Examples:

- done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)