### PR TITLE
Implemented chunked upload for Azure Blobs storage driver

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,38 @@ Compute
   (GITHUB-1346)
   [Tomaz Muraus]
 
+Storage
+~~~~~~~
+
+- [Azure Blobs] Implement chunked upload in the Azure Storage driver.
+
+  Previously, the maximum object size that could be uploaded with the
+  Azure Storage driver was capped at 100 MB: the maximum size that could
+  be uploaded in a single request to Azure. Chunked upload removes this
+  limitation and now enables uploading objects up to Azure's maximum block
+  blob size (~5 TB). The size of the chunks uploaded by the driver can be
+  configured via the ``LIBCLOUD_AZURE_UPLOAD_CHUNK_SIZE_MB`` environment
+  variable and defaults to 4 MB per chunk. Increasing this number trades-off
+  higher memory usage for a lower number of http requests executed by the
+  driver.
+
+  Reported by @rvolykh.
+  (GITHUB-1399, GITHUB-1400)
+  [Clemens Wolff - @c-w]
+
+- [Azure Blobs] Drop support for uploading PageBlob objects via the Azure
+  Storage driver.
+
+  Previously, both PageBlob and BlockBlob objects could be uploaded via the
+  ``upload_object`` and ``upload_object_via_stream`` methods by specifying the
+  ``ex_blob_type`` and ``ex_page_blob_size`` arguments. To simplify the API,
+  these options were removed and all uploaded objects are now of BlockBlob
+  type. Passing ``ex_blob_type`` or ``ex_page_blob_size`` will now raise a
+  ``ValueError``.
+
+  (GITHUB-1400)
+  [Clemens Wolff - @c-w]
+
 Changes in Apache Libcloud v2.8.0
 ---------------------------------
 

--- a/docs/upgrade_notes.rst
+++ b/docs/upgrade_notes.rst
@@ -17,6 +17,11 @@ Libcloud 3.0.0
 * This release removes VMware vSphere driver which relied on old and
   unmaintained ``pysphere`` library which doesn't support Python 3.
 
+* This release removes support for PageBlob objects from the Azure Blobs
+  storage driver. The ``ex_blob_type`` and ``ex_page_blob_size`` arguments
+  have been removed from the ``upload_object`` and ``upload_object_via_stream``
+  methods.
+
 Libcloud 2.8.0
 --------------
 

