### PR TITLE
Correct disk_size parameter support for create_node

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -3994,8 +3994,7 @@ class GCENodeDriver(NodeDriver):
             ex_disks_gce_struct=None, ex_nic_gce_struct=None,
             ex_on_host_maintenance=None, ex_automatic_restart=None,
             ex_preemptible=None, ex_image_family=None, ex_labels=None,
-            ex_accelerator_type=None, ex_accelerator_count=None,
-            ex_disk_size=None):
+            ex_accelerator_type=None, ex_accelerator_count=None):
         """
         Create a new node and return a node object for the node.
 
@@ -4133,9 +4132,6 @@ class GCENodeDriver(NodeDriver):
                                         accelerators to attach to the node.
         :type     ex_accelerator_count: ``int`` or ``None``
 
-        :keyword  ex_disk_size: Specify size of the boot disk.
-                                Integer in gigabytes.
-        :type     ex_disk_size: ``int`` or ``None``
 
         :return:  A Node object for the new node.
         :rtype:   :class:`Node`
@@ -4205,7 +4201,7 @@ class GCENodeDriver(NodeDriver):
             ex_can_ip_forward, ex_disks_gce_struct, ex_nic_gce_struct,
             ex_on_host_maintenance, ex_automatic_restart, ex_preemptible,
             ex_subnetwork, ex_labels, ex_accelerator_type,
-            ex_accelerator_count, ex_disk_size)
+            ex_accelerator_count)
         self.connection.async_request(request, method='POST', data=node_data)
         return self.ex_get_node(name, location.name)
 

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -3994,7 +3994,8 @@ class GCENodeDriver(NodeDriver):
             ex_disks_gce_struct=None, ex_nic_gce_struct=None,
             ex_on_host_maintenance=None, ex_automatic_restart=None,
             ex_preemptible=None, ex_image_family=None, ex_labels=None,
-            ex_accelerator_type=None, ex_accelerator_count=None):
+            ex_accelerator_type=None, ex_accelerator_count=None,
+            ex_disk_size=None):
         """
         Create a new node and return a node object for the node.
 
@@ -4132,6 +4133,9 @@ class GCENodeDriver(NodeDriver):
                                         accelerators to attach to the node.
         :type     ex_accelerator_count: ``int`` or ``None``
 
+        :keyword  ex_disk_size: Defines size of the boot disk.
+                                Integer in gigabytes.
+        :type     ex_disk_size: ``int`` or ``None``
 
         :return:  A Node object for the new node.
         :rtype:   :class:`Node`
@@ -4189,19 +4193,27 @@ class GCENodeDriver(NodeDriver):
                 'deviceName': name,
                 'initializeParams': {
                     'diskName': name,
+                    'diskSizeGb': ex_disk_size,
                     'diskType': ex_disk_type.extra['selfLink'],
                     'sourceImage': image.extra['selfLink']
                 }
             }]
 
         request, node_data = self._create_node_req(
-            name, size, image, location, ex_network, ex_tags, ex_metadata,
-            ex_boot_disk, external_ip, internal_ip, ex_disk_type,
-            ex_disk_auto_delete, ex_service_accounts, description,
-            ex_can_ip_forward, ex_disks_gce_struct, ex_nic_gce_struct,
-            ex_on_host_maintenance, ex_automatic_restart, ex_preemptible,
-            ex_subnetwork, ex_labels, ex_accelerator_type,
-            ex_accelerator_count)
+            name, size, image, location,
+            network=ex_network, tags=ex_tags, metadata=ex_metadata,
+            boot_disk=ex_boot_disk, external_ip=external_ip,
+            internal_ip=internal_ip, ex_disk_type=ex_disk_type,
+            ex_disk_auto_delete=ex_disk_auto_delete,
+            ex_service_accounts=ex_service_accounts, description=description,
+            ex_can_ip_forward=ex_can_ip_forward,
+            ex_disks_gce_struct=ex_disks_gce_struct,
+            ex_nic_gce_struct=ex_nic_gce_struct,
+            ex_on_host_maintenance=ex_on_host_maintenance,
+            ex_automatic_restart=ex_automatic_restart,
+            ex_preemptible=ex_preemptible, ex_subnetwork=ex_subnetwork,
+            ex_labels=ex_labels, ex_accelerator_type=ex_accelerator_type,
+            ex_accelerator_count=ex_accelerator_count)
         self.connection.async_request(request, method='POST', data=node_data)
         return self.ex_get_node(name, location.name)
 

--- a/libcloud/test/compute/fixtures/gce/aggregated_disks.json
+++ b/libcloud/test/compute/fixtures/gce/aggregated_disks.json
@@ -76,7 +76,7 @@
         "name": "node-name",
         "type": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/diskTypes/pd-standard",
         "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/disks/node-name",
-        "sizeGb": "10",
+        "sizeGb": "25",
         "sourceImage": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20131120",
         "sourceImageId": "17312518942796567788",
         "status": "READY",

--- a/libcloud/test/compute/fixtures/gce/aggregated_disks.json
+++ b/libcloud/test/compute/fixtures/gce/aggregated_disks.json
@@ -76,7 +76,7 @@
         "name": "node-name",
         "type": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/diskTypes/pd-standard",
         "selfLink": "https://www.googleapis.com/compute/v1/projects/project_name/zones/us-central1-a/disks/node-name",
-        "sizeGb": "25",
+        "sizeGb": "10",
         "sourceImage": "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-7-wheezy-v20131120",
         "sourceImageId": "17312518942796567788",
         "status": "READY",

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -1409,15 +1409,6 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         self.assertRaises(ResourceExistsError, self.driver.create_node,
                           node_name, size, image, location='europe-west1-a')
 
-    def test_create_node_ex_disk_size(self):
-        node_name = 'node-name'
-        image = self.driver.ex_get_image('debian-7')
-        size = self.driver.ex_get_size('n1-standard-1')
-        ex_disk_size = 25
-        node = self.driver.create_node(node_name, size, image,
-                                       ex_disk_size=ex_disk_size)
-        self.assertEqual(node.extra['boot_disk'].size, str(ex_disk_size))
-
     def test_ex_create_multiple_nodes(self):
         base_name = 'lcnode'
         image = self.driver.ex_get_image('debian-7')

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -1241,6 +1241,17 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         self.assertTrue(isinstance(node, Node))
         self.assertEqual(node.name, node_name)
 
+    def test_create_node_disk_size(self):
+        node_name = 'node-name'
+        image = self.driver.ex_get_image('debian-7')
+        size = self.driver.ex_get_size('n1-standard-1')
+        disk_size = 25
+        node = self.driver.create_node(node_name, size, image,
+                                       ex_disk_size=disk_size)
+        self.assertTrue(isinstance(node, Node))
+        self.assertEqual(node.name, node_name)
+        self.assertEqual(node.extra['boot_disk'].size, str(disk_size))
+
     def test_create_node_image_family(self):
         node_name = 'node-name'
         size = self.driver.ex_get_size('n1-standard-1')


### PR DESCRIPTION
## Correct disk_size parameter support for create_node

### Description
I realized my previous PR (#1386) wasn't quite correct as I wasn't passing in the parameter to the correct place. This fixes it.

### Status

done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) not a big change.
