### PR TITLE
Fix in the CloudFlare DNS driver

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,8 +36,20 @@ Storage
   in 401 "invalid signature" error when object mime type contained mixed
   casing and when S3 Interoperability authentication method was used.
 
-  Reported by Will Abson - wabson.
+  Reported by Will Abson - @wabson.
   (GITHUB-1417, GITHUB-1418)
+  [Tomaz Muraus]
+
+DNS
+~~~
+
+- [CloudFlare] Fix ``export_zone_to_bind_format`` method.
+
+  Previously it threw an exception, because ``record.extra`` dictionary
+  didn't contain ``priority`` key.
+
+  Reported by James Montgomery - @gh-jamesmontgomery.
+  (GITHUB-1428, GITHUB-1429)
   [Tomaz Muraus]
 
 Container

--- a/libcloud/dns/drivers/cloudflare.py
+++ b/libcloud/dns/drivers/cloudflare.py
@@ -74,6 +74,7 @@ RECORD_EXTRA_ATTRIBUTES = {
     'created_on',
     'modified_on',
     'data',
+    'priority'
 }
 
 RECORD_CREATE_ATTRIBUTES = {

--- a/libcloud/test/dns/fixtures/cloudflare/records_GET_1.json
+++ b/libcloud/test/dns/fixtures/cloudflare/records_GET_1.json
@@ -94,6 +94,26 @@
         "managed_by_apps": false,
         "managed_by_argo_tunnel": false
       }
+    },
+    {
+      "content": "aspmx3.googlemail.com",
+      "created_on": "2015-09-04T23:06:50.625895Z",
+      "id": "78526",
+      "locked": false,
+      "meta": {
+          "auto_added": true,
+          "managed_by_apps": false,
+          "managed_by_argo_tunnel": false
+      },
+      "modified_on": "2015-09-04T23:06:50.625895Z",
+      "name": "foo.bar",
+      "priority": 30,
+      "proxiable": false,
+      "proxied": false,
+      "ttl": 1,
+      "type": "MX",
+      "zone_id": "1234",
+      "zone_name": "foo.bar"
     }
   ],
   "result_info": {

--- a/libcloud/test/dns/test_cloudflare.py
+++ b/libcloud/test/dns/test_cloudflare.py
@@ -76,13 +76,14 @@ class CloudFlareDNSDriverTestCase(unittest.TestCase):
     def test_list_records(self):
         zone = self.driver.list_zones()[0]
         records = self.driver.list_records(zone=zone)
-        self.assertEqual(len(records), 9)
+        self.assertEqual(len(records), 10)
 
         record = records[0]
         self.assertEqual(record.id, '364797364')
         self.assertIsNone(record.name)
         self.assertEqual(record.type, 'A')
         self.assertEqual(record.data, '192.30.252.153')
+        self.assertEqual(record.extra['priority'], None)
 
         for attribute_name in RECORD_EXTRA_ATTRIBUTES:
             self.assertTrue(attribute_name in record.extra)
@@ -95,6 +96,13 @@ class CloudFlareDNSDriverTestCase(unittest.TestCase):
 
         for attribute_name in RECORD_EXTRA_ATTRIBUTES:
             self.assertTrue(attribute_name in record.extra)
+
+        record = [r for r in records if r.type == 'MX'][0]
+        self.assertEqual(record.id, '78526')
+        self.assertIsNone(record.name)
+        self.assertEqual(record.type, 'MX')
+        self.assertEqual(record.data, 'aspmx3.googlemail.com')
+        self.assertEqual(record.extra['priority'], 30)
 
     def test_get_zone(self):
         zone = self.driver.get_zone(zone_id='1234')


### PR DESCRIPTION
This pull request fixes ``zone.export_to_bind_format`` method for the CloudFlare driver.

It does that by adding missing ``priority`` attribute to ``record.extra`` dictionary. Without it, that method throws an exception.

Thanks to @gh-jamesmontgomery for reporting this issue.

Resolves #1413 