--- a/libcloud/storage/base.py
+++ b/libcloud/storage/base.py
@@ -584,7 +584,6 @@ class StorageDriver(BaseDriver):
     def _upload_object(self, object_name, content_type, request_path,
                        request_method='PUT',
                        headers=None, file_path=None, stream=None,
-                       upload_func=None, upload_func_kwargs=None,
                        chunked=False, multipart=False):
         """
         Helper function for setting common request headers and calling the
@@ -638,9 +637,6 @@ class StorageDriver(BaseDriver):
 
         if not response.success():
             response.parse_error()
-
-        if upload_func:
-            upload_func(**upload_func_kwargs)
 
         return {'response': response,
                 'bytes_transferred': stream_length,

--- a/libcloud/storage/base.py
+++ b/libcloud/storage/base.py
@@ -599,23 +599,9 @@ class StorageDriver(BaseDriver):
             raise AttributeError('iterator object must implement next() ' +
                                  'method.')
 
-        if not content_type:
-            if file_path:
-                name = file_path
-            else:
-                name = object_name
-            content_type, _ = libcloud.utils.files.guess_file_mime_type(name)
+        headers['Content-Type'] = self._determine_content_type(
+            content_type, object_name, file_path=file_path)
 
-            if not content_type:
-                if self.strict_mode:
-                    raise AttributeError('File content-type could not be '
-                                         'guessed and no content_type value '
-                                         'is provided')
-                else:
-                    # Fallback to a content-type
-                    content_type = DEFAULT_CONTENT_TYPE
-
-        headers['Content-Type'] = content_type
         if stream:
             response = self.connection.request(
                 request_path,
@@ -641,6 +627,26 @@ class StorageDriver(BaseDriver):
         return {'response': response,
                 'bytes_transferred': stream_length,
                 'data_hash': stream_hash}
+
+    def _determine_content_type(self, content_type, object_name,
+                                file_path=None):
+        if not content_type:
+            if file_path:
+                name = file_path
+            else:
+                name = object_name
+            content_type, _ = libcloud.utils.files.guess_file_mime_type(name)
+
+            if not content_type:
+                if self.strict_mode:
+                    raise AttributeError('File content-type could not be '
+                                         'guessed and no content_type value '
+                                         'is provided')
+                else:
+                    # Fallback to a content-type
+                    content_type = DEFAULT_CONTENT_TYPE
+
+        return content_type
 
     def _hash_buffered_stream(self, stream, hasher, blocksize=65536):
         total_len = 0

--- a/libcloud/storage/base.py
+++ b/libcloud/storage/base.py
@@ -630,23 +630,18 @@ class StorageDriver(BaseDriver):
 
     def _determine_content_type(self, content_type, object_name,
                                 file_path=None):
-        if not content_type:
-            if file_path:
-                name = file_path
-            else:
-                name = object_name
-            content_type, _ = libcloud.utils.files.guess_file_mime_type(name)
+        if content_type:
+            return content_type
 
-            if not content_type:
-                if self.strict_mode:
-                    raise AttributeError('File content-type could not be '
-                                         'guessed and no content_type value '
-                                         'is provided')
-                else:
-                    # Fallback to a content-type
-                    content_type = DEFAULT_CONTENT_TYPE
+        name = file_path or object_name
+        content_type, _ = libcloud.utils.files.guess_file_mime_type(name)
 
-        return content_type
+        if self.strict_mode and not content_type:
+            raise AttributeError('File content-type could not be guessed for '
+                                 '"%s" and no content_type value is provided'
+                                 % name)
+
+        return content_type or DEFAULT_CONTENT_TYPE
 
     def _hash_buffered_stream(self, stream, hasher, blocksize=65536):
         total_len = 0

--- a/libcloud/storage/drivers/atmos.py
+++ b/libcloud/storage/drivers/atmos.py
@@ -30,7 +30,7 @@ from libcloud.utils.py3 import urlunquote
 if PY3:
     from io import FileIO as file
 
-from libcloud.utils.files import read_in_chunks, guess_file_mime_type
+from libcloud.utils.files import read_in_chunks
 from libcloud.common.base import ConnectionUserAndKey, XmlResponse
 from libcloud.common.types import LibcloudError
 
@@ -271,13 +271,8 @@ class AtmosDriver(StorageDriver):
             content_type = extra.get('content_type', None)
         else:
             content_type = None
-        if not content_type:
-            content_type, _ = guess_file_mime_type(object_name)
 
-            if not content_type:
-                raise AttributeError(
-                    'File content-type could not be guessed and' +
-                    ' no content_type value provided')
+        content_type = self._determine_content_type(content_type, object_name)
 
         try:
             self.connection.request(path + '?metadata/system')

--- a/libcloud/storage/drivers/azure_blobs.py
+++ b/libcloud/storage/drivers/azure_blobs.py
@@ -18,7 +18,6 @@ from __future__ import with_statement
 import base64
 import os
 import binascii
-from io import BytesIO
 
 from libcloud.utils.py3 import ET
 from libcloud.utils.py3 import httplib
@@ -46,12 +45,7 @@ RESPONSES_PER_REQUEST = 100
 # 100MB, we can upload it in a single request.
 AZURE_BLOCK_MAX_SIZE = 100 * 1024 * 1024
 
-# Azure block blocks must be maximum 4MB
-# Azure page blobs must be aligned in 512 byte boundaries (4MB fits that)
-AZURE_CHUNK_SIZE = 4 * 1024 * 1024
-
-# Azure page blob must be aligned in 512 byte boundaries
-AZURE_PAGE_CHUNK_SIZE = 512
+AZURE_DOWNLOAD_CHUNK_SIZE = 4 * 1024 * 1024
 
 # The time period (in seconds) for which a lease must be obtained.
 # If set as -1, we get an infinite lease, but that is a bad idea. If
@@ -186,7 +180,6 @@ class AzureBlobsStorageDriver(StorageDriver):
     connectionCls = AzureBlobsConnection
     hash_type = 'md5'
     supports_chunked_encoding = False
-    ex_blob_type = 'BlockBlob'
 
     def __init__(self, key, secret=None, secure=True, host=None, port=None,
                  **kwargs):
@@ -608,7 +601,7 @@ class AzureBlobsStorageDriver(StorageDriver):
         obj_path = self._get_object_path(obj.container, obj.name)
         response = self.connection.request(obj_path, method='GET',
                                            stream=True, raw=True)
-        iterator = response.iter_content(AZURE_CHUNK_SIZE)
+        iterator = response.iter_content(AZURE_DOWNLOAD_CHUNK_SIZE)
 
         return self._get_object(obj=obj,
                                 callback=read_in_chunks,
@@ -617,25 +610,16 @@ class AzureBlobsStorageDriver(StorageDriver):
                                                  'chunk_size': chunk_size},
                                 success_status_code=httplib.OK)
 
-    def _upload_in_chunks(self, response, data, iterator, object_path,
-                          blob_type, lease, calculate_hash=True):
+    def _upload_in_chunks(self, iterator, object_path,
+                          lease, calculate_hash=True):
         """
-        Uploads data from an interator in fixed sized chunks to S3
-
-        :param response: Response object from the initial POST request
-        :type response: :class:`RawResponse`
-
-        :param data: Any data from the initial POST request
-        :type data: ``str``
+        Uploads data from an interator in fixed sized chunks to Azure Storage
 
         :param iterator: The generator for fetching the upload data
         :type iterator: ``generator``
 
         :param object_path: The path of the object to which we are uploading
