### PR TITLE
Add type annotations to storage API

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -123,6 +123,15 @@ Storage
   (GITHUB-1403, GITHUB-1408)
   [Clemens Wolff - @c-w]
 
+- [Azure Blobs, Aliyun, Local, Ninefold, S3] Ensure upload headers are respected.
+
+  All storage drivers now pass the optional ``headers`` argument of
+  ``upload_object`` and ``upload_object_via_stream`` to the backend object storage
+  systems (previously the argument was silently ignored).
+
+  (GITHUB-1410)
+  [Clemens Wolff - @c-w]
+
 Changes in Apache Libcloud v2.8.0
 ---------------------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,13 @@ Compute
   (GITHUB-1398)
   [Peter Yu - @yukw777]
 
+Container
+~~~~~~~~~
+
+- [LXD] Add new LXD driver.
+  (GITHUB-1395)
+  [Alexandros Giavaras - @pockerman]
+
 Storage
 ~~~~~~~
 
@@ -57,16 +64,6 @@ Storage
   Reported by Jonathan Harden - @jfharden.
   (GITHUB-1401, GITHUB-1406)
   [Tomaz Muraus - @Kami]
-
-Container
-~~~~~~~~~
-
-- [LXD] Add new LXD driver.
-  (GITHUB-1395)
-  [Alexandros Giavaras - @pockerman]
-
-Storage
-~~~~~~~
 
 - [Azure Blobs] Implement chunked upload in the Azure Storage driver.
 

--- a/libcloud/base.py
+++ b/libcloud/base.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Dict
+
 from libcloud.backup.providers import Provider as BackupProvider
 from libcloud.backup.providers import get_driver as get_backup_driver
 
@@ -60,7 +62,7 @@ DriverTypeFactoryMap = {
     DriverType.DNS: get_dns_driver,
     DriverType.LOADBALANCER: get_loadbalancer_driver,
     DriverType.STORAGE: get_storage_driver
-}
+}  # type: Dict
 
 
 class DriverTypeNotFoundError(KeyError):

--- a/libcloud/common/aws.py
+++ b/libcloud/common/aws.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from typing import Dict
+from typing import Optional
 from typing import Type
 
 import base64
@@ -368,7 +369,7 @@ class AWSRequestSignerAlgorithmV4(AWSRequestSigner):
 
 
 class SignedAWSConnection(AWSTokenConnection):
