### PR TITLE
Support disk_size parameter for create_node

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -8281,6 +8281,10 @@ class GCENodeDriver(NodeDriver):
         :param  ex_accelerator_count: The number of accelerators to associate
                                       with the node.
         :type   ex_accelerator_count: ``int`` or ``None``
+        
+        :keyword  ex_disk_size: Specify size of the boot disk.
+                                Integer in gigabytes.
+        :type     ex_disk_size: ``int`` or ``None``
 
         :return:  A tuple containing a request string and a node_data dict.
         :rtype:   ``tuple`` of ``str`` and ``dict``

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -3994,7 +3994,8 @@ class GCENodeDriver(NodeDriver):
             ex_disks_gce_struct=None, ex_nic_gce_struct=None,
             ex_on_host_maintenance=None, ex_automatic_restart=None,
             ex_preemptible=None, ex_image_family=None, ex_labels=None,
-            ex_accelerator_type=None, ex_accelerator_count=None):
+            ex_accelerator_type=None, ex_accelerator_count=None,
+            ex_disk_size=None):
         """
         Create a new node and return a node object for the node.
 
@@ -4132,6 +4133,9 @@ class GCENodeDriver(NodeDriver):
                                         accelerators to attach to the node.
         :type     ex_accelerator_count: ``int`` or ``None``
 
+        :keyword  ex_disk_size: Specify size of the boot disk.
+                                Integer in gigabytes.
+        :type     ex_disk_size: ``int`` or ``None``
 
         :return:  A Node object for the new node.
         :rtype:   :class:`Node`
@@ -4201,7 +4205,7 @@ class GCENodeDriver(NodeDriver):
             ex_can_ip_forward, ex_disks_gce_struct, ex_nic_gce_struct,
             ex_on_host_maintenance, ex_automatic_restart, ex_preemptible,
             ex_subnetwork, ex_labels, ex_accelerator_type,
-            ex_accelerator_count)
+            ex_accelerator_count, ex_disk_size)
         self.connection.async_request(request, method='POST', data=node_data)
         return self.ex_get_node(name, location.name)
 

--- a/libcloud/test/compute/fixtures/gce/aggregated_disks.json
+++ b/libcloud/test/compute/fixtures/gce/aggregated_disks.json
@@ -76,7 +76,7 @@
         "name": "node-name",
         "type": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/diskTypes/pd-standard",
         "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/disks/node-name",
-        "sizeGb": "10",
+        "sizeGb": "25",
         "sourceImage": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20131120",
         "sourceImageId": "17312518942796567788",
         "status": "READY",

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -1409,6 +1409,15 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         self.assertRaises(ResourceExistsError, self.driver.create_node,
                           node_name, size, image, location='europe-west1-a')
 
+    def test_create_node_ex_disk_size(self):
+        node_name = 'node-name'
+        image = self.driver.ex_get_image('debian-7')
+        size = self.driver.ex_get_size('n1-standard-1')
+        ex_disk_size = 25
+        node = self.driver.create_node(node_name, size, image,
+                                       ex_disk_size=ex_disk_size)
+        self.assertEqual(node.extra['boot_disk'].size, str(ex_disk_size))
+
     def test_ex_create_multiple_nodes(self):
         base_name = 'lcnode'
         image = self.driver.ex_get_image('debian-7')


### PR DESCRIPTION
## Support disk_size parameter for create_node

### Description

I've added support for `disk_size` in `create_node()` for GCE. This closely follows the change that added the same for `ex_create_multiple_nodes()`. This is so that we can launch nodes on GCE with different sizes of disks easily.


### Status
- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes) => I think this is a small change.
