### PR TITLE
Ignore "[Errno 29] Illegal seek" errors which may arise when using "upload_object_via_stream" method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,17 @@ Storage
   (GITHUB-1417, GITHUB-1418)
   [Tomaz Muraus]
 
+- Fix ``upload_object_via_stream`` method so "Illegal seek" errors which
+  can arise when calculating iterator content hash are ignored. Those errors
+  likely indicate that the underlying file handle / iterator is a pipe which
+  doesn't support seek and that the error is not fatal and we should still
+  proceed.
+
+  Reported by Per Buer - @perbu.
+
+  (GITHUB-1424, GITHUB-1427)
+  [Tomaz Muraus]
+
 Container
 ~~~~~~~~~
 

--- a/libcloud/storage/base.py
+++ b/libcloud/storage/base.py
@@ -29,6 +29,7 @@ from typing import Type
 import os.path                          # pylint: disable-msg=W0404
 import hashlib
 import warnings
+import errno
 from os.path import join as pjoin
 
 from libcloud.utils.py3 import httplib
@@ -738,7 +739,18 @@ class StorageDriver(BaseDriver):
             # Ensure we start from the begining of a stream in case stream is
             # not at the beginning
             if hasattr(stream, 'seek'):
-                stream.seek(0)
+                try:
+                    stream.seek(0)
+                except OSError as e:
+                    if e.errno != errno.ESPIPE:
+                        # This error number represents OSError: [Errno 29]
+                        # Illegal seek error.
+                        # This could either mean that the underlying handle
+                        # doesn't support seek operation (e.g. pipe) or that
+                        # the invalid seek position is provided. Sadly there is
+                        # no good robust way to distinghuish that so we simply ignore
+                        # all the "Illeal seek errors"
+                        raise e
 
             for chunk in libcloud.utils.files.read_in_chunks(iterator=stream):
                 hasher.update(b(chunk))

--- a/libcloud/storage/base.py
+++ b/libcloud/storage/base.py
@@ -744,12 +744,12 @@ class StorageDriver(BaseDriver):
                 except OSError as e:
                     if e.errno != errno.ESPIPE:
                         # This represents "OSError: [Errno 29] Illegal seek"
-                        # error. This could either mean that the underlying handle
-                        # doesn't support seek operation (e.g. pipe) or that
-                        # the invalid seek position is provided. Sadly there is
-                        # no good robust way to distinghuish that so we simply
-                        # ignore all the "Illeal seek errors" so this function
-                        # works correctly with pipes.
+                        # error. This could either mean that the underlying
+                        # handle doesn't support seek operation (e.g. pipe) or
+                        # that the invalid seek position is provided. Sadly
+                        # there is no good robust way to distinghuish that so
+                        # we simply ignore all the "Illeal seek" errors so
+                        # this function works correctly with pipes.
                         # See https://github.com/apache/libcloud/pull/1427 for
                         # details
                         raise e

--- a/libcloud/storage/base.py
+++ b/libcloud/storage/base.py
@@ -743,13 +743,15 @@ class StorageDriver(BaseDriver):
                     stream.seek(0)
                 except OSError as e:
                     if e.errno != errno.ESPIPE:
-                        # This error number represents OSError: [Errno 29]
-                        # Illegal seek error.
-                        # This could either mean that the underlying handle
+                        # This represents "OSError: [Errno 29] Illegal seek"
+                        # error. This could either mean that the underlying handle
                         # doesn't support seek operation (e.g. pipe) or that
                         # the invalid seek position is provided. Sadly there is
-                        # no good robust way to distinghuish that so we simply ignore
-                        # all the "Illeal seek errors"
+                        # no good robust way to distinghuish that so we simply
+                        # ignore all the "Illeal seek errors" so this function
+                        # works correctly with pipes.
+                        # See https://github.com/apache/libcloud/pull/1427 for
+                        # details
                         raise e
 
             for chunk in libcloud.utils.files.read_in_chunks(iterator=stream):

