### PR TITLE
Only check Google S3 key prefix

### DIFF
--- a/libcloud/common/google.py
+++ b/libcloud/common/google.py
@@ -617,10 +617,7 @@ class GoogleAuthType(object):
         """
         Checks S3 key format: alphanumeric chars starting with GOOG.
         """
-        return (
-            len(user_id) >= 20 and len(user_id) < 30 and user_id
-            .startswith('GOOG')
-        )
+        return user_id.startswith('GOOG')
 
     @staticmethod
     def _is_sa(user_id):

--- a/libcloud/test/common/test_google.py
+++ b/libcloud/test/common/test_google.py
@@ -60,10 +60,20 @@ GCE_PARAMS_JSON_KEY = ('email@developer.gserviceaccount.com', JSON_KEY)
 GCE_PARAMS_KEY = ('email@developer.gserviceaccount.com', KEY_STR)
 GCE_PARAMS_IA = ('client_id', 'client_secret')
 GCE_PARAMS_GCE = ('foo', 'bar')
-GCS_S3_PARAMS_20 = ('GOOG0123456789ABCXYZ',  # GOOG + 16 alphanumeric chars
-                 '0102030405060708091011121314151617181920')  # 40 base64 chars
-GCS_S3_PARAMS_24 = ('GOOGDF5OVRRGU4APFNSTVCXI',  # GOOG + 20 alphanumeric chars
-                 '0102030405060708091011121314151617181920')  # 40 base64 chars
+# GOOG + 16 alphanumeric chars
+GCS_S3_PARAMS_20 = ('GOOG0123456789ABCXYZ',
+                    # 40 base64 chars
+                    '0102030405060708091011121314151617181920')
+# GOOG + 20 alphanumeric chars
+GCS_S3_PARAMS_24 = ('GOOGDF5OVRRGU4APFNSTVCXI',
+                    # 40 base64 chars
+                    '0102030405060708091011121314151617181920')
+# GOOG + 57 alphanumeric chars
+GCS_S3_PARAMS_61 = (
+    'GOOGDF5OVRRGU4APFNSTVCXIRRGU4AP56789ABCX56789ABCXRRGU4APFNSTV',
+    # 40 base64 chars
+    '0102030405060708091011121314151617181920'
+)
 
 STUB_UTCNOW = _utcnow()
 
@@ -236,6 +246,9 @@ class GoogleAuthTypeTest(GoogleTestCase):
                 GoogleAuthType.GCS_S3)
             self.assertEqual(
                 GoogleAuthType.guess_type(GCS_S3_PARAMS_24[0]),
+                GoogleAuthType.GCS_S3)
+            self.assertEqual(
+                GoogleAuthType.guess_type(GCS_S3_PARAMS_61[0]),
                 GoogleAuthType.GCS_S3)
             self.assertEqual(GoogleAuthType.guess_type(GCE_PARAMS_GCE[0]),
                              GoogleAuthType.GCE)


### PR DESCRIPTION
### Description

Only check Google S3 key prefix (GOOG), as key length is not a reliable hint anymore.

See #1438

[The documentation](https://cloud.google.com/storage/docs/migrating#keys) also now only states:
> Your Google HMAC access ID starts with GOOG.

with no mention of key length anymore.

### Status

Done, ready for review

### Checklist (tick everything that applies)

- [X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [X] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
