### PR TITLE
fix curl command

### DIFF
--- a/docs/compute/drivers/ovh.rst
+++ b/docs/compute/drivers/ovh.rst
@@ -28,7 +28,7 @@ at https://eu.api.ovh.com/createApp/. Next step, create a consumer key with
 following command: ::
 
     curl -X POST \
-        -H 'X-Ra-Application: youApplicationKey' \
+        -H 'X-Ovh-Application: youApplicationKey' \
         -H 'Content-Type: application/json' \
         -d '{
             "accessRules":
@@ -36,7 +36,7 @@ following command: ::
                     {"method":"GET","path":"/*"},
                     {"method":"POST","path":"/*"},
                     {"method":"DELETE","path":"/*"},
-                    {"method":"PUT","path":"/*"},
+                    {"method":"PUT","path":"/*"}
                 ],
                 "redirection":"http://ovh.com"
             }' \


### PR DESCRIPTION
## fix curl command in OVH driver doc

### Description

1. Header must use "X-Ovh-Application" to correctly provide the App Key for OVH Driver.
2. Comma at end of accessRules Array causes "invalid JSON" response.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ x ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
