### PR TITLE
Reduce reliance on **kwargs in "create_node()" methods

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,11 @@ Compute
   (GITHUB-1389)
   [Tomaz Muraus]
 
+- Add MyPy type annotations for ``create_node()`` and ``deploy_node()``
+  method.
+  (GITHUB-1389)
+  [Tomaz Muraus]
+
 Storage
 -------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,15 @@ Compute
   Because of that, a lot of the compute drivers which support deploy
   functionality needed to use ``**kwargs`` in ``create_node()`` method
   signature which made code hard to read and error prone.
+
+  Also update various affected drivers to explicitly declare supported
+  arguments in the  ``create_node()`` method signature (Dummy, Abiquo,
+  Joyent, Bluebox, OpenStack, Gandy, VCL, vCloud, CloudStack, GoGrid
+  HostVirtual, CloudSigma, ElasticStack, RimuHosting, SoftLayer, Voxel,
+  Vpsnet, KTUcloud, BrightBox, ECP, OpenNebula, UPcloud).
+
+  As part of this change, also various issues with invalid argument names
+  were identified and fixed.
   (GITHUB-1389)
   [Tomaz Muraus]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,17 @@ Compute
   (GITHUB-1373)
   [OpenText Corporation]
 
+- Update ``deploy_node()`` method so it now only passes non-deploy node
+  keyword arguments + ``auth`` argument to the underlying ``create_node()``
+  method. Previously it also passed ``deploy_node()`` specific arguments
+  such as ``deploy``, ``ssh_username``, ``max_tries``, etc. to it.
+
+  Because of that, a lot of the compute drivers which support deploy
+  functionality needed to use ``**kwargs`` in ``create_node()`` method
+  signature which made code hard to read and error prone.
+  (GITHUB-1389)
+  [Tomaz Muraus]
+
 Storage
 -------
 

--- a/libcloud/common/upcloud.py
+++ b/libcloud/common/upcloud.py
@@ -55,15 +55,14 @@ class UpcloudCreateNodeRequestBody(object):
     """
 
     def __init__(self, name, size, image, location, auth=None,
-                 **kwargs):
-        username = kwargs.get('ex_username', 'root')
+                 ex_hostname='localhost', ex_username='root'):
         self.body = {
             'server': {
                 'title': name,
-                'hostname': kwargs.get('ex_hostname', 'localhost'),
+                'hostname': ex_hostname,
                 'plan': size.id,
                 'zone': location.id,
-                'login_user': _LoginUser(username, auth).to_dict(),
+                'login_user': _LoginUser(ex_username, auth).to_dict(),
                 'storage_devices': _StorageDevice(image, size).to_dict()
             }
         }

--- a/libcloud/compute/base.py
+++ b/libcloud/compute/base.py
@@ -927,9 +927,10 @@ class NodeDriver(BaseDriver):
         raise NotImplementedError(
             'create_node not implemented for this driver')
 
-    def deploy_node(self, deploy, ssh_username='root', ssh_alternate_usernames=None,
-                    ssh_port=22, ssh_timeout=10, ssh_key=None, auth=None,
-                    timeout=SSH_CONNECT_TIMEOUT, max_tries=3, ssh_interface='public_ips',
+    def deploy_node(self, deploy, ssh_username='root',
+                    ssh_alternate_usernames=None, ssh_port=22, ssh_timeout=10,
+                    ssh_key=None, auth=None, timeout=SSH_CONNECT_TIMEOUT,
+                    max_tries=3, ssh_interface='public_ips',
                     **create_node_kwargs):
         # type: (...) -> Node
         """
@@ -1055,17 +1056,18 @@ class NodeDriver(BaseDriver):
                         'positional arguments.*')
             msg_2_re = r'create_node\(\) takes at least \d+ arguments.*'
             if re.match(msg_1_re, str(e)) or re.match(msg_2_re, str(e)):
-                node = self.create_node(deploy=deploy,
-                                        ssh_username=ssh_username,
-                                        ssh_alternate_usernames=ssh_alternate_usernames,
-                                        ssh_port=ssh_port,
-                                        ssh_timeout=ssh_timeout,
-                                        ssh_key=ssh_key,
-                                        auth=auth,
-                                        timeout=timeout,
-                                        max_tries=max_tries,
-                                        ssh_interface=ssh_interface,
-                                        **create_node_kwargs)
+                node = self.create_node(
+                    deploy=deploy,
+                    ssh_username=ssh_username,
+                    ssh_alternate_usernames=ssh_alternate_usernames,
+                    ssh_port=ssh_port,
+                    ssh_timeout=ssh_timeout,
+                    ssh_key=ssh_key,
+                    auth=auth,
+                    timeout=timeout,
+                    max_tries=max_tries,
+                    ssh_interface=ssh_interface,
+                    **create_node_kwargs)
             else:
                 raise e
 

--- a/libcloud/compute/base.py
+++ b/libcloud/compute/base.py
@@ -76,11 +76,6 @@ NODE_ONLINE_WAIT_TIMEOUT = 10 * 60
 # script.
 SSH_CONNECT_TIMEOUT = 5 * 60
 
-# Keyword arguments which are specific to deploy_node() method, but not
-# create_node()
-DEPLOY_NODE_KWARGS = ['deploy', 'ssh_username', 'ssh_alternate_usernames',
-                      'ssh_port', 'ssh_timeout', 'ssh_key', 'timeout',
-                      'max_tries', 'ssh_interface']
 __all__ = [
     'Node',
     'NodeState',

--- a/libcloud/compute/base.py
+++ b/libcloud/compute/base.py
@@ -69,7 +69,11 @@ NODE_ONLINE_WAIT_TIMEOUT = 10 * 60
 # script.
 SSH_CONNECT_TIMEOUT = 5 * 60
 
-
+# Keyword arguments which are specific to deploy_node() method, but not
+# create_node()
+DEPLOY_NODE_KWARGS = ['deploy', 'ssh_username', 'ssh_alternate_usernames',
+                      'ssh_port', 'ssh_timeout', 'ssh_key', 'timeout',
+                      'max_tries', 'ssh_interface']
 __all__ = [
     'Node',
     'NodeState',
@@ -1041,11 +1045,8 @@ class NodeDriver(BaseDriver):
         # NOTE 2: Some drivers which use password based SSH authentication rely on
         # password being stored on the "auth" argument and that's why we also
         # propagate that argument to "create_node()" method.
-        deploy_node_kwargs = ['deploy', 'ssh_username', 'ssh_alternate_usernames',
-                              'ssh_port', 'ssh_timeout', 'ssh_key', 'timeout',
-                              'max_tries', 'ssh_interface']
         create_node_kwargs = dict([(key, value) for key, value in kwargs.items() if
-                                   key not in deploy_node_kwargs])
+                                   key not in DEPLOY_NODE_KWARGS])
 
         try:
             node = self.create_node(**create_node_kwargs)
@@ -1535,7 +1536,7 @@ class NodeDriver(BaseDriver):
             return [address for address in addresses if is_supported(address)]
 
         if ssh_interface not in ['public_ips', 'private_ips']:
-            raise ValueError('ssh_interface argument must either be' +
+            raise ValueError('ssh_interface argument must either be ' +
                              'public_ips or private_ips')
 
         start = time.time()

--- a/libcloud/compute/base.py
+++ b/libcloud/compute/base.py
@@ -1070,6 +1070,7 @@ class NodeDriver(BaseDriver):
                         'positional arguments.*')
             msg_2_re = r'create_node\(\) takes at least \d+ arguments.*'
             if re.match(msg_1_re, str(e)) or re.match(msg_2_re, str(e)):
+                # pylint: disable=unexpected-keyword-arg
                 node = self.create_node(  # type: ignore
                     deploy=deploy,
                     ssh_username=ssh_username,
@@ -1082,6 +1083,7 @@ class NodeDriver(BaseDriver):
                     max_tries=max_tries,
                     ssh_interface=ssh_interface,
                     **create_node_kwargs)
+                # pylint: enable=unexpected-keyword-arg
             else:
                 raise e
 

--- a/libcloud/compute/base.py
+++ b/libcloud/compute/base.py
@@ -1046,13 +1046,15 @@ class NodeDriver(BaseDriver):
         # NOTE 2: Some drivers which use password based SSH authentication
         # rely on password being stored on the "auth" argument and that's why
         # we also propagate that argument to "create_node()" method.
