### PR TITLE
Skip object checksum check on upload if server side AWS KMS encryption is used

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,21 @@ Compute
   (GITHUB-1398)
   [Peter Yu - @yukw777]
 
+Storage
+~~~~~~~
+
+- [AWS S3] Fix upload object code so uploaded data MD5 checksum check is not
+  performed at the end of the upload when AWS KMS server side encryption is
+  used.
+
+  If AWS KMS server side object encryption is used, ETag header value in the
+  response doesn't contain data MD5 digest so we can't perform a checksum
+  check.
+
+  Reported by Jonathan Harden - @jfharden.
+  (GITHUB-1401, GITHUB-1406)
+  [Tomaz Muraus - @Kami]
+
 Container
 ~~~~~~~~~
 

--- a/libcloud/storage/drivers/s3.py
+++ b/libcloud/storage/drivers/s3.py
@@ -838,7 +838,7 @@ class BaseS3StorageDriver(StorageDriver):
         response = response
         server_hash = headers.get('etag', '').replace('"', '')
         server_side_encryption = headers.get('x-amz-server-side-encryption',
-                                             True)
+                                             None)
 
         # NOTE: If AWS KMS server side encryption is enabled, ETag won't
         # contain object MD5 digest so we skip the checksum check

--- a/libcloud/storage/drivers/s3.py
+++ b/libcloud/storage/drivers/s3.py
@@ -839,6 +839,8 @@ class BaseS3StorageDriver(StorageDriver):
         server_hash = headers.get('etag', '').replace('"', '')
         server_side_encryption = headers.get('x-amz-server-side-encryption',
                                              None)
+        aws_kms_encryption = (server_side_encryption == 'aws:kms')
+        hash_matches = (result_dict['data_hash'] == server_hash)
 
         # NOTE: If AWS KMS server side encryption is enabled, ETag won't
         # contain object MD5 digest so we skip the checksum check
@@ -846,8 +848,7 @@ class BaseS3StorageDriver(StorageDriver):
         # /RESTCommonResponseHeaders.html
         # and https://github.com/apache/libcloud/issues/1401
         # for details
-        if server_side_encryption != 'aws:kms' and (verify_hash and
-                result_dict['data_hash'] != server_hash):
+        if verify_hash and not aws_kms_encryption and not hash_matches:
             raise ObjectHashMismatchError(
                 value='MD5 hash {0} checksum does not match {1}'.format(
                     server_hash, result_dict['data_hash']),

--- a/libcloud/test/storage/test_s3.py
+++ b/libcloud/test/storage/test_s3.py
@@ -335,27 +335,6 @@ class S3MockHttp(MockHttp):
                 headers,
                 httplib.responses[httplib.OK])
 
-    def _foo_bar_container_foo_test_upload_INVALID_HASH1(self, method, url,
-                                                         body, headers):
-        body = ''
-        headers = {}
-        headers['etag'] = '"foobar"'
-        # test_upload_object_invalid_hash1
-        return (httplib.OK,
-                body,
-                headers,
-                httplib.responses[httplib.OK])
-
-    def _foo_bar_container_foo_test_upload_INVALID_HASH2(self, method, url,
-                                                         body, headers):
-        # test_upload_object_invalid_hash2
-        body = ''
-        headers = {'etag': '"hash343hhash89h932439jsaa89"'}
-        return (httplib.OK,
-                body,
-                headers,
-                httplib.responses[httplib.OK])
-
     def _foo_bar_container_foo_test_upload(self, method, url, body, headers):
         # test_upload_object_success
         body = ''
@@ -772,11 +751,10 @@ class S3Tests(unittest.TestCase):
         def upload_file(self, object_name=None, content_type=None,
                         request_path=None, request_method=None,
                         headers=None, file_path=None, stream=None):
-            return {'response': make_response(200),
+            headers = {'etag': '"foobar"'}
+            return {'response': make_response(200, headers=headers),
                     'bytes_transferred': 1000,
                     'data_hash': 'hash343hhash89h932439jsaa89'}
-
-        self.mock_response_klass.type = 'INVALID_HASH1'
 
         old_func = self.driver_type._upload_object
         self.driver_type._upload_object = upload_file
@@ -802,11 +780,10 @@ class S3Tests(unittest.TestCase):
         def upload_file(self, object_name=None, content_type=None,
                         request_path=None, request_method=None,
                         headers=None, file_path=None, stream=None):
-            return {'response': make_response(200, headers={'etag': 'woopwoopwoop'}),
+            headers = {'etag': '"hash343hhash89h932439jsaa89"'}
+            return {'response': make_response(200, headers=headers),
                     'bytes_transferred': 1000,
                     'data_hash': '0cc175b9c0f1b6a831c399e269772661'}
-
-        self.mock_response_klass.type = 'INVALID_HASH2'
 
         old_func = self.driver_type._upload_object
         self.driver_type._upload_object = upload_file


### PR DESCRIPTION
This pull request updates S3 driver code to skip uploaded object checksum check at the end of the upload when server side AWS KMS encryption is used for that object.

In such scenario, ETag header value doesn't contain object data MD5 digest.

As part of that change I also noticed some of the tests were out of date and some of the mock http methods are not needed anymore so I did some cleanup. That likely happened during the requests migration.

Resolves #1401.