-    version = None
+    version = None  # type: Optional[str]
 
     def __init__(self, user_id, key, secure=True, host=None, port=None,
                  url=None, timeout=None, proxy_url=None, token=None,

--- a/libcloud/common/openstack.py
+++ b/libcloud/common/openstack.py
@@ -143,7 +143,7 @@ class OpenStackBaseConnection(ConnectionUserAndKey):
     service_name = None
     service_region = None
     accept_format = None
-    _auth_version = None
+    _auth_version = None  # type: str
 
     def __init__(self, user_id, key, secure=True,
                  host=None, port=None, timeout=None, proxy_url=None,

--- a/libcloud/storage/base.py
+++ b/libcloud/storage/base.py
@@ -20,6 +20,7 @@ Provides base classes for working with storage
 # Backward compatibility for Python 2.5
 from __future__ import with_statement
 
+from typing import Dict
 from typing import Iterator
 from typing import List
 from typing import Optional
@@ -425,7 +426,7 @@ class StorageDriver(BaseDriver):
 
     def upload_object(self, file_path, container, object_name, extra=None,
                       verify_hash=True, headers=None):
-        # type: (str, Container, str, Optional[dict], Optional[bool], Optional[dict]) -> Object  # noqa: E501
+        # type: (str, Container, str, Optional[dict], bool, Optional[Dict[str, str]]) -> Object  # noqa: E501
         """
         Upload an object currently located on a disk.
 

--- a/libcloud/storage/base.py
+++ b/libcloud/storage/base.py
@@ -20,6 +20,9 @@ Provides base classes for working with storage
 # Backward compatibility for Python 2.5
 from __future__ import with_statement
 
+from typing import Iterator
+from typing import List
+from typing import Optional
 from typing import Type
 
 import os.path                          # pylint: disable-msg=W0404
@@ -57,8 +60,15 @@ class Object(object):
     Represents an object (BLOB).
     """
 
-    def __init__(self, name, size, hash, extra, meta_data, container,
-                 driver):
+    def __init__(self,
+                 name,  # type: str
+                 size,  # type: int
+                 hash,  # type: str
+                 extra,  # type: dict
+                 meta_data,  # type: dict
+                 container,  # type: Container
+                 driver,  # type: StorageDriver
+                 ):
         """
         :param name: Object name (must be unique per container).
         :type  name: ``str``
@@ -70,7 +80,7 @@ class Object(object):
         :type  hash: ``str``
 
         :param container: Object container.
-        :type  container: :class:`Container`
+        :type  container: :class:`libcloud.storage.base.Container`
 
         :param extra: Extra attributes.
         :type  extra: ``dict``
@@ -79,7 +89,7 @@ class Object(object):
         :type  meta_data: ``dict``
 
         :param driver: StorageDriver instance.
-        :type  driver: :class:`StorageDriver`
+        :type  driver: :class:`libcloud.storage.base.StorageDriver`
         """
 
         self.name = name
@@ -118,7 +128,11 @@ class Container(object):
     Represents a container (bucket) which can hold multiple objects.
     """
 
-    def __init__(self, name, extra, driver):
+    def __init__(self,
+                 name,  # type: str
+                 extra,  # type: dict
+                 driver,  # type: StorageDriver
+                 ):
         """
         :param name: Container name (must be unique).
         :type name: ``str``
@@ -127,7 +141,7 @@ class Container(object):
         :type extra: ``dict``
 
         :param driver: StorageDriver instance.
-        :type driver: :class:`StorageDriver`
+        :type driver: :class:`libcloud.storage.base.StorageDriver`
         """
 
         self.name = name
@@ -198,16 +212,18 @@ class StorageDriver(BaseDriver):
     strict_mode = False  # type: bool
 
     def iterate_containers(self):
+        # type: () -> Iterator[Container]
         """
-        Return a generator of containers for the given account
+        Return a iterator of containers for the given account
 
-        :return: A generator of Container instances.
-        :rtype: ``generator`` of :class:`Container`
+        :return: A iterator of Container instances.
+        :rtype: ``iterator`` of :class:`libcloud.storage.base.Container`
         """
         raise NotImplementedError(
             'iterate_containers not implemented for this driver')
 
     def list_containers(self):
+        # type: () -> List[Container]
         """
         Return a list of containers.
 
@@ -218,11 +234,12 @@ class StorageDriver(BaseDriver):
 
     def iterate_container_objects(self, container, prefix=None,
                                   ex_prefix=None):
+        # type: (Container, Optional[str], Optional[str]) -> Iterator[Object]
         """
-        Return a generator of objects for the given container.
+        Return a iterator of objects for the given container.
 
         :param container: Container instance
-        :type container: :class:`Container`
+        :type container: :class:`libcloud.storage.base.Container`
 
         :param prefix: Filter objects starting with a prefix.
         :type  prefix: ``str``
@@ -230,18 +247,19 @@ class StorageDriver(BaseDriver):
         :param ex_prefix: (Deprecated.) Filter objects starting with a prefix.
         :type  ex_prefix: ``str``
 
-        :return: A generator of Object instances.
-        :rtype: ``generator`` of :class:`Object`
+        :return: A iterator of Object instances.
+        :rtype: ``iterator`` of :class:`libcloud.storage.base.Object`
         """
         raise NotImplementedError(
             'iterate_container_objects not implemented for this driver')
 
     def list_container_objects(self, container, prefix=None, ex_prefix=None):
+        # type: (Container, Optional[str], Optional[str]) -> List[Object]
         """
         Return a list of objects for the given container.
 
         :param container: Container instance.
-        :type container: :class:`Container`
+        :type container: :class:`libcloud.storage.base.Container`
 
         :param prefix: Filter objects starting with a prefix.
         :type  prefix: ``str``
@@ -250,7 +268,7 @@ class StorageDriver(BaseDriver):
         :type  ex_prefix: ``str``
 
         :return: A list of Object instances.
-        :rtype: ``list`` of :class:`Object`
+        :rtype: ``list`` of :class:`libcloud.storage.base.Object`
         """
         return list(self.iterate_container_objects(container,
                                                    prefix=prefix,
@@ -276,6 +294,7 @@ class StorageDriver(BaseDriver):
                 yield obj
 
     def get_container(self, container_name):
+        # type: (str) -> Container
         """
         Return a container instance.
 
@@ -283,17 +302,18 @@ class StorageDriver(BaseDriver):
         :type container_name: ``str``
 
         :return: :class:`Container` instance.
-        :rtype: :class:`Container`
+        :rtype: :class:`libcloud.storage.base.Container`
         """
         raise NotImplementedError(
             'get_object not implemented for this driver')
 
     def get_container_cdn_url(self, container):
+        # type: (Container) -> str
         """
         Return a container CDN URL.
 
         :param container: Container instance
-        :type  container: :class:`Container`
+        :type  container: :class:`libcloud.storage.base.Container`
 
         :return: A CDN URL for this container.
         :rtype: ``str``
@@ -302,6 +322,7 @@ class StorageDriver(BaseDriver):
             'get_container_cdn_url not implemented for this driver')
 
     def get_object(self, container_name, object_name):
+        # type: (str, str) -> Object
         """
         Return an object instance.
 
@@ -312,17 +333,18 @@ class StorageDriver(BaseDriver):
         :type  object_name: ``str``
 
         :return: :class:`Object` instance.
-        :rtype: :class:`Object`
+        :rtype: :class:`libcloud.storage.base.Object`
         """
         raise NotImplementedError(
             'get_object not implemented for this driver')
 
     def get_object_cdn_url(self, obj):
+        # type: (Object) -> str
         """
         Return an object CDN URL.
 
         :param obj: Object instance
-        :type  obj: :class:`Object`
+        :type  obj: :class:`libcloud.storage.base.Object`
 
         :return: A CDN URL for this object.
         :rtype: ``str``
@@ -331,11 +353,12 @@ class StorageDriver(BaseDriver):
             'get_object_cdn_url not implemented for this driver')
 
     def enable_container_cdn(self, container):
+        # type: (Container) -> bool
         """
         Enable container CDN.
 
         :param container: Container instance
-        :type  container: :class:`Container`
+        :type  container: :class:`libcloud.storage.base.Container`
 
         :rtype: ``bool``
         """
@@ -343,11 +366,12 @@ class StorageDriver(BaseDriver):
             'enable_container_cdn not implemented for this driver')
 
     def enable_object_cdn(self, obj):
+        # type: (Object) -> bool
         """
         Enable object CDN.
 
         :param obj: Object instance
-        :type  obj: :class:`Object`
+        :type  obj: :class:`libcloud.storage.base.Object`
 
         :rtype: ``bool``
         """
@@ -356,11 +380,12 @@ class StorageDriver(BaseDriver):
 
     def download_object(self, obj, destination_path, overwrite_existing=False,
                         delete_on_failure=True):
+        # type: (Object, str, Optional[bool], Optional[bool]) -> bool
         """
         Download an object to the specified destination path.
 
         :param obj: Object instance.
-        :type obj: :class:`Object`
+        :type obj: :class:`libcloud.storage.base.Object`
 
         :param destination_path: Full path to a file or a directory where the
                                  incoming file will be saved.
@@ -383,20 +408,24 @@ class StorageDriver(BaseDriver):
             'download_object not implemented for this driver')
 
     def download_object_as_stream(self, obj, chunk_size=None):
+        # type: (Object, Optional[int]) -> Iterator[bytes]
         """
-        Return a generator which yields object data.
+        Return a iterator which yields object data.
 
         :param obj: Object instance
-        :type obj: :class:`Object`
+        :type obj: :class:`libcloud.storage.base.Object`
 
         :param chunk_size: Optional chunk size (in bytes).
         :type chunk_size: ``int``
+
+        :rtype: ``iterator`` of ``bytes``
         """
         raise NotImplementedError(
             'download_object_as_stream not implemented for this driver')
 
     def upload_object(self, file_path, container, object_name, extra=None,
                       verify_hash=True, headers=None):
+        # type: (str, Container, str, Optional[dict], Optional[bool], Optional[dict]) -> Object  # noqa: E501
         """
         Upload an object currently located on a disk.
 
@@ -404,7 +433,7 @@ class StorageDriver(BaseDriver):
         :type file_path: ``str``
 
         :param container: Destination container.
-        :type container: :class:`Container`
+        :type container: :class:`libcloud.storage.base.Container`
 
         :param object_name: Object name.
         :type object_name: ``str``
@@ -420,7 +449,7 @@ class StorageDriver(BaseDriver):
             headers = {'Access-Control-Allow-Origin': 'http://mozilla.com'}
         :type headers: ``dict``
 
-        :rtype: :class:`Object`
+        :rtype: :class:`libcloud.storage.base.Object`
         """
         raise NotImplementedError(
             'upload_object not implemented for this driver')
@@ -429,6 +458,7 @@ class StorageDriver(BaseDriver):
                                  object_name,
                                  extra=None,
                                  headers=None):
+        # type: (Iterator[bytes], Container, str, Optional[dict], Optional[dict]) -> Object  # noqa: E501
         """
         Upload an object using an iterator.
 
@@ -450,7 +480,7 @@ class StorageDriver(BaseDriver):
         :type iterator: :class:`object`
 
         :param container: Destination container.
-        :type container: :class:`Container`
+        :type container: :class:`libcloud.storage.base.Container`
 
         :param object_name: Object name.
         :type object_name: ``str``
@@ -465,17 +495,18 @@ class StorageDriver(BaseDriver):
             headers = {'Access-Control-Allow-Origin': 'http://mozilla.com'}
         :type headers: ``dict``
 
-        :rtype: ``object``
+        :rtype: ``libcloud.storage.base.Object``
         """
         raise NotImplementedError(
             'upload_object_via_stream not implemented for this driver')
 
     def delete_object(self, obj):
+        # type: (Object) -> bool
         """
         Delete an object.
 
         :param obj: Object instance.
-        :type obj: :class:`Object`
+        :type obj: :class:`libcloud.storage.base.Object`
 
         :return: ``bool`` True on success.
         :rtype: ``bool``
@@ -484,6 +515,7 @@ class StorageDriver(BaseDriver):
             'delete_object not implemented for this driver')
 
     def create_container(self, container_name):
+        # type: (str) -> Container
         """
         Create a new container.
 
@@ -491,17 +523,18 @@ class StorageDriver(BaseDriver):
         :type container_name: ``str``
 
         :return: Container instance on success.
-        :rtype: :class:`Container`
+        :rtype: :class:`libcloud.storage.base.Container`
         """
         raise NotImplementedError(
             'create_container not implemented for this driver')
 
     def delete_container(self, container):
+        # type: (Container) -> bool
         """
         Delete a container.
 
         :param container: Container instance
-        :type container: :class:`Container`
+        :type container: :class:`libcloud.storage.base.Container`
 
         :return: ``True`` on success, ``False`` otherwise.
         :rtype: ``bool``

--- a/libcloud/storage/base.py
+++ b/libcloud/storage/base.py
@@ -102,21 +102,26 @@ class Object(object):
         self.driver = driver
 
     def get_cdn_url(self):
+        # type: () -> str
         return self.driver.get_object_cdn_url(obj=self)
 
-    def enable_cdn(self, **kwargs):
-        return self.driver.enable_object_cdn(obj=self, **kwargs)
+    def enable_cdn(self):
+        # type: () -> bool
+        return self.driver.enable_object_cdn(obj=self)
 
     def download(self, destination_path, overwrite_existing=False,
                  delete_on_failure=True):
+        # type: (str, bool, bool) -> bool
         return self.driver.download_object(self, destination_path,
                                            overwrite_existing,
                                            delete_on_failure)
 
     def as_stream(self, chunk_size=None):
+        # type: (Optional[int]) -> Iterator[bytes]
         return self.driver.download_object_as_stream(self, chunk_size)
 
     def delete(self):
+        # type: () -> bool
         return self.driver.delete_object(self)
 
     def __repr__(self):
@@ -150,47 +155,60 @@ class Container(object):
         self.driver = driver
 
     def iterate_objects(self, prefix=None, ex_prefix=None):
+        # type: (Optional[str], Optional[str]) -> Iterator[Object]
         return self.driver.iterate_container_objects(container=self,
                                                      prefix=prefix,
                                                      ex_prefix=ex_prefix)
 
     def list_objects(self, prefix=None, ex_prefix=None):
+        # type: (Optional[str], Optional[str]) -> List[Object]
         return self.driver.list_container_objects(container=self,
                                                   prefix=prefix,
                                                   ex_prefix=ex_prefix)
 
     def get_cdn_url(self):
+        # type: () -> str
         return self.driver.get_container_cdn_url(container=self)
 
-    def enable_cdn(self, **kwargs):
-        return self.driver.enable_container_cdn(container=self, **kwargs)
+    def enable_cdn(self):
+        # type: () -> bool
+        return self.driver.enable_container_cdn(container=self)
 
     def get_object(self, object_name):
+        # type: (str) -> Object
         return self.driver.get_object(container_name=self.name,
                                       object_name=object_name)
 
-    def upload_object(self, file_path, object_name, extra=None, **kwargs):
+    def upload_object(self, file_path, object_name, extra=None,
+                      verify_hash=True, headers=None):
+        # type: (str, str, Optional[dict], bool, Optional[Dict[str, str]]) -> Object  # noqa: E501
         return self.driver.upload_object(
-            file_path, self, object_name, extra=extra, **kwargs)
+            file_path, self, object_name, extra=extra,
+            verify_hash=verify_hash, headers=headers)
 
     def upload_object_via_stream(self, iterator, object_name, extra=None,
-                                 **kwargs):
+                                 headers=None):
+        # type: (Iterator[bytes], str, Optional[dict], Optional[Dict[str, str]]) -> Object  # noqa: E501
         return self.driver.upload_object_via_stream(
-            iterator, self, object_name, extra=extra, **kwargs)
+            iterator, self, object_name, extra=extra, headers=headers)
 
     def download_object(self, obj, destination_path, overwrite_existing=False,
                         delete_on_failure=True):
+        # type: (Object, str, bool, bool) -> bool
         return self.driver.download_object(
             obj, destination_path, overwrite_existing=overwrite_existing,
             delete_on_failure=delete_on_failure)
 
     def download_object_as_stream(self, obj, chunk_size=None):
+        # type: (Object, Optional[int]) -> Iterator[bytes]
         return self.driver.download_object_as_stream(obj, chunk_size)
 
     def delete_object(self, obj):
+        # type: (Object) -> bool
         return self.driver.delete_object(obj)
 
     def delete(self):
+        # type: () -> bool
         return self.driver.delete_container(self)
 
     def __repr__(self):
@@ -381,7 +399,7 @@ class StorageDriver(BaseDriver):
 
     def download_object(self, obj, destination_path, overwrite_existing=False,
                         delete_on_failure=True):
-        # type: (Object, str, Optional[bool], Optional[bool]) -> bool
+        # type: (Object, str, bool, bool) -> bool
         """
         Download an object to the specified destination path.
 
@@ -459,7 +477,7 @@ class StorageDriver(BaseDriver):
                                  object_name,
                                  extra=None,
                                  headers=None):