-        create_node_kwargs = dict([(key, value) for key, value in kwargs.items()
-                                   if key not in DEPLOY_NODE_KWARGS])
+        create_node_kwargs = dict([(key, value) for key, value in
+                                   kwargs.items() if key
+                                   not in DEPLOY_NODE_KWARGS])
 
         try:
             node = self.create_node(**create_node_kwargs)
         except TypeError as e:
-            msg_1_re = r'create_node\(\) missing \d+ required positional arguments.*'
+            msg_1_re = (r'create_node\(\) missing \d+ required '
+                        'positional arguments.*')
             msg_2_re = r'create_node\(\) takes at least \d+ arguments.*'
             if re.match(msg_1_re, str(e)) or re.match(msg_2_re, str(e)):
                 node = self.create_node(**kwargs)

--- a/libcloud/compute/drivers/bluebox.py
+++ b/libcloud/compute/drivers/bluebox.py
@@ -161,14 +161,10 @@ class BlueboxNodeDriver(NodeDriver):
 
         return images
 
-    def create_node(self, **kwargs):
+    def create_node(self, name, size, image, auth=None, ex_username=None):
         headers = {'Content-Type': 'application/x-www-form-urlencoded'}
 
-        name = kwargs['name']
-        image = kwargs['image']
-        size = kwargs['size']
-
-        auth = self._get_and_check_auth(kwargs.get('auth'))
+        auth = self._get_and_check_auth(auth)
 
         data = {
             'hostname': name,
@@ -186,8 +182,8 @@ class BlueboxNodeDriver(NodeDriver):
             password = auth.password
             data.update(password=password)
 
-        if "ex_username" in kwargs:
-            data.update(username=kwargs["ex_username"])
+        if ex_username:
+            data.update(username=ex_username)
 
         if not ssh and not password:
             raise Exception("SSH public key or password required.")

--- a/libcloud/compute/drivers/brightbox.py
+++ b/libcloud/compute/drivers/brightbox.py
@@ -141,7 +141,8 @@ class BrightboxNodeDriver(NodeDriver):
         return self.connection.request(path, data=data, headers=headers,
                                        method='PUT')
 
-    def create_node(self, **kwargs):
+    def create_node(self, name, size, image, location=None, ex_userdata=None,
+                    ex_servergroup=None):
         """Create a new Brightbox node
 
         Reference: https://api.gb1.brightbox.com/1.0/#server_create_server
@@ -156,22 +157,22 @@ class BrightboxNodeDriver(NodeDriver):
         :type       ex_servergroup: ``str`` or ``list`` of ``str``
         """
         data = {
-            'name': kwargs['name'],
-            'server_type': kwargs['size'].id,
-            'image': kwargs['image'].id,
+            'name': name,
+            'server_type': size.id,
+            'image': image.id,
         }
 
-        if 'ex_userdata' in kwargs:
-            data['user_data'] = base64.b64encode(b(kwargs['ex_userdata'])) \
+        if ex_userdata:
+            data['user_data'] = base64.b64encode(b(ex_userdata)) \
                                       .decode('ascii')
 
-        if 'location' in kwargs:
-            data['zone'] = kwargs['location'].id
+        if location:
+            data['zone'] = location.id
 
-        if 'ex_servergroup' in kwargs:
-            if not isinstance(kwargs['ex_servergroup'], list):
-                kwargs['ex_servergroup'] = [kwargs['ex_servergroup']]
-            data['server_groups'] = kwargs['ex_servergroup']
+        if ex_servergroup:
+            if not isinstance(ex_servergroup, list):
+                ex_servergroup = [ex_servergroup]
+            data['server_groups'] = ex_servergroup
 
         data = self._post('/%s/servers' % self.api_version, data).object
         return self._to_node(data)

--- a/libcloud/compute/drivers/cloudscale.py
+++ b/libcloud/compute/drivers/cloudscale.py
@@ -107,7 +107,8 @@ class CloudscaleNodeDriver(NodeDriver):
         """
         return self._list_resources('/v1/images', self._to_image)
 
-    def create_node(self, name, size, image, location=None, ex_create_attr={}):
+    def create_node(self, name, size, image, location=None,
+                    ex_create_attr=None):
         """
         Create a node.
 
@@ -131,6 +132,7 @@ class CloudscaleNodeDriver(NodeDriver):
         :return: The newly created node.
         :rtype: :class:`Node`
         """
+        ex_create_attr = ex_create_attr or {}
         attr = dict(ex_create_attr)
         attr.update(
             name=name,

--- a/libcloud/compute/drivers/cloudsigma.py
+++ b/libcloud/compute/drivers/cloudsigma.py
@@ -264,7 +264,8 @@ class CloudSigma_1_0_NodeDriver(CloudSigmaNodeDriver):
                 nodes.append(node)
         return nodes
 
-    def create_node(self, **kwargs):
+    def create_node(self, name, size, image, smp='auto', nic_model='e1000',
+                    vnc_password=None, drive_type='hdd'):
         """
         Creates a CloudSigma instance
 
@@ -287,13 +288,6 @@ class CloudSigma_1_0_NodeDriver(CloudSigmaNodeDriver):
         :keyword    drive_type: Drive type (ssd|hdd). Defaults to hdd.
         :type       drive_type: ``str``
         """
-        size = kwargs['size']
-        image = kwargs['image']
-        smp = kwargs.get('smp', 'auto')
-        nic_model = kwargs.get('nic_model', 'e1000')
-        vnc_password = kwargs.get('vnc_password', None)
-        drive_type = kwargs.get('drive_type', 'hdd')
-
         if nic_model not in ['e1000', 'rtl8139', 'virtio']:
             raise CloudSigmaException('Invalid NIC model specified')
 
@@ -302,8 +296,8 @@ class CloudSigma_1_0_NodeDriver(CloudSigmaNodeDriver):
                                       ' are: hdd, ssd' % (drive_type))
 
         drive_data = {}
-        drive_data.update({'name': kwargs['name'],
-                           'size': '%sG' % (kwargs['size'].disk),
+        drive_data.update({'name': name,
+                           'size': '%sG' % (size.disk),
                            'driveType': drive_type})
 
         response = self.connection.request(
@@ -330,7 +324,7 @@ class CloudSigma_1_0_NodeDriver(CloudSigmaNodeDriver):
 
         node_data = {}
         node_data.update(
-            {'name': kwargs['name'], 'cpu': size.cpu, 'mem': size.ram,
+            {'name': name, 'cpu': size.cpu, 'mem': size.ram,
              'ide:0:0': drive_uuid, 'boot': 'ide:0:0', 'smp': smp})
         node_data.update({'nic:0:model': nic_model, 'nic:0:dhcp': 'auto'})
 

--- a/libcloud/compute/drivers/cloudstack.py
+++ b/libcloud/compute/drivers/cloudstack.py
@@ -1535,7 +1535,12 @@ class CloudStackNodeDriver(CloudStackDriverMixIn, NodeDriver):
                                   0, self, extra=extra))
         return sizes
 
-    def create_node(self, **kwargs):
+    def create_node(self, name, size, image, location=None, networks=None,
+                    project=None, diskoffering=None, ex_keyname=None,
+                    ex_userdata=None,
+                    ex_security_groups=None, ex_displayname=None,
+                    ex_ip_address=None, ex_start_vm=False,
+                    ex_rootdisksize=None, ex_affinity_groups=None):
         """
         Create a new node
 
@@ -1585,7 +1590,15 @@ class CloudStackNodeDriver(CloudStackDriverMixIn, NodeDriver):
         :rtype:     :class:`.CloudStackNode`
         """
 
-        server_params = self._create_args_to_params(None, **kwargs)
+        server_params = self._create_args_to_params(
+            node=None,
+            name=name, size=size, image=image, location=location,
+            networks=networks, diskoffering=diskoffering,
+            ex_keyname=ex_keyname, ex_userdata=ex_userdata,
+            ex_security_groups=ex_security_groups,
+            ex_displayname=ex_displayname, ex_ip_address=ex_ip_address,
+            ex_start_vm=ex_start_vm, ex_rootdisksize=ex_rootdisksize,
+            ex_affinity_groups=ex_affinity_groups)
 
         data = self._async_request(command='deployVirtualMachine',
                                    params=server_params,
@@ -1593,25 +1606,14 @@ class CloudStackNodeDriver(CloudStackDriverMixIn, NodeDriver):
         node = self._to_node(data=data)
         return node
 
-    def _create_args_to_params(self, node, **kwargs):
+    def _create_args_to_params(self, node, name, size, image, location=None,
+                               networks=None,
+                               project=None, diskoffering=None,
+                               ex_keyname=None, ex_userdata=None,
+                               ex_security_groups=None, ex_displayname=None,
+                               ex_ip_address=None, ex_start_vm=False,
+                               ex_rootdisksize=None, ex_affinity_groups=None):
         server_params = {}
-
-        # TODO: Refactor and use "kwarg_to_server_params" map
-        name = kwargs.get('name', None)
-        size = kwargs.get('size', None)
-        image = kwargs.get('image', None)
-        location = kwargs.get('location', None)
-        networks = kwargs.get('networks', None)
-        project = kwargs.get('project', None)
-        diskoffering = kwargs.get('diskoffering', None)
-        ex_key_name = kwargs.get('ex_keyname', None)
-        ex_user_data = kwargs.get('ex_userdata', None)
-        ex_security_groups = kwargs.get('ex_security_groups', None)
-        ex_displayname = kwargs.get('ex_displayname', None)
-        ex_ip_address = kwargs.get('ex_ip_address', None)
-        ex_start_vm = kwargs.get('ex_start_vm', None)
-        ex_rootdisksize = kwargs.get('ex_rootdisksize', None)
-        ex_affinity_groups = kwargs.get('ex_affinity_groups', None)
 
         if name:
             server_params['name'] = name
@@ -1641,12 +1643,12 @@ class CloudStackNodeDriver(CloudStackDriverMixIn, NodeDriver):
         if diskoffering:
             server_params['diskofferingid'] = diskoffering.id
 
-        if ex_key_name:
-            server_params['keypair'] = ex_key_name
+        if ex_keyname:
+            server_params['keypair'] = ex_keyname
 
-        if ex_user_data:
-            ex_user_data = base64.b64encode(b(ex_user_data)).decode('ascii')
-            server_params['userdata'] = ex_user_data
+        if ex_userdata:
+            ex_userdata = base64.b64encode(b(ex_userdata)).decode('ascii')
+            server_params['userdata'] = ex_userdata
 
         if ex_security_groups:
             ex_security_groups = ','.join(ex_security_groups)

--- a/libcloud/compute/drivers/dummy.py
+++ b/libcloud/compute/drivers/dummy.py
@@ -291,7 +291,7 @@ class DummyNodeDriver(NodeDriver):
                          driver=self),
         ]
 
-    def create_node(self, **kwargs):
+    def create_node(self, name, size, image):
         """
         Creates a dummy node; the node id is equal to the number of
         nodes in the node list

--- a/libcloud/compute/drivers/ecp.py
+++ b/libcloud/compute/drivers/ecp.py
@@ -329,7 +329,7 @@ class ECPNodeDriver(NodeDriver):
                              driver=self),
                 ]
 
