### PR TITLE
Fix auto assigning of volume device in OpenStack

### DIFF
--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -321,6 +321,8 @@ class OpenStackNodeDriver(NodeDriver, OpenStackDriverMixin):
     def attach_volume(self, node, volume, device="auto"):
         # when "auto" or None is provided for device, openstack will let
         # the guest OS pick the next available device (fi. /dev/vdb)
+        if device == "auto":
+            device = None
         return self.connection.request(
             '/servers/%s/os-volume_attachments' % node.id,
             method='POST',


### PR DESCRIPTION
## Fix auto assigning of volume device in OpenStack

### Description

When trying to attach a volume to a node with the OpenStack driver, using the 'auto' device name fails with:

libcloud.common.exceptions.BaseHTTPError: 400 Bad Request Invalid input for field/attribute device. Value: auto. u'auto' does not match '(^/dev/x{0,1}[a-z]{0,1}d{0,1})([a-z]+)[0-9]*$'

OpenStack expects a device, or a null/None value[0]

https://docs.openstack.org/api-ref/compute/?expanded=#attach-a-volume-to-an-instance


### Status

- done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
