### PR TITLE
Update Gandi Live DNS driver to match service change

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -134,6 +134,14 @@ Storage
 
   (GITHUB-1410)
   [Clemens Wolff - @c-w]
+
+DNS
+~~~
+
+- [Gandi Live] Update the driver and make sure it matches the latest service /
+  API updates.
+  (GITHUB-1416)
+  [Ryan Lee - @zepheiryan]
   
 Container
 ~~~~~~~~~

--- a/libcloud/common/gandi_live.py
+++ b/libcloud/common/gandi_live.py
@@ -139,13 +139,18 @@ class GandiLiveResponse(JsonResponse):
         valid_http_codes = [
             httplib.OK,
             httplib.CREATED,
-            httplib.NO_CONTENT
         ]
         if self.status in valid_http_codes:
             if json_error:
                 raise JsonParseError(body, self.status)
             else:
                 return body
+        elif self.status == httplib.NO_CONTENT:
+            # Parse error for empty body is acceptable, but a non-empty body is not.
+            if len(body) > 0:
+                raise GandiLiveBaseError('"No Content" response contained content', self.status)
+            else:
+                return {}
         elif self.status == httplib.NOT_FOUND:
             message = self._get_error(body, json_error)
             raise ResourceNotFoundError(message, self.status)

--- a/libcloud/common/gandi_live.py
+++ b/libcloud/common/gandi_live.py
@@ -146,9 +146,11 @@ class GandiLiveResponse(JsonResponse):
             else:
                 return body
         elif self.status == httplib.NO_CONTENT:
-            # Parse error for empty body is acceptable, but a non-empty body is not.
+            # Parse error for empty body is acceptable, but a non-empty body
+            # is not.
             if len(body) > 0:
-                raise GandiLiveBaseError('"No Content" response contained content', self.status)
+                msg = '"No Content" response contained content'
+                raise GandiLiveBaseError(msg, self.status)
             else:
                 return {}
         elif self.status == httplib.NOT_FOUND:

--- a/libcloud/test/dns/fixtures/gandi_live/delete_gandi_zone.json
+++ b/libcloud/test/dns/fixtures/gandi_live/delete_gandi_zone.json
@@ -1,3 +1,0 @@
-{
-    "message": "Zone deleted"
-}

--- a/libcloud/test/dns/fixtures/gandi_live/delete_record.json
+++ b/libcloud/test/dns/fixtures/gandi_live/delete_record.json
@@ -1,3 +1,0 @@
-{
-    "message": "Zone Record Deleted"
-}

--- a/libcloud/test/dns/test_gandi_live.py
+++ b/libcloud/test/dns/test_gandi_live.py
@@ -269,8 +269,7 @@ class GandiLiveMockHttp(BaseGandiLiveMockHttp):
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
     def _json_api_v5_zones_111111_delete(self, method, url, body, headers):
-        body = self.fixtures.load('delete_gandi_zone.json')
-        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+        return (httplib.NO_CONTENT, '', {}, httplib.responses[httplib.OK])
 
     def _json_api_v5_domains_example_org_patch(self, method, url, body,
                                                headers):
@@ -347,8 +346,7 @@ class GandiLiveMockHttp(BaseGandiLiveMockHttp):
     def _json_api_v5_domains_example_com_records_bob_A_delete(self, method,
                                                               url, body,
                                                               headers):
-        body = self.fixtures.load('delete_record.json')
-        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+        return (httplib.NO_CONTENT, '', {}, httplib.responses[httplib.OK])
 
 if __name__ == '__main__':
     sys.exit(unittest.main())


### PR DESCRIPTION
## Update Gandi Live DNS driver to match service change

### Description

The Gandi Live API appears to be more fluid and less than informative about its changes.  They've changed their response to DELETE requests from HTTP 200 with a JSON message to HTTP 204 No content with no body at all, which breaks the current implementation.  The driver and tests were updated to reflect the change.

### Status

Done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
