### PR TITLE
Support for managing CAA DNS record types

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -67,7 +67,7 @@ DNS
   included.
   [Tomaz Muraus]
 
-- [Gandi Live, CloudFlare] Add support for managing ``CAA`` record types.
+- [Gandi Live, CloudFlare, GCE] Add support for managing ``CAA`` record types.
 
   When creating a ``CAA`` record, data field needs to be in the following
   format:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -60,8 +60,8 @@ Storage
 DNS
 ~~~
 
-- [CloudFlare] Update driver to include whole error chain the thrown exception
-  message string.
+- [CloudFlare] Update driver to include the whole error chain the thrown
+  exception message field.
 
   This makes various issues easier to debug since the whole error context is
   included.
@@ -79,12 +79,13 @@ DNS
   - ``0 issue caa.example.com``
   - ``0 issuewild caa.example.com``
   - ``0 iodef https://example.com/reports``
-  (GITHUB-1464)
+
+  (GITHUB-1463, GITHUB-1464)
   [Tomaz Muraus]
 
 - [Gandi Live] Don't throw if ``extra['rrset_ttl']`` argument is not passed
   to the ``create_record`` method.
-  (GITHUB-1463, GITHUB-1464)
+  (GITHUB-1463)
   [Tomaz Muraus]
 
 Other

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -57,6 +57,36 @@ Storage
   (GITHUB-1452, GITHUB-1457)
   [Tomaz Muraus]
 
+DNS
+~~~
+
+- [CloudFlare] Update driver to include whole error chain the thrown exception
+  message string.
+
+  This makes various issues easier to debug since the whole error context is
+  included.
+  [Tomaz Muraus]
+
+- [Gandi Live, CloudFlare] Add support for managing ``CAA`` record types.
+
+  When creating a ``CAA`` record, data field needs to be in the following
+  format:
+
+  ``<flags> <tag> <domain name>``
+
+  For example:
+
+  - ``0 issue caa.example.com``
+  - ``0 issuewild caa.example.com``
+  - ``0 iodef https://example.com/reports``
+  (GITHUB-1464)
+  [Tomaz Muraus]
+
+- [Gandi Live] Don't throw if ``extra['rrset_ttl']`` argument is not passed
+  to the ``create_record`` method.
+  (GITHUB-1463, GITHUB-1464)
+  [Tomaz Muraus]
+
 Other
 ~~~~~
 

--- a/docs/dns/examples.rst
+++ b/docs/dns/examples.rst
@@ -31,6 +31,21 @@ example shows how to do that.
 .. literalinclude:: /examples/dns/create_record_with_priority.py
    :language: python
 
+Create a CAA record
+-------------------
+
+.. note::
+
+    Support for CAA record type has been introduced in Libcloud v3.1.0. At this
+    point it has only been implemented and tested with CloudFlare and Gandii
+    Live DNS drivers.
+
+When creating a CAA record, data fields needs to be in the following format:
+``<flags> <tag> <domain name / url>`` as shown below.
+
+.. literalinclude:: /examples/dns/create_record_caa_record_type.py
+   :language: python
+
 Export Libcloud Zone to BIND zone format
 ----------------------------------------
 

--- a/docs/examples/dns/create_record_caa_record_type.py
+++ b/docs/examples/dns/create_record_caa_record_type.py
@@ -13,9 +13,9 @@ print(zone.create_record(name='www', type=RecordType.CAA,
                          data='0 issue caa.domain.com'))
 
 # 2. issuewild tag
-record = zone.create_record(name='www', type=RecordType.CAA
-                            data='0 issuewild caa.domain.com')
+print(zone.create_record(name='www', type=RecordType.CAA,
+                         data='0 issuewild caa.domain.com'))
 
 # 3. iodef tag
-record = zone.create_record(name='www', type=RecordType.CAA,
-                            data='0 iodef caa.domain.com/report')
+print(zone.create_record(name='www', type=RecordType.CAA,
+                         data='0 iodef caa.domain.com/report'))

