### PR TITLE
Only guess host from region map if not explicitly set

### DIFF
--- a/libcloud/storage/drivers/s3.py
+++ b/libcloud/storage/drivers/s3.py
@@ -1050,7 +1050,9 @@ class S3StorageDriver(AWSDriver, BaseS3StorageDriver):
 
         self.name = 'Amazon S3 (%s)' % (region)
 
-        host = REGION_TO_HOST_MAP[region]
+        if host is None:
+            host = REGION_TO_HOST_MAP[region]
+
         super(S3StorageDriver, self).__init__(key=key, secret=secret,
                                               secure=secure, host=host,
                                               port=port,


### PR DESCRIPTION

## Only guess host from region map if not explicitly set

### Description

Overwriting host parameter is inconsistent with function signature and a breaking change compared with previous behavior. This change will respect the host if passed by the user but guess from the region if not explicitly passed.

Reason: If the user passes a host he expects it to be respected, be it because he wants to use a local proxy, test against a local server or any other reason not to use one of the predefined amazon servers.

This fixes #1383 .

### Status

done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
    should pass (tried to keep pep8 for that one extra line)
- [x] Documentation
    small bug fix restores consistent behaviour -- no change vs documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
    CI shows unit tests passed.
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
    a one liner surely doesn't require icla, I'm ticking the check for that reason.
