### PR TITLE
Fix unicode decode errors during deployments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,27 @@ Compute
   (GITHUB-1455, GITHUB-1456)
   [RobertH1993]
 
+- Fix ``deploy_node()`` so an exception is not thrown if any of the output
+  (stdout / stderr) produced by the deployment script contains a non-valid utf-8
+  character.
+
+  Previously, user would see an error similar to "Failed after 3 tries: 'utf-8'
+  codec can't decode byte 0xc0 in position 37: invalid start byte".
+
+  And now we simply ignore byte sequences which we can't decode and include
+  rest of the output which can be decoded.
+
+  (GITHUB-1459)
+  [Tomaz Muraus - @Kami]
+
+- Add new ``timeout`` argument to ``ScriptDeployment`` and
+  ``ScriptFileDeployment`` class constructor.
+
+  With this argument, user can specify an optional run timeout for that
+  deployment step run.
+  (GITHUB-1445)
+  [Tomaz Muraus - @Kami]
+
 Storage
 ~~~~~~~
 

--- a/libcloud/compute/ssh.py
+++ b/libcloud/compute/ssh.py
@@ -520,7 +520,7 @@ class ParamikoSSHClient(BaseSSHClient):
         # We only decode data at the end because a single chunk could contain
         # a part of multi byte UTF-8 character (whole multi bytes character
         # could be split over two chunks)
-        result.write(result_bytes.decode('utf-8'))
+        result.write(result_bytes.decode('utf-8', errors='ignore'))
         return result
 
     def _get_pkey_object(self, key, password=None):


### PR DESCRIPTION
This pull request fixes ``deploy_node()`` method so we ignore any errors which are related to us being unable to decode a byte sequence as utf-8 (aka deployment script stdout / stderr contains non-utf-8 characters).

Previously we would throw in such scenario (which is rather unfortunate since user would lose access to any output (stdout / stderr) produced by the deployment script).

Now we simply ignore byte sequences we can't decode and decode the rest.

## TODO

- [x] Tests