-    def create_node(self, **kwargs):
+    def create_node(self, name, size, image):
         """
         Creates a virtual machine.
 
@@ -356,9 +356,9 @@ class ECPNodeDriver(NodeDriver):
 
         # Prepare to make the VM
         data = {
-            'name': str(kwargs['name']),
-            'package': str(kwargs['image'].id),
-            'hardware': str(kwargs['size'].id),
+            'name': str(name),
+            'package': str(image.id),
+            'hardware': str(size.id),
             'network_uuid': str(network),
             'disk': ''
         }

--- a/libcloud/compute/drivers/elasticstack.py
+++ b/libcloud/compute/drivers/elasticstack.py
@@ -226,7 +226,8 @@ class ElasticStackBaseNodeDriver(NodeDriver):
 
         return nodes
 
-    def create_node(self, **kwargs):
+    def create_node(self, name, size, image, smp='auto', nic_model='e1000',
+                    vnc_password=None, drive_type='hdd'):
         """Creates an ElasticStack instance
 
         @inherits: :class:`NodeDriver.create_node`
@@ -248,11 +249,7 @@ class ElasticStackBaseNodeDriver(NodeDriver):
                                   no SSH login is possible.
         :type       vnc_password: ``str``
         """
-        size = kwargs['size']
-        image = kwargs['image']
-        smp = kwargs.get('smp', 'auto')
-        nic_model = kwargs.get('nic_model', 'e1000')
-        vnc_password = ssh_password = kwargs.get('vnc_password', None)
+        ssh_password = vnc_password
 
         if nic_model not in ('e1000', 'rtl8139', 'virtio'):
             raise ElasticStackException('Invalid NIC model specified')
@@ -261,8 +258,8 @@ class ElasticStackBaseNodeDriver(NodeDriver):
 
         # First we create a drive with the specified size
         drive_data = {}
-        drive_data.update({'name': kwargs['name'],
-                           'size': '%sG' % (kwargs['size'].disk)})
+        drive_data.update({'name': name,
+                           'size': '%sG' % (size.disk)})
 
         response = self.connection.request(action='/drives/create',
                                            data=json.dumps(drive_data),
@@ -302,7 +299,7 @@ class ElasticStackBaseNodeDriver(NodeDriver):
             time.sleep(1)
 
         node_data = {}
-        node_data.update({'name': kwargs['name'],
+        node_data.update({'name': name,
                           'cpu': size.cpu,
                           'mem': size.ram,
                           'ide:0:0': drive_uuid,

--- a/libcloud/compute/drivers/gandi.py
+++ b/libcloud/compute/drivers/gandi.py
@@ -230,7 +230,8 @@ class GandiNodeDriver(BaseGandiDriver, NodeDriver):
         raise NotImplementedError(
             'deploy_node not implemented for gandi driver')
 
-    def create_node(self, **kwargs):
+    def create_node(self, name, size, image, location=None, login=None,
+                    password=None, inet_family=4, keypairs=None):
         """
         Create a new Gandi node
 
@@ -262,24 +263,22 @@ class GandiNodeDriver(BaseGandiDriver, NodeDriver):
 
         :rtype: :class:`Node`
         """
+        keypairs = keypairs or []
 
-        if not kwargs.get('login') and not kwargs.get('keypairs'):
+        if not login and not keypairs:
             raise GandiException(1020, "Login and password or ssh keypair "
                                  "must be defined for node creation")
 
-        location = kwargs.get('location')
         if location and isinstance(location, NodeLocation):
             dc_id = int(location.id)
         else:
             raise GandiException(
                 1021, 'location must be a subclass of NodeLocation')
 
-        size = kwargs.get('size')
         if not size and not isinstance(size, NodeSize):
             raise GandiException(
                 1022, 'size must be a subclass of NodeSize')
 
-        keypairs = kwargs.get('keypairs', [])
         keypair_ids = [
             k if isinstance(k, int) else k.extra['id']
             for k in keypairs
@@ -289,26 +288,26 @@ class GandiNodeDriver(BaseGandiDriver, NodeDriver):
         instance = INSTANCE_TYPES.get(size.id)
         cores = instance['cpu'] if instance else int(size.id)
 
-        src_disk_id = int(kwargs['image'].id)
+        src_disk_id = int(image.id)
 
         disk_spec = {
             'datacenter_id': dc_id,
-            'name': 'disk_%s' % kwargs['name']
+            'name': 'disk_%s' % name
         }
 
         vm_spec = {
             'datacenter_id': dc_id,
-            'hostname': kwargs['name'],
+            'hostname': name,
             'memory': int(size.ram),
             'cores': cores,
             'bandwidth': int(size.bandwidth),
-            'ip_version': kwargs.get('inet_family', 4),
+            'ip_version': inet_family,
         }
 
-        if kwargs.get('login') and kwargs.get('password'):
+        if login and password:
             vm_spec.update({
-                'login': kwargs['login'],
-                'password': kwargs['password'],  # TODO : use NodeAuthPassword
+                'login': login,
+                'password': password,  # TODO : use NodeAuthPassword
             })
         if keypair_ids:
             vm_spec['keys'] = keypair_ids

--- a/libcloud/compute/drivers/gogrid.py
+++ b/libcloud/compute/drivers/gogrid.py
@@ -254,7 +254,8 @@ class GoGridNodeDriver(BaseGoGridDriver, NodeDriver):
                                     params={'lookup': 'ip.datacenter'}).object)
         return locations
 
-    def ex_create_node_nowait(self, **kwargs):
+    def ex_create_node_nowait(self, name, size, image, location=None,
+                              ex_description=None, ex_ip=None):
         """Don't block until GoGrid allocates id for a node
         but return right away with id == None.
 
