### PR TITLE
add latest ubuntu image families to gce

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -1800,6 +1800,7 @@ class GCENodeDriver(NodeDriver):
         "userinfo-email": "userinfo.email"
     }
 
+    # data taken from https://cloud.google.com/compute/docs/images
     IMAGE_PROJECTS = {
         "centos-cloud": [
             "centos-6",
@@ -1846,6 +1847,10 @@ class GCENodeDriver(NodeDriver):
             "ubuntu-minimal-1810",
             "ubuntu-1904",
             "ubuntu-minimal-1904",
+            "ubuntu-1910",
+            "ubuntu-minimal-1910",
+            "ubuntu-2004-lts",
+            "ubuntu-minimal-2004-lts",
         ],
         "windows-cloud": [
             "windows-1709-core-for-containers", "windows-1709-core",


### PR DESCRIPTION
## add latest ubuntu image families to gce

### Description

similar to https://github.com/apache/libcloud/pull/1358 we update the image families with the latest data from https://cloud.google.com/compute/docs/images

still unsure whether ubuntu versions that are now EOL and/or that are no longer listed on that page should be removed - so we just kept them around.