### PR TITLE
Add support for certificate and static token authentication to the Kubernetes driver

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,19 @@ Compute
   (GITHUB-1409, GITHUB-1360)
   [Tomaz Muraus]
 
+- [KubeVirt] For compliance with the base API, rename ``token_bearer_auth``
+  driver constructor argument to ``ex_token_bearer_auth``.
+  (GITHUB-1421)
+  [Tomaz Muraus]
+
+Container
+~~~~~~~~~
+
+- [Kubernetes] Add support for the client certificate and static token based
+  authentication to the driver.
+  (GITHUB-1421)
+  [Tomaz Muraus]
+
 Changes in Apache Libcloud 3.0.0-rc1
 ------------------------------------
 

--- a/docs/container/drivers/kubernetes.rst
+++ b/docs/container/drivers/kubernetes.rst
@@ -14,13 +14,14 @@ it groups the containers which make up an application into logical units for eas
     :width: 300
     :target: http://kubernetes.io/
 
-
 Authentication
 --------------
 
 Authentication currently supported with the following methods:
 
-* Basic HTTP Authentication - http://kubernetes.io/v1.1/docs/admin/authentication.html
+* Client certificate auth (recommended) - https://kubernetes.io/docs/reference/access-authn-authz/authentication/#x509-client-certs
+* Bearer token auth - https://kubernetes.io/docs/reference/access-authn-authz/authentication/#static-token-file
+* Basic HTTP Authentication (deprecated) - https://kubernetes.io/docs/reference/access-authn-authz/authentication/#static-password-file
 * No authentication (testing only)
 
 Instantiating the driver
@@ -29,11 +30,22 @@ Instantiating the driver
 .. literalinclude:: /examples/container/kubernetes/instantiate_driver.py
    :language: python
 
-Instantiating the driver (minikube installation)
-------------------------------------------------
+Instantiating the driver (minikube installation - cert file auth)
+-----------------------------------------------------------------
 
-Currently Kubernetes driver relies on basic auth authentication, which means you
-need to start the minikube with the command shown below:
+This example shows how to connect to a local minikube Kubernetes cluster
+which utilizes certifcate based authentication.
+
+.. literalinclude:: /examples/container/kubernetes/instantiate_driver_minikube_cert_auth.py
+   :language: python
+
+Instantiating the driver (minikube installation - basic auth)
+-------------------------------------------------------------
+
+This example shows how to connect to a local minikube Kubernetes cluster
+which utilizes basic auth authentication.
+
+When using basic auth, you need to start the minikube as shown below.
 
 .. sourcecode:: bash
 
@@ -48,7 +60,7 @@ need to start the minikube with the command shown below:
     # Start miniube
     minikube --extra-config=apiserver.basic-auth-file=/var/lib/docker/users.csv start
 
-.. literalinclude:: /examples/container/kubernetes/instantiate_driver_minikube.py
+.. literalinclude:: /examples/container/kubernetes/instantiate_driver_minikube_basic_auth.py
    :language: python
 
 -------------------------------------

--- a/docs/container/drivers/kubernetes.rst
+++ b/docs/container/drivers/kubernetes.rst
@@ -25,11 +25,32 @@ Authentication currently supported with the following methods:
 
 Instantiating the driver
 ------------------------
-        
+
 .. literalinclude:: /examples/container/kubernetes/instantiate_driver.py
    :language: python
 
-Deploying a container from Docker Hub
+Instantiating the driver (minikube installation)
+------------------------------------------------
+
+Currently Kubernetes driver relies on basic auth authentication, which means you
+need to start the minikube with the command shown below:
+
+.. sourcecode:: bash
+
+    $ cat users.csv
+    pass123,user1,developers
+
+.. sourcecode:: python
+
+    # Mount a share with a local users file
+    minikube mount /home/libcloud/users.csv:/var/lib/docker/users.csv
+
+    # Start miniube
+    minikube --extra-config=apiserver.basic-auth-file=/var/lib/docker/users.csv start
+
+.. literalinclude:: /examples/container/kubernetes/instantiate_driver_minikube.py
+   :language: python
+
 -------------------------------------
 
 Docker Hub Client :class:`~libcloud.container.utils.docker.HubClient` is a shared utility class for interfacing to the public Docker Hub Service.

--- a/docs/examples/container/kubernetes/instantiate_driver_minikube.py
+++ b/docs/examples/container/kubernetes/instantiate_driver_minikube.py
@@ -1,0 +1,22 @@
+from libcloud.container.types import Provider
+from libcloud.container.providers import get_driver
+
+import libcloud.security
+
+# Disable cert vertification when running minikube locally using self signed cert
+libcloud.security.VERIFY_SSL_CERT = False
+
+cls = get_driver(Provider.KUBERNETES)
+
+# You can retrieve cluster ip by running "minikube ip" command
+conn = cls(key='user1',
+           secret='pass123',
+           host='192.168.99.100',
+           port=8443,
+           secure=True)
+
+for container in conn.list_containers():
+    print(container.name)
+
+for cluster in conn.list_clusters():
+    print(cluster.name)