--- a/libcloud/test/storage/test_base.py
+++ b/libcloud/test/storage/test_base.py
@@ -223,8 +223,6 @@ class BaseStorageTests(unittest.TestCase):
 
         iterator = BodyStream('a' * size)
         iterator.seek = mock.Mock(side_effect=seek_error)
-        self.assertTrue(hasattr(iterator, '__next__'))
-        self.assertTrue(hasattr(iterator, 'next'))
 
         result = self.driver1._upload_object(object_name='test1',
                                              content_type=None,
@@ -239,7 +237,6 @@ class BaseStorageTests(unittest.TestCase):
         self.assertEqual(result['bytes_transferred'], size)
 
         # But others shouldn't
-
         self.driver1.connection = Mock()
 
         seek_error = OSError('Other error')

--- a/libcloud/test/storage/test_base.py
+++ b/libcloud/test/storage/test_base.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import sys
+import errno
 import hashlib
 
 from libcloud.utils.py3 import httplib
@@ -92,7 +93,6 @@ class BaseStorageTests(unittest.TestCase):
         response_streamed = mock_response.request.stream
         assert response_streamed is False
 
-
     def test__get_hash_function(self):
         self.driver1.hash_type = 'md5'
         func = self.driver1._get_hash_function()
@@ -141,7 +141,8 @@ class BaseStorageTests(unittest.TestCase):
     def test_upload_object_hash_calculation_is_efficient(self, mock_read_in_chunks,
                                                          mock_exhaust_iterator):
         # Verify that we don't buffer whole file in memory when calculating
-        # object has when iterator has __next__ method, but instead read and calculate hash in chunks
+        # object has when iterator has __next__ method, but instead read and
+        # calculate hash in chunks
         size = 100
 
         self.driver1.connection = Mock()
@@ -209,6 +210,50 @@ class BaseStorageTests(unittest.TestCase):
 
         self.assertEqual(mock_read_in_chunks.call_count, 2)
         self.assertEqual(mock_exhaust_iterator.call_count, 0)
+
+    def test_upload_object_via_stream_illegal_seek_errors_are_ignored(self):
+        # Illegal seek errors should be ignored
+        size = 100
+
+        self.driver1.connection = Mock()
+
+        seek_error = OSError('Illegal seek')
+        seek_error.errno = 29
+        assert errno.ESPIPE == 29
+
+        iterator = BodyStream('a' * size)
+        iterator.seek = mock.Mock(side_effect=seek_error)
+        self.assertTrue(hasattr(iterator, '__next__'))
+        self.assertTrue(hasattr(iterator, 'next'))
+
+        result = self.driver1._upload_object(object_name='test1',
+                                             content_type=None,
+                                             request_path='/',
+                                             stream=iterator)
+
+        hasher = hashlib.md5()
+        hasher.update(b('a') * size)
+        expected_hash = hasher.hexdigest()
+
+        self.assertEqual(result['data_hash'], expected_hash)
+        self.assertEqual(result['bytes_transferred'], size)
+
+        # But others shouldn't
+
+        self.driver1.connection = Mock()
+
+        seek_error = OSError('Other error')
+        seek_error.errno = 21
+
+        iterator = BodyStream('b' * size)
+        iterator.seek = mock.Mock(side_effect=seek_error)
+
+        self.assertRaisesRegex(OSError, 'Other error',
+                               self.driver1._upload_object,
+                               object_name='test1',
+                               content_type=None,
+                               request_path='/',
+                               stream=iterator)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pull request updates ``upload_object_via_stream`` method so any ``[Errno 29] Illegal seek`` error which is thrown by the underlying ``_hash_buffered_stream`` function is ignored.

## Background

It looks like this regression has been inadvertently introduced in 4053779e700e8674856876ee85e6ac954cf2df14 (#1326 - cc @gvengel - just a heads up).

Some iterators such as PIPEs don't support seeking and in such case ``[Errno 29] Illegal seek`` exception is thrown.

In this context such exception is harmless so we should ignore it and proceed with hashing - this change does just that.

Thanks to @perbu for reporting this issue.

Closes #1424.

---

NOTE: If this change is ever cherry-picked into v2.8.x branch, it will need some additional changes to make it work under Python 2.x (OSEror -> IOError, etc.).