-        # type: (Iterator[bytes], Container, str, Optional[dict], Optional[dict]) -> Object  # noqa: E501
+        # type: (Iterator[bytes], Container, str, Optional[dict], Optional[Dict[str, str]]) -> Object  # noqa: E501
         """
         Upload an object using an iterator.
 

--- a/libcloud/storage/drivers/atmos.py
+++ b/libcloud/storage/drivers/atmos.py
@@ -120,8 +120,8 @@ class AtmosConnection(ConnectionUserAndKey):
 class AtmosDriver(StorageDriver):
     connectionCls = AtmosConnection
 
-    host = None
-    path = None
+    host = None  # type: str
+    path = None  # type: str
     api_name = 'atmos'
     supports_chunked_encoding = True
     website = 'http://atmosonline.com/'

--- a/libcloud/storage/drivers/azure_blobs.py
+++ b/libcloud/storage/drivers/azure_blobs.py
@@ -685,7 +685,8 @@ class AzureBlobsStorageDriver(StorageDriver):
                                 success_status_code=httplib.OK)
 
     def _upload_in_chunks(self, stream, object_path, lease, meta_data,
-                          content_type, object_name, file_path, verify_hash):
+                          content_type, object_name, file_path, verify_hash,
+                          headers):
         """
         Uploads data from an interator in fixed sized chunks to Azure Storage
         """
@@ -697,7 +698,7 @@ class AzureBlobsStorageDriver(StorageDriver):
         bytes_transferred = 0
         count = 1
         chunks = []
-        headers = {}
+        headers = headers or {}
 
         lease.update_headers(headers)
 
@@ -815,7 +816,7 @@ class AzureBlobsStorageDriver(StorageDriver):
         return response
 
     def upload_object(self, file_path, container, object_name,
-                      verify_hash=True, extra=None,
+                      verify_hash=True, extra=None, headers=None,
                       ex_use_lease=False,
                       **deprecated_kwargs):
         """
