### PR TITLE
Update Python used in Windows CI to 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,16 +19,16 @@ matrix:
     - name: Unit Tests, Installation Checks (Python 3.7)
       python: 3.7
       before_script: TOX_ENV=py3.7,py3.7-dist,py3.7-dist-wheel
-    - name: Unit Tests (Python 3.7 on Windows)
+    - name: Unit Tests (Python 3.8 on Windows)
       os: windows
-      python: 3.7
+      python: 3.8
       language: shell
       before_install:
-        - choco install python --version 3.7.5
-        - export PATH="/c/Python:/c/Python/Scripts:$PATH"
+        - choco install python --version 3.8.1
+        - export PATH="/c/Python38:/c/Python38/Scripts:$PATH"
         - python -m pip install --upgrade pip
-      before_script: TOX_ENV=py3.7-windows
-      env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
+      before_script: TOX_ENV=py3.8-windows
+      env: PATH=/c/Python38:/c/Python38/Scripts:$PATH
     - name: Unit Tests (Python 3.8)
       python: 3.8
     - name: Unit Tests (PyPy 3.5)

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -8,6 +8,6 @@ coverage==4.5.4
 requests
 requests_mock
 pytest==5.3.2
-cryptography==2.6.1
+cryptography==2.8
 # NOTE: Only needed by nttcis loadbalancer driver
 pyopenssl

--- a/tox.ini
+++ b/tox.ini
@@ -13,15 +13,15 @@ basepython =
     pypypy3.5: pypy3.5
     py3.5: python3.5
     py3.6: python3.6
-    {py3.7,py3.7-windows,docs,checks,lint,pylint,mypy,coverage,docs,py3.7-dist,py3.7-dist-wheel}: python3.7
-    py3.8: python3.8
+    {py3.7,docs,checks,lint,pylint,mypy,coverage,docs,py3.7-dist,py3.7-dist-wheel}: python3.7
+    {py3.8,py3.8-windows}: python3.8
 commands = cp libcloud/test/secrets.py-dist libcloud/test/secrets.py
            python setup.py test
 
 whitelist_externals = cp
                       bash
                       scripts/*.sh
-[testenv:py3.7-windows]
+[testenv:py3.8-windows]
 deps =
     -r{toxinidir}/requirements-tests.txt
     lockfile


### PR DESCRIPTION
## Fix CI on Windows

### Description

The Travis CI build on Windows is currently failing (e.g. see [5073.4](https://travis-ci.org/apache/libcloud/jobs/634519562) or [5074.4](https://travis-ci.org/apache/libcloud/jobs/634521136)) due to an error installing Python via Chocolatey.

This pull request fixes the CI by updating the build to use the latest Python published to Chocolatey (3.8). This also required updating the cryptography dependency to the latest version (2.8) since the previously pinned version (2.6.1) doesn't include a wheel for Python 3.8 on Windows.

### Status

- done, ready for review

### Checklist

- [ ] Code linting (n/a, infrastructure-only change)
- [ ] Documentation (n/a, infrastructure-only change)
- [x] Tests ([CI passed](https://travis-ci.org/CatalystCode/libcloud/builds/634540141))
- [x] ICLA ([committer](http://people.apache.org/phonebook.html?uid=clewolff))
