### PR TITLE
Also run unit tests on Windows using Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,10 +69,10 @@ matrix:
         - python3 ./contrib/trigger_rtd_build.py
 
 install:
-  - pip install --upgrade "pip==19.3.1"
-  - pip install --upgrade "setuptools==42.0.2"
-  - pip install "virtualenv==16.7.6"
-  - pip install "tox==3.14.2"
+  - pip3 install --upgrade "pip==19.3.1"
+  - pip3 install --upgrade "setuptools==42.0.2"
+  - pip3 install "virtualenv==16.7.6"
+  - pip3 install "tox==3.14.2"
   - TOX_ENV=py$TRAVIS_PYTHON_VERSION
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
         - choco install python --version 3.7.5
         - export PATH="/c/Python:/c/Python/Scripts:$PATH"
         - python -m pip install --upgrade pip
-      before_script: TOX_ENV=py3.7
+      before_script: TOX_ENV=py3.7-windows
       env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
     - name: Unit Tests (Python 3.8)
       python: 3.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ matrix:
         - choco install python --version 3.7.5
         - export PATH="/c/Python:/c/Python/Scripts:$PATH"
         - python -m pip install --upgrade pip
+      before_script: TOX_ENV=py3.7
       env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
     - name: Unit Tests (Python 3.8)
       python: 3.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
       python: 3.7
       language: shell
       before_install:
-        - choco install python3.7
+        - choco install python --version 3.7.5
         - export PATH="/c/Python:/c/Python/Scripts:$PATH"
         - python -m pip install --upgrade pip
       env: PATH=/c/Python37:/c/Python37/Scripts:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,11 @@ matrix:
       before_script: TOX_ENV=py3.7,py3.7-dist,py3.7-dist-wheel
     - name: Unit Tests (Python 3.7 on Windows)
       os: windows
+      python: 3.7
       language: shell
       before_install:
-        - choco install python  # this install takes at least 1 min 30 sec
+        - choco install python3.7
+        - export PATH="/c/Python:/c/Python/Scripts:$PATH"
         - python -m pip install --upgrade pip
       env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
     - name: Unit Tests (Python 3.8)
@@ -69,10 +71,10 @@ matrix:
         - python3 ./contrib/trigger_rtd_build.py
 
 install:
-  - pip3 install --upgrade "pip==19.3.1"
-  - pip3 install --upgrade "setuptools==42.0.2"
-  - pip3 install "virtualenv==16.7.6"
-  - pip3 install "tox==3.14.2"
+  - pip install --upgrade "pip==19.3.1"
+  - pip install --upgrade "setuptools==42.0.2"
+  - pip install "virtualenv==16.7.6"
+  - pip install "tox==3.14.2"
   - TOX_ENV=py$TRAVIS_PYTHON_VERSION
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,13 @@ matrix:
     - name: Unit Tests, Installation Checks (Python 3.7)
       python: 3.7
       before_script: TOX_ENV=py3.7,py3.7-dist,py3.7-dist-wheel
+    - name: Unit Tests (Python 3.7 on Windows)
+      os: windows
+      language: shell
+      before_install:
+        - choco install python  # this install takes at least 1 min 30 sec
+        - python -m pip install --upgrade pip
+      env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
     - name: Unit Tests (Python 3.8)
       python: 3.8
     - name: Unit Tests (PyPy 3.5)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,10 @@ General
   (GITHUB-1377)
   [Tomaz Muraus]
 
+- Make sure unit tests now also pass on Windows.
+  (GITHUB-1396)
+  [Tomaz Muraus]
+
 Compute
 -------
 

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -1174,11 +1174,11 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
         self.assertTrue(resp)
 
         expected_msg = 'Unsupported attribute: invalid'
-        self.assertRaisesRegexp(ValueError, expected_msg,
-                                self.driver.ex_modify_subnet_attribute,
-                                subnet,
-                                'invalid',
-                                True)
+        self.assertRaisesRegex(ValueError, expected_msg,
+                               self.driver.ex_modify_subnet_attribute,
+                               subnet,
+                               'invalid',
+                               True)
 
     def test_ex_delete_subnet(self):
         subnet = self.driver.ex_list_subnets()[0]
@@ -1319,7 +1319,7 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
         }
 
         expected_msg = 'dictionary contains an attribute "not" which value'
