### PR TITLE
Don't encode ~ in the object name in the S3 driver

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,17 @@ Compute
   (GITHUB-1455, GITHUB-1456)
   [RobertH1993]
 
+Storage
+~~~~~~~
+
+- [AWS S3] Make sure driver works correctly for objects with ``~`` in the name.
+
+  Now when sanitizing the object name, we don't url encode ``~`` character.
+
+  Reported by Michael Militzer - @mmilitzer.
+  (GITHUB-1452, GITHUB-1457)
+  [Tomaz Muraus]
+
 Other
 ~~~~~
 

--- a/libcloud/storage/drivers/s3.py
+++ b/libcloud/storage/drivers/s3.py
@@ -856,7 +856,7 @@ class BaseS3StorageDriver(StorageDriver):
             self._abort_multipart(container, upload.key, upload.id)
 
     def _clean_object_name(self, name):
-        name = urlquote(name)
+        name = urlquote(name, safe='/~')
         return name
 
     def _put_object(self, container, object_name, method='PUT',

--- a/libcloud/test/storage/test_s3.py
+++ b/libcloud/test/storage/test_s3.py
@@ -409,6 +409,18 @@ class S3Tests(unittest.TestCase):
         except OSError:
             pass
 
+    def test_clean_object_name(self):
+        # Ensure ~ is not URL encoded
+        # See https://github.com/apache/libcloud/issues/1452 for details
+        cleaned = self.driver._clean_object_name(name='valid')
+        self.assertEqual(cleaned, 'valid')
+
+        cleaned = self.driver._clean_object_name(name='valid/~')
+        self.assertEqual(cleaned, 'valid/~')
+
+        cleaned = self.driver._clean_object_name(name='valid/~%foo ')
+        self.assertEqual(cleaned, 'valid/~%25foo%20')
+
     def test_invalid_credentials(self):
         self.mock_response_klass.type = 'UNAUTHORIZED'
         try:


### PR DESCRIPTION
This pull request addresses the issue reported in #1452.

It makes sure we don't url encode ``~`` character in the internal driver ``_clean_object_name`` method.

I tested the change and verified it works for objects with ``~`` in the name.

## Background, Context

@mmilitzer reported this issue in 1452.

I was able to replicate the bug in the S3 driver.

As far as changed Python 3 behavior goes - I tested it using Python 3.6 and ``~`` is still url encoded by default.

It looks like the change itself was introduced in 3.7 - https://github.com/python/cpython/commit/21024f06622c4c55b666adb130797a4ee205d005#diff-67a4980d053b561c26794c63eb5ac1deR461.

That's why I decided it's safer to only make that change in the S3 driver to begin with.

Doing it inside our ``urlquote`` wrapper may be too risky - who knows how many provider APIs (if any) on ``~`` being encoded as ``%7E``.