@@ -836,12 +837,12 @@ class AzureBlobsStorageDriver(StorageDriver):
             return self._put_object(container=container,
                                     object_name=object_name,
                                     extra=extra, verify_hash=verify_hash,
-                                    use_lease=ex_use_lease,
+                                    use_lease=ex_use_lease, headers=headers,
                                     blob_size=blob_size, file_path=file_path,
                                     stream=fobj)
 
     def upload_object_via_stream(self, iterator, container, object_name,
-                                 verify_hash=True, extra=None,
+                                 verify_hash=True, extra=None, headers=None,
                                  ex_use_lease=False,
                                  **deprecated_kwargs):
         """
@@ -858,6 +859,7 @@ class AzureBlobsStorageDriver(StorageDriver):
                                 object_name=object_name,
                                 extra=extra, verify_hash=verify_hash,
                                 use_lease=ex_use_lease,
+                                headers=headers,
                                 blob_size=None,
                                 stream=iterator)
 
@@ -891,7 +893,7 @@ class AzureBlobsStorageDriver(StorageDriver):
             headers[key] = value
 
     def _put_object(self, container, object_name, stream,
-                    extra=None, verify_hash=True,
+                    extra=None, verify_hash=True, headers=None,
                     blob_size=None, file_path=None,
                     use_lease=False):
         """
