### PR TITLE
Fix S3 interoperability authentication in the Google Storage driver

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,17 @@ Compute
   (GITHUB-1409, GITHUB-1360)
   [Tomaz Muraus]
 
+Storage
+~~~~~~~
+
+- [Google Storage] Fix a bug when uploading an object would fail and result
+  in 401 "invalid signature" error when object mime type contained mixed
+  casing and when S3 Interoperability authentication method was used.
+
+  Reported by Will Abson - wabson.
+  (GITHUB-1417, GITHUB-1418)
+  [Tomaz Muraus]
+
 Changes in Apache Libcloud 3.0.0-rc1
 ------------------------------------
 

--- a/libcloud/storage/drivers/google_storage.py
+++ b/libcloud/storage/drivers/google_storage.py
@@ -119,7 +119,9 @@ class GoogleStorageConnection(ConnectionUserAndKey):
         # Lowercase all headers except 'date' and Google header values
         for k, v in headers.items():
             k_lower = k.lower()
-            if (k_lower == 'date' or k_lower.startswith(
+            # NOTE: It's important that the value of Content-Type header is
+            # left as is and not lowercased
+            if (k_lower in ['date', 'content-type'] or k_lower.startswith(
                     GoogleStorageDriver.http_vendor_prefix) or
                     not isinstance(v, str)):
                 headers_copy[k_lower] = v

--- a/libcloud/test/storage/test_google_storage.py
+++ b/libcloud/test/storage/test_google_storage.py
@@ -235,10 +235,12 @@ class GoogleStorageConnectionTest(GoogleTestCase):
             'Date': TODAY,
             'x-goog-foo': 'X-GOOG: MAINTAIN UPPERCASE!',
             'x-Goog-bar': 'Header key should be lowered',
+            'Content-Type': 'application/mIXED casING MAINTAINED',
             'Other': 'LOWER THIS!'
         }
         modified_headers = {
             'date': TODAY,
+            'content-type': 'application/mIXED casING MAINTAINED',
             'x-goog-foo': 'X-GOOG: MAINTAIN UPPERCASE!',
             'x-goog-bar': 'Header key should be lowered',
             'other': 'lower this!'


### PR DESCRIPTION
This pull request fixes a bug which would result in 401 invalid signature error when uploading an object with the Google Storage driver utilizing S3 Interoparability authentication when object mime / content type contained mixed casing (e.g. ``application/vnd.ms-excel.sheet.macroEnabled.12``).

The issue is that we incorrectly lower cased the value of the ``Content-Type`` header. This pull request fixes that by making sure we leave that header value as is.

Resolves #1417.