### PR TITLE
Add KubeVirt driver & tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,8 +50,14 @@ Compute
   [Tomaz Muraus]
 
 - [OpenStack] Fix error with getting node id in ``_to_floating_ip`` method
-  when region is not called ``nova``. (GITHUB-1411, GITHUB-1412)
+  when region is not called ``nova``.
+  (GITHUB-1411, GITHUB-1412)
   [Miguel Caballer - @micafer]
+
+- [KubeVirt] New KubeVirt driver with initial support for the k8s/KubeVirt
+  add-on.
+  (GITHUB-1394)
+  [Eis D. Zaster - @Eis-D-Z]
 
 Storage
 ~~~~~~~

--- a/libcloud/compute/drivers/kubevirt.py
+++ b/libcloud/compute/drivers/kubevirt.py
@@ -68,7 +68,8 @@ class KubernetesTLSConnection(KeyCertificateConnection):
                 raise InvalidCredsError(
                     'You need an key PEM file to authenticate with '
                     'via tls. For more info please visit:'
-                    'https://kubernetes.io/docs/concepts/cluster-administration/certificates/')
+                    'https://kubernetes.io/docs/concepts/'
+                    'cluster-administration/certificates/')
             self.key_file = key_file
             certpath = os.path.expanduser(cert_file)
             is_file_path = os.path.exists(
@@ -77,7 +78,8 @@ class KubernetesTLSConnection(KeyCertificateConnection):
                 raise InvalidCredsError(
                     'You need an certificate PEM file to authenticate'
                     'via tls. For more info please visit:'
-                    'https://kubernetes.io/docs/concepts/cluster-administration/certificates/'
+                    'https://kubernetes.io/docs/concepts/'
+                    'cluster-administration/certificates/'
                 )
 
             self.cert_file = cert_file
@@ -235,7 +237,7 @@ class KubeVirtNodeDriver(NodeDriver):
 
             return result.status in VALID_RESPONSE_CODES
 
-        except Exception as exc:
+        except Exception:
             raise
 
     def stop_node(self, node):
@@ -255,7 +257,7 @@ class KubeVirtNodeDriver(NodeDriver):
 
             return result.status in VALID_RESPONSE_CODES
 
-        except Exception as exc:
+        except Exception:
             raise
 
     def reboot_node(self, node):
@@ -273,7 +275,7 @@ class KubeVirtNodeDriver(NodeDriver):
                                              method=method)
 
             return result.status in VALID_RESPONSE_CODES
-        except Exception as e:
+        except Exception:
             raise
         return
 
@@ -291,12 +293,13 @@ class KubeVirtNodeDriver(NodeDriver):
                                              '/virtualmachines/' + name,
                                              method='DELETE')
             return result.status in VALID_RESPONSE_CODES