-        self.assertRaisesRegexp(ValueError, expected_msg,
+        self.assertRaisesRegex(ValueError, expected_msg,
                                self.driver.connection.request, '/', params=params)
 
         params = {
@@ -1327,7 +1327,7 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
         }
 
         expected_msg = 'dictionary contains an attribute "invalid" which value'
-        self.assertRaisesRegexp(ValueError, expected_msg,
+        self.assertRaisesRegex(ValueError, expected_msg,
                                self.driver.connection.request, '/', params=params)
 
 

--- a/libcloud/test/compute/test_ssh_client.py
+++ b/libcloud/test/compute/test_ssh_client.py
@@ -60,6 +60,10 @@ class ParamikoSSHClientTests(LibcloudTestCase):
         _init_once()
         self.ssh_cli = ParamikoSSHClient(**conn_params)
 
+    def tearDown(self):
+        if 'LIBCLOUD_DEBUG' in os.environ:
+            del os.environ['LIBCLOUD_DEBUG']
+
     @patch('paramiko.SSHClient', Mock)
     def test_create_with_password(self):
         conn_params = {'hostname': 'dummy.host.org',

--- a/libcloud/test/storage/test_local.py
+++ b/libcloud/test/storage/test_local.py
@@ -17,6 +17,7 @@ from __future__ import with_statement
 
 import os
 import sys
+import platform
 import shutil
 import unittest
 import tempfile
@@ -62,7 +63,13 @@ class LocalTests(unittest.TestCase):
         return tmppath
 
     def remove_tmp_file(self, tmppath):
-        os.unlink(tmppath)
+        try:
+            os.unlink(tmppath)
+        except Exception as e:
+            msg = str(e)
+            if 'being used by another process' in msg and platform.system().lower() == 'windows':
+                return
+            raise e
 
     def test_list_containers_empty(self):
         containers = self.driver.list_containers()

--- a/libcloud/test/storage/test_s3.py
+++ b/libcloud/test/storage/test_s3.py
@@ -1068,8 +1068,8 @@ class S3Tests(unittest.TestCase):
 
         # Invalid region
         expected_msg = 'Invalid or unsupported region: foo'
-        self.assertRaisesRegexp(ValueError, expected_msg, S3StorageDriver,
-                                *self.driver_args, region='foo')
+        self.assertRaisesRegex(ValueError, expected_msg, S3StorageDriver,
+                               *self.driver_args, region='foo')
 
         # host argument still has precedence over reguin
         driver3  = S3StorageDriver(*self.driver_args, region='ap-south-1', host='host1.bar.com')

--- a/libcloud/test/test_init.py
+++ b/libcloud/test/test_init.py
@@ -76,7 +76,7 @@ class TestUtils(unittest.TestCase):
     @patch.object(libcloud.requests.packages.chardet, '__version__', '2.2.1')
     def test_init_once_detects_bad_yum_install_requests(self, *args):
         expected_msg = 'Known bad version of requests detected'
-        with self.assertRaisesRegexp(AssertionError, expected_msg):
+        with self.assertRaisesRegex(AssertionError, expected_msg):
             _init_once()
 
     @patch.object(libcloud.requests, '__version__', '2.6.0')

--- a/libcloud/test/test_init.py
+++ b/libcloud/test/test_init.py
@@ -49,7 +49,7 @@ class TestUtils(unittest.TestCase):
             self.assertEqual(paramiko_log_level, logging.INFO)
 
         # Enable debug mode
-        os.environ['LIBCLOUD_DEBUG'] = '/dev/null'
+        os.environ['LIBCLOUD_DEBUG'] = '/tmp/foobartest'
         _init_once()
 
         self.assertTrue(LoggingConnection.log is not None)

--- a/libcloud/test/test_init.py
+++ b/libcloud/test/test_init.py
@@ -34,6 +34,10 @@ from libcloud.test import unittest
 
 
 class TestUtils(unittest.TestCase):
+    def tearDown(self):
+        if 'LIBCLOUD_DEBUG' in os.environ:
+            del os.environ['LIBCLOUD_DEBUG']
+
     def test_init_once_and_debug_mode(self):
         if have_paramiko:
             paramiko_logger = logging.getLogger('paramiko')

--- a/libcloud/test/test_init.py
+++ b/libcloud/test/test_init.py
@@ -16,10 +16,11 @@
 
 import os
 import sys
+import tempfile
 import logging
 
 try:
-    import paramiko
+    import paramiko  # NOQA
     have_paramiko = True
 except ImportError:
     have_paramiko = False
@@ -53,7 +54,8 @@ class TestUtils(unittest.TestCase):
             self.assertEqual(paramiko_log_level, logging.INFO)
 
         # Enable debug mode
-        os.environ['LIBCLOUD_DEBUG'] = '/tmp/foobartest'
+        _, tmp_path = tempfile.mkstemp()
+        os.environ['LIBCLOUD_DEBUG'] = tmp_path
         _init_once()
 
         self.assertTrue(LoggingConnection.log is not None)

--- a/libcloud/test/test_utils.py
+++ b/libcloud/test/test_utils.py
@@ -304,7 +304,6 @@ class TestUtils(unittest.TestCase):
 
 
 class NetworkingUtilsTestCase(unittest.TestCase):
-    @unittest.skipIf(platform.platform().lower() == 'windows', 'Unsupported on Windows')
     def test_is_public_and_is_private_subnet(self):
         public_ips = [
             '213.151.0.8',
@@ -333,7 +332,6 @@ class NetworkingUtilsTestCase(unittest.TestCase):
             self.assertFalse(is_public)
             self.assertTrue(is_private)
 
-    @unittest.skipIf(platform.platform().lower() == 'windows', 'Unsupported on Windows')
     def test_is_valid_ip_address(self):
         valid_ipv4_addresses = [
             '192.168.1.100',

--- a/libcloud/test/test_utils.py
+++ b/libcloud/test/test_utils.py
@@ -20,6 +20,7 @@ import socket
 import codecs
 import unittest
 import warnings
+import platform
 import os.path
 import requests_mock
 from itertools import chain
@@ -65,6 +66,7 @@ if PY3:
 def show_warning(msg, cat, fname, lno, file=None, line=None):
     WARNINGS_BUFFER.append((msg, cat, fname, lno))
 
+
 original_func = warnings.showwarning
 
 
@@ -78,6 +80,7 @@ class TestUtils(unittest.TestCase):
         WARNINGS_BUFFER = []
         warnings.showwarning = original_func
 
+    @unittest.skipIf(platform.platform().lower() == 'windows', 'Unsupported on Windows')
     def test_guess_file_mime_type(self):
         file_path = os.path.abspath(__file__)
         mimetype, encoding = libcloud.utils.files.guess_file_mime_type(
@@ -210,32 +213,32 @@ class TestUtils(unittest.TestCase):
             self.assertEqual(result, b('aaaaaaaaaa'))
 
     def test_read_in_chunks_filelike(self):
-            class FakeFile(file):
-                def __init__(self):
-                    self.remaining = 500
+        class FakeFile(file):
+            def __init__(self):
+                self.remaining = 500
 
-                def read(self, size):
-                    self.remaining -= 1
-                    if self.remaining == 0:
-                        return ''
-                    return 'b' * (size + 1)
+            def read(self, size):
+                self.remaining -= 1
+                if self.remaining == 0:
+                    return ''
+                return 'b' * (size + 1)
 
-            for index, result in enumerate(libcloud.utils.files.read_in_chunks(
-                                           FakeFile(), chunk_size=10,
-                                           fill_size=False)):
-                self.assertEqual(result, b('b' * 11))
+        for index, result in enumerate(libcloud.utils.files.read_in_chunks(
+                                       FakeFile(), chunk_size=10,
+                                       fill_size=False)):
+            self.assertEqual(result, b('b' * 11))
 
-            self.assertEqual(index, 498)
+        self.assertEqual(index, 498)
 
-            for index, result in enumerate(libcloud.utils.files.read_in_chunks(
-                                           FakeFile(), chunk_size=10,
-                                           fill_size=True)):
-                if index != 548:
-                    self.assertEqual(result, b('b' * 10))
-                else:
-                    self.assertEqual(result, b('b' * 9))
+        for index, result in enumerate(libcloud.utils.files.read_in_chunks(
+                                       FakeFile(), chunk_size=10,
+                                       fill_size=True)):
+            if index != 548:
+                self.assertEqual(result, b('b' * 10))
+            else:
+                self.assertEqual(result, b('b' * 9))
 
-            self.assertEqual(index, 548)
+        self.assertEqual(index, 548)
 
     def test_exhaust_iterator(self):
         def iterator_func():
@@ -301,6 +304,7 @@ class TestUtils(unittest.TestCase):
 
 
 class NetworkingUtilsTestCase(unittest.TestCase):
+    @unittest.skipIf(platform.platform().lower() == 'windows', 'Unsupported on Windows')
     def test_is_public_and_is_private_subnet(self):
         public_ips = [
             '213.151.0.8',
@@ -435,6 +439,7 @@ def test_get_response_object():
         m.get('http://test.com/test', text='data')
         response = get_response_object('http://test.com/test')
         assert response.body == 'data'
+
 
 if __name__ == '__main__':
     sys.exit(unittest.main())

--- a/libcloud/test/test_utils.py
+++ b/libcloud/test/test_utils.py
@@ -80,7 +80,7 @@ class TestUtils(unittest.TestCase):
         WARNINGS_BUFFER = []
         warnings.showwarning = original_func
 
-    @unittest.skipIf(platform.platform().lower() == 'windows', 'Unsupported on Windows')
+    @unittest.skipIf(platform.system().lower() == 'windows', 'Unsupported on Windows')
     def test_guess_file_mime_type(self):
         file_path = os.path.abspath(__file__)
         mimetype, encoding = libcloud.utils.files.guess_file_mime_type(

--- a/libcloud/test/test_utils.py
+++ b/libcloud/test/test_utils.py
@@ -333,6 +333,7 @@ class NetworkingUtilsTestCase(unittest.TestCase):
             self.assertFalse(is_public)
             self.assertTrue(is_private)
 
+    @unittest.skipIf(platform.platform().lower() == 'windows', 'Unsupported on Windows')
     def test_is_valid_ip_address(self):
         valid_ipv4_addresses = [
             '192.168.1.100',

--- a/libcloud/utils/networking.py
+++ b/libcloud/utils/networking.py
@@ -15,7 +15,6 @@
 
 import socket
 import struct
-import platform
 
 __all__ = [
     'is_private_subnet',
@@ -75,16 +74,8 @@ def is_valid_ip_address(address, family=socket.AF_INET):
 
     :return: ``bool`` True if the provided address is valid.
     """
-    is_windows = platform.system() == 'Windows'
-
-    if is_windows and family == socket.AF_INET6:
-        raise ValueError('Checking IPv6 addresses is not supported on Windows')
-
     try:
-        if is_windows:
-            socket.inet_aton(address)
-        else:
-            socket.inet_pton(family, address)
+        socket.inet_pton(family, address)
     except socket.error:
         return False
 

--- a/libcloud/utils/py3.py
+++ b/libcloud/utils/py3.py
@@ -232,11 +232,11 @@ else:
             raise ValueError('First argument "self" needs to be an instance '
                              'of unittest.TestCase')
 
-        return getattr(self, 'assertRaisesRegexp')(*args, **kwargs)
+        return getattr(self, 'assertRaisesRegex')(*args, **kwargs)
 
     def assertRegex(self, *args, **kwargs):
         if not isinstance(self, unittest.TestCase):
             raise ValueError('First argument "self" needs to be an instance '
                              'of unittest.TestCase')
 
-        return getattr(self, 'assertRegexpMatches')(*args, **kwargs)
+        return getattr(self, 'assertRegex')(*args, **kwargs)

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ basepython =
     pypypy3.5: pypy3.5
     py3.5: python3.5
     py3.6: python3.6
-    {py3.7,docs,checks,lint,pylint,mypy,coverage,docs,py3.7-dist,py3.7-dist-wheel}: python3.7
+    {py3.7,py3.7-windows,docs,checks,lint,pylint,mypy,coverage,docs,py3.7-dist,py3.7-dist-wheel}: python3.7
     py3.8: python3.8
 commands = cp libcloud/test/secrets.py-dist libcloud/test/secrets.py
            python setup.py test
@@ -21,6 +21,11 @@ commands = cp libcloud/test/secrets.py-dist libcloud/test/secrets.py
 whitelist_externals = cp
                       bash
                       scripts/*.sh
+[testenv:py3.7-windows]
+deps =
+    -r{toxinidir}/requirements-tests.txt
+    lockfile
+    setuptools==42.0.2
 
 [testenv:py3.7-dist]
 # Verify library installs without any dependencies when using python setup.py


### PR DESCRIPTION
Just an experiment to see if we can get unit tests to run under Python 3.7 on Windows.

IIRC, at some point in the past, we did have some unit tests running in Windows, but for one reason or another, they were removed.

Now that #1377 has been merged, this has freed up some Travis CI builders which means that even if we add another builder, in theory, overall test run time should still be the same / shouldn't increase (as long as Windows build doesn't take more than ~2 minutes).