@@ -911,6 +913,7 @@ class AzureBlobsStorageDriver(StorageDriver):
                                                     lease=lease,
                                                     blob_size=blob_size,
                                                     meta_data=meta_data,
+                                                    headers=headers,
                                                     content_type=content_type,
                                                     object_name=object_name,
                                                     file_path=file_path)
@@ -919,6 +922,7 @@ class AzureBlobsStorageDriver(StorageDriver):
                                                      object_path=object_path,
                                                      lease=lease,
                                                      meta_data=meta_data,
+                                                     headers=headers,
                                                      content_type=content_type,
                                                      object_name=object_name,
                                                      file_path=file_path,
@@ -955,9 +959,10 @@ class AzureBlobsStorageDriver(StorageDriver):
                       driver=self)
 
     def _upload_directly(self, stream, object_path, lease, blob_size,
-                         meta_data, content_type, object_name, file_path):
+                         meta_data, content_type, object_name, file_path,
+                         headers):
 
-        headers = {}
+        headers = headers or {}
         lease.update_headers(headers)
 
         self._update_metadata(headers, meta_data)

--- a/libcloud/storage/drivers/backblaze_b2.py
+++ b/libcloud/storage/drivers/backblaze_b2.py
@@ -23,7 +23,7 @@ import hashlib
 try:
     import simplejson as json
 except ImportError:
-    import json
+    import json  # type: ignore
 
 from libcloud.utils.py3 import b
 from libcloud.utils.py3 import httplib
@@ -130,7 +130,7 @@ class BackblazeB2AuthConnection(ConnectionUserAndKey):
 
 
 class BackblazeB2Connection(ConnectionUserAndKey):
-    host = None  # Note: host is set after authentication
+    host = None  # type: ignore  # Note: host is set after authentication
     secure = True
     responseCls = BackblazeB2Response
     authCls = BackblazeB2AuthConnection

--- a/libcloud/storage/drivers/dummy.py
+++ b/libcloud/storage/drivers/dummy.py
@@ -398,7 +398,7 @@ class DummyStorageDriver(StorageDriver):
         return DummyFileObject()
 
     def upload_object(self, file_path, container, object_name, extra=None,
-                      file_hash=None):
+                      verify_hash=True, headers=None):
         """
         >>> driver = DummyStorageDriver('key', 'secret')
         >>> container_name = 'test container 1'
@@ -417,8 +417,6 @@ class DummyStorageDriver(StorageDriver):
         True
 
         @inherits: :class:`StorageDriver.upload_object`
-        :param file_hash: File hash
-        :type file_hash: ``str``
         """
 
         if not os.path.exists(file_path):
@@ -430,7 +428,7 @@ class DummyStorageDriver(StorageDriver):
                                 size=size, extra=extra)
 
     def upload_object_via_stream(self, iterator, container,
-                                 object_name, extra=None):
+                                 object_name, extra=None, headers=None):
         """
         >>> driver = DummyStorageDriver('key', 'secret')
         >>> container = driver.create_container(

--- a/libcloud/storage/drivers/local.py
+++ b/libcloud/storage/drivers/local.py
@@ -417,7 +417,7 @@ class LocalStorageDriver(StorageDriver):
                 yield data
 
     def upload_object(self, file_path, container, object_name, extra=None,
-                      verify_hash=True):
+                      verify_hash=True, headers=None):
         """
         Upload an object currently located on a disk.
 
