### PR TITLE
Implement SAS URL generation for Azure Storage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -98,6 +98,19 @@ Storage
   (GITHUB-1397)
   [Clemens Wolff - @c-w]
 
+- [Azure Blobs] Implement ``get_object_cdn_url`` for the Azure Storage driver.
+
+  Leveraging Azure storage service shared access signatures, the Azure Storage
+  driver can now be used to generate temporary URLs that grant clients read
+  access to objects. The URLs expire after a certain period of time, either
+  configured via the ``ex_expiry`` argument or the
+  ``LIBCLOUD_AZURE_STORAGE_CDN_URL_EXPIRY_HOURS`` environment variable
+  (default: 24 hours).
+
+  Reported by @rvolykh.
+  (GITHUB-1403, GITHUB-1408)
+  [Clemens Wolff - @c-w]
+
 Changes in Apache Libcloud v2.8.0
 ---------------------------------
 

--- a/libcloud/test/storage/test_azure_blobs.py
+++ b/libcloud/test/storage/test_azure_blobs.py
@@ -502,6 +502,16 @@ class AzureBlobsTests(unittest.TestCase):
         self.assertTrue(container.extra['lease']['state'], 'available')
         self.assertTrue(container.extra['meta_data']['meta1'], 'value1')
 
+    def test_get_object_cdn_url(self):
+        obj = self.driver.get_object(container_name='test_container200',
+                                     object_name='test')
+
+        url = urlparse.urlparse(self.driver.get_object_cdn_url(obj))
+        query = urlparse.parse_qs(url.query)
+
+        self.assertEqual(len(query['sig']), 1)
+        self.assertGreater(len(query['sig'][0]), 0)
+
     def test_get_object_container_doesnt_exist(self):
         # This method makes two requests which makes mocking the response a bit
         # trickier


### PR DESCRIPTION
## Implement SAS URL generation for Azure Storage

### Description

As discussed in https://github.com/apache/libcloud/issues/1403, this pull request implements `AzureBlobsStorageDriver.get_object_cdn_url` via a [service SAS](https://docs.microsoft.com/en-us/rest/api/storageservices/create-service-sas#construct-a-service-sas).

### Status

- done, ready for review

### Checklist

- [x] Code linting ([build passed](https://travis-ci.org/CatalystCode/libcloud/builds/635449613))
- [x] Documentation ([updated changelog](https://github.com/CatalystCode/libcloud/blob/azure-sas-url/CHANGES.rst#storage))
- [x] Tests ([e2e tests passed](https://clewolff.visualstudio.com/libcloud-tests/_build/results?buildId=682))
- [x] ICLA ([committer](https://people.apache.org/phonebook.html?uid=clewolff))
