### PR TITLE
Fix pagination in the "list_nodes()" method in the GCE driver

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -171,7 +171,6 @@ class GCEConnection(GoogleBaseConnection):
                     # Special case when we are handling pagination for a
                     # specific zone
                     items = response['items']
-                    response['items'] = {}
                     response['items'] = {
                         'zones/%s' % (zone): {
                             api_name: items

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -643,9 +643,11 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         nodes = self.driver.list_nodes()
         nodes_all = self.driver.list_nodes(ex_zone='all')
         nodes_uc1a = self.driver.list_nodes(ex_zone='us-central1-a')
+        nodes_uc1b = self.driver.list_nodes(ex_zone='us-central1-b')
         self.assertEqual(len(nodes), 1)
         self.assertEqual(len(nodes_all), 8)
         self.assertEqual(len(nodes_uc1a), 1)
+        self.assertEqual(len(nodes_uc1b), 0)
         self.assertEqual(nodes[0].name, 'node-name')
         self.assertEqual(nodes_uc1a[0].name, 'node-name')
         self.assertEqual(nodes_uc1a[0].extra['cpuPlatform'], 'Intel Skylake')
@@ -3508,6 +3510,11 @@ class GCEMockHttp(MockHttp):
                 'zones_europe-west1-a_instances_post.json')
         else:
             body = self.fixtures.load('zones_europe-west1-a_instances.json')
+        return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
+
+    def _zones_us_central1_b_instances(self, method, url, body, headers):
+        if method == 'GET':
+            body = '{}'
         return (httplib.OK, body, self.json_hdr, httplib.responses[httplib.OK])
 
     def _zones_europe_west1_a_diskTypes_pd_standard(self, method, url, body,


### PR DESCRIPTION
This pull request is an attempt to try to fix an issue reported in #1360.

### Background / Problem Description

Currently ``list_nodes()`` method only returns up to 500 nodes (which is a page size value we use with our list requests and also a max page size limit set by Google).

This is true either when we are requesting nodes for all the zones (aggregated request) or when requesting nodes for a single zone.

### Proposed Fix

This pull request fixes that by utilizing ``request_aggregated_items`` method in both scenarios (when we are requesting nodes in all the zones and also when requesting nodes for a single zone).

I tested the change by setting ``maxResults`` in the ``request_aggregated_items`` method to ``1`` and verified that all the pages are correctly retrieved since I don't have an account with more than 500 instances to test it out.

I tested the following scenarios:

1. List nodes for all the zones
2. List nodes for a particular zones with multiple nodes in that zone
3. List nodes for a particular zone with no nodes in that zones

---

On a somewhat related note -  unless I'm missing something, it appears the same issue may also exist with other "list" API endpoints when retrieving items for a specific zone and that response contains more then max page size number of items (since we don't follow through pagination when requesting items for a single zone).

As you can see in the diff, this change also allowed me to simplify ``list_nodes()`` method. If my assertion / observation above is correct, this would mean we can also simplify other list methods.

@erjohnso Please correct me if I'm wrong or missing something.

Resolves #1360.