--- a/docs/examples/container/kubernetes/instantiate_driver_minikube_basic_auth.py
+++ b/docs/examples/container/kubernetes/instantiate_driver_minikube_basic_auth.py
@@ -3,7 +3,8 @@ from libcloud.container.providers import get_driver
 
 import libcloud.security
 
-# Disable cert vertification when running minikube locally using self signed cert
+# Disable cert vertification when running minikube locally using self signed
+# cert
 libcloud.security.VERIFY_SSL_CERT = False
 
 cls = get_driver(Provider.KUBERNETES)

--- a/docs/examples/container/kubernetes/instantiate_driver_minikube_cert_auth.py
+++ b/docs/examples/container/kubernetes/instantiate_driver_minikube_cert_auth.py
@@ -1,25 +1,21 @@
 from libcloud.container.types import Provider
 from libcloud.container.providers import get_driver
 
+import libcloud.security
+
+# Disable cert vertification when running minikube locally using self signed
+# cert
+libcloud.security.VERIFY_SSL_CERT = False
+
 cls = get_driver(Provider.KUBERNETES)
 
-# 1. Client side cert auth
+# You can retrieve cluster ip by running "minikube ip" command
 conn = cls(host='192.168.99.103',
            port=8443,
            secure=True,
            key_file='/home/user/.minikube/client.key',
            cert_file='/home/user/.minikube/client.crt',
            ca_cert='/home/user/.minikube/ca.crt')
-
-# 2. Bearer bootstrap token auth
-conn = cls(key='my_token',
-           host='126.32.21.4',
-           ex_token_bearer_auth=True)
-
-# 3. Basic auth
-conn = cls(key='my_username',
-           secret='THIS_IS)+_MY_SECRET_KEY+I6TVkv68o4H',
-           host='126.32.21.4')
 
 for container in conn.list_containers():
     print(container.name)