@@ -282,17 +283,12 @@ class GoGridNodeDriver(BaseGoGridDriver, NodeDriver):
 
         :rtype: :class:`GoGridNode`
         """
-        name = kwargs['name']
-        image = kwargs['image']
-        size = kwargs['size']
-        try:
-            ip = kwargs['ex_ip']
-        except KeyError:
-            ip = self._get_first_ip(kwargs.get('location'))
+        if not ex_ip:
+            ip = self._get_first_ip(location)
 
         params = {'name': name,
                   'image': image.id,
-                  'description': kwargs.get('ex_description', ''),
+                  'description': ex_description or '',
                   'server.ram': size.id,
                   'ip': ip}
 
@@ -302,7 +298,8 @@ class GoGridNodeDriver(BaseGoGridDriver, NodeDriver):
 
         return node
 
-    def create_node(self, **kwargs):
+    def create_node(self, name, size, image, location=None,
+                    ex_description=None, ex_ip=None):
         """Create a new GoGird node
 
         @inherits: :class:`NodeDriver.create_node`
@@ -316,7 +313,9 @@ class GoGridNodeDriver(BaseGoGridDriver, NodeDriver):
 
         :rtype: :class:`GoGridNode`
         """
-        node = self.ex_create_node_nowait(**kwargs)
+        node = self.ex_create_node_nowait(name=name, size=size, image=image,
+                                          ex_description=ex_description,
+                                          ex_ip=ex_ip)
 
         timeout = 60 * 20
         waittime = 0

--- a/libcloud/compute/drivers/hostvirtual.py
+++ b/libcloud/compute/drivers/hostvirtual.py
@@ -126,7 +126,7 @@ class HostVirtualNodeDriver(NodeDriver):
             images.append(i)
         return images
 
-    def create_node(self, name, image, size, **kwargs):
+    def create_node(self, name, image, size, location=None, auth=None):
         """
         Creates a node
 
@@ -148,7 +148,7 @@ class HostVirtualNodeDriver(NodeDriver):
 
         dc = None
 
-        auth = self._get_and_check_auth(kwargs.get('auth'))
+        auth = self._get_and_check_auth(auth)
 
         if not self._is_valid_fqdn(name):
             raise HostVirtualException(
@@ -157,8 +157,8 @@ class HostVirtualNodeDriver(NodeDriver):
         # simply order a package first
         pkg = self.ex_order_package(size)
 
-        if 'location' in kwargs:
-            dc = kwargs['location'].id
+        if location:
+            dc = location.id
         else:
             dc = DEFAULT_NODE_LOCATION_ID
 

--- a/libcloud/compute/drivers/joyent.py
+++ b/libcloud/compute/drivers/joyent.py
@@ -167,11 +167,7 @@ class JoyentNodeDriver(NodeDriver):
                                          method='DELETE')
         return result.status == httplib.NO_CONTENT
 
-    def create_node(self, **kwargs):
-        name = kwargs['name']
-        size = kwargs['size']
-        image = kwargs['image']
-
+    def create_node(self, name, size, image):
         data = json.dumps({'name': name, 'package': size.id,
                            'dataset': image.id})
         result = self.connection.request('/my/machines', data=data,

--- a/libcloud/compute/drivers/ktucloud.py
+++ b/libcloud/compute/drivers/ktucloud.py
@@ -66,17 +66,17 @@ class KTUCloudNodeDriver(CloudStackNodeDriver):
             )
         return sizes
 
-    def create_node(self, name, size, image, location=None, **kwargs):
+    def create_node(self, name, size, image, location=None,
+                    ex_usageplantype='hourly'):
         params = {'displayname': name,
                   'serviceofferingid': image.id,
                   'templateid': str(image.extra['templateid']),
                   'zoneid': str(image.extra['zoneid'])}
 
-        usageplantype = kwargs.pop('usageplantype', None)
-        if usageplantype is None:
+        if ex_usageplantype is None:
             params['usageplantype'] = 'hourly'
         else:
-            params['usageplantype'] = usageplantype
+            params['usageplantype'] = ex_usageplantype
 
         if size.id != self.EMPTY_DISKOFFERINGID:
             params['diskofferingid'] = size.id

--- a/libcloud/compute/drivers/linode.py
+++ b/libcloud/compute/drivers/linode.py
@@ -175,8 +175,8 @@ class LinodeNodeDriver(NodeDriver):
 
     def create_node(self, name, image, size, auth, location=None, ex_swap=None,
                     ex_rsize=None, ex_kernel=None, ex_payment=None,
-                    ex_comment=None, ex_private=False, lconfig=None, lroot=None,
-                    lswap=None):
+                    ex_comment=None, ex_private=False, lconfig=None,
+                    lroot=None, lswap=None):
         """Create a new Linode, deploy a Linux distribution, and boot
 
         This call abstracts much of the functionality of provisioning a Linode
@@ -270,7 +270,7 @@ class LinodeNodeDriver(NodeDriver):
 
         # Swap size
         try:
-            swap = 128 if not ex_swap else int(kwargs["ex_swap"])
+            swap = 128 if not ex_swap else int(ex_swap)
         except Exception:
             raise LinodeException(0xFB, "Need an integer swap size")
 

--- a/libcloud/compute/drivers/linode.py
+++ b/libcloud/compute/drivers/linode.py
@@ -173,7 +173,10 @@ class LinodeNodeDriver(NodeDriver):
         self.connection.request(API_ROOT, params=params)
         return True
 
-    def create_node(self, **kwargs):
+    def create_node(self, name, image, size, auth, location=None, ex_swap=None,
+                    ex_rsize=None, ex_kernel=None, ex_payment=None,
+                    ex_comment=None, ex_private=False, lconfig=None, lroot=None,
+                    lswap=None):
         """Create a new Linode, deploy a Linux distribution, and boot
 
         This call abstracts much of the functionality of provisioning a Linode