--- a/docs/examples/dns/create_record_caa_record_type.py
+++ b/docs/examples/dns/create_record_caa_record_type.py
@@ -1,0 +1,18 @@
+from libcloud.dns.providers import get_driver
+from libcloud.dns.types import Provider, RecordType
+
+CREDENTIALS = ('email', 'api key')
+
+cls = get_driver(Provider.CLOUDFLARE)
+driver = cls(*CREDENTIALS)
+
+zone = [z for z in driver.list_zones() if z.domain == 'example.com'][0]
+
+# 1. issue tag
+print(zone.create_record(name='www', type=RecordType.CAA, data='0 issue caa.domain.com'))
+
+# 2. issuewild tag
+record = zone.create_record(name='www', type=RecordType.CAA, data='0 issuewild caa.domain.com')
+
+# 3. iodef tag
+record = zone.create_record(name='www', type=RecordType.CAA, data='0 iodef caa.domain.com/report')

--- a/docs/examples/dns/create_record_caa_record_type.py
+++ b/docs/examples/dns/create_record_caa_record_type.py
@@ -9,10 +9,13 @@ driver = cls(*CREDENTIALS)
 zone = [z for z in driver.list_zones() if z.domain == 'example.com'][0]
 
 # 1. issue tag
-print(zone.create_record(name='www', type=RecordType.CAA, data='0 issue caa.domain.com'))
+print(zone.create_record(name='www', type=RecordType.CAA,
+                         data='0 issue caa.domain.com'))
 
 # 2. issuewild tag
-record = zone.create_record(name='www', type=RecordType.CAA, data='0 issuewild caa.domain.com')
+record = zone.create_record(name='www', type=RecordType.CAA
+                            data='0 issuewild caa.domain.com')
 
 # 3. iodef tag
-record = zone.create_record(name='www', type=RecordType.CAA, data='0 iodef caa.domain.com/report')
+record = zone.create_record(name='www', type=RecordType.CAA,
+                            data='0 iodef caa.domain.com/report')

--- a/libcloud/dns/drivers/cloudflare.py
+++ b/libcloud/dns/drivers/cloudflare.py
@@ -310,8 +310,17 @@ class CloudFlareDNSDriver(DNSDriver):
         Note that for ``extra`` record properties, only the ones specified in
         ``RECORD_CREATE_ATTRIBUTES`` can be set at creation time. Any
         non-settable properties are ignored.
+
+        NOTE: For CAA RecordType, data needs to be in the following format:
+            <flags> <tag> <ca domain name> where the tag can be issue, issuewild or iodef.
+
+            For example: 0 issue test.caa.com
         """
         url = '{}/zones/{}/dns_records'.format(API_BASE, zone.id)
+
+        if type == RecordType.CAA:
+            # Replace whitespace with \t character which CloudFlare API expects.
+            data = data.replace(' ', '\t')
 
         body = {
             'type': type,

--- a/libcloud/dns/drivers/cloudflare.py
+++ b/libcloud/dns/drivers/cloudflare.py
@@ -125,9 +125,10 @@ class CloudFlareDNSResponse(JsonResponse):
                 exception_class, context = LibcloudError, []
 
             kwargs = {
-                'value': '{}: {} (error chain: {})'.format(error['code'],
-                                                           error['message'],
-                                                           ', '.join(error_chain_errors)),
+                'value': '{}: {} (error chain: {})'.format(
+                    error['code'],
+                    error['message'],
+                    ', '.join(error_chain_errors)),
                 'driver': self.connection.driver,
             }
 
@@ -312,9 +313,10 @@ class CloudFlareDNSDriver(DNSDriver):
         non-settable properties are ignored.
 
         NOTE: For CAA RecordType, data needs to be in the following format:
-            <flags> <tag> <ca domain name> where the tag can be issue, issuewild or iodef.
+        <flags> <tag> <ca domain name> where the tag can be issue, issuewild
+        or iodef.
 
-            For example: 0 issue test.caa.com
+        For example: 0 issue test.caa.com
         """
         url = '{}/zones/{}/dns_records'.format(API_BASE, zone.id)
 