--- a/libcloud/common/base.py
+++ b/libcloud/common/base.py
@@ -886,7 +886,7 @@ class KeyCertificateConnection(CertificateConnection):
 
     def __init__(self, key_file, cert_file, secure=True, host=None, port=None,
                  url=None, proxy_url=None, timeout=None, backoff=None,
-                 retry_delay=None):
+                 retry_delay=None, ca_cert=None):
         """
         Initialize `cert_file`; set `secure` to an ``int`` based on
         passed value.

--- a/libcloud/common/kubernetes.py
+++ b/libcloud/common/kubernetes.py
@@ -1,0 +1,263 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Module which contains common Kubernetes related code.
+"""
+
+import os
+import base64
+import warnings
+
+
+from libcloud.utils.py3 import httplib
+from libcloud.utils.py3 import b
+
+from libcloud.common.base import JsonResponse, ConnectionUserAndKey
+from libcloud.common.base import KeyCertificateConnection, ConnectionKey
+from libcloud.common.types import InvalidCredsError
+
+__all__ = [
+    'KubernetesException',
+
+    'KubernetesBasicAuthConnection',
+    'KubernetesTLSAuthConnection',
+    'KubernetesTokenAuthConnection',
+
+    'KubernetesDriverMixin',
+
+    'VALID_RESPONSE_CODES'
+]
+
+VALID_RESPONSE_CODES = [httplib.OK, httplib.ACCEPTED, httplib.CREATED,
+                        httplib.NO_CONTENT]
+
+
+class KubernetesException(Exception):
+
+    def __init__(self, code, message):
+        self.code = code
+        self.message = message
+        self.args = (code, message)
+
+    def __str__(self):
+        return "%s %s" % (self.code, self.message)
+
+    def __repr__(self):
+        return "KubernetesException %s %s" % (self.code, self.message)
+
+
+class KubernetesResponse(JsonResponse):
+
+    valid_response_codes = [httplib.OK, httplib.ACCEPTED, httplib.CREATED,
+                            httplib.NO_CONTENT]
+
+    def parse_error(self):
+        if self.status == 401:
+            raise InvalidCredsError('Invalid credentials')
+        return self.body
+
+    def success(self):
+        return self.status in self.valid_response_codes
+
+
+class KubernetesTLSAuthConnection(KeyCertificateConnection):
+    responseCls = KubernetesResponse
+    timeout = 60
+
+    def __init__(self, key, secure=True, host='localhost',
+                 port='6443', key_file=None, cert_file=None, ca_cert=None,
+                 **kwargs):
+
+        super(KubernetesTLSAuthConnection, self).__init__(
+            key_file=key_file,
+            cert_file=cert_file,
+            secure=secure, host=host,
+            port=port, url=None,
+            proxy_url=None,
+            timeout=None,
+            backoff=None,
+            retry_delay=None)
+
+        if key_file:
+            keypath = os.path.expanduser(key_file)
+            is_file_path = os.path.exists(keypath) and os.path.isfile(keypath)
+            if not is_file_path:
+                raise InvalidCredsError(
+                    'You need an key PEM file to authenticate '
+                    'via tls. For more info please visit:'
+                    'https://kubernetes.io/docs/concepts/'
+                    'cluster-administration/certificates/')
+            self.key_file = key_file
+            certpath = os.path.expanduser(cert_file)
+            is_file_path = os.path.exists(
+                certpath) and os.path.isfile(certpath)
+            if not is_file_path:
+                raise InvalidCredsError(
+                    'You need an certificate PEM file to authenticate '
+                    'via tls. For more info please visit:'
+                    'https://kubernetes.io/docs/concepts/'
+                    'cluster-administration/certificates/'
+                )
+
+            self.cert_file = cert_file
+
+    def add_default_headers(self, headers):
+        if 'Content-Type' not in headers:
+            headers['Content-Type'] = 'application/json'
+        return headers
+
+
+class KubernetesTokenAuthConnection(ConnectionKey):
+    responseCls = KubernetesResponse
+    timeout = 60
+
+    def add_default_headers(self, headers):
+        if 'Content-Type' not in headers:
+            headers['Content-Type'] = 'application/json'
+        if self.key:
+            headers['Authorization'] = 'Bearer ' + self.key
+        else:
+            raise ValueError("Please provide a valid token in the key param")
+        return headers
+
+
+class KubernetesBasicAuthConnection(ConnectionUserAndKey):
+    responseCls = KubernetesResponse
+    timeout = 60
+
+    def add_default_headers(self, headers):
+        """
+        Add parameters that are necessary for every request
+        If user and password are specified, include a base http auth
+        header
+        """
+        if 'Content-Type' not in headers:
+            headers['Content-Type'] = 'application/json'
+        if self.key and self.secret:
+            user_b64 = base64.b64encode(b('%s:%s' % (self.key, self.secret)))
+            headers['Authorization'] = 'Basic %s' % (user_b64.decode('utf-8'))
+        return headers
+
+    def _ex_connection_class_kwargs(self):
+        kwargs = {}
+        if hasattr(self, 'key_file'):
+            kwargs['key_file'] = self.key_file
+        if hasattr(self, 'cert_file'):
+            kwargs['cert_file'] = self.cert_file
+        return kwargs
+
+
+class KubernetesDriverMixin(object):
+    """
+    Base driver class to be used with various Kubernetes drivers.
+
+    NOTE: This base class can be used in different APIs such as container and
+    compute one.
+    """
+
+    def __init__(self, key=None, secret=None, secure=False, host='localhost',
+                 port=4243, key_file=None, cert_file=None, ca_cert=None,
+                 ex_token_bearer_auth=False):
+        """
+        :param    key: API key or username to be used (required)
+        :type     key: ``str``
+
+        :param    secret: Secret password to be used (required)
+        :type     secret: ``str``
+
+        :param    secure: Whether to use HTTPS or HTTP. Note: Some providers
+                          only support HTTPS, and it is on by default.
+        :type     secure: ``bool``
+
+        :param    host: Override hostname used for connections.
+        :type     host: ``str``
+
+        :param    port: Override port used for connections.
+        :type     port: ``int``
+
+        :param    key_file: Path to the key file used to authenticate (when
+                            using key file auth).
+        :type     key_file: ``str``
+
+        :param    cert_file: Path to the cert file used to authenticate (when
+                             using key file auth).
+        :type     cert_file: ``str``
+
+        :param    ex_token_bearer_auth: True to use token bearer auth.
+        :type     ex_token_bearer_auth: ``bool``
+
+        :return: ``None``
+        """
+        if ex_token_bearer_auth:
+            self.connectionCls = KubernetesTokenAuthConnection
+            if not key:
+                msg = 'The token must be a string provided via "key" argument'
+                raise ValueError(msg)
+            secure = True
+
+        if key_file or cert_file:
+            # Certificate based auth is used
+            if not (key_file and cert_file):
+                raise ValueError("Both key and certificate files are needed")
+
+        if key_file:
+            self.connectionCls = KubernetesTLSAuthConnection
+            self.key_file = key_file
+            self.cert_file = cert_file
+            secure = True
+
+        if host is not None:
+            if host.startswith('https://'):
+                secure = True
+
+            # strip the prefix
+            prefixes = ['http://', 'https://']
+            for prefix in prefixes:
+                if host.startswith(prefix):
+                    host = host.lstrip(prefix)
+
+        super(KubernetesDriverMixin, self).__init__(key=key, secret=secret,
+                                                    secure=secure,
+                                                    host=host,
+                                                    port=port,
+                                                    key_file=key_file,
+                                                    cert_file=cert_file)
+
+        if ca_cert:
+            self.connection.connection.ca_cert = ca_cert
+        else:
+            # do not verify SSL certificate
+            warnings.warn("Kubernetes has its own CA, since you didn't supply "
+                          "a CA certificate be aware that SSL verification "
+                          "will be disabled for this session.")
+            self.connection.connection.ca_cert = False
+
+        self.connection.host = host
+        self.connection.port = port
+        self.connection.secure = secure
+
+        if self.connectionCls == KubernetesBasicAuthConnection:
+            self.connection.secret = secret
+
+        self.connection.key = key
+
+    def _ex_connection_class_kwargs(self):
+        kwargs = {}
+        if hasattr(self, 'key_file'):
+            kwargs['key_file'] = self.key_file
+        if hasattr(self, 'cert_file'):
+            kwargs['cert_file'] = self.cert_file
+        return kwargs

