### PR TITLE
Fix error getting node_id in OpenStack_1_1_FloatingIpAddress:  #1411

### DIFF
--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -3927,8 +3927,8 @@ class OpenStack_2_FloatingIpPool(object):
                                            port.extra["mac_address"]}
 
         if 'port_details' in obj and obj['port_details']:
-            if obj['port_details']['device_owner'] in ['compute:nova',
-                                                       'compute:None']:
+            dev_owner = obj['port_details']['device_owner']
+            if dev_owner and dev_owner.startswith("compute:"):
                 instance_id = obj['port_details']['device_id']
 
         ip_address = obj['floating_ip_address']

--- a/libcloud/test/compute/fixtures/openstack_v1.1/_v2_0__floatingips.json
+++ b/libcloud/test/compute/fixtures/openstack_v1.1/_v2_0__floatingips.json
@@ -75,6 +75,34 @@
             },
             "tags": ["tag3"],
             "port_forwardings": []
+        },
+        {
+            "router_id": "d23abc8d-2991-4a55-ba98-2aaea84cc72f",
+            "description": "for test",
+            "dns_domain": "my-domain.org.",
+            "dns_name": "myfip",
+            "created_at": "2016-12-21T10:55:50Z",
+            "updated_at": "2016-12-21T10:55:53Z",
+            "revision_number": 1,
+            "project_id": "4969c491a3c74ee4af974e6d800c62de",
+            "tenant_id": "4969c491a3c74ee4af974e6d800c62de",
+            "floating_network_id": "376da547-b977-4cfe-9cba-275c80debf57",
+            "fixed_ip_address": "10.0.0.4",
+            "floating_ip_address": "10.3.1.3",
+            "port_id": "ce705c24-c1ef-408a-bda3-7bbd946164ab",
+            "id": "123c5336a-0629-4694-ba30-04b0bdfa88a4",
+            "status": "ACTIVE",
+            "port_details": {
+                "status": "ACTIVE",
+                "name": "",
+                "admin_state_up": true,
+                "network_id": "02dd8479-ef26-4398-a102-d19d0a7b3a1f",
+                "device_owner": "compute:region",
+                "mac_address": "fa:16:3e:b1:3b:30",
+                "device_id": "cb4fba64-19e2-40fd-8497-f29da1b21143"
+            },
+            "tags": ["tag3"],
+            "port_forwardings": []
         }
     ]
 }

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -1442,6 +1442,11 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
         self.assertEqual(ret[2].ip_address, '10.3.1.2')
         self.assertEqual(
             ret[2].node_id, 'cb4fba64-19e2-40fd-8497-f29da1b21143')
+        self.assertEqual(ret[3].id, '123c5336a-0629-4694-ba30-04b0bdfa88a4')
+        self.assertEqual(ret[3].pool, pool)
+        self.assertEqual(ret[3].ip_address, '10.3.1.3')
+        self.assertEqual(
+            ret[3].node_id, 'cb4fba64-19e2-40fd-8497-f29da1b21143')
 
     def test_OpenStack_2_FloatingIpPool_get_floating_ip(self):
         pool = OpenStack_2_FloatingIpPool(1, 'foo', self.driver.connection)


### PR DESCRIPTION
## Fix error getting node_id in OpenStack_1_1_FloatingIpAddress in case of region is not called "nova".

### Description

In the function OpenStack_2_FloatingIpPool._to_floating_ip the instance_id of the node where the IP is attached to is not correctly obtained if the name of the region is not the expected one "nova".

Resolves #1411.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