-        except Exception as exc:
+        except Exception:
             raise
 
     # only has container disk support atm with no persistency
     def create_node(self, name, image, location=None, ex_memory=128, ex_cpu=1,
-                    ex_disks=None, ex_network=None, ex_termination_grace_period=0):
+                    ex_disks=None, ex_network=None,
+                    ex_termination_grace_period=0):
         """
         Creating a VM with a containerDisk.
         :param name: A name to give the VM. The VM will be identified by
@@ -341,7 +344,7 @@ class KubeVirtNodeDriver(NodeDriver):
                             created by providing the following:
                             required:
                             -size: the desired size (implied in GB)
-                            -storage_class_name: the name of the storage class to
+                            -storage_class_name: the name of the storage class to # NOQA
                                                be used for the creation of the
                                                Persistent Volume Claim.
                                                Make sure it allows for
@@ -369,7 +372,7 @@ class KubeVirtNodeDriver(NodeDriver):
                                accepted values.
                                The parameter must be a tupple or list with
                                (network_type, interface, name)
-        :type ex_network: `iterable` (tupple or list) [network_type, inteface, name]
+        :type ex_network: `iterable` (tupple or list) [network_type, inteface, name] # NOQA
                       network_type: `str` | only "pod" is accepted atm
                       interface: `str` | "masquerade" or "bridge"
                       name: `str`
@@ -417,7 +420,7 @@ class KubeVirtNodeDriver(NodeDriver):
                             },
                         },
                         "networks": [],
-                        "terminationGracePeriodSeconds": ex_termination_grace_period,
+                        "terminationGracePeriodSeconds": ex_termination_grace_period, # NOQA
                         "volumes": []
                     }
                 }
@@ -450,7 +453,7 @@ class KubeVirtNodeDriver(NodeDriver):
             if disk_type == "containerDisk":
                 try:
                     image = disk['image']
-                except KeyError as exc:
+                except KeyError:
                     raise KeyError('A container disk needs a '
                                    'containerized image')
 
@@ -463,7 +466,8 @@ class KubeVirtNodeDriver(NodeDriver):
                     if claimName not in self.list_persistent_volume_claims(
                         namespace=namespace
                     ):
-                        if 'size' not in disk or "storage_class_name" not in disk:
+                        if ('size' not in disk or "storage_class_name"
+                                not in disk):
                             msg = ("disk['size'] and "
                                    "disk['storage_class_name'] "
                                    "are both required to create "
@@ -533,7 +537,7 @@ class KubeVirtNodeDriver(NodeDriver):
 
             self.connection.request(req, method=method, data=data)
 
-        except Exception as exc:
+        except Exception:
             raise
         # check if new node is present
         nodes = self.list_nodes()
@@ -625,7 +629,7 @@ class KubeVirtNodeDriver(NodeDriver):
                             -glusterfs
                             -vsphereVolume
                             -quobyte Volumes
-                            -hostPath (Single node testing only – local storage is not supported in any way and WILL NOT WORK in a multi-node cluster)
+                            -hostPath (Single node testing only – local storage is not supported in any way and WILL NOT WORK in a multi-node cluster) # NOQA
                             -portworx Volumes
                             -scaleIO Volumes
                             -storageOS
@@ -651,11 +655,13 @@ class KubeVirtNodeDriver(NodeDriver):
             if location is None:
                 msg = "Please provide a namespace for the PVC."
                 raise ValueError(msg)
-            vol = self._create_volume_dynamic(size=size, name=name,
-                                              storage_class_name=ex_storage_class_name,
-                                              namespace=location.name,
-                                              volume_mode=ex_volume_mode,
-                                              access_mode=ex_access_mode)
+            vol = self._create_volume_dynamic(
+                size=size,
+                name=name,
+                storage_class_name=ex_storage_class_name,
+                namespace=location.name,
+                volume_mode=ex_volume_mode,
+                access_mode=ex_access_mode)
             return vol
         else:
             if ex_volume_type is None or ex_volume_params is None:
@@ -689,7 +695,7 @@ class KubeVirtNodeDriver(NodeDriver):
         try:
             self.connection.request(req, method=method, data=data)
 
-        except Exception as exc:
+        except Exception:
             raise
         # make sure that the volume was created
         volumes = self.list_volumes()
@@ -760,7 +766,7 @@ class KubeVirtNodeDriver(NodeDriver):
         data = json.dumps(pvc)
         try:
             result = self.connection.request(req, method=method, data=data)
-        except Exception as exc:
+        except Exception:
             raise
         if result.object['status']['phase'] != "Bound":
             for _ in range(3):
@@ -769,7 +775,7 @@ class KubeVirtNodeDriver(NodeDriver):
                     "/persistentvolumeclaims/" + name
                 try:
                     result = self.connection.request(req).object
-                except Exception as exc:
+                except Exception:
                     raise
                 if result['status']['phase'] == "Bound":
                     break
@@ -814,7 +820,7 @@ class KubeVirtNodeDriver(NodeDriver):
             try:
                 result = self.connection.request(req, method=method)
 
-            except Exception as exc:
+            except Exception:
                 raise
 
         pv = volume.name
@@ -823,7 +829,7 @@ class KubeVirtNodeDriver(NodeDriver):
         try:
             result = self.connection.request(req, method=method)
             return result.status
-        except Exception as exc:
+        except Exception:
             raise
 
     def attach_volume(self, node, volume, device='disk',
@@ -859,7 +865,7 @@ class KubeVirtNodeDriver(NodeDriver):
         # Get all the volumes of the vm
         try:
             result = self.connection.request(req).object
-        except Exception as exc:
+        except Exception:
             raise
         disks = result['spec']['template']['spec']['domain'][
             'devices']['disks']
@@ -889,7 +895,7 @@ class KubeVirtNodeDriver(NodeDriver):
             else:
                 node.extra['pvcs'] = [claimName]
             return result in VALID_RESPONSE_CODES
-        except Exception as exc:
+        except Exception:
             raise
 
     def detach_volume(self, volume, ex_node):
@@ -910,7 +916,7 @@ class KubeVirtNodeDriver(NodeDriver):
 
         try:
             result = self.connection.request(req).object
-        except Exception as exc:
+        except Exception:
             raise
         disks = result['spec']['template']['spec']['domain'][
             'devices']['disks']
@@ -949,7 +955,7 @@ class KubeVirtNodeDriver(NodeDriver):
                                              headers=headers)
             ex_node.extra['pvcs'].remove(claimName)
             return result in VALID_RESPONSE_CODES
-        except Exception as exc:
+        except Exception:
             raise
 
     def ex_list_persistent_volume_claims(self, namespace="default"):
@@ -958,7 +964,7 @@ class KubeVirtNodeDriver(NodeDriver):
             "/persistentvolumeclaims"
         try:
             result = self.connection.request(pvc_req).object
-        except Exception as exc:
+        except Exception:
             raise
         pvcs = [item['metadata']['name'] for item in result['items']]
         return pvcs
@@ -968,8 +974,8 @@ class KubeVirtNodeDriver(NodeDriver):
         # sc = storage class
         sc_req = "/apis/storage.k8s.io/v1/storageclasses"
         try:
-                result = self.connection.request(sc_req).object
-        except Exception as exc:
+            result = self.connection.request(sc_req).object
+        except Exception:
             raise
         scs = [item['metadata']['name'] for item in result['items']]
 
@@ -985,7 +991,7 @@ class KubeVirtNodeDriver(NodeDriver):
 
         try:
             result = self.connection.request(pv_rec).object
-        except Exception as exc:
+        except Exception:
             raise
 
         for item in result['items']:

--- a/libcloud/compute/drivers/kubevirt.py
+++ b/libcloud/compute/drivers/kubevirt.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# NOTE: Re-enable once we add mypy annotations for the base container API
+# type: ignore
+
 """
 kubevirt driver with support for nodes (vms)
 """

--- a/libcloud/compute/drivers/kubevirt.py
+++ b/libcloud/compute/drivers/kubevirt.py
@@ -30,7 +30,7 @@ from libcloud.container.drivers.kubernetes import KubernetesConnection
 from libcloud.container.drivers.kubernetes import VALID_RESPONSE_CODES
 
 from libcloud.common.base import KeyCertificateConnection, ConnectionKey
-from libcloud.common.types import InvalidCredsError, ProviderError
+from libcloud.common.types import InvalidCredsError, LibcloudError
 
 from libcloud.compute.types import Provider, NodeState
 from libcloud.compute.base import NodeDriver, NodeSize, Node
@@ -463,7 +463,7 @@ class KubeVirtNodeDriver(NodeDriver):
             if disk_type == "persistentVolumeClaim":
                 if 'claim_name' in disk:
                     claimName = disk['claim_name']
-                    if claimName not in self.list_persistent_volume_claims(
+                    if claimName not in self.ex_list_persistent_volume_claims(
                         namespace=namespace
                     ):
                         if ('size' not in disk or "storage_class_name"
@@ -841,8 +841,9 @@ class KubeVirtNodeDriver(NodeDriver):
         if not volume.extra['is_bound']:
             volume = self._bind_volume(volume, node.extra['namespace'])
             if volume is None:
-                raise ProviderError("Selected Volume (PV) could not be bound "
-                                    "(to a PVC), please select another volume")
+                raise LibcloudError("Selected Volume (PV) could not be bound "
+                                    "(to a PVC), please select another volume",
+                                    driver=self)
 
         claimName = volume.extra['pvc']['name']
         if ex_name is None:

--- a/libcloud/compute/drivers/kubevirt.py
+++ b/libcloud/compute/drivers/kubevirt.py
@@ -1,0 +1,1143 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+kubevirt driver with support for nodes (vms)
+"""
+import os
+import json
+import time
+import warnings
+from datetime import datetime
+
+import libcloud.security
+
+
+from libcloud.container.drivers.kubernetes import KubernetesResponse
+from libcloud.container.drivers.kubernetes import KubernetesConnection
+from libcloud.container.drivers.kubernetes import VALID_RESPONSE_CODES
+
+from libcloud.common.base import KeyCertificateConnection, ConnectionKey
+from libcloud.common.types import InvalidCredsError, ProviderError
+
+from libcloud.compute.types import Provider, NodeState
+from libcloud.compute.base import NodeDriver, NodeSize, Node
+from libcloud.compute.base import NodeImage, NodeLocation, StorageVolume
+
+__all__ = [
+    "KubernetesTLSConnection",
+    "KubernetesTokenAuthentication",
+    "KubeVirtNodeDriver"
+]
+ROOT_URL = '/api/v1/'
+KUBEVIRT_URL = '/apis/kubevirt.io/v1alpha3/'
+
+
+class KubernetesTLSConnection(KeyCertificateConnection):
+    responseCls = KubernetesResponse
+    timeout = 60
+
+    def __init__(self, key, secure=True, host='localhost',
+                 port='6443', key_file=None, cert_file=None, ca_cert='',
+                 **kwargs):
+
+        super(KubernetesTLSConnection, self).__init__(key_file=key_file,
+                                                      cert_file=cert_file,
+                                                      secure=secure, host=host,
+                                                      port=port, url=None,
+                                                      proxy_url=None,
+                                                      timeout=None,
+                                                      backoff=None,
+                                                      retry_delay=None)
+        if key_file:
+            keypath = os.path.expanduser(key_file)
+            is_file_path = os.path.exists(keypath) and os.path.isfile(keypath)
+            if not is_file_path:
+                raise InvalidCredsError(
+                    'You need an key PEM file to authenticate with '
+                    'via tls. For more info please visit:'
+                    'https://kubernetes.io/docs/concepts/cluster-administration/certificates/')
+            self.key_file = key_file
+            certpath = os.path.expanduser(cert_file)
+            is_file_path = os.path.exists(
+                certpath) and os.path.isfile(certpath)
+            if not is_file_path:
+                raise InvalidCredsError(
+                    'You need an certificate PEM file to authenticate'
+                    'via tls. For more info please visit:'
+                    'https://kubernetes.io/docs/concepts/cluster-administration/certificates/'
+                )
+
+            self.cert_file = cert_file
+
+    def add_default_headers(self, headers):
+        if 'Content-Type' not in headers:
+            headers['Content-Type'] = 'application/json'
+        return headers
+
+
+class KubernetesTokenAuthentication(ConnectionKey):
+    responseCls = KubernetesResponse
+    timeout = 60
+
+    def add_default_headers(self, headers):
+        if 'Content-Type' not in headers:
+            headers['Content-Type'] = 'application/json'
+        if self.key:
+            headers['Authorization'] = 'Bearer ' + self.key
+        else:
+            raise ValueError("Please provide a valid token in the key param")
+        return headers
+
+
+class KubeVirtNodeDriver(NodeDriver):
+    type = Provider.KUBEVIRT
+    name = "kubevirt"
+    website = 'https://www.kubevirt.io'
+    connectionCls = KubernetesConnection
+
+    NODE_STATE_MAP = {
+        'pending': NodeState.PENDING,
+        'running': NodeState.RUNNING,
+        'stopped': NodeState.STOPPED
+    }
+
+    def __init__(self, key=None, secret=None, secure=True, host="localhost",
+                 port=6443, key_file=None, cert_file=None, ca_cert='',
+                 token_bearer_auth=False, verify=True):
+
+        libcloud.security.VERIFY_SSL_CERT = verify
+        if token_bearer_auth:
+            self.connectionCls = KubernetesTokenAuthentication
+            if not key:
+                raise ValueError("The token must be a string")
+            secure = True
+
+        if key_file:
+            self.connectionCls = KubernetesTLSConnection
+            self.key_file = key_file
+            self.cert_file = cert_file
+            secure = True
+
+        if host.startswith('https://'):
+            secure = True
+
+        # strip the prefix
+        prefixes = ['http://', 'https://']
+        for prefix in prefixes:
+            if host.startswith(prefix):
+                host = host.lstrip(prefix)
+
+        super(KubeVirtNodeDriver, self).__init__(key=key,
+                                                 secret=secret,
+                                                 secure=secure,
+                                                 host=host,
+                                                 port=port,
+                                                 key_file=key_file,
+                                                 cert_file=cert_file)
+
+        # check if both key and cert files are present
+        if key_file or cert_file:
+            if not(key_file and cert_file):
+                raise Exception("Both key and certificate files are needed")
+
+        if ca_cert:
+            self.connection.connection.ca_cert = ca_cert
+        else:
+            # do not verify SSL certificate
+            warnings.warn("Kubernetes has its own CA, since you didn't supply "
+                          "a CA certificate be aware that SSL verification "
+                          "will be disabled for this session.")
+            self.connection.connection.ca_cert = False
+
+        self.connection.secure = secure
+        self.connection.host = host
+        self.connection.port = port
+
+        if self.connectionCls == KubernetesConnection:
+            self.connection.secret = secret
+        self.connection.key = key
+
+    def list_nodes(self, location=None):
+        namespaces = []
+        if location is not None:
+            namespaces.append(location.name)
+        else:
+            for ns in self.list_locations():
+                namespaces.append(ns.name)
+
+        dormant = []
+        live = []
+        for ns in namespaces:
+            req = KUBEVIRT_URL + 'namespaces/' + ns + \
+                "/virtualmachines"
+            result = self.connection.request(req)
+            if result.status != 200:
+                continue
+            result = result.object
+            for item in result['items']:
+                if not item['spec']['running']:
+                    dormant.append(item)
+                else:
+                    live.append(item)
+        vms = []
+        for vm in dormant:
+            vms.append(self._to_node(vm, is_stopped=True))
+
+        for vm in live:
+            vms.append(self._to_node(vm, is_stopped=False))
+
+        return vms
+
+    def get_node(self, id=None, name=None):
+        "get a vm by name or id"
+        if not id and not name:
+            raise ValueError("This method needs id or name to be specified")
+        nodes = self.list_nodes()
+        if id:
+            node_gen = filter(lambda x: x.id == id,
+                              nodes)
+        if name:
+            node_gen = filter(lambda x: x.name == name,
+                              nodes)
+
+        try:
+            return next(node_gen)
+        except StopIteration:
+            raise ValueError("Node does not exist")
+
+    def start_node(self, node):
+        # make sure it is stopped
+        if node.state is NodeState.RUNNING:
+            return True
+        name = node.name
+        namespace = node.extra['namespace']
+        req = KUBEVIRT_URL + 'namespaces/' + namespace +\
+            '/virtualmachines/' + name
+        data = {"spec": {"running": True}}
+        headers = {"Content-Type": "application/merge-patch+json"}
+        try:
+            result = self.connection.request(req, method="PATCH",
+                                             data=json.dumps(data),
+                                             headers=headers)
+
+            return result.status in VALID_RESPONSE_CODES
+
+        except Exception as exc:
+            raise
+
+    def stop_node(self, node):
+        # check if running
+        if node.state is NodeState.STOPPED:
+            return True
+        name = node.name
+        namespace = node.extra['namespace']
+        req = KUBEVIRT_URL + 'namespaces/' + namespace + \
+            '/virtualmachines/' + name
+        headers = {"Content-Type": "application/merge-patch+json"}
+        data = {"spec": {"running": False}}
+        try:
+            result = self.connection.request(req, method="PATCH",
+                                             data=json.dumps(data),
+                                             headers=headers)
+
+            return result.status in VALID_RESPONSE_CODES
+
+        except Exception as exc:
+            raise
+
+    def reboot_node(self, node):
+        """
+        Rebooting a node.
+        """
+        namespace = node.extra['namespace']
+        name = node.name
+        method = 'DELETE'
+        try:
+            result = self.connection.request(KUBEVIRT_URL + 'namespaces/' +
+                                             namespace +
+                                             '/virtualmachineinstances/' +
+                                             name,
+                                             method=method)
+
+            return result.status in VALID_RESPONSE_CODES
+        except Exception as e:
+            raise
+        return
+
+    def destroy_node(self, node):
+        """
+        Terminating a VMI and deleting the VM resource backing it
+        """
+        namespace = node.extra['namespace']
+        name = node.name
+        # stop the vmi first
+        self.stop_node(node)
+        try:
+            result = self.connection.request(KUBEVIRT_URL + 'namespaces/' +
+                                             namespace +
+                                             '/virtualmachines/' + name,
+                                             method='DELETE')
+            return result.status in VALID_RESPONSE_CODES
+        except Exception as exc:
+            raise
+
+    # only has container disk support atm with no persistency
+    def create_node(self, name, image, location=None, ex_memory=128, ex_cpu=1,
+                    ex_disks=None, ex_network=None, ex_termination_grace_period=0):
+        """
+        Creating a VM with a containerDisk.
+        :param name: A name to give the VM. The VM will be identified by
+                     this name and atm it cannot be changed after it is set.
+        :type name: ``str``
+
+        :param image: Either a libcloud NodeImage or a string.
+                      In both cases it must point to a Docker image with an
+                      embedded disk.
+                      May be a URI like `kubevirt/cirros-registry-disk-demo`,
+                      kubevirt will automatically pull it from
+                      https://hub.docker.com/u/URI.
+                      For more info visit:
+                      https://kubevirt.io/user-guide/docs/latest/creating-virtual-machines/disks-and-volumes.html#containerdisk
+        :type image: `str`
+
+        :param location: The namespace where the VM will live.
+                          (default is 'default')
+        :type location: ``str``
+
+        :param ex_memory: The RAM in MB to be allocated to the VM
+        :type ex_memory: ``int``
+
+        :param ex_cpu: The ammount of cpu to be allocated in miliCPUs
+                    ie: 400 will mean 0.4 of a core, 1000 will mean 1 core
+                    and 3000 will mean 3 cores.
+        :type ex_cpu: ``int``
+
+        :param ex_disks: A list containing disk dictionaries.
+                             Each dictionaries should have the
+                             following optional keys:
+                             -bus: can be "virtio", "sata", or "scsi"
+                             -device: can be "lun" or "disk"
+                             The following are required keys:
+                             -disk_type: atm only "persistentVolumeClaim"
+                                         is supported
+                             -name: The name of the disk configuration
+                             -claim_name: the name of the
+                                         Persistent Volume Claim
+
+                            If you wish a new Persistent Volume Claim can be
+                            created by providing the following:
+                            required:
+                            -size: the desired size (implied in GB)
+                            -storage_class_name: the name of the storage class to
+                                               be used for the creation of the
+                                               Persistent Volume Claim.
+                                               Make sure it allows for
+                                               dymamic provisioning.
+                             optional:
+                            -access_mode: default is ReadWriteOnce
+                            -volume_mode: default is `Filesystem`,
+                                         it can also be `Block`
+
+        :type ex_disks: `list` of `dict`. For each `dict` the types
+                            for its keys are:
+                            -bus: `str`
+                            -device: `str`
+                            -disk_type: `str`
+                            -name: `str`
+                            -claim_name: `str`
+                            (for creating a claim:)
+                            -size: `int`
+                            -storage_class_name: `str`
+                            -volume_mode: `str`
+                            -access_mode: `str`
+
+        :param ex_network: Only the pod type is supported, and in the
+                               configuration masquerade or bridge are the
+                               accepted values.
+                               The parameter must be a tupple or list with
+                               (network_type, interface, name)
+        :type ex_network: `iterable` (tupple or list) [network_type, inteface, name]
+                      network_type: `str` | only "pod" is accepted atm
+                      interface: `str` | "masquerade" or "bridge"
+                      name: `str`
+        """
+        # all valid disk types for which support will be added in the future
+        DISK_TYPES = {'containerDisk', 'ephemeral', 'configMap', 'dataVolume',
+                      'cloudInitNoCloud', 'persistentVolumeClaim', 'emptyDisk',
+                      'cloudInitConfigDrive', 'hostDisk'}
+
+        if location is not None:
+            namespace = location.name
+        else:
+            namespace = 'default'
+
+        # vm template to be populated
+        vm = {
+            "apiVersion": "kubevirt.io/v1alpha3",
+            "kind": "VirtualMachine",
+            "metadata": {
+                "labels": {
+                    "kubevirt.io/vm": name
+                },
+                "name": name
+            },
+            "spec": {
+                "running": False,
+                "template": {
+                    "metadata": {
+                        "labels": {
+                            "kubevirt.io/vm": name
+                        }
+                    },
+                    "spec": {
+                        "domain": {
+                            "devices": {
+                                "disks": [],
+                                "interfaces": [],
+                                "networkInterfaceMultiqueue": False,
+                            },
+                            "machine": {
+                                "type": ""
+                            },
+                            "resources": {
+                                "requests": {},
+                            },
+                        },
+                        "networks": [],
+                        "terminationGracePeriodSeconds": ex_termination_grace_period,
+                        "volumes": []
+                    }
+                }
+            }
+        }
+        memory = str(ex_memory) + "M"
+        vm['spec']['template']['spec']['domain']['resources'][
+            'requests']['memory'] = memory
+        if ex_cpu < 10:
+            cpu = int(ex_cpu)
+            vm['spec']['template']['spec']['domain'][
+                'cpu'] = {'cores': cpu}
+        else:
+            cpu = str(ex_cpu) + "m"
+            vm['spec']['template']['spec']['domain']['resources'][
+                'requests']['cpu'] = cpu
+        i = 0
+        for disk in ex_disks:
+            disk_type = disk.get('disk_type')
+            bus = disk.get('bus', 'virtio')
+            disk_name = disk.get('name', 'disk{}'.format(i))
+            i += 1
+            device = disk.get('device', 'disk')
+            if disk_type not in DISK_TYPES:
+                raise ValueError("The possible values for this "
+                                 "parameter are: ", DISK_TYPES)
+            # depending on disk_type, in the future,
+            # when more will be supported,
+            # additional elif should be added
+            if disk_type == "containerDisk":
+                try:
+                    image = disk['image']
+                except KeyError as exc:
+                    raise KeyError('A container disk needs a '
+                                   'containerized image')
+
+                volumes_dict = {'containerDisk': {'image': image},
+                                'name': disk_name}
+
+            if disk_type == "persistentVolumeClaim":
+                if 'claim_name' in disk:
+                    claimName = disk['claim_name']
+                    if claimName not in self.list_persistent_volume_claims(
+                        namespace=namespace
+                    ):
+                        if 'size' not in disk or "storage_class_name" not in disk:
+                            msg = ("disk['size'] and "
+                                   "disk['storage_class_name'] "
+                                   "are both required to create "
+                                   "a new claim.")
+                            raise KeyError(msg)
+                        size = disk['size']
+                        storage_class = disk['storage_class_name']
+                        volume_mode = disk.get('volume_mode', 'Filesystem')
+                        access_mode = disk.get('access_mode', 'ReadWriteOnce')
+                        self.create_volume(size=size, name=claimName,
+                                           location=location,
+                                           ex_storage_class_name=storage_class,
+                                           ex_volume_mode=volume_mode,
+                                           ex_access_mode=access_mode)
+
+                else:
+                    msg = ("You must provide either a claim_name of an "
+                           "existing claim or if you want one to be "
+                           "created you must additionally provide size "
+                           "and the storage_class_name of the "
+                           "cluster, which allows dynamic provisioning, "
+                           "so a Persistent Volume Claim can be created. "
+                           "In the latter case please provide the desired "
+                           "size as well.")
+                    raise KeyError(msg)
+
+                volumes_dict = {'persistentVolumeClaim': {
+                                'claimName': claimName},
+                                'name': disk_name}
+            disk_dict = {device: {'bus': bus}, 'name': disk_name}
+            vm['spec']['template']['spec']['domain'][
+                'devices']['disks'].append(disk_dict)
+            vm['spec']['template']['spec']['volumes'].append(volumes_dict)
+
+        # adding image in a container Disk
+        if isinstance(image, NodeImage):
+            image = image.name
+
+        volumes_dict = {'containerDisk': {'image': image},
+                        'name': 'boot-disk'}
+        disk_dict = {'disk': {'bus': 'virtio'}, 'name': 'boot-disk'}
+        vm['spec']['template']['spec']['domain'][
+            'devices']['disks'].append(disk_dict)
+        vm['spec']['template']['spec']['volumes'].append(volumes_dict)
+
+        # network
+        if ex_network:
+            interface = ex_network[1]
+            network_name = ex_network[2]
+            network_type = ex_network[0]
+        # add a default network
+        else:
+            interface = 'masquerade'
+            network_name = "netw1"
+            network_type = "pod"
+        network_dict = {network_type: {}, 'name': network_name}
+        interface_dict = {interface: {}, 'name': network_name}
+        vm['spec']['template']['spec'][
+            'networks'].append(network_dict)
+        vm['spec']['template']['spec']['domain']['devices'][
+            'interfaces'].append(interface_dict)
+
+        method = "POST"
+        data = json.dumps(vm)
+        req = KUBEVIRT_URL + "namespaces/" + namespace + "/virtualmachines/"
+        try:
+
+            self.connection.request(req, method=method, data=data)
+
+        except Exception as exc:
+            raise
+        # check if new node is present
+        nodes = self.list_nodes()
+        for node in nodes:
+            if node.name == name:
+                return node
+
+    def list_images(self, location=None):
+        """
+        If location (namespace) is provided only the images
+        in that location will be provided. Otherwise all of them.
+        """
+        nodes = self.list_nodes()
+        if location:
+            namespace = location.name
+            nodes = list(filter(lambda x: x['extra'][
+                                'namespace'] == namespace, nodes))
+        name_set = set()
+        images = []
+        for node in nodes:
+            if node.image.name in name_set:
+                continue
+            name_set.add(node.image.name)
+            images.append(node.image)
+
+        return images
+
+    def list_locations(self):
+        """
+        By locations here it is meant namespaces.
+        """
+        req = ROOT_URL + "namespaces"
+
+        namespaces = []
+        result = self.connection.request(req).object
+        for item in result['items']:
+            name = item['metadata']['name']
+            ID = item['metadata']['uid']
+            namespaces.append(NodeLocation(id=ID, name=name,
+                                           country='',
+                                           driver=self.connection.driver))
+        return namespaces
+
+    def list_sizes(self, location=None):
+
+        namespace = ''
+        if location:
+            namespace = location.name
+        nodes = self.list_nodes()
+        sizes = []
+        for node in nodes:
+            if not namespace:
+                sizes.append(node.size)
+            elif namespace == node.extra['namespace']:
+                sizes.append(node.size)
+
+        return sizes
+
+    def create_volume(self, size, name,
+                      location=None,
+                      ex_storage_class_name='',
+                      ex_volume_mode='Filesystem',
+                      ex_access_mode='ReadWriteOnce',
+                      ex_dynamic=True,
+                      ex_reclaim_policy='Recycle',
+                      ex_volume_type=None,
+                      ex_volume_params=None,
+                      ):
+        """
+        :param size: The size in Gigabytes
+        :type size: `int`
+
+        :param volume_type: This is the type of volume to be created that is
+                            dependent on the underlying cloud where Kubernetes
+                            is deployed. K8s is supporting the following types:
+                            -gcePersistentDisk
+                            -awsElasticBlockStore
+                            -azureFile
+                            -azureDisk
+                            -csi
+                            -fc (Fibre Channel)
+                            -flexVolume
+                            -flocker
+                            -nfs
+                            -iSCSI
+                            -rbd (Ceph Block Device)
+                            -cephFS
+                            -cinder (OpenStack block storage)
+                            -glusterfs
+                            -vsphereVolume
+                            -quobyte Volumes
+                            -hostPath (Single node testing only – local storage is not supported in any way and WILL NOT WORK in a multi-node cluster)
+                            -portworx Volumes
+                            -scaleIO Volumes
+                            -storageOS
+                            This parameter is a dict in the form {type: {key1:value1, key2:value2,...}},
+                            where type is one of the above and key1, key2... are type specific keys and
+                            their corresponding values. eg: {nsf: {server: "172.0.0.0", path: "/tmp"}}
+                                            {awsElasticBlockStore: {fsType: 'ext4', volumeID: "1234"}}
+        :type volume_type: `str`
+
+        :param volume_params: A dict with the key:value that the
+                              volume_type needs.
+                              This parameter is a dict in the form
+                              {key1:value1, key2:value2,...},
+                              where type is one of the above and key1, key2...
+                              are type specific keys and
+                              their corresponding values.
+                              eg: for nsf volume_type
+                              {server: "172.0.0.0", path: "/tmp"}
+                              for awsElasticBlockStore volume_type
+                              {fsType: 'ext4', volumeID: "1234"}
+        """
+        if ex_dynamic:
+            if location is None:
+                msg = "Please provide a namespace for the PVC."
+                raise ValueError(msg)
+            vol = self._create_volume_dynamic(size=size, name=name,
+                                              storage_class_name=ex_storage_class_name,
+                                              namespace=location.name,
+                                              volume_mode=ex_volume_mode,
+                                              access_mode=ex_access_mode)
+            return vol
+        else:
+            if ex_volume_type is None or ex_volume_params is None:
+                msg = ("An ex_volume_type must be provided from the list "
+                       "of supported clouds, as well as the ex_volume_params "
+                       "necessesary for your volume type choice.")
+                raise ValueError(msg)
+
+        pv = {
+            'apiVersion': 'v1',
+            'kind': 'PersistentVolume',
+            'metadata': {
+                'name': name,
+            },
+            'spec': {
+                'capacity': {
+                    'storage': str(size) + 'Gi'
+                },
+                'volumeMode': ex_volume_mode,
+                'accessModes': [ex_access_mode],
+                'persistentVolumeReclaimPolicy': ex_reclaim_policy,
+                'storageClassName': ex_storage_class_name,
+                'mountOptions': [],  # beta, to add in the future
+                ex_volume_type: ex_volume_params,
+            }
+        }
+
+        req = ROOT_URL + "persistentvolumes/"
+        method = 'POST'
+        data = json.dumps(pv)
+        try:
+            self.connection.request(req, method=method, data=data)
+
+        except Exception as exc:
+            raise
+        # make sure that the volume was created
+        volumes = self.list_volumes()
+        for volume in volumes:
+            if volume.name == name:
+                return volume
+
+    def _create_volume_dynamic(self, size, name, storage_class_name,
+                               volume_mode='Filesystem', namespace='default',
+                               access_mode='ReadWriteOnce'):
+        """
+        Method to create a Persistent Volume Claim for storage,
+        thus storage is required in the arguments.
+        This method assumes dynamic provisioning of the
+        Persistent Volume so the storage_class given should
+        allow for it (by default it usually is), or already
+        have unbounded Persistent Volumes created by an admin.
+
+        :param name: The name of the pvc an arbitrary string of lower letters
+        :type name: `str`
+
+        :param size: An int of the ammount of gigabytes desired
+        :type size: `int`
+
+        :param namespace: The namespace where the claim will live
+        :type namespace: `str`
+
+        :param storage_class_name: If you want the pvc to be bound to
+                                 a particular class of PVs specified here.
+        :type storage_class_name: `str`
+
+        :param access_mode: The desired access mode, ie "ReadOnlyMany"
+        :type access_mode: `str`
+
+        :param matchLabels: A dictionary with the labels, ie:
+                            {'release': 'stable,}
+        :type matchLabels: `dict` with keys `str` and values `str`
+        """
+        pvc = {
+            'apiVersion': 'v1',
+            'kind': 'PersistentVolumeClaim',
+            'metadata': {
+                'name': name
+            },
+            'spec': {
+                'accessModes': [],
+                'volumeMode': volume_mode,
+                'resources': {
+                    'requests': {
+                        'storage': ''
+                    }
+                },
+            }
+        }
+
+        pvc['spec']['accessModes'].append(access_mode)
+
+        if storage_class_name is not None:
+            pvc['spec']['storageClassName'] = storage_class_name
+        else:
+            raise ValueError("The storage class name must be provided of a"
+                             "storage class which allows for dynamic "
+                             "provisioning")
+        pvc['spec']['resources']['requests']['storage'] = str(size) + 'Gi'
+
+        method = "POST"
+        req = ROOT_URL + "namespaces/" + namespace + "/persistentvolumeclaims"
+        data = json.dumps(pvc)
+        try:
+            result = self.connection.request(req, method=method, data=data)
+        except Exception as exc:
+            raise
+        if result.object['status']['phase'] != "Bound":
+            for _ in range(3):
+
+                req = ROOT_URL + "namespaces/" + namespace + \
+                    "/persistentvolumeclaims/" + name
+                try:
+                    result = self.connection.request(req).object
+                except Exception as exc:
+                    raise
+                if result['status']['phase'] == "Bound":
+                    break
+                time.sleep(3)
+
+        # check that the pv was created and bound
+        volumes = self.list_volumes()
+        for volume in volumes:
+            if volume.extra['pvc']['name'] == name:
+                return volume
+
+    def _bind_volume(self, volume, namespace='default'):
+        """
+        This method is for unbound volumes that were statically made.
+        It will bind them to a pvc so they can be used by
+        a kubernetes resource.
+        """
+        if volume.extra['is_bound']:
+            return  # volume already bound
+
+        storage_class = volume.extra['storage_class_name']
+        size = volume.size
+        name = volume.name + "-pvc"
+        volume_mode = volume.extra['volume_mode']
+        access_mode = volume.extra['access_modes'][0]
+
+        vol = self._create_volume_dynamic(size=size, name=name,
+                                          storage_class_name=storage_class,
+                                          volume_mode=volume_mode,
+                                          namespace=namespace,
+                                          access_mode=access_mode)
+        return vol
+
+    def destroy_volume(self, volume):
+        # first delete the pvc
+        method = 'DELETE'
+        if volume.extra['is_bound']:
+            pvc = volume.extra['pvc']['name']
+            namespace = volume.extra['pvc']['namespace']
+            req = ROOT_URL + "namespaces/" + namespace + \
+                "/persistentvolumeclaims/" + pvc
+            try:
+                result = self.connection.request(req, method=method)
+
+            except Exception as exc:
+                raise
+
+        pv = volume.name
+        req = ROOT_URL + "persistentvolumes/" + pv
+
+        try:
+            result = self.connection.request(req, method=method)
+            return result.status
+        except Exception as exc:
+            raise
+
+    def attach_volume(self, node, volume, device='disk',
+                      ex_bus='virtio', ex_name=None):
+        """
+        params: bus, name , device (disk or lun)
+        """
+        # volume must be bound to a claim
+        if not volume.extra['is_bound']:
+            volume = self._bind_volume(volume, node.extra['namespace'])
+            if volume is None:
+                raise ProviderError("Selected Volume (PV) could not be bound "
+                                    "(to a PVC), please select another volume")
+
+        claimName = volume.extra['pvc']['name']
+        if ex_name is None:
+            name = claimName
+        else:
+            name = ex_name
+        namespace = volume.extra['pvc']['namespace']
+        # check if vm is stopped
+        self.stop_node(node)
+        # check if it is the same namespace
+        if node.extra['namespace'] != namespace:
+            msg = "The PVC and the VM must be in the same namespace"
+            raise ValueError(msg)
+        vm = node.name
+        req = KUBEVIRT_URL + 'namespaces/' + namespace + '/virtualmachines/'\
+            + vm
+        disk_dict = {device: {'bus': ex_bus}, 'name': name}
+        volumes_dict = {'persistentVolumeClaim': {'claimName': claimName},
+                        'name': name}
+        # Get all the volumes of the vm
+        try:
+            result = self.connection.request(req).object
+        except Exception as exc:
+            raise
+        disks = result['spec']['template']['spec']['domain'][
+            'devices']['disks']
+        volumes = result['spec']['template']['spec']['volumes']
+        disks.append(disk_dict)
+        volumes.append(volumes_dict)
+        # now patch the new volumes and disks lists into the resource
+        headers = {"Content-Type": "application/merge-patch+json"}
+        data = {'spec': {
+            'template': {
+                'spec': {
+                    'volumes': volumes,
+                    'domain': {
+                        'devices':
+                        {'disks': disks}
+                    }
+                }
+            }
+        }
+        }
+        try:
+            result = self.connection.request(req, method="PATCH",
+                                             data=json.dumps(data),
+                                             headers=headers)
+            if 'pvcs' in node.extra:
+                node.extra['pvcs'].append(claimName)
+            else:
+                node.extra['pvcs'] = [claimName]
+            return result in VALID_RESPONSE_CODES
+        except Exception as exc:
+            raise
+
+    def detach_volume(self, volume, ex_node):
+        """
+        Detaches a volume from a node but the node must be given since a PVC
+        can have more than one VMI's pointing to it
+        """
+        # vmi must be stopped
+        self.stop_node(ex_node)
+
+        claimName = volume.extra['pvc']['name']
+        name = ex_node.name
+        namespace = ex_node.extra['namespace']
+        req = KUBEVIRT_URL + 'namespaces/' + namespace + '/virtualmachines/'\
+            + name
+        headers = {"Content-Type": "application/merge-patch+json"}
+        # Get all the volumes of the vm
+
+        try:
+            result = self.connection.request(req).object
+        except Exception as exc:
+            raise
+        disks = result['spec']['template']['spec']['domain'][
+            'devices']['disks']
+        volumes = result['spec']['template']['spec']['volumes']
+        to_delete = None
+        for volume in volumes:
+            if 'persistentVolumeClaim' in volume:
+                if volume['persistentVolumeClaim']['claimName'] == claimName:
+                    to_delete = volume['name']
+                    volumes.remove(volume)
+                    break
+        if not to_delete:
+            msg = "The given volume is not attached to the given VM"
+            raise ValueError(msg)
+
+        for disk in disks:
+            if disk['name'] == to_delete:
+                disks.remove(disk)
+                break
+        # now patch the new volumes and disks lists into the resource
+        data = {'spec': {
+            'template': {
+                'spec': {
+                    'volumes': volumes,
+                    'domain': {
+                        'devices':
+                        {'disks': disks}
+                    }
+                }
+            }
+        }
+        }
+        try:
+            result = self.connection.request(req, method="PATCH",
+                                             data=json.dumps(data),
+                                             headers=headers)
+            ex_node.extra['pvcs'].remove(claimName)
+            return result in VALID_RESPONSE_CODES
+        except Exception as exc:
+            raise
+
+    def ex_list_persistent_volume_claims(self, namespace="default"):
+
+        pvc_req = ROOT_URL + "namespaces/" + namespace + \
+            "/persistentvolumeclaims"
+        try:
+            result = self.connection.request(pvc_req).object
+        except Exception as exc:
+            raise
+        pvcs = [item['metadata']['name'] for item in result['items']]
+        return pvcs
+
+    def ex_list_storage_classes(self):
+
+        # sc = storage class
+        sc_req = "/apis/storage.k8s.io/v1/storageclasses"
+        try:
+                result = self.connection.request(sc_req).object
+        except Exception as exc:
+            raise
+        scs = [item['metadata']['name'] for item in result['items']]
+
+        return scs
+
+    def list_volumes(self):
+        """
+        Location is a namespace of the cluster.
+        """
+        volumes = []
+
+        pv_rec = ROOT_URL + "/persistentvolumes/"
+
+        try:
+            result = self.connection.request(pv_rec).object
+        except Exception as exc:
+            raise
+
+        for item in result['items']:
+            if item['status']['phase'] not in {'Available', 'Bound'}:
+                continue
+            ID = item['metadata']['uid']
+            size = item['spec']['capacity']['storage']
+            size = int(size.rstrip('Gi'))
+            extra = {'pvc': {}}
+            extra['storage_class_name'] = item['spec']['storageClassName']
+            extra['is_bound'] = item['status']['phase'] == "Bound"
+            extra['access_modes'] = item['spec']['accessModes']
+            extra['volume_mode'] = item['spec']['volumeMode']
+            if extra['is_bound']:
+                extra['pvc']['name'] = item['spec']['claimRef']['name']
+                extra['pvc']['namespace'] = item['spec']['claimRef'][
+                    'namespace']
+                extra['pvc']['uid'] = item['spec']['claimRef']['uid']
+                name = extra['pvc']['name']
+            else:
+                name = item['metadata']['name']
+            volume = StorageVolume(id=ID, name=name, size=size,
+                                   driver=self.connection.driver,
+                                   extra=extra)
+            volumes.append(volume)
+
+        return volumes
+
+    def _ex_connection_class_kwargs(self):
+        kwargs = {}
+        if hasattr(self, 'key_file'):
+            kwargs['key_file'] = self.key_file
+        if hasattr(self, 'cert_file'):
+            kwargs['cert_file'] = self.cert_file
+        return kwargs
+
+    def _to_node(self, vm, is_stopped=False):
+        """
+        This will conver a VM resource to a node with state "Stopped"
+        It can be started with self.start
+        """
+        ID = vm['metadata']['uid']
+        name = vm['metadata']['name']
+        driver = self.connection.driver
+        extra = {'namespace': vm['metadata']['namespace']}
+        extra['pvcs'] = []
+        if 'limits' in vm['spec']['template']['spec'][
+                'domain']['resources']:
+            if 'memory' in vm['spec']['template']['spec'][
+                    'domain']['resources']['limits']:
+                memory = vm['spec']['template']['spec'][
+                    'domain']['resources']['limits']['memory']
+                memory = int(memory.rstrip('M'))
+        else:
+            memory = 0
+        if 'limits' in vm['spec']['template']['spec'][
+                'domain']['resources']:
+            if 'cpu' in vm['spec']['template']['spec'][
+                    'domain']['resources']['limits']:
+                cpu = vm['spec']['template']['spec'][
+                    'domain']['resources']['requests']['cpu']
+                cpu = int(cpu.rstrip('m'))
+
+        else:
+            cpu = 0
+        extra_size = {'cpus': cpu}
+        size = NodeSize(id=ID, name=name, ram=memory,
+                        disk=0, bandwidth=0, price=0,
+                        driver=driver, extra=extra_size)
+        extra['memory'] = memory
+        extra['cpu'] = cpu
+        image_name = "undefined"
+        for volume in vm['spec']['template'][
+                'spec']['volumes']:
+            for k, v in volume.items():
+                if type(v) is dict:
+                    if 'image' in v:
+                        image_name = v['image']
+        image = NodeImage(ID, image_name, driver)
+        if 'volumes' in vm['spec']['template']['spec']:
+            for volume in vm['spec']['template']['spec']['volumes']:
+                if 'persistentVolumeClaim' in volume:
+                    extra['pvcs'].append(volume[
+                        'persistentVolumeClaim']['claimName'])
+        if is_stopped:
+            state = NodeState.STOPPED
+            public_ips = None
+            private_ips = None
+            return Node(id=ID, name=name, state=state,
+                        public_ips=public_ips,
+                        private_ips=private_ips,
+                        driver=driver, size=size,
+                        image=image, extra=extra)
+
+        # getting image and image_ID from the container
+        req = ROOT_URL + "namespaces/" + extra['namespace'] + "/pods"
+        result = self.connection.request(req).object
+        pod = None
+        for pd in result['items']:
+            if 'metadata' in pd and 'ownerReferences' in pd['metadata']:
+                if pd['metadata']['ownerReferences'][0]['name'] == name:
+                    pod = pd
+        if pod is None or 'containerStatuses' not in pod['status']:
+            state = NodeState.PENDING
+            public_ips = None
+            private_ips = None
+            return Node(id=ID, name=name, state=state,
+                        public_ips=public_ips,
+                        private_ips=private_ips,
+                        driver=driver, size=size,
+                        image=image, extra=extra)
+        extra['pod'] = {'name': pod['metadata']['name']}
+        for cont_status in pod['status']['containerStatuses']:
+            # only 2 containers are present the launcher and the vmi
+            if cont_status['name'] != 'compute':
+                image = NodeImage(ID, cont_status['image'],
+                                  driver)
+                state = NodeState.RUNNING if "running" in cont_status[
+                    'state'] else NodeState.PENDING
+
+        # getting size data
+        for container in pod['spec']['containers']:
+            if container['name'] != "compute":
+                if 'memory' in container['resources']['limits']:
+                    memory = container['resources']['limits']['memory']
+                    memory = int(memory.rstrip('M'))
+                else:
+                    memory = 0
+                if 'cpu' in container['resources']['limits']:
+                    cpu = container['resources']['limits']['cpu']
+                    cpu = int(cpu.rstrip('m'))
+                else:
+                    cpu = 0
+                extra['memory'] = memory
+                extra['cpu'] = cpu
+                extra_size = {'cpus': cpu}
+                size = NodeSize(id=ID, name=name, ram=memory,
+                                disk=0, bandwidth=0, price=0,
+                                driver=driver, extra=extra_size)
+
+        public_ips = None
+        created_at = datetime.strptime(vm['metadata']['creationTimestamp'],
+                                       '%Y-%m-%dT%H:%M:%SZ')
+
+        if 'podIPs' in pod['status']:
+            private_ips = [ip['ip'] for ip in pod['status']['podIPs']]
+        else:
+            private_ips = []
+
+        return Node(id=ID, name=name, state=state,
+                    public_ips=public_ips,
+                    private_ips=private_ips,
+                    driver=driver, size=size,
+                    image=image, extra=extra,
+                    created_at=created_at)

