### PR TITLE
Improve location / zone handling in the GCE driver

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,11 +32,13 @@ Compute
   ``location`` argument to the method).
 
   Reported by Kevin K. - @kbknapp.
+  (GITHUB-1443)
   [Tomaz Muraus]
 
 - [GCE] Update ``ex_get_disktype`` method so it works if ``zone`` argument is
   not set.
   [Tomaz Muraus]
+  (GITHUB-1443)
 
 Storage
 ~~~~~~~

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,21 @@ Common
   (GITHUB-1439)
   [Miguel Caballer - @micafer]
 
+Compute
+~~~~~~~
+
+- [GCE] Update ``create_node()`` method so it throws an exception if node
+  location can't be inferred and location is not specified by the user (
+  either by passing ``datacenter`` constructor argument or by passing
+  ``location`` argument to the method).
+
+  Reported by Kevin K. - @kbknapp.
+  [Tomaz Muraus]
+
+- [GCE] Update ``ex_get_disktype`` method so it works if ``zone`` argument is
+  not set.
+  [Tomaz Muraus]
+
 Storage
 ~~~~~~~
 

--- a/docs/compute/drivers/gce.rst
+++ b/docs/compute/drivers/gce.rst
@@ -45,7 +45,6 @@ authentication information to the driver as described in `Examples`_. Also
 bear in mind that large clock drift (difference in time) between authenticating
 host and google will cause authentication to fail.
 
-
 Service Account
 ~~~~~~~~~~~~~~~
 
@@ -143,6 +142,16 @@ illustrate how to use Service Account Scopes.
 
 Examples
 --------
+
+Keep in mind that a lot of the driver methods depend on the zone / location
+being set.
+
+For that reason, you are advised to pass ``datacenter`` argument to the driver
+constructor. This value should contain a name of the zone where you want your
+operations to be performed (e.g. ``us-east1-b``).
+
+Some of the methods allow this value to be overridden on per method invocation
+basis - either by specifying ``zone`` or ``location`` method argument.
 
 Additional example code can be found in the "demos" directory of Libcloud here:
 https://github.com/apache/libcloud/blob/trunk/demos/gce_demo.py

--- a/docs/examples/compute/gce/gce_installed_application.py
+++ b/docs/examples/compute/gce/gce_installed_application.py
@@ -3,4 +3,5 @@ from libcloud.compute.providers import get_driver
 
 ComputeEngine = get_driver(Provider.GCE)
 driver = ComputeEngine('your_client_id', 'your_client_secret',
+                       datacenter='us-central1-a',
                        project='your_project_id')

--- a/docs/examples/compute/gce/gce_internal_auth.py
+++ b/docs/examples/compute/gce/gce_internal_auth.py
@@ -9,4 +9,5 @@ from libcloud.compute.providers import get_driver
 # You must still place placeholder empty strings for user_id / key
 # due to the nature of the driver's __init__() params.
 ComputeEngine = get_driver(Provider.GCE)
-driver = ComputeEngine('', '', project='your_project_id')
+driver = ComputeEngine('', '', project='your_project_id',
+                       datacenter='us-central1-a')

--- a/docs/examples/compute/gce/gce_service_account.py
+++ b/docs/examples/compute/gce/gce_service_account.py
@@ -5,4 +5,5 @@ ComputeEngine = get_driver(Provider.GCE)
 # Note that the 'PEM file' argument can either be the JSON format or
 # the P12 format.
 driver = ComputeEngine('your_service_account_email', 'path_to_pem_file',
-                       project='your_project_id')
+                       project='your_project_id',
+                       datacenter='us-central1-a')

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -7138,9 +7138,9 @@ class GCENodeDriver(NodeDriver):
         response = self.connection.request(request_path, method='GET')
 
         if 'items' in response.object:
+            # Aggregated response, zone not provided
             data = None
 
-            # Aggregated response, zone not provided
             for zone_item in response.object['items'].values():
                 for item in zone_item['diskTypes']:
                     if item['name'] == name:
@@ -7150,7 +7150,7 @@ class GCENodeDriver(NodeDriver):
             data = response.object
 
         if not data:
-            raise ValueError('Disk type with name %s not found' % (name))
+            raise ValueError('Disk type with name "%s" not found' % (name))
 
         return self._to_disktype(data)
 


### PR DESCRIPTION
## Description

This pull request improves zone / location handling in the GCE driver.

It includes the following changes:

1. ``create_node()`` method now also works if datacenter / location argument is not specified. If zone is not specified, it's inferred from the size object and if that's not possible, we throw a more user-friendly error.

2. Update GCE docs and examples and make it clear that a lot of operations depend on zone being set.

Previously, if user didn't specify a zone to work with (either via ``datacenter`` driver constructor argument or via ``zone`` / ``location`` argument passed to a specific method), a cryptic and non user-friendly error such as "AttributeError: 'NoneType' object has no attribute 'startswith'" was thrown.

Thanks to @kbknapp for reporting this issue.

Resolves #1441.