@@ -441,20 +443,23 @@ class CloudFlareDNSDriver(DNSDriver):
             return data
 
         if type == RecordType.CAA:
-            # Replace whitespace with \t character which CloudFlare API expects.
+            # Replace whitespace with \t character which CloudFlare API
+            # expects
             data = data.replace(' ', '\t')
 
         return data
 
     def _normalize_record_data_from_api(self, type, data):
         """
-        Normalize record data for special records so it's consistent with the Libcloud API.
+        Normalize record data for special records so it's consistent with
+        the Libcloud API.
         """
         if not data:
             return data
 
         if type == RecordType.CAA:
-            # Replace whitespace with \t character which CloudFlare API expects.
+            # CloudFlare uses \t but we normalize it to whitespace so it's
+            # consistent across all the drivers.
             data = data.replace('\t', ' ')
 
         return data

--- a/libcloud/dns/drivers/gandi_live.py
+++ b/libcloud/dns/drivers/gandi_live.py
@@ -84,6 +84,7 @@ class GandiLiveDNSDriver(BaseGandiLiveDriver, DNSDriver):
         RecordType.TLSA: 'TLSA',
         RecordType.TXT: 'TXT',
         RecordType.WKS: 'WKS',
+        RecordType.CAA: 'CAA',
     }
 
     def list_zones(self):
@@ -412,9 +413,10 @@ class GandiLiveDNSDriver(BaseGandiLiveDriver, DNSDriver):
         return records
 
     def _to_record_sub(self, data, zone, value):
-        extra = {
-            'ttl': int(data['rrset_ttl']),
-        }
+        extra = {}
+        ttl = data.get('rrset_ttl', None)
+        if ttl is not None:
+            extra['ttl'] = int(ttl)
         if data['rrset_type'] == 'MX':
             priority, value = value.split()
             extra['priority'] = priority
@@ -425,7 +427,7 @@ class GandiLiveDNSDriver(BaseGandiLiveDriver, DNSDriver):
             data=value,
             zone=zone,
             driver=self,
-            ttl=data['rrset_ttl'],
+            ttl=ttl,
             extra=extra)
 
     def _to_records(self, data, zone):

--- a/libcloud/dns/drivers/google.py
+++ b/libcloud/dns/drivers/google.py
@@ -61,6 +61,7 @@ class GoogleDNSDriver(DNSDriver):
         RecordType.SPF: 'SPF',
         RecordType.SRV: 'SRV',
         RecordType.TXT: 'TXT',
+        RecordType.CAA: 'CAA',
     }
 
     def __init__(self, user_id, key, project=None, auth_type=None, scopes=None,

--- a/libcloud/dns/types.py
+++ b/libcloud/dns/types.py
@@ -111,6 +111,7 @@ class RecordType(object):
     TXT = 'TXT'
     URL = 'URL'
     WKS = 'WKS'
+    CAA = 'CAA'
 
 
 class ZoneError(LibcloudError):

--- a/libcloud/test/dns/fixtures/cloudflare/error_with_error_chain.json
+++ b/libcloud/test/dns/fixtures/cloudflare/error_with_error_chain.json
@@ -1,0 +1,1 @@
+ {"result":null,"success":false,"errors":[{"code":1004,"message":"DNS Validation Error","error_chain":[{"code":9011,"message":"Length of content is invalid"}]}],"messages":[]}

--- a/libcloud/test/dns/fixtures/cloudflare/records_GET_2.json
+++ b/libcloud/test/dns/fixtures/cloudflare/records_GET_2.json
@@ -77,7 +77,32 @@
         "managed_by_apps": false,
         "managed_by_argo_tunnel": false
       }