--- a/libcloud/compute/providers.py
+++ b/libcloud/compute/providers.py
@@ -164,7 +164,9 @@ DRIVERS = {
     Provider.MAXIHOST:
     ('libcloud.compute.drivers.maxihost', 'MaxihostNodeDriver'),
     Provider.GRIDSCALE:
-    ('libcloud.compute.drivers.gridscale', 'GridscaleNodeDriver')
+    ('libcloud.compute.drivers.gridscale', 'GridscaleNodeDriver'),
+    Provider.KUBEVIRT:
+    ('libcloud.compute.drivers.kubevirt', 'KubeVirtNodeDriver')
 }
 
 

--- a/libcloud/compute/types.py
+++ b/libcloud/compute/types.py
@@ -125,6 +125,7 @@ class Provider(Type):
     :cvar IKOULA: Ikoula driver.
     :cvar JOYENT: Joyent driver
     :cvar KTUCLOUD: kt ucloud driver
+    :cvar KUBEVIRT: kubevirt driver
     :cvar LIBVIRT: Libvirt driver
     :cvar LINODE: Linode.com
     :cvar NEPHOSCALE: NephoScale driver
@@ -179,6 +180,7 @@ class Provider(Type):
     INTERNETSOLUTIONS = 'internetsolutions'
     JOYENT = 'joyent'
     KTUCLOUD = 'ktucloud'