@@ -435,6 +435,9 @@ class LocalStorageDriver(StorageDriver):
 
         :param extra: (optional) Extra attributes (driver specific).
         :type extra: ``dict``
+
+        :param headers: (optional) Headers (driver specific).
+        :type headers: ``dict``
 
         :rtype: ``object``
         """
@@ -454,7 +457,7 @@ class LocalStorageDriver(StorageDriver):
 
     def upload_object_via_stream(self, iterator, container,
                                  object_name,
-                                 extra=None):
+                                 extra=None, headers=None):
         """
         Upload an object using an iterator.
 
@@ -486,6 +489,9 @@ class LocalStorageDriver(StorageDriver):
         :param extra: (optional) Extra attributes (driver specific). Note:
             This dictionary must contain a 'content_type' key which represents
             a content type of the stored object.
+
+        :param headers: (optional) Headers (driver specific).
+        :type headers: ``dict``
 
         :rtype: ``object``
         """

--- a/libcloud/storage/drivers/nimbus.py
+++ b/libcloud/storage/drivers/nimbus.py
@@ -20,7 +20,7 @@ import hmac
 try:
     import simplejson as json
 except ImportError:
-    import json  # NOQA
+    import json  # type: ignore  # noqa: F401
 
 from libcloud.utils.py3 import httplib
 from libcloud.utils.py3 import urlencode

--- a/libcloud/storage/drivers/oss.py
+++ b/libcloud/storage/drivers/oss.py
@@ -460,7 +460,8 @@ class OSSStorageDriver(StorageDriver):
             pass
         return self._put_object(container=container, object_name=object_name,
                                 extra=extra, method=method, query_args=params,
-                                stream=iterator, verify_hash=False)
+                                stream=iterator, verify_hash=False,
+                                headers=headers)
 
     def delete_object(self, obj):
         object_path = self._get_object_path(obj.container, obj.name)
@@ -577,11 +578,11 @@ class OSSStorageDriver(StorageDriver):
 
     def _put_object(self, container, object_name, method='PUT',
                     query_args=None, extra=None, file_path=None,
-                    stream=None, verify_hash=False):
+                    stream=None, verify_hash=False, headers=None):
         """
         Create an object and upload data using the given function.
         """
-        headers = {}
+        headers = headers or {}
         extra = extra or {}
 
         content_type = extra.get('content_type', None)

--- a/libcloud/storage/drivers/s3.py
+++ b/libcloud/storage/drivers/s3.py
@@ -470,7 +470,7 @@ class BaseS3StorageDriver(StorageDriver):
             success_status_code=httplib.OK)
 
     def upload_object(self, file_path, container, object_name, extra=None,
-                      verify_hash=True, ex_storage_class=None):
+                      verify_hash=True, headers=None, ex_storage_class=None):
         """
         @inherits: :class:`StorageDriver.upload_object`
 
@@ -480,6 +480,7 @@ class BaseS3StorageDriver(StorageDriver):
         return self._put_object(container=container, object_name=object_name,
                                 extra=extra, file_path=file_path,
                                 verify_hash=verify_hash,
+                                headers=headers,
                                 storage_class=ex_storage_class)
 
     def _initiate_multipart(self, container, object_name, headers=None):
@@ -662,7 +663,8 @@ class BaseS3StorageDriver(StorageDriver):
                                 (resp.status), driver=self)
 
     def upload_object_via_stream(self, iterator, container, object_name,
-                                 extra=None, ex_storage_class=None):
+                                 extra=None, headers=None,
+                                 ex_storage_class=None):
         """
         @inherits: :class:`StorageDriver.upload_object_via_stream`
 
@@ -682,10 +684,12 @@ class BaseS3StorageDriver(StorageDriver):
                                               extra=extra,
                                               stream=iterator,
                                               verify_hash=False,
+                                              headers=headers,
                                               storage_class=ex_storage_class)
         return self._put_object(container=container, object_name=object_name,
                                 extra=extra, method=method, query_args=params,
                                 stream=iterator, verify_hash=False,
+                                headers=headers,
                                 storage_class=ex_storage_class)
 
     def delete_object(self, obj):
@@ -804,8 +808,9 @@ class BaseS3StorageDriver(StorageDriver):
 
     def _put_object(self, container, object_name, method='PUT',
                     query_args=None, extra=None, file_path=None,
-                    stream=None, verify_hash=True, storage_class=None):
-        headers = {}
+                    stream=None, verify_hash=True, storage_class=None,
+                    headers=None):
+        headers = headers or {}
         extra = extra or {}
 
         headers.update(self._to_storage_class_headers(storage_class))
@@ -866,7 +871,7 @@ class BaseS3StorageDriver(StorageDriver):
                 driver=self)
 
     def _put_object_multipart(self, container, object_name, stream,
-                              extra=None, verify_hash=False,
+                              extra=None, verify_hash=False, headers=None,
                               storage_class=None):
         """
         Uploads an object using the S3 multipart algorithm.
