### PR TITLE
storage account default value in azure_arm

### DIFF
--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -405,7 +405,7 @@ class AzureNodeDriver(NodeDriver):
                     image,
                     auth,
                     ex_resource_group,
-                    ex_storage_account,
+                    ex_storage_account=None,
                     ex_blob_container="vhds",
                     location=None,
                     ex_user_name="azureuser",
@@ -524,7 +524,9 @@ class AzureNodeDriver(NodeDriver):
         :return: The newly created node.
         :rtype: :class:`.Node`
         """
-
+        if not ex_use_managed_disks:
+            if ex_storage_account is None:
+                raise ValueError("ex_use_managed_disks is False, must provide ex_storage_account")
         if location is None:
             location = self.default_location
         if ex_nic is None:

--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -526,7 +526,8 @@ class AzureNodeDriver(NodeDriver):
         """
         if not ex_use_managed_disks:
             if ex_storage_account is None:
-                raise ValueError("ex_use_managed_disks is False, must provide ex_storage_account")
+                raise ValueError("ex_use_managed_disks is False, "
+                                 "must provide ex_storage_account")
         if location is None:
             location = self.default_location
         if ex_nic is None:


### PR DESCRIPTION
#1068  Default Value of create_node in azure_arm

### Description

The parameter "ex_storage_account" must be provided even if the "ex_use_managed_disks" is set as True. Therefore this will lead to an error even if no storage account is needed if "ex_use_managed_disks" is set as True.

### Status

Replace this: describe the PR status. Examples:

- done, ready for review