-        :type object_name: ``str``
-
-        :param blob_type: The blob type being uploaded
-        :type blob_type: ``str``
+        :type object_path: ``str``
 
         :param lease: The lease object to be used for renewal
         :type lease: :class:`AzureBlobLease`
@@ -643,14 +627,9 @@ class AzureBlobsStorageDriver(StorageDriver):
         :keyword calculate_hash: Indicates if we must calculate the data hash
         :type calculate_hash: ``bool``
 
-        :return: A tuple of (status, checksum, bytes transferred)
-        :rtype: ``tuple``
+        :return: A dict of (response, data_hash, bytes_transferred)
+        :rtype: ``dict``
         """
-
-        # Get the upload id from the response xml
-        if response.status != httplib.CREATED:
-            raise LibcloudError('Error initializing upload. Code: %d' %
-                                (response.status), driver=self)
 
         data_hash = None
         if calculate_hash:
@@ -663,16 +642,12 @@ class AzureBlobsStorageDriver(StorageDriver):
 
         lease.update_headers(headers)
 
-        if blob_type == 'BlockBlob':
-            params = {'comp': 'block'}
-        else:
-            params = {'comp': 'page'}
+        params = {'comp': 'block'}
 
-        # Read the input data in chunk sizes suitable for AWS
-        for data in read_in_chunks(iterator, AZURE_CHUNK_SIZE):
+        # Read the input data in chunk sizes suitable for Azure
+        for data in read_in_chunks(iterator, AZURE_BLOCK_MAX_SIZE):
             data = b(data)
             content_length = len(data)
-            offset = bytes_transferred
             bytes_transferred += content_length
 
             if calculate_hash:
@@ -685,20 +660,15 @@ class AzureBlobsStorageDriver(StorageDriver):
             headers['Content-MD5'] = chunk_hash.decode('utf-8')
             headers['Content-Length'] = str(content_length)
 
-            if blob_type == 'BlockBlob':
-                # Block id can be any unique string that is base64 encoded
-                # A 10 digit number can hold the max value of 50000 blocks
-                # that are allowed for azure
-                block_id = base64.b64encode(b('%10d' % (count)))
-                block_id = block_id.decode('utf-8')
-                params['blockid'] = block_id
+            # Block id can be any unique string that is base64 encoded
+            # A 10 digit number can hold the max value of 50000 blocks
+            # that are allowed for azure
+            block_id = base64.b64encode(b('%10d' % (count)))
+            block_id = block_id.decode('utf-8')
+            params['blockid'] = block_id
 
-                # Keep this data for a later commit
-                chunks.append(block_id)
-            else:
-                headers['x-ms-page-write'] = 'update'
-                headers['x-ms-range'] = 'bytes=%d-%d' % \
-                    (offset, (bytes_transferred - 1))
+            # Keep this data for a later commit
+            chunks.append(block_id)
 
             # Renew lease before updating
             lease.renew()
@@ -717,14 +687,20 @@ class AzureBlobsStorageDriver(StorageDriver):
         if calculate_hash:
             data_hash = data_hash.hexdigest()
 
-        if blob_type == 'BlockBlob':
-            self._commit_blocks(object_path, chunks, lease)
+        response = self._commit_blocks(object_path, chunks, lease)
 
-        # The Azure service does not return a hash immediately for
-        # chunked uploads. It takes some time for the data to get synced
+        # According to the Azure docs:
+        # > This header refers to the content of the request, meaning, in this
+        # > case, the list of blocks, and not the content of the blob itself.
+        # However, the validation code assumes that the content-md5 in the
+        # server response refers to the object so we must discard the value
         response.headers['content-md5'] = None
 
-        return (True, data_hash, bytes_transferred)
+        return {
+            'response': response,
+            'data_hash': data_hash,
+            'bytes_transferred': bytes_transferred,
+        }
 
     def _commit_blocks(self, object_path, chunks, lease):
         """
@@ -733,8 +709,11 @@ class AzureBlobsStorageDriver(StorageDriver):
         :param object_path: Server side object path.
         :type object_path: ``str``
 
-        :param upload_id: A list of (chunk_number, chunk_hash) tuples.
-        :type upload_id: ``list``
+        :param chunks: A list of block ids to be committed.
+        :type chunks: ``list``
+
+        :param lease: The lease object to be used for renewal
+        :type lease: :class:`AzureBlobLease`
         """
 
         root = ET.Element('BlockList')
@@ -750,6 +729,13 @@ class AzureBlobsStorageDriver(StorageDriver):
         lease.update_headers(headers)
         lease.renew()
 
+        data_hash = self._get_hash_function()
+        data_hash.update(data.encode('utf-8'))
+        data_hash = base64.b64encode(b(data_hash.digest()))
+        headers['Content-MD5'] = data_hash.decode('utf-8')
+
+        headers['Content-Length'] = len(data)
+
         response = self.connection.request(object_path, data=data,
                                            params=params, headers=headers,
                                            method='PUT')
@@ -757,121 +743,53 @@ class AzureBlobsStorageDriver(StorageDriver):
         if response.status != httplib.CREATED:
             raise LibcloudError('Error in blocklist commit', driver=self)
 
-    def _check_values(self, blob_type, object_size):
-        """
-        Checks if extension arguments are valid
+        return response
 
