### PR TITLE
Fix LIBCLOUD_DEBUG_PRETTY_PRINT_RESPONSE functionality under Python 3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,16 @@
 Changes in Apache Libcloud in development (3.0.0)
 -------------------------------------------------
 
+Common
+~~~~~~~
+
+- Fix ``LIBCLOUD_DEBUG_PRETTY_PRINT_RESPONSE`` functionality and make sure it
+  works correctly under Python 3 when ``response.read()`` function returns
+  unicode and not bytes.
+
+  (GITHUB-1430)
+  [Tomaz Muraus]
+
 Compute
 ~~~~~~~
 

--- a/libcloud/utils/loggingconnection.py
+++ b/libcloud/utils/loggingconnection.py
@@ -74,7 +74,7 @@ class LoggingConnection(LibcloudConnection):
             except Exception:
                 # Invalid JSON or server is lying about content-type
                 pass
-        elif pretty_print and content_type == 'text/xml':
+        elif pretty_print and content_type in ['text/xml', 'application/xml']:
             try:
                 elem = parseString(body.decode('utf-8'))
                 body = elem.toprettyxml()

--- a/libcloud/utils/loggingconnection.py
+++ b/libcloud/utils/loggingconnection.py
@@ -71,7 +71,7 @@ class LoggingConnection(LibcloudConnection):
             try:
                 body = json.loads(ensure_string(body))
                 body = json.dumps(body, sort_keys=True, indent=4)
-            except Exception as e:
+            except Exception:
                 # Invalid JSON or server is lying about content-type
                 pass
         elif pretty_print and content_type == 'text/xml':

--- a/libcloud/utils/loggingconnection.py
+++ b/libcloud/utils/loggingconnection.py
@@ -28,6 +28,7 @@ import os
 from libcloud.common.base import (LibcloudConnection,
                                   HttpLibResponseProxy)
 from libcloud.utils.py3 import _real_unicode as u
+from libcloud.utils.py3 import ensure_string
 
 from libcloud.utils.misc import lowercase_keys
 
@@ -68,9 +69,9 @@ class LoggingConnection(LibcloudConnection):
 
         if pretty_print and content_type == 'application/json':
             try:
-                body = json.loads(body.decode('utf-8'))
+                body = json.loads(ensure_string(body))
                 body = json.dumps(body, sort_keys=True, indent=4)
-            except Exception:
+            except Exception as e:
                 # Invalid JSON or server is lying about content-type
                 pass
         elif pretty_print and content_type == 'text/xml':
@@ -81,7 +82,7 @@ class LoggingConnection(LibcloudConnection):
                 # Invalid XML
                 pass
 
-        ht += u(body)
+        ht += ensure_string(body)
 
         rv += ht
         rv += ("\n# -------- end %d:%d response ----------\n"


### PR DESCRIPTION
This pull request fixes logging connection so ``LIBCLOUD_DEBUG_PRETTY_PRINT_RESPONSE`` functionality works correctly under Python 3.

It also adds some test cases for that functionality (previously we had none).