--- a/libcloud/common/kubernetes.py
+++ b/libcloud/common/kubernetes.py
@@ -246,7 +246,10 @@ class KubernetesDriverMixin(object):
             self.connection.connection.ca_cert = False
 
         self.connection.host = host
-        self.connection.port = port
+
+        if port is not None:
+            self.connection.port = port
+
         self.connection.secure = secure
 
         if self.connectionCls == KubernetesBasicAuthConnection:

--- a/libcloud/compute/drivers/kubevirt.py
+++ b/libcloud/compute/drivers/kubevirt.py
@@ -19,161 +19,40 @@
 """
 kubevirt driver with support for nodes (vms)
 """
-import os
+
 import json
 import time
-import warnings
+
 from datetime import datetime
 
-import libcloud.security
-
-
-from libcloud.container.drivers.kubernetes import KubernetesResponse
-from libcloud.container.drivers.kubernetes import KubernetesConnection
-from libcloud.container.drivers.kubernetes import VALID_RESPONSE_CODES
-
-from libcloud.common.base import KeyCertificateConnection, ConnectionKey
-from libcloud.common.types import InvalidCredsError, LibcloudError
+from libcloud.common.types import LibcloudError
+from libcloud.common.kubernetes import KubernetesBasicAuthConnection
+from libcloud.common.kubernetes import KubernetesDriverMixin
+from libcloud.common.kubernetes import VALID_RESPONSE_CODES
 
 from libcloud.compute.types import Provider, NodeState
 from libcloud.compute.base import NodeDriver, NodeSize, Node
 from libcloud.compute.base import NodeImage, NodeLocation, StorageVolume
 
 __all__ = [
-    "KubernetesTLSConnection",
-    "KubernetesTokenAuthentication",
     "KubeVirtNodeDriver"
 ]
+
 ROOT_URL = '/api/v1/'
 KUBEVIRT_URL = '/apis/kubevirt.io/v1alpha3/'
 
 
-class KubernetesTLSConnection(KeyCertificateConnection):
-    responseCls = KubernetesResponse
-    timeout = 60
-
-    def __init__(self, key, secure=True, host='localhost',
-                 port='6443', key_file=None, cert_file=None, ca_cert='',
-                 **kwargs):
-
-        super(KubernetesTLSConnection, self).__init__(key_file=key_file,
-                                                      cert_file=cert_file,
-                                                      secure=secure, host=host,
-                                                      port=port, url=None,
-                                                      proxy_url=None,
-                                                      timeout=None,
-                                                      backoff=None,
-                                                      retry_delay=None)
-        if key_file:
-            keypath = os.path.expanduser(key_file)
-            is_file_path = os.path.exists(keypath) and os.path.isfile(keypath)
-            if not is_file_path:
-                raise InvalidCredsError(
-                    'You need an key PEM file to authenticate with '
-                    'via tls. For more info please visit:'
-                    'https://kubernetes.io/docs/concepts/'
-                    'cluster-administration/certificates/')
-            self.key_file = key_file
-            certpath = os.path.expanduser(cert_file)
-            is_file_path = os.path.exists(
-                certpath) and os.path.isfile(certpath)
-            if not is_file_path:
-                raise InvalidCredsError(
-                    'You need an certificate PEM file to authenticate'
-                    'via tls. For more info please visit:'
-                    'https://kubernetes.io/docs/concepts/'
-                    'cluster-administration/certificates/'
-                )
-
-            self.cert_file = cert_file
-
-    def add_default_headers(self, headers):
-        if 'Content-Type' not in headers:
-            headers['Content-Type'] = 'application/json'
-        return headers
-
-
-class KubernetesTokenAuthentication(ConnectionKey):
-    responseCls = KubernetesResponse
-    timeout = 60
-
-    def add_default_headers(self, headers):
-        if 'Content-Type' not in headers:
-            headers['Content-Type'] = 'application/json'
-        if self.key:
-            headers['Authorization'] = 'Bearer ' + self.key
-        else:
-            raise ValueError("Please provide a valid token in the key param")
-        return headers
-
-
-class KubeVirtNodeDriver(NodeDriver):
+class KubeVirtNodeDriver(KubernetesDriverMixin, NodeDriver):
     type = Provider.KUBEVIRT
     name = "kubevirt"
     website = 'https://www.kubevirt.io'