@@ -886,13 +891,16 @@ class BaseS3StorageDriver(StorageDriver):
         :keyword extra: Additional options
         :type extra: ``dict``
 
+        :keyword headers: Additional headers
+        :type headers: ``dict``
+
         :keyword storage_class: The name of the S3 object's storage class
         :type extra: ``str``
 
         :return: The uploaded object
         :rtype: :class:`Object`
         """
-        headers = {}
+        headers = headers or {}
         extra = extra or {}
 
         headers.update(self._to_storage_class_headers(storage_class))

--- a/libcloud/storage/providers.py
+++ b/libcloud/storage/providers.py
@@ -13,10 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Type
+from typing import Union
+from types import ModuleType
+from typing import TYPE_CHECKING
+
 from libcloud.common.providers import get_driver as _get_provider_driver
 from libcloud.common.providers import set_driver as _set_provider_driver
 from libcloud.storage.types import OLD_CONSTANT_TO_NEW_MAPPING
 from libcloud.storage.types import Provider
+
+if TYPE_CHECKING:
+    from libcloud.storage.base import StorageDriver
 
 DRIVERS = {
     Provider.DUMMY:
@@ -92,11 +100,13 @@ DRIVERS = {
 
 
 def get_driver(provider):
+    # type: (Union[Provider, str]) -> Type[StorageDriver]
     deprecated_constants = OLD_CONSTANT_TO_NEW_MAPPING
     return _get_provider_driver(drivers=DRIVERS, provider=provider,
                                 deprecated_constants=deprecated_constants)
 
 
 def set_driver(provider, module, klass):
+    # type: (Union[Provider, str], ModuleType, type) -> Type[StorageDriver]
     return _set_provider_driver(drivers=DRIVERS, provider=provider,
                                 module=module, klass=klass)

--- a/mypy.ini
+++ b/mypy.ini
@@ -22,10 +22,25 @@ ignore_missing_imports = True
 [mypy-cryptography.*]
 ignore_missing_imports = True
 
+[mypy-lockfile.*]
+ignore_missing_imports = True
+
 # Ignored local modules
 [mypy-libcloud.utils.py3]
 ignore_errors = True
 
 # NOTE: Fixing drivers will take a while
 [mypy-libcloud.compute.drivers.*]
+ignore_errors = True
+
+# NOTE: Fixing drivers will take a while
+[mypy-libcloud.storage.drivers.s3]
+ignore_errors = True
+
+# NOTE: Fixing drivers will take a while
+[mypy-libcloud.storage.drivers.google_storage]
+ignore_errors = True
+
+# NOTE: Fixing drivers will take a while
+[mypy-libcloud.storage.drivers.cloudfiles]
 ignore_errors = True

--- a/tox.ini
+++ b/tox.ini
@@ -198,4 +198,6 @@ deps =
 commands =
     mypy --no-incremental libcloud/common/
     mypy --no-incremental libcloud/compute/
+    mypy --no-incremental libcloud/storage/
     mypy --no-incremental example_compute.py
+    mypy --no-incremental example_storage.py


### PR DESCRIPTION
## Add type annotations to storage API

### Description

As discussed in https://github.com/apache/libcloud/pull/1408#discussion_r366147905, this PR adds type annotations to the StorageDriver API.

For now, mypy errors are ignored for the s3, google_storage and cloudfiles drivers since the use of inheritance on the connection classes is causing issues which will require a more thorough strategy to address.

### Status

- done, ready for review

### Checklist

- [x] Code linting ([build passed](https://travis-ci.org/CatalystCode/libcloud/builds/636950988))
- [x] Documentation (updated docstrings)
- [x] Tests ([build passed](https://travis-ci.org/CatalystCode/libcloud/builds/636950988))
- [x] ICLA ([committer](https://people.apache.org/phonebook.html?uid=clewolff))