@@ -228,14 +231,11 @@ class LinodeNodeDriver(NodeDriver):
         :return: Node representing the newly-created Linode
         :rtype: :class:`Node`
         """
-        name = kwargs["name"]
-        image = kwargs["image"]
-        size = kwargs["size"]
-        auth = self._get_and_check_auth(kwargs["auth"])
+        auth = self._get_and_check_auth(auth)
 
         # Pick a location (resolves LIBCLOUD-41 in JIRA)
-        if "location" in kwargs:
-            chosen = kwargs["location"].id
+        if location:
+            chosen = location.id
         elif self.datacenter:
             chosen = self.datacenter
         else:
@@ -251,8 +251,7 @@ class LinodeNodeDriver(NodeDriver):
             raise LinodeException(0xFB, "Invalid plan ID -- avail.plans")
 
         # Payment schedule
-        payment = "1" if "ex_payment" not in kwargs else \
-            str(kwargs["ex_payment"])
+        payment = "1" if not ex_payment else str(ex_payment)
         if payment not in ["1", "12", "24"]:
             raise LinodeException(0xFB, "Invalid subscription (1, 12, 24)")
 
@@ -271,13 +270,13 @@ class LinodeNodeDriver(NodeDriver):
 
         # Swap size
         try:
-            swap = 128 if "ex_swap" not in kwargs else int(kwargs["ex_swap"])
+            swap = 128 if not ex_swap else int(kwargs["ex_swap"])
         except Exception:
             raise LinodeException(0xFB, "Need an integer swap size")
 
         # Root partition size
-        imagesize = (size.disk - swap) if "ex_rsize" not in kwargs else\
-            int(kwargs["ex_rsize"])
+        imagesize = (size.disk - swap) if not ex_rsize else\
+            int(ex_rsize)
         if (imagesize + swap) > size.disk:
             raise LinodeException(0xFB, "Total disk images are too big")
 
@@ -288,8 +287,8 @@ class LinodeNodeDriver(NodeDriver):
                                   "Invalid distro -- avail.distributions")
 
         # Kernel
-        if "ex_kernel" in kwargs:
-            kernel = kwargs["ex_kernel"]
+        if ex_kernel:
+            kernel = ex_kernel
         else:
             if image.extra['64bit']:
                 # For a list of available kernel ids, see
@@ -303,8 +302,8 @@ class LinodeNodeDriver(NodeDriver):
             raise LinodeException(0xFB, "Invalid kernel -- avail.kernels")
 
         # Comments
-        comments = "Created by Apache libcloud <http://www.libcloud.org>" if\
-            "ex_comment" not in kwargs else kwargs["ex_comment"]
+        comments = "Created by Apache libcloud <https://www.libcloud.org>" if\
+            not ex_comment else ex_comment
 
         # Step 1: linode.create
         params = {
@@ -325,7 +324,7 @@ class LinodeNodeDriver(NodeDriver):
         self.connection.request(API_ROOT, params=params)
 
         # Step 1c. linode.ip.addprivate if it was requested
-        if "ex_private" in kwargs and kwargs["ex_private"]:
+        if ex_private:
             params = {
                 "api_action": "linode.ip.addprivate",
                 "LinodeID": linode["id"]
@@ -340,9 +339,15 @@ class LinodeNodeDriver(NodeDriver):
             "lroot": "[%s] %s Disk Image" % (linode["id"], image.name),
             "lswap": "[%s] Swap Space" % linode["id"]
         }
-        for what in ["lconfig", "lroot", "lswap"]:
-            if what in kwargs:
-                label[what] = kwargs[what]
+
+        if lconfig:
+            label['lconfig'] = lconfig
+
+        if lroot:
+            label['lroot'] = lroot
+
+        if lswap:
+            label['lswap'] = lswap
 
         # Step 2: linode.disk.createfromdistribution
         if not root:
@@ -382,7 +387,7 @@ class LinodeNodeDriver(NodeDriver):
             "Comments": comments,
             "DiskList": disks
         }
-        if "ex_private" in kwargs and kwargs["ex_private"]:
+        if ex_private:
             params['helper_network'] = True
             params['helper_distro'] = True
 

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -900,7 +900,7 @@ class OpenStack_1_0_NodeDriver(OpenStackNodeDriver):
         return self._to_ip_addresses(resp.object)
 
     def _metadata_to_xml(self, metadata):
-        if len(metadata) == 0:
+        if not metadata:
             return None
 
         metadata_elm = ET.Element('metadata')
@@ -911,7 +911,7 @@ class OpenStack_1_0_NodeDriver(OpenStackNodeDriver):
         return metadata_elm
 
     def _files_to_xml(self, files):
-        if len(files) == 0:
+        if not files:
             return None
 
         personality_elm = ET.Element('personality')
@@ -919,7 +919,7 @@ class OpenStack_1_0_NodeDriver(OpenStackNodeDriver):
             file_elm = ET.SubElement(personality_elm,
                                      'file',
                                      {'path': str(k)})
-            file_elm.text = base64.b64encode(b(v))
+            file_elm.text = base64.b64encode(b(v)).decode('ascii')
 
         return personality_elm
 
@@ -1488,58 +1488,58 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
     def _create_args_to_params(self, node, **kwargs):
         server_params = {
             'name': kwargs.get('name'),
-            'metadata': kwargs.get('ex_metadata', {}),
+            'metadata': kwargs.get('ex_metadata', {}) or {},
             'personality': self._files_to_personality(kwargs.get("ex_files",
-                                                                 {}))
+                                                                 {}) or {})
         }
 
-        if 'ex_availability_zone' in kwargs:
+        if kwargs.get('ex_availability_zone', None):
             server_params['availability_zone'] = kwargs['ex_availability_zone']
 
-        if 'ex_keyname' in kwargs:
+        if kwargs.get('ex_keyname', None):
             server_params['key_name'] = kwargs['ex_keyname']
 
-        if 'ex_userdata' in kwargs:
+        if kwargs.get('ex_userdata', None):
             server_params['user_data'] = base64.b64encode(
                 b(kwargs['ex_userdata'])).decode('ascii')
 
-        if 'ex_disk_config' in kwargs:
+        if kwargs.get('ex_disk_config', None):
             server_params['OS-DCF:diskConfig'] = kwargs['ex_disk_config']
 
-        if 'ex_config_drive' in kwargs:
+        if kwargs.get('ex_config_drive', None):
             server_params['config_drive'] = str(kwargs['ex_config_drive'])
 
-        if 'ex_admin_pass' in kwargs:
+        if kwargs.get('ex_admin_pass', None):
             server_params['adminPass'] = kwargs['ex_admin_pass']
 
-        if 'networks' in kwargs:
-            networks = kwargs['networks']
+        if kwargs.get('networks', None):
+            networks = kwargs['networks'] or []
             networks = [{'uuid': network.id} for network in networks]
             server_params['networks'] = networks
 
-        if 'ex_security_groups' in kwargs:
+        if kwargs.get('ex_security_groups', None):
             server_params['security_groups'] = []
-            for security_group in kwargs['ex_security_groups']:
+            for security_group in kwargs['ex_security_groups'] or []:
                 name = security_group.name
                 server_params['security_groups'].append({'name': name})
 
-        if 'ex_blockdevicemappings' in kwargs:
+        if kwargs.get('ex_blockdevicemappings', None):
             server_params['block_device_mapping_v2'] = \
                 kwargs['ex_blockdevicemappings']
 
-        if 'name' in kwargs:
+        if kwargs.get('name', None):
             server_params['name'] = kwargs.get('name')
         else:
             server_params['name'] = node.name
 
-        if 'image' in kwargs and kwargs['image']:
+        if kwargs.get('image', None):
             server_params['imageRef'] = kwargs.get('image').id
         else:
             server_params['imageRef'] = node.extra.get(
                 'imageId', ''
             ) if node else ''
 
-        if 'size' in kwargs:
+        if kwargs.get('size', None):
             server_params['flavorRef'] = kwargs.get('size').id
         else:
             server_params['flavorRef'] = node.extra.get('flavorId')

--- a/libcloud/compute/drivers/rimuhosting.py
+++ b/libcloud/compute/drivers/rimuhosting.py
@@ -222,7 +222,11 @@ class RimuHostingNodeDriver(NodeDriver):
         # XXX check that the response was actually successful
         return True
 
-    def create_node(self, **kwargs):
+    def create_node(self, name, size, image, auth=None, ex_billing_oid=None,
+                    ex_host_server_oid=None, ex_vps_order_oid_to_clone=None,
+                    ex_num_ips=1, ex_extra_ip_reason=None, ex_memory_mb=None,
+                    ex_disk_space_mb=None, ex_disk_space_2_mb=None,
+                    ex_control_panel=None):
         """Creates a RimuHosting instance
 
         @inherits: :class:`NodeDriver.create_node`
@@ -263,10 +267,6 @@ class RimuHostingNodeDriver(NodeDriver):
         """
         # Note we don't do much error checking in this because we
         # expect the API to error out if there is a problem.
-        name = kwargs['name']
-        image = kwargs['image']
-        size = kwargs['size']
-
         data = {
             'instantiation_options': {
                 'domain_name': name,
@@ -276,45 +276,41 @@ class RimuHostingNodeDriver(NodeDriver):
             'vps_parameters': {}
         }
 
-        if 'ex_control_panel' in kwargs:
+        if ex_control_panel:
             data['instantiation_options']['control_panel'] = \
-                kwargs['ex_control_panel']
+                ex_control_panel
 
-        auth = self._get_and_check_auth(kwargs.get('auth'))
+        auth = self._get_and_check_auth(auth)
         data['instantiation_options']['password'] = auth.password
 
-        if 'ex_billing_oid' in kwargs:
+        if ex_billing_oid:
             # TODO check for valid oid.
-            data['billing_oid'] = kwargs['ex_billing_oid']
+            data['billing_oid'] = ex_billing_oid
 
-        if 'ex_host_server_oid' in kwargs:
-            data['host_server_oid'] = kwargs['ex_host_server_oid']
+        if ex_host_server_oid:
+            data['host_server_oid'] = ex_host_server_oid
 
-        if 'ex_vps_order_oid_to_clone' in kwargs:
-            data['vps_order_oid_to_clone'] = \
-                kwargs['ex_vps_order_oid_to_clone']
+        if ex_vps_order_oid_to_clone:
+            data['vps_order_oid_to_clone'] = ex_vps_order_oid_to_clone
 
-        if 'ex_num_ips' in kwargs and int(kwargs['ex_num_ips']) > 1:
-            if 'ex_extra_ip_reason' not in kwargs:
+        if ex_num_ips and int(ex_num_ips) > 1:
+            if not ex_extra_ip_reason:
                 raise RimuHostingException(
                     'Need an reason for having an extra IP')
             else:
                 if 'ip_request' not in data:
                     data['ip_request'] = {}
-                data['ip_request']['num_ips'] = int(kwargs['ex_num_ips'])
-                data['ip_request']['extra_ip_reason'] = \
-                    kwargs['ex_extra_ip_reason']
+                data['ip_request']['num_ips'] = int('ex_num_ips')
+                data['ip_request']['extra_ip_reason'] = ex_extra_ip_reason
 
-        if 'ex_memory_mb' in kwargs:
-            data['vps_parameters']['memory_mb'] = kwargs['ex_memory_mb']
+        if ex_memory_mb:
+            data['vps_parameters']['memory_mb'] = ex_memory_mb
 
-        if 'ex_disk_space_mb' in kwargs:
-            data['vps_parameters']['disk_space_mb'] = \
-                kwargs['ex_disk_space_mb']
+        if ex_disk_space_mb:
+            data['vps_parameters']['disk_space_mb'] = ex_disk_space_mb
 
-        if 'ex_disk_space_2_mb' in kwargs:
-            data['vps_parameters']['disk_space_2_mb'] =\
-                kwargs['ex_disk_space_2_mb']
+        if ex_disk_space_2_mb:
+            data['vps_parameters']['disk_space_2_mb'] = ex_disk_space_2_mb
 
         # Don't send empty 'vps_parameters' attribute
         if not data['vps_parameters']:

--- a/libcloud/compute/drivers/softlayer.py
+++ b/libcloud/compute/drivers/softlayer.py
@@ -269,7 +269,11 @@ class SoftLayerNodeDriver(NodeDriver):
 
         raise SoftLayerException('Timeout on getting node details')
 
-    def create_node(self, **kwargs):
+    def create_node(self, name, size=None, image=None, location=None,
+                    ex_domain=None, ex_cpus=None,
+                    ex_disk=None, ex_ram=None, ex_bandwidth=None,
+                    ex_local_disk=None, ex_datacenter=None, ex_os=None,
+                    ex_keyname=None, ex_hourly=True):
         """Create a new SoftLayer node
 
         @inherits: :class:`NodeDriver.create_node`