-    connectionCls = KubernetesConnection
+    connectionCls = KubernetesBasicAuthConnection
 
     NODE_STATE_MAP = {
         'pending': NodeState.PENDING,
         'running': NodeState.RUNNING,
         'stopped': NodeState.STOPPED
     }
-
-    def __init__(self, key=None, secret=None, secure=True, host="localhost",
-                 port=6443, key_file=None, cert_file=None, ca_cert='',
-                 token_bearer_auth=False, verify=True):
-
-        libcloud.security.VERIFY_SSL_CERT = verify
-        if token_bearer_auth:
-            self.connectionCls = KubernetesTokenAuthentication
-            if not key:
-                raise ValueError("The token must be a string")
-            secure = True
-
-        if key_file:
-            self.connectionCls = KubernetesTLSConnection
-            self.key_file = key_file
-            self.cert_file = cert_file
-            secure = True
-
-        if host.startswith('https://'):
-            secure = True
-
-        # strip the prefix
-        prefixes = ['http://', 'https://']
-        for prefix in prefixes:
-            if host.startswith(prefix):
-                host = host.lstrip(prefix)
-
-        super(KubeVirtNodeDriver, self).__init__(key=key,
-                                                 secret=secret,
-                                                 secure=secure,
-                                                 host=host,
-                                                 port=port,
-                                                 key_file=key_file,
-                                                 cert_file=cert_file)
-
-        # check if both key and cert files are present
-        if key_file or cert_file:
-            if not(key_file and cert_file):
-                raise Exception("Both key and certificate files are needed")
-
-        if ca_cert:
-            self.connection.connection.ca_cert = ca_cert
-        else:
-            # do not verify SSL certificate
-            warnings.warn("Kubernetes has its own CA, since you didn't supply "
-                          "a CA certificate be aware that SSL verification "
-                          "will be disabled for this session.")
-            self.connection.connection.ca_cert = False
-
-        self.connection.secure = secure
-        self.connection.host = host
-        self.connection.port = port
-
-        if self.connectionCls == KubernetesConnection:
-            self.connection.secret = secret
-        self.connection.key = key
 
     def list_nodes(self, location=None):
         namespaces = []
@@ -1023,14 +902,6 @@ class KubeVirtNodeDriver(NodeDriver):
             volumes.append(volume)
 
         return volumes
-
-    def _ex_connection_class_kwargs(self):
-        kwargs = {}
-        if hasattr(self, 'key_file'):
-            kwargs['key_file'] = self.key_file
-        if hasattr(self, 'cert_file'):
-            kwargs['cert_file'] = self.cert_file
-        return kwargs
 
     def _to_node(self, vm, is_stopped=False):
         """

--- a/libcloud/container/drivers/kubernetes.py
+++ b/libcloud/container/drivers/kubernetes.py
@@ -13,73 +13,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import base64
 import datetime
 import json
-
-from libcloud.utils.py3 import httplib
-from libcloud.utils.py3 import b
-
-from libcloud.common.base import JsonResponse, ConnectionUserAndKey
-from libcloud.common.types import InvalidCredsError
 
 from libcloud.container.base import (Container, ContainerDriver,
                                      ContainerImage, ContainerCluster)
 
+from libcloud.common.kubernetes import KubernetesException
+from libcloud.common.kubernetes import KubernetesBasicAuthConnection
+from libcloud.common.kubernetes import KubernetesDriverMixin
+
 from libcloud.container.providers import Provider
 from libcloud.container.types import ContainerState
 
+__all__ = [
+    'KubernetesContainerDriver'
+]
 
-VALID_RESPONSE_CODES = [httplib.OK, httplib.ACCEPTED, httplib.CREATED,
-                        httplib.NO_CONTENT]
 
 ROOT_URL = '/api/'
-
-
-class KubernetesResponse(JsonResponse):
-
-    valid_response_codes = [httplib.OK, httplib.ACCEPTED, httplib.CREATED,
-                            httplib.NO_CONTENT]
-
-    def parse_error(self):
-        if self.status == 401:
-            raise InvalidCredsError('Invalid credentials')
-        return self.body
-
-    def success(self):
-        return self.status in self.valid_response_codes
-
-
-class KubernetesException(Exception):
-
-    def __init__(self, code, message):
-        self.code = code
-        self.message = message
-        self.args = (code, message)
-
-    def __str__(self):
-        return "%s %s" % (self.code, self.message)
-
-    def __repr__(self):
-        return "KubernetesException %s %s" % (self.code, self.message)
-
-
-class KubernetesConnection(ConnectionUserAndKey):
-    responseCls = KubernetesResponse
-    timeout = 60
-
-    def add_default_headers(self, headers):
-        """
-        Add parameters that are necessary for every request
-        If user and password are specified, include a base http auth
-        header
-        """
-        if 'Content-Type' not in headers:
-            headers['Content-Type'] = 'application/json'
-        if self.key and self.secret:
-            user_b64 = base64.b64encode(b('%s:%s' % (self.key, self.secret)))
-            headers['Authorization'] = 'Basic %s' % (user_b64.decode('utf-8'))
-        return headers
 
 
 class KubernetesPod(object):
@@ -92,55 +44,12 @@ class KubernetesPod(object):
         self.namespace = namespace
 
 
-class KubernetesContainerDriver(ContainerDriver):
+class KubernetesContainerDriver(KubernetesDriverMixin, ContainerDriver):
     type = Provider.KUBERNETES
     name = 'Kubernetes'
     website = 'http://kubernetes.io'
-    connectionCls = KubernetesConnection
+    connectionCls = KubernetesBasicAuthConnection
     supports_clusters = True
-
-    def __init__(self, key=None, secret=None, secure=False, host='localhost',
-                 port=4243):
-        """
-        :param    key: API key or username to used (required)
-        :type     key: ``str``
-
-        :param    secret: Secret password to be used (required)
-        :type     secret: ``str``
-
-        :param    secure: Whether to use HTTPS or HTTP. Note: Some providers
-                only support HTTPS, and it is on by default.
-        :type     secure: ``bool``
-
-        :param    host: Override hostname used for connections.
-        :type     host: ``str``
-
-        :param    port: Override port used for connections.
-        :type     port: ``int``
-
-        :return: ``None``
-        """
-        super(KubernetesContainerDriver, self).__init__(key=key, secret=secret,
-                                                        secure=secure,
-                                                        host=host,
-                                                        port=port)
-
-        if host is not None:
-            if host.startswith('https://'):
-                secure = True
-
-            # strip the prefix
-            prefixes = ['http://', 'https://']
-            for prefix in prefixes:
-                if host.startswith(prefix):
-                    host = host.lstrip(prefix)
-
-            self.connection.host = host
-            self.connection.port = port
-
-        self.connection.secure = secure
-        self.connection.key = key
-        self.connection.secret = secret
 
     def list_containers(self, image=None, all=True):
         """

