### PR TITLE
Fix wheel METADATA and ensure conditional dependencies are handled correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,14 @@ matrix:
   fast_finish: true
   include:
     - python: 2.7
-      before_script: TOX_ENV=py2.7,py2.7-dist
+      before_script: TOX_ENV=py2.7,py2.7-dist,py2.7-dist-wheel
     - python: 3.4
     - python: 3.5
     - python: 3.6
     - python: 3.7
       dist: xenial
       sudo: required
-      before_script: TOX_ENV=py3.7,py3.7-dist
+      before_script: TOX_ENV=py3.7,py3.7-dist,py3.7-dist-wheel
     - python: 3.8
       dist: xenial
       sudo: required

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changes in Apache Libcloud in development
 -----------------------------------------
 
 Common
--------
+------
 
 - Fix a regression with ``get_driver()`` method not working if ``provider``
   argument value was a string (e.g. using ``get_driver('openstack')``
@@ -25,6 +25,13 @@ Common
 
   NOTE: At the moment, type annotations are only available for the base
   compute API.
+  [Tomaz Muraus]
+
+- Fix universal wheel METADATA and ensure conditional dependencies
+  (backports.ssl_match_hostname, typing, enum34) are handled correctly.
+
+  Reported by Adam Terrey (@arterrey).
+  (GITHUB-1392, GITHUB-1393)
   [Tomaz Muraus]
 
 Compute

--- a/docs/committer_guide.rst
+++ b/docs/committer_guide.rst
@@ -95,6 +95,12 @@ preparing a release.
 3. Creating release artifacts
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. note::
+
+  It's important that you have the latest versions of ``setuptools``, ``wheel``
+  and ``pip`` installed to ensure the generated wheel files contain correct
+  metadata.
+
 We have a script that runs the required setup.py commands and then hashes
 and signs the files. You will need the latest version of ``pip`` and the ``wheel``
 package. To run it:

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,8 @@ whitelist_externals = cp
                       bash
                       scripts/*.sh
 [testenv:py2.7-dist]
-# Verify library installs without any dependencies
+# Verify library installs without any dependencies when using python setup.py
+# install
 skipdist = True
 recreate = True
 # NOTE: We intentionally set empty deps to ensure it works on a clean
@@ -42,9 +43,15 @@ commands = bash -c "pip show requests && exit 1 || exit 0"
            bash -c "pip show apache-libcloud || exit 0"
            python setup.py install
            pip show apache-libcloud
+           # Verify all dependencies were installed
+           pip show requests
+           pip show typing
+           pip show enum34
+           pip show requests
 
 [testenv:py3.7-dist]
-# Verify library installs without any dependencies
+# Verify library installs without any dependencies when using python setup.py
+# install
 skipdist = True
 recreate = True
 # NOTE: We intentionally set empty deps to ensure it works on a clean
@@ -53,9 +60,15 @@ deps =
 # Ensure those packages are not installed. If they are, it indicates unclean
 # environment so those checks won't work correctly
 commands = bash -c "pip show requests && exit 1 || exit 0"
+           bash -c "pip show typing && exit 1 || exit 0"
+           bash -c "pip show enum34 && exit 1 || exit 0"
            bash -c "pip show apache-libcloud || exit 0"
            python setup.py install
            pip show apache-libcloud
+           # Verify all dependencies were installed
+           pip show requests
+           bash -c "pip show typing && exit 1 || exit 0"
+           bash -c "pip show enum34 && exit 1 || exit 0"
 
 [testenv:docs]
 deps = pysphere

--- a/tox.ini
+++ b/tox.ini
@@ -61,6 +61,8 @@ commands = bash -c "pip show requests && exit 1 || exit 0"
            bash -c "pip show typing && exit 1 || exit 0"
            bash -c "pip show enum34 && exit 1 || exit 0"
            bash -c "pip show apache-libcloud || exit 0"
+           bash -c "rm -rf dist/apache_libcloud-*.whl"
+           pip install wheel
            python setup.py bdist_wheel
            bash -c "pip install dist/apache_libcloud-*.whl"
            pip show apache-libcloud
@@ -103,8 +105,10 @@ commands = bash -c "pip show requests && exit 1 || exit 0"
            bash -c "pip show typing && exit 1 || exit 0"
            bash -c "pip show enum34 && exit 1 || exit 0"
            bash -c "pip show apache-libcloud || exit 0"
-           python setup.py install
-           pip show apache-libcloud
+           bash -c "rm -rf dist/apache_libcloud-*.whl"
+           pip install wheel
+           python setup.py bdist_wheel
+           bash -c "pip install dist/apache_libcloud-*.whl"
            # Verify all dependencies were installed
            pip show requests
            bash -c "pip show typing && exit 1 || exit 0"

--- a/tox.ini
+++ b/tox.ini
@@ -14,14 +14,14 @@ deps =
 commands = cp libcloud/test/secrets.py-dist libcloud/test/secrets.py
            python setup.py test
 basepython =
-    {py2.7,checks,lint,pylint,coverage,py2.7-dist}: python2.7
+    {py2.7,checks,lint,pylint,coverage,py2.7-dist,py2.7-wheel}: python2.7
     docs: python3.5
     pypypy: pypy
     pypypy3: pypy3
     py3.4: python3.4
     py3.5: python3.5
     py3.6: python3.6
-    {py3.7,py3.7-dist}: python3.7
+    {py3.7,py3.7-dist,py3.7-dist-wheel}: python3.7
     py3.8: python3.8
     mypy: python3.7
 whitelist_externals = cp
@@ -47,11 +47,51 @@ commands = bash -c "pip show requests && exit 1 || exit 0"
            pip show requests
            pip show typing
            pip show enum34
+
+[testenv:py2.7-dist-wheel]
+# Verify library installs without any dependencies when using built wheel
+skipdist = True
+recreate = True
+# NOTE: We intentionally set empty deps to ensure it works on a clean
+# environment without any dependencies
+deps =
+# Ensure those packages are not installed. If they are, it indicates unclean
+# environment so those checks won't work correctly
+commands = bash -c "pip show requests && exit 1 || exit 0"
+           bash -c "pip show typing && exit 1 || exit 0"
+           bash -c "pip show enum34 && exit 1 || exit 0"
+           bash -c "pip show apache-libcloud || exit 0"
+           python setup.py bdist_wheel
+           bash -c "pip install dist/apache_libcloud-*.whl"
+           pip show apache-libcloud
+           # Verify all dependencies were installed
            pip show requests
+           pip show typing
+           pip show enum34
 
 [testenv:py3.7-dist]
 # Verify library installs without any dependencies when using python setup.py
 # install
+skipdist = True
+recreate = True
+# NOTE: We intentionally set empty deps to ensure it works on a clean
+# environment without any dependencies
+deps =
+# Ensure those packages are not installed. If they are, it indicates unclean
+# environment so those checks won't work correctly
+commands = bash -c "pip show requests && exit 1 || exit 0"
+           bash -c "pip show typing && exit 1 || exit 0"
+           bash -c "pip show enum34 && exit 1 || exit 0"
+           bash -c "pip show apache-libcloud || exit 0"
+           python setup.py install
+           pip show apache-libcloud
+           # Verify all dependencies were installed
+           pip show requests
+           bash -c "pip show typing && exit 1 || exit 0"
+           bash -c "pip show enum34 && exit 1 || exit 0"
+
+[testenv:py3.7-dist-wheel]
+# Verify library installs without any dependencies when using built wheel
 skipdist = True
 recreate = True
 # NOTE: We intentionally set empty deps to ensure it works on a clean


### PR DESCRIPTION
In a prevision version we added some more conditional dependencies - ``typing`` and ``enum34`` packages which are needed for Python versions older than 3.4.0.

Those versions were dynamically included as part of ``install_requirements`` so the actual ``Reqires-Dist`` metadata entry which is part of the wheel file was not correct and depended on the version of Python which was used to generate the wheel.

## Proposed Solution

This pull request fixes that by utilizing PEP 508 (https://www.python.org/dev/peps/pep-0508/#environment-markers) environment markers notation.

In addition to that, we also use ``extra_requires`` fallback notation for users who install Libcloud using old versions of pip and setuptools (reference: https://hynek.me/articles/conditional-python-dependencies/).

Keep in mind that this change now requires a Libcloud committer which is making a release to generate a wheel using a recent version of setuptools for the METADATA entries to be correct.

I updated ``setup.py`` to fail on ``bdist_wheel`` command if an older version is used. I will also document this under committer docs.

I tested it locally using various Python versions and confirmed it works correctly.

The universal wheel metadata now looks like this:

```bash
...
Requires-Dist: requests (>=2.5.0)
Requires-Dist: backports.ssl-match-hostname ; python_version < "2.7.9"
Requires-Dist: typing ; python_version < "3.4.0"
Requires-Dist: enum34 ; python_version < "3.4.0"
...
```

## Note on supporting Python <= 3.4.0

In the very near future (#1377), we plan to drop support for Python <= 3.4.0.  At that point, this change won't be needed anymore and we will be able to simplify ``setup.py``.

The reason why I made this change is so we can make another release in the ``v2.x`` release series which contains the correct wheel metadata entries. This will be the last release which will support Python <= 3.4.0.

If we planned to support Python 2.7 and Python 3.4.0 for longer, I would probably also work on automated tests for this fix / change, but at this point, I don't think it's worth the effort since we will be dropping support for that versions soon.

Resolves #1392.

### Thanks

Thanks to @arterrey for reporting this issue.