@@ -293,46 +297,45 @@ class SoftLayerNodeDriver(NodeDriver):
         :keyword    ex_keyname: The name of the key pair
         :type       ex_keyname: ``str``
         """
-        name = kwargs['name']
         os = 'DEBIAN_LATEST'
-        if 'ex_os' in kwargs:
-            os = kwargs['ex_os']
-        elif 'image' in kwargs:
-            os = kwargs['image'].id
+        if ex_os:
+            os = ex_os
+        elif image:
+            os = image.id
 
-        size = kwargs.get('size', NodeSize(id=123, name='Custom', ram=None,
-                                           disk=None, bandwidth=None,
-                                           price=None,
-                                           driver=self.connection.driver))
+        size = size or NodeSize(id=123, name='Custom', ram=None,
+                                disk=None, bandwidth=None,
+                                price=None,
+                                driver=self.connection.driver)
         ex_size_data = SL_TEMPLATES.get(int(size.id)) or {}
         # plan keys are ints
-        cpu_count = kwargs.get('ex_cpus') or ex_size_data.get('cpus') or \
+        cpu_count = ex_cpus or ex_size_data.get('cpus') or \
             DEFAULT_CPU_SIZE
-        ram = kwargs.get('ex_ram') or ex_size_data.get('ram') or \
+        ram = ex_ram or ex_size_data.get('ram') or \
             DEFAULT_RAM_SIZE
-        bandwidth = kwargs.get('ex_bandwidth') or size.bandwidth or 10
-        hourly = kwargs.get('ex_hourly', True)
+        bandwidth = ex_bandwidth or size.bandwidth or 10
+        hourly = ex_hourly
 
         local_disk = 'true'
         if ex_size_data.get('local_disk') is False:
             local_disk = 'false'
 
-        if kwargs.get('ex_local_disk') is False:
+        if ex_local_disk is False:
             local_disk = 'false'
 
         disk_size = DEFAULT_DISK_SIZE
         if size.disk:
             disk_size = size.disk
-        if kwargs.get('ex_disk'):
-            disk_size = kwargs.get('ex_disk')
+        if ex_disk:
+            disk_size = ex_disk
 
         datacenter = ''
-        if 'ex_datacenter' in kwargs:
-            datacenter = kwargs['ex_datacenter']
-        elif 'location' in kwargs:
-            datacenter = kwargs['location'].id
+        if ex_datacenter:
+            datacenter = ex_datacenter
+        elif location:
+            datacenter = location.id
 
-        domain = kwargs.get('ex_domain')
+        domain = ex_domain
         if domain is None:
             if name.find('.') != -1:
                 domain = name[name.find('.') + 1:]
@@ -364,10 +367,10 @@ class SoftLayerNodeDriver(NodeDriver):
         if datacenter:
             newCCI['datacenter'] = {'name': datacenter}
 
-        if 'ex_keyname' in kwargs:
+        if ex_keyname:
             newCCI['sshKeys'] = [
                 {
-                    'id': self._key_name_to_id(kwargs['ex_keyname'])
+                    'id': self._key_name_to_id(ex_keyname)
                 }
             ]
 

--- a/libcloud/compute/drivers/upcloud.py
+++ b/libcloud/compute/drivers/upcloud.py
@@ -136,7 +136,8 @@ class UpcloudDriver(NodeDriver):
         obj['storages']['storage'].extend(storage)
         return self._to_node_images(obj['storages']['storage'])
 
-    def create_node(self, name, size, image, location, auth=None, **kwargs):
+    def create_node(self, name, size, image, location, auth=None,
+                    ex_hostname='localhost', ex_username='root'):
         """
         Creates instance to upcloud.
 
@@ -172,7 +173,8 @@ class UpcloudDriver(NodeDriver):
         """
         body = UpcloudCreateNodeRequestBody(name=name, size=size, image=image,
                                             location=location, auth=auth,
-                                            **kwargs)
+                                            ex_hostname=ex_hostname,
+                                            ex_username=ex_username)
         response = self.connection.request('1.2/server',
                                            method='POST',
                                            data=body.to_json())

--- a/libcloud/compute/drivers/vcl.py
+++ b/libcloud/compute/drivers/vcl.py
@@ -105,7 +105,7 @@ class VCLNodeDriver(NodeDriver):
             raise LibcloudError(res['errormsg'], driver=self)
         return res
 
-    def create_node(self, **kwargs):
+    def create_node(self, image, start=None, length='60'):
         """Create a new VCL reservation
         size and name ignored, image is the id from list_image
 
@@ -121,12 +121,10 @@ class VCLNodeDriver(NodeDriver):
         :type       length: ``str``
         """
 
-        image = kwargs["image"]
-
         # Special case for xmlrpclib not handling 64 bit integers when writting
         # XML - we always  cast value to string.
-        start = str(kwargs.get('start', str(time.time())))
-        length = kwargs.get('length', '60')
+        start = start or str(time.time())
+        length = length or '60'
 
         res = self._vcl_request(
             "XMLRPCaddRequest",

--- a/libcloud/compute/drivers/voxel.py
+++ b/libcloud/compute/drivers/voxel.py
@@ -159,7 +159,9 @@ class VoxelNodeDriver(NodeDriver):
         result = self.connection.request('/', params=params).object
         return self._to_images(result)
 
-    def create_node(self, **kwargs):
+    def create_node(self, name, size, image, location, ex_privateip=None,
+                    ex_publicip=None, ex_rootpass=None, ex_consolepass=None,
+                    ex_sshuser=None, ex_sshpass=None, ex_voxel_access=None):
         """Create Voxel Node
 
         :keyword name: the name to assign the node (mandatory)