--- a/libcloud/test/common/test_kubernetes.py
+++ b/libcloud/test/common/test_kubernetes.py
@@ -46,8 +46,8 @@ class KubernetesAuthTestCaseMixin(object):
     def test_http_basic_auth(self):
         driver = self.driver_cls(key='username', secret='password')
         self.assertEqual(driver.connectionCls, KubernetesBasicAuthConnection)
-        self.assertEqual(driver.connection.key, 'username')
-        self.assertEqual(driver.connection.secret, 'password')
+        self.assertEqual(driver.connection.user_id, 'username')
+        self.assertEqual(driver.connection.key, 'password')
 
         auth_string = base64.b64encode(b('%s:%s' % ('username', 'password'))).decode('utf-8')
 
@@ -96,3 +96,13 @@ class KubernetesAuthTestCaseMixin(object):
         headers = driver.connection.add_default_headers({})
         self.assertEqual(headers['Content-Type'], 'application/json')
         self.assertEqual(headers['Authorization'], 'Bearer %s' % ('foobar'))
+
+    def test_host_sanitization(self):
+        driver = self.driver_cls(host='example.com')
+        self.assertEqual(driver.connection.host, 'example.com')
+
+        driver = self.driver_cls(host='http://example.com')
+        self.assertEqual(driver.connection.host, 'example.com')
+
+        driver = self.driver_cls(host='https://example.com')
+        self.assertEqual(driver.connection.host, 'example.com')

