### PR TITLE
Enable to set project id in OpenStack OIDC authentication

### DIFF
--- a/libcloud/common/openstack_identity.py
+++ b/libcloud/common/openstack_identity.py
@@ -1560,7 +1560,8 @@ class OpenStackIdentity_3_0_Connection_OIDC_access_token(
                 # as we have used tenant as the protocol
                 if self.domain_name and self.domain_name != 'Default':
                     for project in body['projects']:
-                        if self.domain_name in [project['name'], project['id']]:
+                        if self.domain_name in [project['name'],
+                                                project['id']]:
                             return project['id']
                     raise ValueError('Project %s not found' % self.domain_name)
                 else:

--- a/libcloud/common/openstack_identity.py
+++ b/libcloud/common/openstack_identity.py
@@ -1560,7 +1560,7 @@ class OpenStackIdentity_3_0_Connection_OIDC_access_token(
                 # as we have used tenant as the protocol
                 if self.domain_name and self.domain_name != 'Default':
                     for project in body['projects']:
-                        if project['name'] == self.domain_name:
+                        if self.domain_name in [project['name'], project['id']]:
                             return project['id']
                     raise ValueError('Project %s not found' % self.domain_name)
                 else:

--- a/libcloud/test/common/test_openstack_identity.py
+++ b/libcloud/test/common/test_openstack_identity.py
@@ -522,6 +522,30 @@ class OpenStackIdentity_3_0_Connection_OIDC_access_tokenTests(
         auth.authenticate()
 
 
+class OpenStackIdentity_3_0_Connection_OIDC_access_token_project_idTests(
+        unittest.TestCase):
+    def setUp(self):
+        mock_cls = OpenStackIdentity_3_0_MockHttp
+        mock_cls.type = None
+        OpenStackIdentity_3_0_Connection_OIDC_access_token.conn_class = mock_cls
+
+        self.auth_instance = OpenStackIdentity_3_0_Connection_OIDC_access_token(auth_url='http://none',
+                                                                                user_id='idp',
+                                                                                key='token',
+                                                                                tenant_name='oidc',
+                                                                                domain_name='project_id2')
+        self.auth_instance.auth_token = 'mock'
+
+    def test_authenticate(self):
+        auth = OpenStackIdentity_3_0_Connection_OIDC_access_token(auth_url='http://none',
+                                                                  user_id='idp',
+                                                                  key='token',
+                                                                  token_scope='project',
+                                                                  tenant_name="oidc",
+                                                                  domain_name='project_id2')
+        auth.authenticate()
+
+
 class OpenStackIdentity_2_0_Connection_VOMSTests(unittest.TestCase):
     def setUp(self):
         mock_cls = OpenStackIdentity_2_0_Connection_VOMSMockHttp


### PR DESCRIPTION
## Enable to set project id in OpenStack OIDC authentication

### Description

In a previous PR (#1293) we enable to specify project name in OpenStack OIDC auth.
With this new PR also project id  can be specified.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