+    KUBEVIRT = 'kubevirt'
     LIBVIRT = 'libvirt'
     LINODE = 'linode'
     MAXIHOST = 'maxihost'

--- a/libcloud/container/drivers/kubernetes.py
+++ b/libcloud/container/drivers/kubernetes.py
@@ -15,11 +15,7 @@
 
 import base64
 import datetime
-
-try:
-    import simplejson as json
-except Exception:
-    import json
+import json
 
 from libcloud.utils.py3 import httplib
 from libcloud.utils.py3 import b

--- a/libcloud/container/drivers/kubernetes.py
+++ b/libcloud/container/drivers/kubernetes.py
@@ -78,7 +78,8 @@ class KubernetesConnection(ConnectionUserAndKey):
         If user and password are specified, include a base http auth
         header
         """
-        headers['Content-Type'] = 'application/json'
+        if 'Content-Type' not in headers:
+            headers['Content-Type'] = 'application/json'
         if self.key and self.secret:
             user_b64 = base64.b64encode(b('%s:%s' % (self.key, self.secret)))
             headers['Authorization'] = 'Basic %s' % (user_b64.decode('utf-8'))
@@ -136,7 +137,7 @@ class KubernetesContainerDriver(ContainerDriver):
             prefixes = ['http://', 'https://']
             for prefix in prefixes:
                 if host.startswith(prefix):
-                    host = host.strip(prefix)
+                    host = host.lstrip(prefix)
 
             self.connection.host = host
             self.connection.port = port

--- a/libcloud/http.py
+++ b/libcloud/http.py
@@ -209,7 +209,6 @@ class LibcloudConnection(LibcloudBaseConnection):
 
         if proxy_url:
             self.set_http_proxy(proxy_url=proxy_url)
-        
 
     @property
     def verification(self):

--- a/libcloud/http.py
+++ b/libcloud/http.py
@@ -194,7 +194,7 @@ class LibcloudConnection(LibcloudBaseConnection):
         http_proxy_url_env = os.environ.get(HTTP_PROXY_ENV_VARIABLE_NAME,
                                             https_proxy_url_env)
 
-        # Connection argument rgument has precedence over environment variables
+        # Connection argument has precedence over environment variables
         proxy_url = kwargs.pop('proxy_url', http_proxy_url_env)
 
         self._setup_verify()
@@ -202,12 +202,14 @@ class LibcloudConnection(LibcloudBaseConnection):
 
         LibcloudBaseConnection.__init__(self)
 
+        self.session.timeout = kwargs.pop('timeout', 60)
+
         if 'cert_file' in kwargs or 'key_file' in kwargs:
             self._setup_signing(**kwargs)
 
         if proxy_url:
             self.set_http_proxy(proxy_url=proxy_url)
-        self.session.timeout = kwargs.get('timeout', 60)
+        
 
     @property
     def verification(self):

--- a/libcloud/test/compute/fixtures/kubevirt/_api_v1_namespaces.json
+++ b/libcloud/test/compute/fixtures/kubevirt/_api_v1_namespaces.json
@@ -1,0 +1,98 @@
+{
+    "apiVersion": "v1",
+    "metadata": {
+      "selfLink": "/api/v1/namespaces",
+      "resourceVersion": "227032"
+    },
+    "kind": "NamespaceList",
+    "items": [
+      {
+        "spec": {
+          "finalizers": [
+            "kubernetes"
+          ]
+        },
+        "metadata": {
+          "name": "default",
+          "creationTimestamp": "2019-12-01T15:54:25Z",
+          "selfLink": "/api/v1/namespaces/default",
+          "resourceVersion": "146",
+          "uid": "a5370eda-e8d8-4a1b-a97b-aeb9271bdcf8"
+        },
+        "status": {
+          "phase": "Active"
+        }
+      },
+      {
+        "spec": {
+          "finalizers": [
+            "kubernetes"
+          ]
+        },
+        "metadata": {
+          "name": "kube-node-lease",
+          "creationTimestamp": "2019-12-01T15:54:23Z",
+          "selfLink": "/api/v1/namespaces/kube-node-lease",
+          "resourceVersion": "39",
+          "uid": "0f934934-aefd-4d8d-862a-dd123b51b966"
+        },
+        "status": {
+          "phase": "Active"
+        }
+      },
+      {
+        "spec": {
+          "finalizers": [
+            "kubernetes"
+          ]
+        },
+        "metadata": {
+          "name": "kube-public",
+          "creationTimestamp": "2019-12-01T15:54:23Z",
+          "selfLink": "/api/v1/namespaces/kube-public",
+          "resourceVersion": "38",
+          "uid": "8f7c5fec-fc55-4057-9cf4-b2b0441848bd"
+        },
+        "status": {
+          "phase": "Active"
+        }
+      },
+      {
+        "spec": {
+          "finalizers": [
+            "kubernetes"
+          ]
+        },
+        "metadata": {
+          "name": "kube-system",
+          "creationTimestamp": "2019-12-01T15:54:23Z",
+          "selfLink": "/api/v1/namespaces/kube-system",
+          "resourceVersion": "37",
+          "uid": "9263771e-166e-4b6b-8fbf-6a9af569ac93"
+        },
+        "status": {
+          "phase": "Active"
+        }
+      },
+      {
+        "spec": {
+          "finalizers": [
+            "kubernetes"
+          ]
+        },
+        "metadata": {
+          "labels": {
+            "kubevirt.io": ""
+          },
+          "selfLink": "/api/v1/namespaces/kubevirt",
+          "name": "kubevirt",
+          "creationTimestamp": "2019-12-01T15:58:27Z",
+          "resourceVersion": "689",
+          "uid": "e6d3d7e8-0ee5-428b-8e17-5187779e5627"
+        },
+        "status": {
+          "phase": "Active"
+        }
+      }
+    ]
+  }

--- a/libcloud/test/compute/fixtures/kubevirt/create_vm.json
+++ b/libcloud/test/compute/fixtures/kubevirt/create_vm.json
@@ -1,0 +1,83 @@
+{
+    "metadata": {
+      "creationTimestamp": "2019-12-23T13:33:14Z",
+      "namespace": "default",
+      "resourceVersion": "911058",
+      "generation": 1,
+      "name": "libcloud-created",
+      "labels": {
+        "kubevirt.io/vm": "libcloud-created"
+      },
+      "uid": "e553010d-e904-436f-a92a-396be0f8bd4c",
+      "selfLink": "/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines/libcloud-created"
+    },
+    "spec": {
+      "running": false,
+      "template": {
+        "metadata": {
+          "labels": {
+            "kubevirt.io/vm": "libcloud-created"
+          }
+        },
+        "spec": {
+          "volumes": [
+            {
+              "persistentVolumeClaim": {
+                "claimName": "mypvc2"
+              },
+              "name": "anpvc"
+            },
+            {
+              "name": "boot-disk",
+              "containerDisk": {
+                "image": "kubevirt/cirros-registry-disk-demo"
+              }
+            }
+          ],
+          "networks": [
+            {
+              "name": "netw1",
+              "pod": {}
+            }
+          ],
+          "terminationGracePeriodSeconds": 0,
+          "domain": {
+            "resources": {
+              "requests": {
+                "memory": "128M"
+              }
+            },
+            "cpu": {},
+            "devices": {
+              "interfaces": [
+                {
+                  "name": "netw1",
+                  "masquerade": {}
+                }
+              ],
+              "disks": [
+                {
+                  "name": "anpvc",
+                  "disk": {
+                    "bus": "virtio"
+                  }
+                },
+                {
+                  "name": "boot-disk",
+                  "disk": {
+                    "bus": "virtio"
+                  }
+                }
+              ],
+              "networkInterfaceMultiqueue": false
+            },
+            "machine": {
+              "type": ""
+            }
+          }
+        }
+      }
+    },
+    "kind": "VirtualMachine",
+    "apiVersion": "kubevirt.io/v1alpha3"
+  }

--- a/libcloud/test/compute/fixtures/kubevirt/delete_vmi_testvm.json
+++ b/libcloud/test/compute/fixtures/kubevirt/delete_vmi_testvm.json
@@ -1,0 +1,132 @@
+{
+    "apiVersion": "kubevirt.io/v1alpha3",
+    "status": {
+      "phase": "Running",
+      "migrationMethod": "BlockMigration",
+      "conditions": [
+        {
+          "type": "LiveMigratable",
+          "lastTransitionTime": null,
+          "message": "cannot migrate VMI with a bridge interface connected to a pod network",
+          "status": "False",
+          "lastProbeTime": null,
+          "reason": "InterfaceNotLiveMigratable"
+        },
+        {
+          "type": "Ready",
+          "lastTransitionTime": "2019-12-08T13:17:48Z",
+          "status": "True",
+          "lastProbeTime": null
+        }
+      ],
+      "guestOSInfo": {},
+      "nodeName": "minikube",
+      "interfaces": [
+        {
+          "ipAddress": "172.17.0.11",
+          "name": "default",
+          "mac": "02:42:ac:11:00:0b"
+        }
+      ],
+      "qosClass": "Burstable"
+    },
+    "kind": "VirtualMachineInstance",
+    "metadata": {
+      "generateName": "testvm",
+      "deletionGracePeriodSeconds": 0,
+      "labels": {
+        "kubevirt.io/nodeName": "minikube",
+        "kubevirt.io/size": "small",
+        "kubevirt.io/domain": "testvm"
+      },
+      "annotations": {
+        "kubevirt.io/latest-observed-api-version": "v1alpha3",
+        "kubevirt.io/storage-observed-api-version": "v1alpha3"
+      },
+      "namespace": "default",
+      "creationTimestamp": "2019-12-08T13:17:41Z",
+      "name": "testvm",
+      "generation": 9,
+      "selfLink": "/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachineinstances/testvm",
+      "ownerReferences": [
+        {
+          "apiVersion": "kubevirt.io/v1alpha3",
+          "name": "testvm",
+          "kind": "VirtualMachine",
+          "blockOwnerDeletion": true,
+          "uid": "74fd7665-fbd6-4565-977c-96bd21fb785a",
+          "controller": true
+        }
+      ],
+      "deletionTimestamp": "2019-12-08T13:18:54Z",
+      "resourceVersion": "276064",
+      "finalizers": [
+        "foregroundDeleteVirtualMachine"
+      ],
+      "uid": "4106caa7-836f-40fe-b872-6f46be4eb6cf"
+    },
+    "spec": {
+      "domain": {
+        "devices": {
+          "disks": [
+            {
+              "disk": {
+                "bus": "virtio"
+              },
+              "name": "containerdisk"
+            },
+            {
+              "disk": {
+                "bus": "virtio"
+              },
+              "name": "cloudinitdisk"
+            }
+          ],
+          "interfaces": [
+            {
+              "name": "default",
+              "bridge": {}
+            }
+          ]
+        },
+        "firmware": {
+          "uuid": "5a9fc181-957e-5c32-9e5a-2de5e9673531"
+        },
+        "machine": {
+          "type": "q35"
+        },
+        "resources": {
+          "requests": {
+            "cpu": "100m",
+            "memory": "64M"
+          }
+        },
+        "features": {
+          "acpi": {
+            "enabled": true
+          }
+        }
+      },
+      "networks": [
+        {
+          "name": "default",
+          "pod": {}
+        }
+      ],
+      "volumes": [
+        {
+          "name": "containerdisk",
+          "containerDisk": {
+            "image": "kubevirt/cirros-registry-disk-demo",
+            "imagePullPolicy": "Always"
+          }
+        },
+        {
+          "cloudInitNoCloud": {
+            "userDataBase64": "SGkuXG4="
+          },
+          "name": "cloudinitdisk"
+        }
+      ]
+    }
+  }

--- a/libcloud/test/compute/fixtures/kubevirt/get_default_vms.json
+++ b/libcloud/test/compute/fixtures/kubevirt/get_default_vms.json
@@ -1,0 +1,99 @@
+{
+  "items": [
+    {
+      "spec": {
+        "template": {
+          "spec": {
+            "domain": {
+              "resources": {
+                "requests": {
+                  "memory": "64M"
+                }
+              },
+              "devices": {
+                "disks": [
+                  {
+                    "name": "containerdisk",
+                    "disk": {
+                      "bus": "virtio"
+                    }
+                  },
+                  {
+                    "name": "cloudinitdisk",
+                    "disk": {
+                      "bus": "virtio"
+                    }
+                  }
+                ],
+                "interfaces": [
+                  {
+                    "name": "default",
+                    "bridge": {}
+                  }
+                ]
+              },
+              "machine": {
+                "type": ""
+              }
+            },
+            "networks": [
+              {
+                "name": "default",
+                "pod": {}
+              }
+            ],
+            "volumes": [
+              {
+                "name": "containerdisk",
+                "containerDisk": {
+                  "image": "kubevirt/cirros-registry-disk-demo"
+                }
+              },
+              {
+                "cloudInitNoCloud": {
+                  "userDataBase64": "SGkuXG4="
+                },
+                "name": "cloudinitdisk"
+              }
+            ]
+          },
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "kubevirt.io/domain": "testvm",
+              "kubevirt.io/size": "small"
+            }
+          }
+        },
+        "running": true
+      },
+      "apiVersion": "kubevirt.io/v1alpha3",
+      "metadata": {
+        "annotations": {
+          "kubevirt.io/latest-observed-api-version": "v1alpha3",
+          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"kubevirt.io/v1alpha3\",\"kind\":\"VirtualMachine\",\"metadata\":{\"annotations\":{},\"name\":\"testvm\",\"namespace\":\"default\"},\"spec\":{\"running\":false,\"template\":{\"metadata\":{\"labels\":{\"kubevirt.io/domain\":\"testvm\",\"kubevirt.io/size\":\"small\"}},\"spec\":{\"domain\":{\"devices\":{\"disks\":[{\"disk\":{\"bus\":\"virtio\"},\"name\":\"containerdisk\"},{\"disk\":{\"bus\":\"virtio\"},\"name\":\"cloudinitdisk\"}],\"interfaces\":[{\"bridge\":{},\"name\":\"default\"}]},\"resources\":{\"requests\":{\"memory\":\"64M\"}}},\"networks\":[{\"name\":\"default\",\"pod\":{}}],\"volumes\":[{\"containerDisk\":{\"image\":\"kubevirt/cirros-registry-disk-demo\"},\"name\":\"containerdisk\"},{\"cloudInitNoCloud\":{\"userDataBase64\":\"SGkuXG4=\"},\"name\":\"cloudinitdisk\"}]}}}}\n",
+          "kubevirt.io/storage-observed-api-version": "v1alpha3"
+        },
+        "creationTimestamp": "2019-12-02T15:35:14Z",
+        "generation": 39,
+        "namespace": "default",
+        "name": "testvm",
+        "selfLink": "/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines/testvm",
+        "resourceVersion": "284863",
+        "uid": "74fd7665-fbd6-4565-977c-96bd21fb785a"
+      },
+      "kind": "VirtualMachine",
+      "status": {
+        "ready": true,
+        "created": true
+      }
+    }
+  ],
+  "apiVersion": "kubevirt.io/v1alpha3",
+  "metadata": {
+    "continue": "",
+    "selfLink": "/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines",
+    "resourceVersion": "285618"
+  },
+  "kind": "VirtualMachineList"
+}

--- a/libcloud/test/compute/fixtures/kubevirt/get_kube_node_lease_vms.json
+++ b/libcloud/test/compute/fixtures/kubevirt/get_kube_node_lease_vms.json
@@ -1,0 +1,10 @@
+{
+    "kind": "VirtualMachineList",
+    "items": [],
+    "metadata": {
+      "continue": "",
+      "selfLink": "/apis/kubevirt.io/v1alpha3/namespaces/kube-node-lease/virtualmachines",
+      "resourceVersion": "242134"
+    },
+    "apiVersion": "kubevirt.io/v1alpha3"
+  }

--- a/libcloud/test/compute/fixtures/kubevirt/get_kube_public_vms.json
+++ b/libcloud/test/compute/fixtures/kubevirt/get_kube_public_vms.json
@@ -1,0 +1,10 @@
+{
+    "kind": "VirtualMachineList",
+    "items": [],
+    "metadata": {
+      "continue": "",
+      "selfLink": "/apis/kubevirt.io/v1alpha3/namespaces/kube-public/virtualmachines",
+      "resourceVersion": "243536"
+    },
+    "apiVersion": "kubevirt.io/v1alpha3"
+  }

--- a/libcloud/test/compute/fixtures/kubevirt/get_kube_system_vms.json
+++ b/libcloud/test/compute/fixtures/kubevirt/get_kube_system_vms.json
@@ -1,0 +1,10 @@
+{
+    "kind": "VirtualMachineList",
+    "items": [],
+    "metadata": {
+      "continue": "",
+      "selfLink": "/apis/kubevirt.io/v1alpha3/namespaces/kube-system/virtualmachines",
+      "resourceVersion": "243702"
+    },
+    "apiVersion": "kubevirt.io/v1alpha3"
+  }

--- a/libcloud/test/compute/fixtures/kubevirt/get_kubevirt_vms.json
+++ b/libcloud/test/compute/fixtures/kubevirt/get_kubevirt_vms.json
@@ -1,0 +1,10 @@
+{
+    "kind": "VirtualMachineList",
+    "items": [],
+    "metadata": {
+      "continue": "",
+      "selfLink": "/apis/kubevirt.io/v1alpha3/namespaces/kubevirt/virtualmachines",
+      "resourceVersion": "245647"
+    },
+    "apiVersion": "kubevirt.io/v1alpha3"
+  }

--- a/libcloud/test/compute/fixtures/kubevirt/get_pods.json
+++ b/libcloud/test/compute/fixtures/kubevirt/get_pods.json
@@ -1,0 +1,322 @@
+{
+    "items": [
+      {
+        "status": {
+          "startTime": "2019-12-08T13:34:37Z",
+          "conditions": [
+            {
+              "type": "Initialized",
+              "lastTransitionTime": "2019-12-08T13:34:37Z",
+              "lastProbeTime": null,
+              "status": "True"
+            },
+            {
+              "type": "Ready",
+              "lastTransitionTime": "2019-12-08T13:34:44Z",
+              "lastProbeTime": null,
+              "status": "True"
+            },
+            {
+              "type": "ContainersReady",
+              "lastTransitionTime": "2019-12-08T13:34:44Z",
+              "lastProbeTime": null,
+              "status": "True"
+            },
+            {
+              "type": "PodScheduled",
+              "lastTransitionTime": "2019-12-08T13:34:37Z",
+              "lastProbeTime": null,
+              "status": "True"
+            }
+          ],
+          "containerStatuses": [
+            {
+              "imageID": "docker-pullable://kubevirt/virt-launcher@sha256:eb68bf622cc5802f77d85587b414810fa7d4d7e0aeefc7ab1591b3b6efe8db3c",
+              "name": "compute",
+              "restartCount": 0,
+              "image": "sha256:73568f22b146ceff112103b53855fdb3ebdaea0a48988e3b0636a66fb3260a4a",
+              "lastState": {},
+              "started": true,
+              "state": {
+                "running": {
+                  "startedAt": "2019-12-08T13:34:38Z"
+                }
+              },
+              "containerID": "docker://aa579ffde24182bb934722bfb0d3de5fbfc27a03ae91c76a32230d8e8dec7d6b",
+              "ready": true
+            },
+            {
+              "imageID": "docker-pullable://kubevirt/cirros-registry-disk-demo@sha256:657bfaaea4720e494058da55b35b302065d384576d49fa17be32d10e8ddfe2e7",
+              "name": "volumecontainerdisk",
+              "restartCount": 0,
+              "image": "kubevirt/cirros-registry-disk-demo:latest",
+              "lastState": {},
+              "started": true,
+              "state": {
+                "running": {
+                  "startedAt": "2019-12-08T13:34:40Z"
+                }
+              },
+              "containerID": "docker://67a5b13cb5ad3a3bccde84e1388103018d6abd8cbec095c19ca1057b9c87c2c2",
+              "ready": true
+            }
+          ],
+          "qosClass": "Burstable",
+          "hostIP": "192.168.39.242",
+          "phase": "Running",
+          "podIP": "172.17.0.11",
+          "podIPs": [
+            {
+              "ip": "172.17.0.11"
+            }
+          ]
+        },
+        "metadata": {
+          "creationTimestamp": "2019-12-08T13:34:37Z",
+          "name": "virt-launcher-testvm-4sdfc",
+          "generateName": "virt-launcher-testvm-",
+          "ownerReferences": [
+            {
+              "apiVersion": "kubevirt.io/v1alpha3",
+              "name": "testvm",
+              "kind": "VirtualMachineInstance",
+              "blockOwnerDeletion": true,
+              "uid": "3909c8af-73b9-4797-b70d-1c06e0923101",
+              "controller": true
+            }
+          ],
+          "selfLink": "/api/v1/namespaces/default/pods/virt-launcher-testvm-4sdfc",
+          "uid": "633f0272-4550-4805-ac26-2d7b4d7d186a",
+          "labels": {
+            "kubevirt.io": "virt-launcher",
+            "kubevirt.io/size": "small",
+            "kubevirt.io/domain": "testvm",
+            "kubevirt.io/created-by": "3909c8af-73b9-4797-b70d-1c06e0923101"
+          },
+          "resourceVersion": "276430",
+          "annotations": {
+            "kubevirt.io/domain": "testvm"
+          },
+          "namespace": "default"
+        },
+        "spec": {
+          "enableServiceLinks": true,
+          "terminationGracePeriodSeconds": 60,
+          "securityContext": {
+            "seLinuxOptions": {
+              "type": "virt_launcher.process"
+            },
+            "runAsUser": 0
+          },
+          "volumes": [
+            {
+              "emptyDir": {},
+              "name": "infra-ready-mount"
+            },
+            {
+              "hostPath": {
+                "type": "",
+                "path": "/var/run/kubevirt"
+              },
+              "name": "virt-share-dir"
+            },
+            {
+              "hostPath": {
+                "type": "",
+                "path": "/var/lib/kubevirt/init/usr/bin"
+              },
+              "name": "virt-bin-share-dir"
+            },
+            {
+              "emptyDir": {},
+              "name": "libvirt-runtime"
+            },
+            {
+              "emptyDir": {},
+              "name": "ephemeral-disks"
+            },
+            {
+              "hostPath": {
+                "type": "",
+                "path": "/var/run/kubevirt/container-disks/3909c8af-73b9-4797-b70d-1c06e0923101"
+              },
+              "name": "container-disks"
+            }
+          ],
+          "automountServiceAccountToken": false,
+          "priority": 0,
+          "serviceAccountName": "default",
+          "serviceAccount": "default",
+          "hostname": "testvm",
+          "schedulerName": "default-scheduler",
+          "containers": [
+            {
+              "volumeMounts": [
+                {
+                  "mountPath": "/var/run/kubevirt-ephemeral-disks",
+                  "name": "ephemeral-disks"
+                },
+                {
+                  "mountPath": "/var/run/kubevirt/container-disks",
+                  "name": "container-disks",
+                  "mountPropagation": "HostToContainer"
+                },
+                {
+                  "mountPath": "/var/run/kubevirt",
+                  "name": "virt-share-dir"
+                },
+                {
+                  "mountPath": "/var/run/libvirt",
+                  "name": "libvirt-runtime"
+                },
+                {
+                  "mountPath": "/var/run/kubevirt-infra",
+                  "name": "infra-ready-mount"
+                }
+              ],
+              "name": "compute",
+              "imagePullPolicy": "IfNotPresent",
+              "command": [
+                "/usr/bin/virt-launcher",
+                "--qemu-timeout",
+                "5m",
+                "--name",
+                "testvm",
+                "--uid",
+                "3909c8af-73b9-4797-b70d-1c06e0923101",
+                "--namespace",
+                "default",
+                "--kubevirt-share-dir",
+                "/var/run/kubevirt",
+                "--ephemeral-disk-dir",
+                "/var/run/kubevirt-ephemeral-disks",
+                "--container-disk-dir",
+                "/var/run/kubevirt/container-disks",
+                "--readiness-file",
+                "/var/run/kubevirt-infra/healthy",
+                "--grace-period-seconds",
+                "45",
+                "--hook-sidecars",
+                "0",
+                "--less-pvc-space-toleration",
+                "10"
+              ],
+              "terminationMessagePath": "/dev/termination-log",
+              "image": "index.docker.io/kubevirt/virt-launcher@sha256:eb68bf622cc5802f77d85587b414810fa7d4d7e0aeefc7ab1591b3b6efe8db3c",
+              "securityContext": {
+                "privileged": false,
+                "runAsUser": 0,
+                "capabilities": {
+                  "add": [
+                    "NET_ADMIN",
+                    "SYS_NICE"
+                  ]
+                }
+              },
+              "terminationMessagePolicy": "File",
+              "resources": {
+                "limits": {
+                  "devices.kubevirt.io/tun": "1",
+                  "devices.kubevirt.io/vhost-net": "1",
+                  "devices.kubevirt.io/kvm": "1"
+                },
+                "requests": {
+                  "devices.kubevirt.io/tun": "1",
+                  "cpu": "100m",
+                  "memory": "225679432",
+                  "devices.kubevirt.io/vhost-net": "1",
+                  "devices.kubevirt.io/kvm": "1"
+                }
+              },
+              "readinessProbe": {
+                "timeoutSeconds": 5,
+                "failureThreshold": 5,
+                "successThreshold": 1,
+                "initialDelaySeconds": 4,
+                "exec": {
+                  "command": [
+                    "cat",
+                    "/var/run/kubevirt-infra/healthy"
+                  ]
+                },
+                "periodSeconds": 1
+              }
+            },
+            {
+              "volumeMounts": [
+                {
+                  "mountPath": "/var/run/kubevirt-ephemeral-disks/container-disk-data/3909c8af-73b9-4797-b70d-1c06e0923101",
+                  "name": "container-disks"
+                },
+                {
+                  "mountPath": "/usr/bin",
+                  "name": "virt-bin-share-dir"
+                }
+              ],
+              "name": "volumecontainerdisk",
+              "imagePullPolicy": "Always",
+              "command": [
+                "/usr/bin/container-disk"
+              ],
+              "args": [
+                "--copy-path",
+                "/var/run/kubevirt-ephemeral-disks/container-disk-data/3909c8af-73b9-4797-b70d-1c06e0923101/disk_0"
+              ],
+              "terminationMessagePath": "/dev/termination-log",
+              "image": "kubevirt/cirros-registry-disk-demo",
+              "terminationMessagePolicy": "File",
+              "resources": {
+                "limits": {
+                  "cpu": "100m",
+                  "memory": "40M"
+                },
+                "requests": {
+                  "cpu": "10m",
+                  "memory": "1M"
+                }
+              },
+              "readinessProbe": {
+                "timeoutSeconds": 1,
+                "failureThreshold": 5,
+                "successThreshold": 1,
+                "initialDelaySeconds": 1,
+                "exec": {
+                  "command": [
+                    "/usr/bin/container-disk",
+                    "--health-check"
+                  ]
+                },
+                "periodSeconds": 1
+              }
+            }
+          ],
+          "nodeSelector": {
+            "kubevirt.io/schedulable": "true"
+          },
+          "nodeName": "minikube",
+          "dnsPolicy": "ClusterFirst",
+          "tolerations": [
+            {
+              "operator": "Exists",
+              "tolerationSeconds": 300,
+              "effect": "NoExecute",
+              "key": "node.kubernetes.io/not-ready"
+            },
+            {
+              "operator": "Exists",
+              "tolerationSeconds": 300,
+              "effect": "NoExecute",
+              "key": "node.kubernetes.io/unreachable"
+            }
+          ],
+          "restartPolicy": "Never"
+        }
+      }
+    ],
+    "apiVersion": "v1",
+    "kind": "PodList",
+    "metadata": {
+      "resourceVersion": "277853",
+      "selfLink": "/api/v1/namespaces/default/pods"
+    }
+  }

--- a/libcloud/test/compute/fixtures/kubevirt/start_testvm.json
+++ b/libcloud/test/compute/fixtures/kubevirt/start_testvm.json
@@ -1,0 +1,85 @@
+{
+    "status": {},
+    "spec": {
+      "running": true,
+      "template": {
+        "spec": {
+          "volumes": [
+            {
+              "containerDisk": {
+                "image": "kubevirt/cirros-registry-disk-demo"
+              },
+              "name": "containerdisk"
+            },
+            {
+              "name": "cloudinitdisk",
+              "cloudInitNoCloud": {
+                "userDataBase64": "SGkuXG4="
+              }
+            }
+          ],
+          "networks": [
+            {
+              "name": "default",
+              "pod": {}
+            }
+          ],
+          "domain": {
+            "machine": {
+              "type": ""
+            },
+            "resources": {
+              "requests": {
+                "memory": "64M"
+              }
+            },
+            "devices": {
+              "disks": [
+                {
+                  "disk": {
+                    "bus": "virtio"
+                  },
+                  "name": "containerdisk"
+                },
+                {
+                  "disk": {
+                    "bus": "virtio"
+                  },
+                  "name": "cloudinitdisk"
+                }
+              ],
+              "interfaces": [
+                {
+                  "name": "default",
+                  "bridge": {}
+                }
+              ]
+            }
+          }
+        },
+        "metadata": {
+          "labels": {
+            "kubevirt.io/domain": "testvm",
+            "kubevirt.io/size": "small"
+          },
+          "creationTimestamp": null
+        }
+      }
+    },
+    "kind": "VirtualMachine",
+    "metadata": {
+      "name": "testvm",
+      "resourceVersion": "253345",
+      "annotations": {
+        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"kubevirt.io/v1alpha3\",\"kind\":\"VirtualMachine\",\"metadata\":{\"annotations\":{},\"name\":\"testvm\",\"namespace\":\"default\"},\"spec\":{\"running\":false,\"template\":{\"metadata\":{\"labels\":{\"kubevirt.io/domain\":\"testvm\",\"kubevirt.io/size\":\"small\"}},\"spec\":{\"domain\":{\"devices\":{\"disks\":[{\"disk\":{\"bus\":\"virtio\"},\"name\":\"containerdisk\"},{\"disk\":{\"bus\":\"virtio\"},\"name\":\"cloudinitdisk\"}],\"interfaces\":[{\"bridge\":{},\"name\":\"default\"}]},\"resources\":{\"requests\":{\"memory\":\"64M\"}}},\"networks\":[{\"name\":\"default\",\"pod\":{}}],\"volumes\":[{\"containerDisk\":{\"image\":\"kubevirt/cirros-registry-disk-demo\"},\"name\":\"containerdisk\"},{\"cloudInitNoCloud\":{\"userDataBase64\":\"SGkuXG4=\"},\"name\":\"cloudinitdisk\"}]}}}}\n",
+        "kubevirt.io/storage-observed-api-version": "v1alpha3",
+        "kubevirt.io/latest-observed-api-version": "v1alpha3"
+      },
+      "selfLink": "/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines/testvm",
+      "uid": "74fd7665-fbd6-4565-977c-96bd21fb785a",
+      "creationTimestamp": "2019-12-02T15:35:14Z",
+      "generation": 20,
+      "namespace": "default"
+    },
+    "apiVersion": "kubevirt.io/v1alpha3"
+  }

--- a/libcloud/test/compute/fixtures/kubevirt/stop_testvm.json
+++ b/libcloud/test/compute/fixtures/kubevirt/stop_testvm.json
@@ -1,0 +1,88 @@
+{
+    "status": {
+      "created": true,
+      "ready": true
+    },
+    "spec": {
+      "running": false,
+      "template": {
+        "spec": {
+          "volumes": [
+            {
+              "containerDisk": {
+                "image": "kubevirt/cirros-registry-disk-demo"
+              },
+              "name": "containerdisk"
+            },
+            {
+              "name": "cloudinitdisk",
+              "cloudInitNoCloud": {
+                "userDataBase64": "SGkuXG4="
+              }
+            }
+          ],
+          "networks": [
+            {
+              "name": "default",
+              "pod": {}
+            }
+          ],
+          "domain": {
+            "machine": {
+              "type": ""
+            },
+            "resources": {
+              "requests": {
+                "memory": "64M"
+              }
+            },
+            "devices": {
+              "disks": [
+                {
+                  "disk": {
+                    "bus": "virtio"
+                  },
+                  "name": "containerdisk"
+                },
+                {
+                  "disk": {
+                    "bus": "virtio"
+                  },
+                  "name": "cloudinitdisk"
+                }
+              ],
+              "interfaces": [
+                {
+                  "name": "default",
+                  "bridge": {}
+                }
+              ]
+            }
+          }
+        },
+        "metadata": {
+          "labels": {
+            "kubevirt.io/domain": "testvm",
+            "kubevirt.io/size": "small"
+          },
+          "creationTimestamp": null
+        }
+      }
+    },
+    "kind": "VirtualMachine",
+    "metadata": {
+      "name": "testvm",
+      "resourceVersion": "254958",
+      "annotations": {
+        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"kubevirt.io/v1alpha3\",\"kind\":\"VirtualMachine\",\"metadata\":{\"annotations\":{},\"name\":\"testvm\",\"namespace\":\"default\"},\"spec\":{\"running\":false,\"template\":{\"metadata\":{\"labels\":{\"kubevirt.io/domain\":\"testvm\",\"kubevirt.io/size\":\"small\"}},\"spec\":{\"domain\":{\"devices\":{\"disks\":[{\"disk\":{\"bus\":\"virtio\"},\"name\":\"containerdisk\"},{\"disk\":{\"bus\":\"virtio\"},\"name\":\"cloudinitdisk\"}],\"interfaces\":[{\"bridge\":{},\"name\":\"default\"}]},\"resources\":{\"requests\":{\"memory\":\"64M\"}}},\"networks\":[{\"name\":\"default\",\"pod\":{}}],\"volumes\":[{\"containerDisk\":{\"image\":\"kubevirt/cirros-registry-disk-demo\"},\"name\":\"containerdisk\"},{\"cloudInitNoCloud\":{\"userDataBase64\":\"SGkuXG4=\"},\"name\":\"cloudinitdisk\"}]}}}}\n",
+        "kubevirt.io/storage-observed-api-version": "v1alpha3",
+        "kubevirt.io/latest-observed-api-version": "v1alpha3"
+      },
+      "selfLink": "/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachines/testvm",
+      "uid": "74fd7665-fbd6-4565-977c-96bd21fb785a",
+      "creationTimestamp": "2019-12-02T15:35:14Z",
+      "generation": 23,
+      "namespace": "default"
+    },
+    "apiVersion": "kubevirt.io/v1alpha3"
+  }

--- a/libcloud/test/compute/test_kubevirt.py
+++ b/libcloud/test/compute/test_kubevirt.py
@@ -1,0 +1,194 @@
+import sys
+
+from libcloud.compute.drivers.kubevirt import KubeVirtNodeDriver
+from libcloud.compute.types import NodeState
+
+from libcloud.utils.py3 import httplib
+
+from libcloud.test import unittest
+from libcloud.test import MockHttp
+from libcloud.test.compute import TestCaseMixin
+from libcloud.test.file_fixtures import ComputeFileFixtures
+
+
+class KubeVirtTest(unittest.TestCase, TestCaseMixin):
+
+    fixtures = ComputeFileFixtures('kubevirt')
+
+    def setUp(self):
+        KubeVirtNodeDriver.connectionCls.conn_class = KubeVirtMockHttp
+        self.driver = KubeVirtNodeDriver(key='user',secret='pass',
+                                         secure=True,
+                                         host='foo',port=6443)
+
+    def test_list_locations(self):
+        locations = self.driver.list_locations()
+        self.assertEqual(len(locations), 5)
+        self.assertEqual(locations[0].name, 'default')
+        self.assertEqual(locations[1].name, 'kube-node-lease')
+        self.assertEqual(locations[2].name, 'kube-public')
+        self.assertEqual(locations[3].name, 'kube-system')
+
+        namespace4 = locations[0].driver.list_locations()[4].name
+        self.assertEqual(namespace4, 'kubevirt')
+        id4 = locations[2].driver.list_locations()[4].id
+        self.assertEqual(id4, 'e6d3d7e8-0ee5-428b-8e17-5187779e5627')
+
+    def test_list_nodes(self):
+        nodes = self.driver.list_nodes()
+        id0 = "74fd7665-fbd6-4565-977c-96bd21fb785a"
+
+        self.assertEqual(len(nodes), 1)
+        self.assertEqual(nodes[0].extra['namespace'], 'default')
+        valid_node_states = {NodeState.RUNNING, NodeState.PENDING, NodeState.STOPPED}
+        self.assertTrue(nodes[0].state in valid_node_states)
+        self.assertEqual(nodes[0].name, 'testvm')
+        self.assertEqual(nodes[0].id, id0)
+
+    def test_destroy_node(self):
+        nodes = self.driver.list_nodes()
+        to_destroy = nodes[-1]
+        resp = self.driver.destroy_node(to_destroy)
+        self.assertTrue(resp)
+
+
+    def test_start_node(self):
+        nodes = self.driver.list_nodes()
+        r1 = self.driver.ex_start_node(nodes[0])
+        self.assertTrue(r1)
+
+    def test_stop_node(self):
+        nodes = self.driver.list_nodes()
+        r1 = self.driver.ex_stop_node(nodes[0])
+        self.assertTrue(r1)
+
+    def test_reboot_node(self):
+        nodes = self.driver.list_nodes()
+        for node in nodes:
+            if node.name == "testvm":
+                resp = self.driver.reboot_node(node)
+
+        self.assertTrue(resp)
+
+
+
+class KubeVirtMockHttp(MockHttp):
+
+    fixtures = ComputeFileFixtures('kubevirt')
+
+
+    def _api_v1_namespaces(self, method, url, body, headers):
+        if method == "GET":
+            body = self.fixtures.load('_api_v1_namespaces.json')
+        else:
+            raise AssertionError('Unsupported method')
+
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+
+    def _apis_kubevirt_io_v1alpha3_namespaces_default_virtualmachines(self,
+                                                     method, url, body, headers):
+        if method == "GET":
+            body = self.fixtures.load('get_default_vms.json')
+            resp = httplib.OK
+        elif method == "POST":
+            body = self.fixtures.load('create_vm.json')
+            resp = httplib.CREATED
+        else:
+            AssertionError('Unsupported method')
+        return (resp, body, {}, httplib.responses[httplib.OK])
+
+    def _apis_kubevirt_io_v1alpha3_namespaces_kube_node_lease_virtualmachines(self,
+                                                     method, url, body, headers):
+        if method == "GET":
+            body = self.fixtures.load('get_kube_node_lease_vms.json')
+        elif method == "POST":
+            pass
+        else:
+            AssertionError('Unsupported method')
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+
+    def _apis_kubevirt_io_v1alpha3_namespaces_kube_public_virtualmachines(self,
+                                                     method, url, body, headers):
+        if method == "GET":
+            body = self.fixtures.load('get_kube_public_vms.json')
+        elif method == "POST":
+            pass
+        else:
+            AssertionError('Unsupported method')
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+    
+    def _apis_kubevirt_io_v1alpha3_namespaces_kube_system_virtualmachines(self,
+                                                     method, url, body, headers):
+        if method == "GET":
+            body = self.fixtures.load('get_kube_system_vms.json')
+        elif method == "POST":
+            pass
+        else:
+            AssertionError('Unsupported method')
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+
+    def _apis_kubevirt_io_v1alpha3_namespaces_kubevirt_virtualmachines(self,
+                                                     method, url, body, headers):
+        if method == "GET":
+            body = self.fixtures.load('get_kube_public_vms.json')
+        elif method == "POST":
+            pass
+        else:
+            AssertionError('Unsupported method')
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+    
+    def _apis_kubevirt_io_v1alpha3_namespaces_default_virtualmachines_testvm(self,
+                                                    method, url, body, headers):
+        header = "application/merge-patch+json"
+        data_stop = {"spec": {"running": False}}
+        data_start = {"spec": {"running": True}}
+
+        if method == "PATCH" and headers['Content-Type'] == header and body == data_start:
+            body = self.fixtures.load('start_testvm.json')
+
+        elif method == "PATCH" and headers['Content-Type'] == header and body == data_stop:
+            body = self.fixtures.load('stop_testvm.json')
+
+        else:
+            AssertionError('Unsupported method')
+
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+
+    def _apis_kubevirt_io_v1alpha3_namespaces_default_virtualmachines_vm_cirros(self,
+                                                    method, url, body, headers):
+        header = "application/merge-patch+json"
+        data_stop = {"spec": {"running": False}}
+        data_start = {"spec": {"running": True}}
+
+        if method == "PATCH" and headers['Content-Type'] == header and body == data_start:
+            body = self.fixtures.load('start_vm_cirros.json')
+
+        elif method == "PATCH" and headers['Content-Type'] == header and body == data_stop:
+            body = self.fixtures.load('stop_vm_cirros.json')
+
+        else:
+            AssertionError('Unsupported method')
+
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+
+    def _apis_kubevirt_io_v1alpha3_namespaces_default_virtualmachineinstances_testvm(self,
+                                                method, url, body, headers):
+        if method == "DELETE":
+            body = self.fixtures.load('delete_vmi_testvm.json')
+        else:
+            AssertionError('Unsupported method')
+
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+
+    def _api_v1_namespaces_default_pods(self, method, url, body, headers):
+
+        if method == "GET":
+            body = self.fixtures.load('get_pods.json')
+        else:
+            AssertionError('Unsupported method')
+
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+
+
+if __name__ == '__main__':
+    sys.exit(unittest.main())

--- a/libcloud/test/compute/test_kubevirt.py
+++ b/libcloud/test/compute/test_kubevirt.py
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import sys
 
 from libcloud.compute.drivers.kubevirt import KubeVirtNodeDriver

--- a/libcloud/test/compute/test_kubevirt.py
+++ b/libcloud/test/compute/test_kubevirt.py
@@ -7,19 +7,20 @@ from libcloud.utils.py3 import httplib
 
 from libcloud.test import unittest
 from libcloud.test import MockHttp
-from libcloud.test.compute import TestCaseMixin
 from libcloud.test.file_fixtures import ComputeFileFixtures
 
 
-class KubeVirtTest(unittest.TestCase, TestCaseMixin):
+class KubeVirtTest(unittest.TestCase):
 
     fixtures = ComputeFileFixtures('kubevirt')
 
     def setUp(self):
         KubeVirtNodeDriver.connectionCls.conn_class = KubeVirtMockHttp
-        self.driver = KubeVirtNodeDriver(key='user',secret='pass',
+        self.driver = KubeVirtNodeDriver(key='user',
+                                         secret='pass',
                                          secure=True,
-                                         host='foo',port=6443)
+                                         host='foo',
+                                         port=6443)
 
     def test_list_locations(self):
         locations = self.driver.list_locations()
@@ -51,15 +52,14 @@ class KubeVirtTest(unittest.TestCase, TestCaseMixin):
         resp = self.driver.destroy_node(to_destroy)
         self.assertTrue(resp)
 
-
     def test_start_node(self):
         nodes = self.driver.list_nodes()
-        r1 = self.driver.ex_start_node(nodes[0])
+        r1 = self.driver.start_node(nodes[0])
         self.assertTrue(r1)
 
     def test_stop_node(self):
         nodes = self.driver.list_nodes()
-        r1 = self.driver.ex_stop_node(nodes[0])
+        r1 = self.driver.stop_node(nodes[0])
         self.assertTrue(r1)
 
     def test_reboot_node(self):
@@ -71,11 +71,9 @@ class KubeVirtTest(unittest.TestCase, TestCaseMixin):
         self.assertTrue(resp)
 
 
-
 class KubeVirtMockHttp(MockHttp):
 
     fixtures = ComputeFileFixtures('kubevirt')
-
 
     def _api_v1_namespaces(self, method, url, body, headers):
         if method == "GET":
@@ -116,7 +114,7 @@ class KubeVirtMockHttp(MockHttp):
         else:
             AssertionError('Unsupported method')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
-    
+
     def _apis_kubevirt_io_v1alpha3_namespaces_kube_system_virtualmachines(self,
                                                      method, url, body, headers):
         if method == "GET":
@@ -136,7 +134,7 @@ class KubeVirtMockHttp(MockHttp):
         else:
             AssertionError('Unsupported method')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
-    
+
     def _apis_kubevirt_io_v1alpha3_namespaces_default_virtualmachines_testvm(self,
                                                     method, url, body, headers):
         header = "application/merge-patch+json"


### PR DESCRIPTION
## KubeVirt  driver

### Description

Kubevirt driver with initial support for the k8s/KubeVirt add-on.

Can list, start, stop, destroy kubevirt type vm's from a kubernetes cluster.

Can create a Persistent Volume Claim with the assumption that the Persistent Volume will be created dynamically by Kubernetes, so a relevant storage class that allows for such provisioning must be declared. (You can list storage classes to view them)

Can create a vm with a docker image with embedded disk as image, and as many persistent volume claims as desired. 
  - Network support is limited to 'pod' with 'bridge' or 'masquearde' type interfaces.
 - From the supported disk types of KubeVirt, containerDisk is used for the image, while only  persistentVolumeClaims can be added as disks. Disk types can either be "disk" or "lun" and the supported bus are "virtio", "sata" and "scsi".


### Status


- working driver, can be further extended to include more features, needs docstrings
- Note: Many features of the driver are logically more suited to be in the Kubernetes container driver, please keep this in consideration in the review


### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
