### PR TITLE
Fix a regression with "get_driver()" function not working with string values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,9 @@ Common
   ``Provider.FOO`` enum type constant, but since the string notation was
   unofficially supported in the past, we will still support it until the next
   major release.
+
+  Reported by @dpeschman.
+  (GITHUB-1391, GITHUB-1390)
   [Tomaz Muraus]
 
 Compute

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,19 @@
 Changes in Apache Libcloud in development
 -----------------------------------------
 
+Common
+-------
+
+- Fix a regression with ``get_driver()`` method not working if ``provider``
+  argument value was a string (e.g. using ``get_driver('openstack')``
+  instead of ``get_driver(Provider.OPENSTACK)``).
+
+  Only officially supported and recommended approach still is to use
+  ``Provider.FOO`` enum type constant, but since the string notation was
+  unofficially supported in the past, we will still support it until the next
+  major release.
+  [Tomaz Muraus]
+
 Compute
 -------
 

--- a/libcloud/common/providers.py
+++ b/libcloud/common/providers.py
@@ -70,8 +70,9 @@ def get_driver(drivers, provider, deprecated_providers=None,
         _mod = __import__(mod_name, globals(), locals(), [driver_name])
         return getattr(_mod, driver_name)
 
-    # NOTE: This is for backward compatibility reasons where user user a
-    # string provider name instead of a Provider.FOO enum constant.
+    # NOTE: This is for backward compatibility reasons where user could use
+    # a string value instead of a Provider.FOO enum constant and this function
+    # would still work
     for provider_name, (mod_name, driver_name) in drivers.items():
         # NOTE: This works because Provider enum class overloads __eq__
         if provider.lower() == provider_name.lower():

--- a/libcloud/common/providers.py
+++ b/libcloud/common/providers.py
@@ -70,6 +70,14 @@ def get_driver(drivers, provider, deprecated_providers=None,
         _mod = __import__(mod_name, globals(), locals(), [driver_name])
         return getattr(_mod, driver_name)
 
+    # NOTE: This is for backward compatibility reasons where user user a
+    # string provider name instead of a Provider.FOO enum constant.
+    for provider_name, (mod_name, driver_name) in drivers.items():
+        # NOTE: This works because Provider enum class overloads __eq__
+        if provider.lower() == provider_name.lower():
+            _mod = __import__(mod_name, globals(), locals(), [driver_name])
+            return getattr(_mod, driver_name)
+
     raise AttributeError('Provider %s does not exist' % (provider))
 
 

--- a/libcloud/test/test_utils.py
+++ b/libcloud/test/test_utils.py
@@ -39,6 +39,7 @@ from libcloud.utils.py3 import hexadigits
 from libcloud.utils.py3 import urlquote
 from libcloud.compute.types import Provider
 from libcloud.compute.providers import DRIVERS
+from libcloud.compute.drivers.dummy import DummyNodeDriver
 from libcloud.utils.misc import get_secure_random_string
 from libcloud.utils.networking import is_public_subnet
 from libcloud.utils.networking import is_private_subnet
@@ -94,6 +95,16 @@ class TestUtils(unittest.TestCase):
             pass
         else:
             self.fail('Invalid provider, but an exception was not thrown')
+
+    def test_get_driver_string_and_enum_notation(self):
+        driver = get_driver(drivers=DRIVERS, provider=Provider.DUMMY)
+        self.assertEqual(driver, DummyNodeDriver)
+
+        driver = get_driver(drivers=DRIVERS, provider='dummy')
+        self.assertEqual(driver, DummyNodeDriver)
+
+        driver = get_driver(drivers=DRIVERS, provider='DUMMY')
+        self.assertEqual(driver, DummyNodeDriver)
 
     def test_set_driver(self):
         # Set an existing driver


### PR DESCRIPTION
This pull request fixes a regression which was inadvertently introduced in #1306 as part of MyPy refactoring changes.

That change broke ``get_driver()`` method so it doesn't work anymore if ``provider`` argument is a string and not an ``Provider.FOO`` enum type.

Only officially supported and recommended approach still is to use ``Provider.FOO`` enum constants, but since string notation was supported in the past and likely a lot of the existing code relies on it, we should still support (at least until we have the time to properly officially deprecate and remove support for it).

Resolves #1390.