--- a/libcloud/test/common/test_kubernetes.py
+++ b/libcloud/test/common/test_kubernetes.py
@@ -1,0 +1,98 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+__all__ = [
+    'KubernetesAuthTestCaseMixin'
+]
+
+import os
+import base64
+
+from libcloud.utils.py3 import b
+
+from libcloud.common.kubernetes import KubernetesBasicAuthConnection
+from libcloud.common.kubernetes import KubernetesTLSAuthConnection
+from libcloud.common.kubernetes import KubernetesTokenAuthConnection
+
+KEY_FILE = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                           '../compute/fixtures/azure/libcloud.pem'))
+CERT_FILE = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                            '../loadbalancer/fixtures/nttcis/denis.crt'))
+CA_CERT_FILE = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                               '../loadbalancer/fixtures/nttcis/chain.crt'))
+
+
+class KubernetesAuthTestCaseMixin(object):
+    """
+    Test class mixin which tests different type of Kubernetes authentication
+    mechanisms (client cert, token, basic auth).
+
+    It's to be used with all the drivers which inherit from KubernetesDriverMixin.
+    """
+
+    def test_http_basic_auth(self):
+        driver = self.driver_cls(key='username', secret='password')
+        self.assertEqual(driver.connectionCls, KubernetesBasicAuthConnection)
+        self.assertEqual(driver.connection.key, 'username')
+        self.assertEqual(driver.connection.secret, 'password')
+
+        auth_string = base64.b64encode(b('%s:%s' % ('username', 'password'))).decode('utf-8')
+
+        headers = driver.connection.add_default_headers({})
+        self.assertEqual(headers['Content-Type'], 'application/json')
+        self.assertEqual(headers['Authorization'], 'Basic %s' % (auth_string))
+
+    def test_cert_auth(self):
+        # key_file provided, but not cert_file
+        expected_msg = 'Both key and certificate files are needed'
+        self.assertRaisesRegex(ValueError, expected_msg, self.driver_cls,
+                               key_file=KEY_FILE, ca_cert=CA_CERT_FILE)
+
+        # cert_file provided, but not key_file
+        expected_msg = 'Both key and certificate files are needed'
+        self.assertRaisesRegex(ValueError, expected_msg, self.driver_cls,
+                               cert_file=CERT_FILE, ca_cert=CA_CERT_FILE)
+
+        # ca_cert argument specified
+        driver = self.driver_cls(key_file=KEY_FILE, cert_file=CERT_FILE,
+                                 ca_cert=CA_CERT_FILE)
+        self.assertEqual(driver.connectionCls, KubernetesTLSAuthConnection)
+        self.assertEqual(driver.connection.key_file, KEY_FILE)
+        self.assertEqual(driver.connection.cert_file, CERT_FILE)
+        self.assertEqual(driver.connection.connection.ca_cert, CA_CERT_FILE)
+
+        headers = driver.connection.add_default_headers({})
+        self.assertEqual(headers['Content-Type'], 'application/json')
+
+        # ca_cert argument not specified
+        driver = self.driver_cls(key_file=KEY_FILE, cert_file=CERT_FILE,
+                                 ca_cert=None)
+        self.assertEqual(driver.connectionCls, KubernetesTLSAuthConnection)
+        self.assertEqual(driver.connection.key_file, KEY_FILE)
+        self.assertEqual(driver.connection.cert_file, CERT_FILE)
+        self.assertEqual(driver.connection.connection.ca_cert, False)
+
+        headers = driver.connection.add_default_headers({})
+        self.assertEqual(headers['Content-Type'], 'application/json')
+
+    def test_bearer_token_auth(self):
+        driver = self.driver_cls(ex_token_bearer_auth=True, key='foobar')
+        self.assertEqual(driver.connectionCls, KubernetesTokenAuthConnection)
+        self.assertEqual(driver.connection.key, 'foobar')
+
+        headers = driver.connection.add_default_headers({})
+        self.assertEqual(headers['Content-Type'], 'application/json')
+        self.assertEqual(headers['Authorization'], 'Bearer %s' % ('foobar'))

--- a/libcloud/test/compute/test_kubevirt.py
+++ b/libcloud/test/compute/test_kubevirt.py
@@ -22,11 +22,13 @@ from libcloud.utils.py3 import httplib
 
 from libcloud.test import unittest
 from libcloud.test import MockHttp
+from libcloud.test.common.test_kubernetes import KubernetesAuthTestCaseMixin
 from libcloud.test.file_fixtures import ComputeFileFixtures
 
 
-class KubeVirtTest(unittest.TestCase):
+class KubeVirtTestCase(unittest.TestCase, KubernetesAuthTestCaseMixin):
 
+    driver_cls = KubeVirtNodeDriver
     fixtures = ComputeFileFixtures('kubevirt')
 
     def setUp(self):

--- a/libcloud/test/container/test_kubernetes.py
+++ b/libcloud/test/container/test_kubernetes.py
@@ -13,98 +13,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import sys
-import base64
 
 from libcloud.utils.py3 import httplib
-from libcloud.utils.py3 import b
-
-from libcloud.common.kubernetes import KubernetesBasicAuthConnection
-from libcloud.common.kubernetes import KubernetesTLSAuthConnection
-from libcloud.common.kubernetes import KubernetesTokenAuthConnection
 
 from libcloud.container.base import ContainerImage
 from libcloud.container.drivers.kubernetes import KubernetesContainerDriver
 
 from libcloud.test.secrets import CONTAINER_PARAMS_KUBERNETES
+from libcloud.test.common.test_kubernetes import KubernetesAuthTestCaseMixin
 from libcloud.test.file_fixtures import ContainerFileFixtures
 from libcloud.test import MockHttp
 from libcloud.test import unittest
 
-KEY_FILE = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                           '../compute/fixtures/azure/libcloud.pem'))
-CERT_FILE = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                            '../loadbalancer/fixtures/nttcis/denis.crt'))
-CA_CERT_FILE = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                               '../loadbalancer/fixtures/nttcis/chain.crt'))
 
