### PR TITLE
Minor bugfix: ec2 driver create_node ex_userdata broken in tag 2.8

### DIFF
--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -1970,7 +1970,7 @@ class BaseEC2NodeDriver(NodeDriver):
             params['KeyName'] = ex_keyname
 
         if ex_userdata:
-            params['UserData'] = base64.b64encode(b('ex_userdata'))\
+            params['UserData'] = base64.b64encode(b(ex_userdata))\
                 .decode('utf-8')
 
         if ex_clienttoken:


### PR DESCRIPTION
## Minor bugfix: ec2 driver create_node ex_userdata broken in tag 2.8

### Description

Release tag 2.8 reworked the kwargs based implementation of the ec2 driver, introducing this error where the literal string 'ex_userdata' was passed during create_node intead of the actual ex_userdata kwarg
### Status

done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)

Packaged tests are broken, tested manually using 3.0.0rc1
No change to documentation
No material change to code linting status