### PR TITLE
Make id lower for consistent uuid generation

### DIFF
--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -2235,7 +2235,7 @@ class AzureNodeDriver(NodeDriver):
             elif ps == "succeeded":
                 state = NodeState.RUNNING
 
-        node = Node(data["id"],
+        node = Node(data["id"].lower(),
                     data["name"],
                     state,
                     public_ips,


### PR DESCRIPTION
## Make id lower for consistent uuid generation

### Description

When a node is created, the resource groups name in the id string is lower case. In subsequent calls, like in list_nodes(), for some reason Azure returns the resource groups name in upper case. This results in a different uuid from when create_node is called. This also breaks wait_until_running(). Forcing lower case in _to_node() seems to resolve this issue.

### Status

- done, ready for review

### Checklist

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