-        :param blob_type: The blob type that is being uploaded
-        :type blob_type: ``str``
-
-        :param object_size: The (max) size of the object being uploaded
-        :type object_size: ``int``
-        """
-
-        if blob_type not in ['BlockBlob', 'PageBlob']:
-            raise LibcloudError('Invalid blob type', driver=self)
-
-        if blob_type == 'PageBlob':
-            if not object_size:
-                raise LibcloudError('Max blob size is mandatory for page blob',
-                                    driver=self)
-
-            if object_size % AZURE_PAGE_CHUNK_SIZE:
-                raise LibcloudError('Max blob size is not aligned to '
-                                    'page boundary', driver=self)
-
-    def upload_object(self, file_path, container, object_name, extra=None,
-                      verify_hash=True, ex_blob_type=None, ex_use_lease=False):
+    def upload_object(self, file_path, container, object_name,
+                      verify_hash=True, extra=None,
+                      ex_use_lease=False,
+                      **deprecated_kwargs):
         """
         Upload an object currently located on a disk.
 
         @inherits: :class:`StorageDriver.upload_object`
 
-        :param ex_blob_type: Storage class
-        :type ex_blob_type: ``str``
-
         :param ex_use_lease: Indicates if we must take a lease before upload
         :type ex_use_lease: ``bool``
         """
+        if deprecated_kwargs:
+            raise ValueError('Support for arguments was removed: %s'
+                             % ', '.join(deprecated_kwargs.keys()))
 
-        if ex_blob_type is None:
-            ex_blob_type = self.ex_blob_type
+        blob_size = os.stat(file_path).st_size
 
-        # Get the size of the file
-        file_size = os.stat(file_path).st_size
-
-        # The presumed size of the object
-        object_size = file_size
-
-        self._check_values(ex_blob_type, file_size)
-
-        # If size is greater than 64MB or type is Page, upload in chunks
-        if ex_blob_type == 'PageBlob' or file_size > AZURE_BLOCK_MAX_SIZE:
-            # For chunked upload of block blobs, the initial size must
-            # be 0.
-            if ex_blob_type == 'BlockBlob':
-                object_size = None
-        return self._put_object(container=container,
-                                object_name=object_name,
-                                object_size=object_size,
-                                file_path=file_path, extra=extra,
-                                verify_hash=verify_hash,
-                                blob_type=ex_blob_type,
-                                use_lease=ex_use_lease)
+        with open(file_path, 'rb') as fobj:
+            return self._put_object(container=container,
+                                    object_name=object_name,
+                                    extra=extra, verify_hash=verify_hash,
+                                    use_lease=ex_use_lease,
+                                    blob_size=blob_size, file_path=file_path,
+                                    stream=fobj)
 
     def upload_object_via_stream(self, iterator, container, object_name,
                                  verify_hash=False, extra=None,
-                                 ex_use_lease=False, ex_blob_type=None,
-                                 ex_page_blob_size=None):
+                                 ex_use_lease=False,
+                                 **deprecated_kwargs):
         """
         @inherits: :class:`StorageDriver.upload_object_via_stream`
