### PR TITLE
Fix attach and detach volume for Digital Ocean. Volume name instead of id is needed

### DIFF
--- a/libcloud/compute/drivers/digitalocean.py
+++ b/libcloud/compute/drivers/digitalocean.py
@@ -424,7 +424,7 @@ class DigitalOcean_v2_NodeDriver(DigitalOcean_v2_BaseDriver,
         :rytpe: ``bool``
         """
         attr = {'type': 'attach', 'droplet_id': node.id,
-                'volume_id': volume.id, 'region': volume.extra['region_slug']}
+                'volume_name': volume.name, 'region': volume.extra['region_slug']}
 
         res = self.connection.request('/v2/volumes/actions',
                                       data=json.dumps(attr), method='POST')
@@ -440,7 +440,7 @@ class DigitalOcean_v2_NodeDriver(DigitalOcean_v2_BaseDriver,
 
         :rtype: ``bool``
         """
-        attr = {'type': 'detach', 'volume_id': volume.id,
+        attr = {'type': 'detach', 'volume_name': volume.name,
                 'region': volume.extra['region_slug']}
 
         responses = []


### PR DESCRIPTION
### Title

Fix attach and detach volume for Digital Ocean. Volume name instead of id is needed

Docs can be found here: https://developers.digitalocean.com/documentation/v2/#attach-a-block-storage-volume-to-a-droplet

For more information on contributing, please see [Contributing](http://libcloud.readthedocs.org/en/latest/development.html#contributing)
section of our documentation.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