-
-class KubernetesContainerDriverTestCase(unittest.TestCase):
+class KubernetesContainerDriverTestCase(unittest.TestCase,
+                                        KubernetesAuthTestCaseMixin):
+    driver_cls = KubernetesContainerDriver
 
     def setUp(self):
         KubernetesContainerDriver.connectionCls.conn_class = KubernetesMockHttp
         KubernetesMockHttp.type = None
         KubernetesMockHttp.use_param = 'a'
         self.driver = KubernetesContainerDriver(*CONTAINER_PARAMS_KUBERNETES)
-
-    def test_http_basic_auth(self):
-        # TODO: Move this into shared kubernetes driver tests file
-        driver = KubernetesContainerDriver(key='username', secret='password')
-        self.assertEqual(driver.connectionCls, KubernetesBasicAuthConnection)
-        self.assertEqual(driver.connection.key, 'username')
-        self.assertEqual(driver.connection.secret, 'password')
-
-        auth_string = base64.b64encode(b('%s:%s' % ('username', 'password'))).decode('utf-8')
-
-        headers = driver.connection.add_default_headers({})
-        self.assertEqual(headers['Content-Type'], 'application/json')
-        self.assertEqual(headers['Authorization'], 'Basic %s' % (auth_string))
-
-    def test_cert_auth(self):
-        # TODO: Move this into shared kubernetes driver tests file
-        # key_file provided, but not cert_file
-        expected_msg = 'Both key and certificate files are needed'
-        self.assertRaisesRegex(ValueError, expected_msg, KubernetesContainerDriver,
-                               key_file=KEY_FILE, ca_cert=CA_CERT_FILE)
-
-        # cert_file provided, but not key_file
-        expected_msg = 'Both key and certificate files are needed'
-        self.assertRaisesRegex(ValueError, expected_msg, KubernetesContainerDriver,
-                               cert_file=CERT_FILE, ca_cert=CA_CERT_FILE)
-
-        # ca_cert argument specified
-        driver = KubernetesContainerDriver(key_file=KEY_FILE, cert_file=CERT_FILE,
-                                           ca_cert=CA_CERT_FILE)
-        self.assertEqual(driver.connectionCls, KubernetesTLSAuthConnection)
-        self.assertEqual(driver.connection.key_file, KEY_FILE)
-        self.assertEqual(driver.connection.cert_file, CERT_FILE)
-        self.assertEqual(driver.connection.connection.ca_cert, CA_CERT_FILE)
-
-        headers = driver.connection.add_default_headers({})
-        self.assertEqual(headers['Content-Type'], 'application/json')
-
-        # ca_cert argument not specified
-        # TODO: Move this into shared kubernetes driver tests file
-        driver = KubernetesContainerDriver(key_file=KEY_FILE, cert_file=CERT_FILE,
-                                           ca_cert=None)
-        self.assertEqual(driver.connectionCls, KubernetesTLSAuthConnection)
-        self.assertEqual(driver.connection.key_file, KEY_FILE)
-        self.assertEqual(driver.connection.cert_file, CERT_FILE)
-        self.assertEqual(driver.connection.connection.ca_cert, False)
-
-        headers = driver.connection.add_default_headers({})
-        self.assertEqual(headers['Content-Type'], 'application/json')
-
-    def test_bearer_token_auth(self):
-        # TODO: Move this into shared kubernetes driver tests file
-        driver = KubernetesContainerDriver(ex_token_bearer_auth=True, key='foobar')
-        self.assertEqual(driver.connectionCls, KubernetesTokenAuthConnection)
-        self.assertEqual(driver.connection.key, 'foobar')
-
-        headers = driver.connection.add_default_headers({})
-        self.assertEqual(headers['Content-Type'], 'application/json')
-        self.assertEqual(headers['Authorization'], 'Bearer %s' % ('foobar'))
 
     def test_list_containers(self):
         containers = self.driver.list_containers()


### PR DESCRIPTION
This pull request updates Kubernetes container driver so it now also supports client side certificate and static bearer token authentication

## Background

Previously the driver only supported HTTP basic auth which is now deprecated.

## Implementation Details

Most of the code for handling various types of authentication mechanism was already there (either available in the Kubernetes container driver or the KubeVirt compute one),
this PR just updates it to make it more re-usable.

This way we avoid duplicated (copy and pasted) code and re-use those base connection classes by both of the Kubernetes driver.

## Testing

I tested the Kubernetes container driver and KubeVirt compute driver against a local minikube deployment.

It probably wouldn't hurt if KubeVirt one gets more testing (cc @Eis-D-Z).

On that note, for compliance with the base API (I missed that during the review), ``token_bearer_auth`` KubeVirt driver constructor argument has been renamed to ``ex_token_bearer_auth``.

## TODO

- [x] Refactor auth classes tests and also use them with the KubeVirt compute driver tests