-
-        Note that if ``iterator`` does not support ``seek``, the
-        entire generator will be buffered in memory.
-
-        :param ex_blob_type: Storage class
-        :type ex_blob_type: ``str``
-
-        :param ex_page_blob_size: The maximum size to which the
-            page blob can grow to
-        :type ex_page_blob_size: ``int``
 
         :param ex_use_lease: Indicates if we must take a lease before upload
         :type ex_use_lease: ``bool``
         """
-
-        if ex_blob_type is None:
-            ex_blob_type = self.ex_blob_type
-
-        """
-        Azure requires that for page blobs that a maximum size that the page
-        can grow to.  For block blobs, it is required that the Content-Length
-        header be set.  The size of the block blob will be the total size of
-        the stream minus the current position, so in this case
-        ex_page_blob_size should be 0 (and will be checked in
-        self._check_values).
-        Source:
-        https://docs.microsoft.com/en-us/rest/api/storageservices/put-blob
-        """
-        self._check_values(ex_blob_type, ex_page_blob_size)
-        if ex_blob_type == "BlockBlob":
-            try:
-                iterator.seek(0, os.SEEK_END)
-            except AttributeError:
-                buffer = BytesIO()
-                buffer.writelines(iterator)
-                iterator = buffer
-            blob_size = iterator.tell()
-            iterator.seek(0)
-        else:
-            blob_size = ex_page_blob_size
+        if deprecated_kwargs:
+            raise ValueError('Support for arguments was removed: %s'
+                             % ', '.join(deprecated_kwargs.keys()))
 
         return self._put_object(container=container,
                                 object_name=object_name,
-                                object_size=blob_size,
                                 extra=extra, verify_hash=verify_hash,
-                                blob_type=ex_blob_type,
                                 use_lease=ex_use_lease,
+                                blob_size=None,
                                 stream=iterator)
 
     def delete_object(self, obj):
@@ -903,69 +821,35 @@ class AzureBlobsStorageDriver(StorageDriver):
             key = 'x-ms-meta-%s' % (key)
             headers[key] = value
 
-    def _prepare_upload_headers(self, object_name, object_size,
-                                extra, meta_data, blob_type):
-        """
-        Prepare headers for uploading an object
-
-        :param object_name: The full name of the object being updated
-        :type object_name: ``str``
-
-        :param object_size: The size of the object. In case of PageBlobs,
-            this indicates the maximum size the blob can grow to
-        :type object_size: ``int``
-
-        :param extra: Extra control data for the upload
-        :type extra: ``dict``
-
-        :param meta_data: Metadata key value pairs
-        :type meta_data: ``dict``
-
-        :param blob_type: Page or Block blob type
-        :type blob_type: ``str``
-        """
-        headers = {}
-
-        if blob_type is None:
-            blob_type = self.ex_blob_type
-
-        headers['x-ms-blob-type'] = blob_type
-
-        self._update_metadata(headers, meta_data)
-
-        if object_size is not None:
-            headers['Content-Length'] = str(object_size)
-
-        if blob_type == 'PageBlob':
-            headers['Content-Length'] = str('0')
-            headers['x-ms-blob-content-length'] = str(object_size)
-
-        return headers
-
-    def _put_object(self, container, object_name, object_size,
-                    file_path=None, extra=None,
-                    verify_hash=True, blob_type=None, use_lease=False,
-                    stream=None):
+    def _put_object(self, container, object_name, stream,
+                    extra=None, verify_hash=True,
+                    blob_size=None, file_path=None,
+                    use_lease=False):
         """
         Control function that does the real job of uploading data to a blob
         """
         extra = extra or {}
-        meta_data = extra.get('meta_data', {})
         content_type = extra.get('content_type', None)
-
-        headers = self._prepare_upload_headers(object_name, object_size,
-                                               extra, meta_data, blob_type)
+        meta_data = extra.get('meta_data', {})
 
         object_path = self._get_object_path(container, object_name)
 
         # Get a lease if required and do the operations
         with AzureBlobLease(self, object_path, use_lease) as lease:
-            lease.update_headers(headers)
-
-            result_dict = self._upload_object(object_name, content_type,
-                                              object_path, headers=headers,
-                                              file_path=file_path,
-                                              stream=stream)
+            if blob_size is not None and blob_size <= AZURE_BLOCK_MAX_SIZE:
+                result_dict = self._upload_directly(stream=stream,
+                                                    object_path=object_path,
+                                                    lease=lease,
+                                                    blob_size=blob_size,
+                                                    meta_data=meta_data,
+                                                    content_type=content_type,
+                                                    object_name=object_name,
+                                                    file_path=file_path)
+            else:
+                result_dict = self._upload_in_chunks(stream,
+                                                     object_path,
+                                                     lease,
+                                                     verify_hash)
 
             response = result_dict['response']
             bytes_transferred = result_dict['bytes_transferred']
@@ -996,6 +880,24 @@ class AzureBlobsStorageDriver(StorageDriver):
                       hash=headers['etag'], extra=None,
                       meta_data=meta_data, container=container,
                       driver=self)
+
+    def _upload_directly(self, stream, object_path, lease, blob_size,
+                         meta_data, content_type, object_name, file_path):
+
+        headers = {}
+        lease.update_headers(headers)
+
+        self._update_metadata(headers, meta_data)
+
+        headers['Content-Length'] = str(blob_size)
+        headers['x-ms-blob-type'] = 'BlockBlob'
+
+        return self._upload_object(object_name=object_name,
+                                   file_path=file_path,
+                                   content_type=content_type,
+                                   request_path=object_path,
+                                   stream=stream,
+                                   headers=headers)
 
     def ex_set_object_metadata(self, obj, meta_data):
         """

--- a/libcloud/storage/drivers/azure_blobs.py
+++ b/libcloud/storage/drivers/azure_blobs.py
@@ -46,16 +46,22 @@ RESPONSES_PER_REQUEST = 100
 # > 2016-05-31 and later (4 MB for older versions).
 # However for performance reasons, using a lower upload chunk size
 # usually leads to fewer dropped requests and retries.
-AZURE_UPLOAD_CHUNK_SIZE = 4 * 1024 * 1024
+AZURE_UPLOAD_CHUNK_SIZE = int(
+    os.getenv('LIBCLOUD_AZURE_UPLOAD_CHUNK_SIZE_MB', '4')
+) * 1024 * 1024
 