@@ -206,28 +208,27 @@ class VoxelNodeDriver(NodeDriver):
         """
 
         # assert that disk > 0
-        if not kwargs["size"].disk:
+        if not size.disk:
             raise ValueError("size.disk must be non-zero")
 
         # convert voxel_access to string boolean if needed
-        voxel_access = kwargs.get("ex_voxel_access", None)
-        if voxel_access is not None:
-            voxel_access = "true" if voxel_access else "false"
+        if ex_voxel_access is not None:
+            ex_voxel_access = "true" if ex_voxel_access else "false"
 
         params = {
             'method': 'voxel.voxcloud.create',
-            'hostname': kwargs["name"],
-            'disk_size': int(kwargs["size"].disk),
-            'facility': kwargs["location"].id,
-            'image_id': kwargs["image"].id,
-            'processing_cores': kwargs["size"].ram / RAM_PER_CPU,
-            'backend_ip': kwargs.get("ex_privateip", None),
-            'frontend_ip': kwargs.get("ex_publicip", None),
-            'admin_password': kwargs.get("ex_rootpass", None),
-            'console_password': kwargs.get("ex_consolepass", None),
-            'ssh_username': kwargs.get("ex_sshuser", None),
-            'ssh_password': kwargs.get("ex_sshpass", None),
-            'voxel_access': voxel_access,
+            'hostname': name,
+            'disk_size': int(size.disk),
+            'facility': location.id,
+            'image_id': image.id,
+            'processing_cores': size.ram / RAM_PER_CPU,
+            'backend_ip': ex_privateip,
+            'frontend_ip': ex_publicip,
+            'admin_password': ex_rootpass,
+            'console_password': ex_consolepass,
+            'ssh_username': ex_sshuser,
+            'ssh_password': ex_sshpass,
+            'voxel_access': ex_voxel_access,
         }
 
         object = self.connection.request('/', params=params).object
@@ -235,10 +236,10 @@ class VoxelNodeDriver(NodeDriver):
         if self._getstatus(object):
             return Node(
                 id=object.findtext("device/id"),
-                name=kwargs["name"],
+                name=name,
                 state=NODE_STATE_MAP[object.findtext("device/status")],
-                public_ips=kwargs.get("publicip", None),
-                private_ips=kwargs.get("privateip", None),
+                public_ips=ex_publicip,
+                private_ips=ex_privateip,
                 driver=self.connection.driver
             )
         else:

--- a/libcloud/compute/drivers/vpsnet.py
+++ b/libcloud/compute/drivers/vpsnet.py
@@ -125,7 +125,8 @@ class VPSNetNodeDriver(NodeDriver):
         single_node_price = self._get_size_price(size_id='1')
         return num * single_node_price
 
-    def create_node(self, name, image, size, **kwargs):
+    def create_node(self, name, image, size, ex_backups_enabled=False,
+                    ex_fqdn=None):
         """Create a new VPS.net node
 
         @inherits: :class:`NodeDriver.create_node`
@@ -136,12 +137,13 @@ class VPSNetNodeDriver(NodeDriver):
         :keyword    ex_fqdn:   Fully Qualified domain of the node
         :type       ex_fqdn:   ``str``
         """
+        ex_backups_enabled = 1 if ex_backups_enabled else 0
         headers = {'Content-Type': 'application/json'}
         request = {'virtual_machine':
                    {'label': name,
-                    'fqdn': kwargs.get('ex_fqdn', ''),
+                    'fqdn': ex_fqdn or '',
                     'system_template_id': image.id,
-                    'backups_enabled': kwargs.get('ex_backups_enabled', 0),
+                    'backups_enabled': ex_backups_enabled,
                     'slices_required': size.id}}
 
         res = self.connection.request('/virtual_machines.%s' % (API_VERSION,),

--- a/libcloud/test/compute/test_abiquo.py
+++ b/libcloud/test/compute/test_abiquo.py
@@ -90,7 +90,7 @@ class AbiquoNodeDriverTest(TestCaseMixin, unittest.TestCase):
         Test the 'create_node' function without 'image' parameter raises
         an Exception
         """
-        self.assertRaises(LibcloudError, self.driver.create_node)
+        self.assertRaises(TypeError, self.driver.create_node)
 
     def test_list_locations_response(self):
         if not self.should_list_locations:
@@ -135,7 +135,7 @@ class AbiquoNodeDriverTest(TestCaseMixin, unittest.TestCase):
         Test 'create_node' into a concrete group.
         """
         image = self.driver.list_images()[0]
-        self.driver.create_node(image=image, group_name='new_group_name')
+        self.driver.create_node(image=image, ex_group_name='new_group_name')
 
     def test_create_group_location_does_not_exist(self):
         """

--- a/libcloud/test/compute/test_deployment.py
+++ b/libcloud/test/compute/test_deployment.py
@@ -29,6 +29,8 @@ from libcloud.compute.deployment import MultiStepDeployment, Deployment
 from libcloud.compute.deployment import SSHKeyDeployment, ScriptDeployment
 from libcloud.compute.deployment import ScriptFileDeployment, FileDeployment
 from libcloud.compute.base import Node
+from libcloud.compute.base import DEPLOY_NODE_KWARGS
+from libcloud.compute.base import NodeAuthPassword
 from libcloud.compute.types import NodeState, DeploymentError, LibcloudError
 from libcloud.compute.ssh import BaseSSHClient
 from libcloud.compute.drivers.rackspace import RackspaceFirstGenNodeDriver as Rackspace
@@ -386,6 +388,85 @@ class DeploymentTests(unittest.TestCase):
 
         node = self.driver.deploy_node(deploy=deploy)
         self.assertEqual(self.node.id, node.id)
+
+    @patch('libcloud.compute.base.SSHClient')
+    @patch('libcloud.compute.ssh')
+    def test_deploy_node_deploy_node_kwargs_except_auth_are_not_propagated_on(self, mock_ssh_module, _):
+        # Verify that keyword arguments which are specific to deploy_node()
+        # are not propagated to create_node()
+        mock_ssh_module.have_paramiko = True
+        self.driver.create_node = Mock()
+        self.driver.create_node.return_value = self.node
+        self.driver._connect_and_run_deployment_script = Mock()
+        self.driver._wait_until_running = Mock()
+
+        kwargs = {}
+        for key in DEPLOY_NODE_KWARGS:
+            kwargs[key] = key
+
+        kwargs['ssh_interface'] = 'public_ips'
+        kwargs['ssh_alternate_usernames'] = ['foo', 'bar']
+        kwargs['timeout'] = 10
+
+        auth = NodeAuthPassword('P@$$w0rd')
+
+        node = self.driver.deploy_node(name='name', image='image', size='size',
+                                       auth=auth, ex_foo='ex_foo', **kwargs)
+        self.assertEqual(self.node.id, node.id)
+        self.assertEqual(self.driver.create_node.call_count, 1)
+
+        call_kwargs = self.driver.create_node.call_args_list[0][1]
+        expected_call_kwargs = {
+            'name': 'name',
+            'image': 'image',
+            'size': 'size',
+            'auth': auth,
+            'ex_foo': 'ex_foo'
+        }
+        self.assertEqual(expected_call_kwargs, call_kwargs)
+
+        # If driver throws an exception it should fall back to passing in all
+        # the arguments
+        global call_count
+        call_count = 0
+        def create_node(name, image, size, ex_custom_arg_1, ex_custom_arg_2,
+                        ex_foo=None, auth=None, **kwargs):
+            global call_count
+
+            call_count += 1
+            if call_count == 1:
+                msg = 'create_node() takes at least 5 arguments (7 given)'
+                raise TypeError(msg)
+            return self.node
+
+        self.driver.create_node = create_node
+
+        node = self.driver.deploy_node(name='name', image='image', size='size',
+                                       auth=auth, ex_foo='ex_foo', ex_custom_arg_1='a',
+                                       ex_custom_arg_2='b', **kwargs)
+        self.assertEqual(self.node.id, node.id)
+        self.assertEqual(call_count, 2)
+
+        global call_count
+        call_count = 0
+        def create_node(name, image, size, ex_custom_arg_1, ex_custom_arg_2,
+                        ex_foo=None, auth=None, **kwargs):
+            global call_count
+
+            call_count += 1
+            if call_count == 1:
+                msg = 'create_node() missing 3 required positional arguments'
+                raise TypeError(msg)
+            return self.node
+
+        self.driver.create_node = create_node
+
+        node = self.driver.deploy_node(name='name', image='image', size='size',
+                                       auth=auth, ex_foo='ex_foo', ex_custom_arg_1='a',
+                                       ex_custom_arg_2='b', **kwargs)
+        self.assertEqual(self.node.id, node.id)
+        self.assertEqual(call_count, 2)
+
 
     @patch('libcloud.compute.base.SSHClient')
     @patch('libcloud.compute.ssh')

--- a/libcloud/test/compute/test_deployment.py
+++ b/libcloud/test/compute/test_deployment.py
@@ -447,7 +447,6 @@ class DeploymentTests(unittest.TestCase):
         self.assertEqual(self.node.id, node.id)
         self.assertEqual(call_count, 2)
 