-    }
+    },
+    {
+            "id": "r8",
+            "zone_id": "1234",
+            "zone_name": "foo.bar",
+            "name": "test1",
+            "type": "CAA",
+            "content": "0\tissue\ttest.example.com",
+            "proxiable": false,
+            "proxied": false,
+            "ttl": 1,
+            "locked": false,
+            "data": {
+                "flags": 0,
+                "tag": "issue",
+                "value": "test.example.com"
+            },
+            "meta": {
+                "auto_added": false,
+                "managed_by_apps": false,
+                "managed_by_argo_tunnel": false,
+                "source": "primary"
+            },
+            "created_on": "2020-06-01T14:02:37.544331Z",
+            "modified_on": "2020-06-01T14:02:37.544331Z"
+        }
   ],
   "result_info": {
     "page": 2,

--- a/libcloud/test/dns/test_cloudflare.py
+++ b/libcloud/test/dns/test_cloudflare.py
@@ -76,7 +76,7 @@ class CloudFlareDNSDriverTestCase(unittest.TestCase):
     def test_list_records(self):
         zone = self.driver.list_zones()[0]
         records = self.driver.list_records(zone=zone)
-        self.assertEqual(len(records), 10)
+        self.assertEqual(len(records), 11)
 
         record = records[0]
         self.assertEqual(record.id, '364797364')
@@ -103,6 +103,12 @@ class CloudFlareDNSDriverTestCase(unittest.TestCase):
         self.assertEqual(record.type, 'MX')
         self.assertEqual(record.data, 'aspmx3.googlemail.com')
         self.assertEqual(record.extra['priority'], 30)
+
+        record = records[-1]
+        self.assertEqual(record.id, 'r8')
+        self.assertEqual(record.name, 'test1')
+        self.assertEqual(record.type, 'CAA')
+        self.assertEqual(record.data, '0 issue test.example.com')
 
     def test_get_zone(self):
         zone = self.driver.get_zone(zone_id='1234')
@@ -240,6 +246,14 @@ class CloudFlareDNSDriverTestCase(unittest.TestCase):
             zone, domain='', extra={'paused': True, 'plan': None})
 
         self.assertEqual(zone, updated_zone)
+
+    def test_normalize_record_data_for_api(self):
+        result = self.driver._normalize_record_data_for_api(RecordType.CAA, '0 issue foo.bar')
+        self.assertEqual(result, '0\tissue\tfoo.bar')
+
+    def test_normalize_record_data_from_apu(self):
+        result = self.driver._normalize_record_data_from_api(RecordType.CAA, '0\tissue\tfoo.bar')
+        self.assertEqual(result, '0 issue foo.bar')
 
 
 class CloudFlareMockHttp(MockHttp):

--- a/libcloud/test/dns/test_gandi_live.py
+++ b/libcloud/test/dns/test_gandi_live.py
@@ -119,6 +119,14 @@ class GandiLiveTests(unittest.TestCase):
         self.assertEqual(record.type, RecordType.AAAA)
         self.assertEqual(record.data, '::1')
 
+    def test_create_record_doesnt_throw_if_ttl_is_not_provided(self):
+        record = self.driver.create_record('alice', self.test_zone, 'AAAA',
+                                           '::1')
+        self.assertEqual(record.id, 'AAAA:alice')
+        self.assertEqual(record.name, 'alice')
+        self.assertEqual(record.type, RecordType.AAAA)
+        self.assertEqual(record.data, '::1')
+
     def test_bad_record_validation(self):
         with self.assertRaises(RecordError) as ctx:
             self.driver.create_record('alice', self.test_zone, 'AAAA',


### PR DESCRIPTION
This pull request adds support for managing ``CAA`` record types.

Right now it supports and has been tested with CloudFlare and Gandi Live DNS driver.

It's possible that it also works with some other provider drivers (either out of the box or they need to be updated), but I didn't test it.

In addition to that, this PR also includes some other improvements and fixes:

* Update CloudFlare DNS driver so we include whole error chain in the exception error message. This makes various issues easier to debug since the whole context is included.

* Fix ``create_ecord`` method in the Gandi Live DNS driver to not throw if ``exra['rrset_ttl']`` argument is not passed to the method.

## TODO

- [x] Tests
- [x] Docs
- [x] Add release notes entry (document expect format for data field for CAA records)

Resolves #1463.