-AZURE_DOWNLOAD_CHUNK_SIZE = 4 * 1024 * 1024
+AZURE_DOWNLOAD_CHUNK_SIZE = int(
+    os.getenv('LIBCLOUD_AZURE_DOWNLOAD_CHUNK_SIZE_MB', '4')
+) * 1024 * 1024
 
 # The time period (in seconds) for which a lease must be obtained.
 # If set as -1, we get an infinite lease, but that is a bad idea. If
 # after getting an infinite lease, there was an issue in releasing the
 # lease, the object will remain 'locked' forever, unless the lease is
 # released using the lease_id (which is not exposed to the user)
-AZURE_LEASE_PERIOD = 60
+AZURE_LEASE_PERIOD = int(
+    os.getenv('LIBCLOUD_AZURE_LEASE_PERIOD_SECONDS', '60')
+)
 
 AZURE_STORAGE_HOST_SUFFIX = 'blob.core.windows.net'
 

--- a/libcloud/storage/drivers/s3.py
+++ b/libcloud/storage/drivers/s3.py
@@ -900,12 +900,8 @@ class BaseS3StorageDriver(StorageDriver):
         meta_data = extra.get('meta_data', None)
         acl = extra.get('acl', None)
 
-        if not content_type:
-            content_type, _ = libcloud.utils.files.guess_file_mime_type(
-                object_name)
-
-        if content_type:
-            headers['Content-Type'] = content_type
+        headers['Content-Type'] = self._determine_content_type(
+            content_type, object_name)
 
         if meta_data:
             for key, value in list(meta_data.items()):

--- a/libcloud/test/storage/test_atmos.py
+++ b/libcloud/test/storage/test_atmos.py
@@ -384,8 +384,8 @@ class AtmosTests(unittest.TestCase):
         def dummy_content_type(name):
             return 'application/zip', None
 
-        old_func = libcloud.storage.drivers.atmos.guess_file_mime_type
-        libcloud.storage.drivers.atmos.guess_file_mime_type = dummy_content_type
+        old_func = libcloud.utils.files.guess_file_mime_type
+        libcloud.utils.files.guess_file_mime_type = dummy_content_type
 
         container = Container(name='fbc', extra={}, driver=self)
         object_name = 'ftsdn'
@@ -395,14 +395,14 @@ class AtmosTests(unittest.TestCase):
                                                  object_name=object_name,
                                                  iterator=iterator)
         finally:
-            libcloud.storage.drivers.atmos.guess_file_mime_type = old_func
+            libcloud.utils.files.guess_file_mime_type = old_func
 
     def test_upload_object_via_stream_existing_object(self):
         def dummy_content_type(name):
             return 'application/zip', None
 
-        old_func = libcloud.storage.drivers.atmos.guess_file_mime_type
-        libcloud.storage.drivers.atmos.guess_file_mime_type = dummy_content_type
+        old_func = libcloud.utils.files.guess_file_mime_type
+        libcloud.utils.files.guess_file_mime_type = dummy_content_type
 
         container = Container(name='fbc', extra={}, driver=self)
         object_name = 'ftsde'
@@ -412,14 +412,14 @@ class AtmosTests(unittest.TestCase):
                                                  object_name=object_name,
                                                  iterator=iterator)
         finally:
-            libcloud.storage.drivers.atmos.guess_file_mime_type = old_func
+            libcloud.utils.files.guess_file_mime_type = old_func
 
     def test_upload_object_via_stream_no_content_type(self):
         def no_content_type(name):
             return None, None
 
-        old_func = libcloud.storage.drivers.atmos.guess_file_mime_type
-        libcloud.storage.drivers.atmos.guess_file_mime_type = no_content_type
+        old_func = libcloud.utils.files.guess_file_mime_type
+        libcloud.utils.files.guess_file_mime_type = no_content_type
 
         container = Container(name='fbc', extra={}, driver=self)
         object_name = 'ftsdct'
@@ -435,7 +435,7 @@ class AtmosTests(unittest.TestCase):
                 'File content type not provided'
                 ' but an exception was not thrown')
         finally:
-            libcloud.storage.drivers.atmos.guess_file_mime_type = old_func
+            libcloud.utils.files.guess_file_mime_type = old_func
 
     def test_signature_algorithm(self):
         test_uid = 'fredsmagicuid'

--- a/libcloud/test/storage/test_azure_blobs.py
+++ b/libcloud/test/storage/test_azure_blobs.py
@@ -36,7 +36,7 @@ from libcloud.storage.types import InvalidContainerNameError
 from libcloud.storage.types import ObjectDoesNotExistError
 from libcloud.storage.types import ObjectHashMismatchError
 from libcloud.storage.drivers.azure_blobs import AzureBlobsStorageDriver
-from libcloud.storage.drivers.azure_blobs import AZURE_BLOCK_MAX_SIZE
+from libcloud.storage.drivers.azure_blobs import AZURE_UPLOAD_CHUNK_SIZE
 
 from libcloud.test import unittest
 from libcloud.test import MockHttp, generate_random_data  # pylint: disable-msg=E0611
@@ -701,7 +701,7 @@ class AzureBlobsTests(unittest.TestCase):
 
     def test_upload_big_block_object_success(self):
         file_path = tempfile.mktemp(suffix='.jpg')