-        global call_count
         call_count = 0
         def create_node(name, image, size, ex_custom_arg_1, ex_custom_arg_2,
                         ex_foo=None, auth=None, **kwargs):

--- a/libcloud/test/compute/test_deployment.py
+++ b/libcloud/test/compute/test_deployment.py
@@ -29,7 +29,6 @@ from libcloud.compute.deployment import MultiStepDeployment, Deployment
 from libcloud.compute.deployment import SSHKeyDeployment, ScriptDeployment
 from libcloud.compute.deployment import ScriptFileDeployment, FileDeployment
 from libcloud.compute.base import Node
-from libcloud.compute.base import DEPLOY_NODE_KWARGS
 from libcloud.compute.base import NodeAuthPassword
 from libcloud.compute.types import NodeState, DeploymentError, LibcloudError
 from libcloud.compute.ssh import BaseSSHClient
@@ -40,6 +39,12 @@ from libcloud.test.file_fixtures import ComputeFileFixtures
 from mock import Mock, patch
 
 from libcloud.test.secrets import RACKSPACE_PARAMS
+
+# Keyword arguments which are specific to deploy_node() method, but not
+# create_node()
+DEPLOY_NODE_KWARGS = ['deploy', 'ssh_username', 'ssh_alternate_usernames',
+                      'ssh_port', 'ssh_timeout', 'ssh_key', 'timeout',
+                      'max_tries', 'ssh_interface']
 
 
 class MockDeployment(Deployment):

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -456,9 +456,9 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
         node1 = self.driver.create_node(name='foo', image=image, size=size)
         EC2MockHttp.type = 'ex_iam_profile'
         node2 = self.driver.create_node(name='bar', image=image, size=size,
-                                        ex_iam_profile=iamProfile['name'])
+                                        ex_iamprofile=iamProfile['name'])
         node3 = self.driver.create_node(name='bar', image=image, size=size,
-                                        ex_iam_profile=iamProfile['arn'])
+                                        ex_iamprofile=iamProfile['arn'])
 
         self.assertFalse(node1.extra['iam_profile'])
         self.assertEqual(node2.extra['iam_profile'], iamProfile['id'])
@@ -1991,6 +1991,18 @@ class OutscaleTests(EC2Tests):
         self.assertTrue('m1.small' in ids)
         self.assertTrue('m1.large' in ids)
         self.assertTrue('m1.xlarge' in ids)
+
+    def test_ex_create_node_with_ex_iam_profile(self):
+        image = NodeImage(id='ami-be3adfd7',
+                          name=self.image_name,
+                          driver=self.driver)
+        size = NodeSize('m1.small', 'Small Instance', None, None, None, None,
+                        driver=self.driver)
+
+        self.assertRaises(NotImplementedError, self.driver.create_node,
+                          name='foo',
+                          image=image, size=size,
+                          ex_iamprofile='foo')
 
 
 class FCUMockHttp(EC2MockHttp):

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -314,7 +314,7 @@ class OpenStack_1_0_Tests(TestCaseMixin, unittest.TestCase):
         metadata = {'a': 'b', 'c': 'd'}
         files = {'/file1': 'content1', '/file2': 'content2'}
         node = self.driver.create_node(name='racktest', image=image, size=size,
-                                       metadata=metadata, files=files)
+                                       ex_metadata=metadata, ex_files=files)
         self.assertEqual(node.name, 'racktest')
         self.assertEqual(node.extra.get('password'), 'racktestvJq7d3')
         self.assertEqual(node.extra.get('metadata'), metadata)
@@ -950,7 +950,7 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
         size = NodeSize(
             1, '256 slice', None, None, None, None, driver=self.driver)
         node = self.driver.create_node(name='racktest', image=image, size=size,
-                                       availability_zone='testaz')
+                                       ex_availability_zone='testaz')
         self.assertEqual(node.id, '26f7fbee-8ce1-4c28-887a-bfe8e4bb10fe')
         self.assertEqual(node.name, 'racktest')
         self.assertEqual(node.extra['password'], 'racktestvJq7d3')

--- a/libcloud/test/compute/test_softlayer.py
+++ b/libcloud/test/compute/test_softlayer.py
@@ -157,7 +157,7 @@ class SoftLayerTests(unittest.TestCase):
                                 ex_cpus=2,
                                 ex_ram=2048,
                                 ex_disk=100,
-                                ex_key='test1',
+                                ex_keyname='test1',
                                 ex_bandwidth=10,
                                 ex_local_disk=False,
                                 ex_datacenter='Dal05',

--- a/libcloud/test/compute/test_vcloud.py
+++ b/libcloud/test/compute/test_vcloud.py
@@ -94,9 +94,9 @@ class TerremarkTests(unittest.TestCase, TestCaseMixin):
             name='testerpart2',
             image=image,
             size=size,
-            vdc='https://services.vcloudexpress.terremark.com/api/v0.8/vdc/224',
-            network='https://services.vcloudexpress.terremark.com/api/v0.8/network/725',
-            cpus=2,
+            ex_vdc='https://services.vcloudexpress.terremark.com/api/v0.8/vdc/224',
+            ex_network='https://services.vcloudexpress.terremark.com/api/v0.8/network/725',
+            ex_cpus=2,
         )
         self.assertTrue(isinstance(node, Node))
         self.assertEqual(

--- a/libcloud/test/compute/test_voxel.py
+++ b/libcloud/test/compute/test_voxel.py
@@ -109,7 +109,7 @@ class VoxelTest(unittest.TestCase):
         self.assertEqual(node.id, '1234')
 
         node = self.driver.create_node(name='foo', image=image, size=size,
-                                       location=location, voxel_access=True)
+                                       location=location, ex_voxel_access=True)
         self.assertEqual(node.id, '1234')
 
     def test_reboot_node(self):

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
     pyopenssl
     lockfile
     libvirt-python==5.9.0
-    py2.7: paramiko
+    py2.7: paramiko==2.7.1
     py3.7: setuptools==42.0.1
     py3.8: setuptools==42.0.1
 commands = cp libcloud/test/secrets.py-dist libcloud/test/secrets.py
@@ -117,7 +117,7 @@ deps = -r{toxinidir}/requirements-tests.txt
        backports.ssl_match_hostname
        bottle
        lockfile
-       paramiko
+       paramiko==2.7.1
        pysphere
 setenv =
     PYTHONPATH={toxinidir}
@@ -163,7 +163,7 @@ commands = python -m integration
 [testenv:coverage]
 deps =
     -r{toxinidir}/requirements-tests.txt
-    paramiko
+    paramiko==2.7.1
     pyopenssl
     python-dateutil
     libvirt-python==5.9.0
@@ -176,7 +176,7 @@ commands = cp libcloud/test/secrets.py-dist libcloud/test/secrets.py
 passenv = TOXENV CI TRAVIS TRAVIS_*
 deps =
     -r{toxinidir}/requirements-tests.txt
-    paramiko
+    paramiko==2.7.1
     pyopenssl
     libvirt-python==5.9.0
     lockfile


### PR DESCRIPTION
This pull request tries to mitigate / resolve an issue with legacy code / kwargs abuse brought up in #1383.

## Description, Background

Currently a lot of ``create_node()`` method signatures use ``**kwargs`` instead of regular positional + keyword arguments.

That's bad for many reasons (makes code introspection hard / impossible, bad API, hard to follow and understand the code, etc.).

One of the reasons for that is that ``deploy_node()`` method passes all the keyword argument it takes to ``create_node()`` method, even though majority of the arguments it takes are ``deploy_node()`` specific (ssh_username, max_tries, ssh_interface, etc.) and shouldn't be passed / propagated to ``create_node()``.

Only keyword argument which potentially needs to be propagated is ``auth`` argument. That argument is used by provider drivers which support password based SSH authentication (e.g. Linode).

## Proposed Solution

This solution updates ``deploy_node()`` code to only pass non deploy_node specific keyword arguments to the ``create_node()`` method.

If for some reason driver method throws (e.g. that driver still expects some deploy_node arguments which really shouldn't happen, but there might be some legacy code which does that out there), we simply fall back to the old approach and pass all the arguments to ``create_node()`` method.

This will allow drivers to still support ``deploy_node()`` functionality without needing to use ``**kwargs`` in ``create_node()`` method signature. They will be able to normally declare positional and keyword arguments they support in that method.


## TODO

- [x] Changelog entry
- [x] Update some of the existing drivers to explicitly declare supported arguments in ``create_node()`` method instead of using ``**kwargs``