-        file_size = AZURE_BLOCK_MAX_SIZE + 1
+        file_size = AZURE_UPLOAD_CHUNK_SIZE + 1
 
         with open(file_path, 'w') as file_hdl:
             file_hdl.write('0' * file_size)
@@ -746,7 +746,7 @@ class AzureBlobsTests(unittest.TestCase):
     def test_upload_big_block_object_success_with_lease(self):
         self.mock_response_klass.use_param = 'comp'
         file_path = tempfile.mktemp(suffix='.jpg')
-        file_size = AZURE_BLOCK_MAX_SIZE * 2
+        file_size = AZURE_UPLOAD_CHUNK_SIZE * 2
 
         with open(file_path, 'w') as file_hdl:
             file_hdl.write('0' * file_size)

--- a/libcloud/test/storage/test_azure_blobs.py
+++ b/libcloud/test/storage/test_azure_blobs.py
@@ -247,13 +247,23 @@ class AzureBlobsMockHttp(MockHttp, unittest.TestCase):
                 httplib.responses[httplib.ACCEPTED])
 
     def _foo_bar_container_foo_test_upload(self, method, url, body, headers):
-        # test_upload_object_success
         self._assert_content_length_header_is_string(headers=headers)
 
-        body = ''
+        query_string = urlparse.urlsplit(url).query
+        query = parse_qs(query_string)
+        comp = query.get('comp', [])
+
         headers = {}
-        headers['etag'] = '0x8CFB877BB56A6FB'
-        headers['content-md5'] = 'd4fe4c9829f7ca1cc89db7ad670d2bbd'
+        body = ''
+
+        if 'blocklist' in comp or not comp:
+            headers['etag'] = '"0x8CFB877BB56A6FB"'
+            headers['content-md5'] = 'd4fe4c9829f7ca1cc89db7ad670d2bbd'
+        elif 'block' in comp:
+            headers['content-md5'] = 'lvcfx/bOJvndpRlrdKU1YQ=='
+        else:
+            raise NotImplementedError('Unknown request comp: {}'.format(comp))
+
         return (httplib.CREATED,
                 body,
                 headers,
@@ -264,17 +274,6 @@ class AzureBlobsMockHttp(MockHttp, unittest.TestCase):
         # test_upload_object_success
         self._assert_content_length_header_is_string(headers=headers)
 
-        body = ''
-        headers = {}
-        headers['etag'] = '0x8CFB877BB56A6FB'
-        return (httplib.CREATED,
-                body,
-                headers,
-                httplib.responses[httplib.CREATED])
-
-    def _foo_bar_container_foo_test_upload_page(self, method, url,
-                                                body, headers):
-        # test_upload_object_success
         body = ''
         headers = {}
         headers['etag'] = '0x8CFB877BB56A6FB'

--- a/libcloud/test/storage/test_base.py
+++ b/libcloud/test/storage/test_base.py
@@ -127,8 +127,8 @@ class BaseStorageTests(unittest.TestCase):
         # strict_mode is enabled, exception should be thrown
 
         self.driver1.strict_mode = True
-        expected_msg = ('File content-type could not be guessed and no'
-                        ' content_type value is provided')
+        expected_msg = ('File content-type could not be guessed for "test" '
+                        'and no content_type value is provided')
         assertRaisesRegex(self, AttributeError, expected_msg,
                           self.driver1._upload_object,
                           object_name='test',

--- a/libcloud/test/storage/test_base.py
+++ b/libcloud/test/storage/test_base.py
@@ -65,11 +65,7 @@ class BaseStorageTests(unittest.TestCase):
         valid_iterators = [BytesIO(b('134')), StringIO('bar')]
         invalid_iterators = ['foobar', '', False, True, 1, object()]
 
-        def upload_func(*args, **kwargs):
-            return True, 'barfoo', 100
-
         kwargs = {'object_name': 'foo', 'content_type': 'foo/bar',
-                  'upload_func': upload_func, 'upload_func_kwargs': {},
                   'request_path': '/', 'headers': {}}
 
         for value in valid_iterators:
@@ -117,16 +113,11 @@ class BaseStorageTests(unittest.TestCase):
     def test_upload_no_content_type_supplied_or_detected(self):
         iterator = StringIO()
 
-        upload_func = Mock()
-        upload_func.return_value = True, '', 0
-
         # strict_mode is disabled, default content type should be used
         self.driver1.connection = Mock()
 
         self.driver1._upload_object(object_name='test',
                                     content_type=None,
-                                    upload_func=upload_func,
-                                    upload_func_kwargs={},
                                     request_path='/',
                                     stream=iterator)
 
@@ -142,8 +133,6 @@ class BaseStorageTests(unittest.TestCase):
                           self.driver1._upload_object,
                           object_name='test',
                           content_type=None,
-                          upload_func=upload_func,
-                          upload_func_kwargs={},
                           request_path='/',
                           stream=iterator)
 
@@ -164,16 +153,11 @@ class BaseStorageTests(unittest.TestCase):
         self.assertTrue(hasattr(iterator, '__next__'))
         self.assertTrue(hasattr(iterator, 'next'))
 
-        upload_func = Mock()
-        upload_func.return_value = True, '', size
-
         self.assertEqual(mock_read_in_chunks.call_count, 0)
         self.assertEqual(mock_exhaust_iterator.call_count, 0)
 
         result = self.driver1._upload_object(object_name='test1',
                                              content_type=None,
-                                             upload_func=upload_func,
-                                             upload_func_kwargs={},
                                              request_path='/',
                                              stream=iterator)
 
@@ -210,8 +194,6 @@ class BaseStorageTests(unittest.TestCase):
 
         result = self.driver1._upload_object(object_name='test2',
                                              content_type=None,
-                                             upload_func=upload_func,
-                                             upload_func_kwargs={},
                                              request_path='/',
                                              stream=iterator)
 

--- a/libcloud/utils/files.py
+++ b/libcloud/utils/files.py
@@ -16,13 +16,8 @@
 import os
 import mimetypes
 
-from libcloud.utils.py3 import PY3
-from libcloud.utils.py3 import httplib
 from libcloud.utils.py3 import next
 from libcloud.utils.py3 import b
-
-if PY3:
-    from io import FileIO as file
 
 CHUNK_SIZE = 8096
 
@@ -58,10 +53,10 @@ def read_in_chunks(iterator, chunk_size=None, fill_size=False,
     """
     chunk_size = chunk_size or CHUNK_SIZE
 
-    if isinstance(iterator, (file, httplib.HTTPResponse)):
+    try:
         get_data = iterator.read
         args = (chunk_size, )
-    else:
+    except AttributeError:
         get_data = next
         args = (iterator, )
 


### PR DESCRIPTION
## Implemented chunked upload for Azure Blobs storage driver

### Description

This pull request fixes https://github.com/apache/libcloud/issues/1399 by implementing chunked upload in the Azure Blobs storage driver via the [Put Block](https://docs.microsoft.com/en-us/rest/api/storageservices/put-block) and [Put Block List](https://docs.microsoft.com/en-us/rest/api/storageservices/put-block-list) APIs.

The implementation mostly leverages the `AzureBlobsStorageDriver._upload_in_chunks` function that was first introduced in [24f34c9](https://github.com/apache/libcloud/blob/24f34c99c9440523a53e940a346bced551281953/libcloud/storage/drivers/azure_blobs.py#L732-L788) and was stopped being used in [6e0040d](https://github.com/apache/libcloud/commit/6e0040d8904cacb5dbe88309e9051be08cdc59f9) with the the following main updates:

- Enable setting object metadata, content-type and content-md5 for chunked uploads.

- Drop support for PageBlob. **This is a breaking API change.** However, given the non-trivial differences between the PageBlob and BlockBlob APIs, I'd hypothesize that the improved simplicity of the code will aid in the long run with bugfixes and maintenance. If keeping support for PageBlob is a hard requirement, I suspect a non-trivial amount of refactoring would have to be undertaken to cleanly support chunked upload for both BlockBlob and PageBlob object types. I'm open to do the work as part of this pull request, but I'd love to first discuss the pros/cons of both approaches.

Additionally, the following companion changes were made:

- Remove unused `upload_func` and `upload_func_kwargs` arguments in `StorageDriver._upload_object` ([7e55057](https://github.com/apache/libcloud/commit/7e550577758cb95ec42819e77b6773566a180e5c))
- Rationalize determination of content type to a new helper function `StorageDriver._determine_content_type` ([0dc5cbb](https://github.com/apache/libcloud/commit/0dc5cbb0410fa3b1f9ca0d54b59d514cbc7e6c7a))
- Switch `libcloud.utils.files.read_in_chunks` from type checking to duck-typing to ensure that more iterators (e.g. opened file objects) use the fast `read(int)` code-path ([0fded11](https://github.com/apache/libcloud/commit/0fded110e69f020388d76d8094d3ca25fa868e13))
- Make Azure Storage constants configurable via environment variables ([638a189](https://github.com/apache/libcloud/pull/1400/commits/638a18943b2992211564e63a26ec7421e6ca5339))

### Status

- done, ready for review

### Checklist

- [x] Code linting ([CI passed](https://travis-ci.org/CatalystCode/libcloud/builds/632547395))
- [x] Documentation ([changelog updated](https://github.com/apache/libcloud/pull/1400/commits/cfdb2bd53f43d1caa7a144c59bc9d245bc34962f))
- [x] Tests ([E2E tests passed](https://clewolff.visualstudio.com/libcloud-tests/_build/results?buildId=661), [unit tests updated](https://github.com/apache/libcloud/pull/1400/commits/9174502b36452729f3b5bde02699b37dcb197bd5))
- [x] ICLA ([committer](http://people.apache.org/phonebook.html?uid=clewolff))