### PR TITLE
Add new file for price scraping for azure arm cloud

### DIFF
--- a/contrib/scrape-azure-prices.py
+++ b/contrib/scrape-azure-prices.py
@@ -1,3 +1,22 @@
+#!/usr/bin/env python
+#
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
 import json
 import time
 import os
@@ -35,8 +54,8 @@ def get_azure_prices():
             continue
         for reg, price in value['prices']['perhour'].items():
             region = region_map[reg].lower().replace(" ", "")
-            region = region.replace("(public)", "") # for germany
-            region = region.replace("(sovereign)", "") # for germany
+            region = region.replace("(public)", "")  # for germany
+            region = region.replace("(sovereign)", "")  # for germany
             prices[region] = price['value']
         result[size_raw[0]][size] = prices
 

--- a/contrib/scrape-azure-prices.py
+++ b/contrib/scrape-azure-prices.py
@@ -1,0 +1,70 @@
+import json
+import time
+import os
+import requests
+
+
+PRICES_URL = ("https://azure.microsoft.com/api/v3/pricing/"
+              "virtual-machines/calculator/")
+BASE_PATH = os.path.dirname(os.path.abspath(__file__))
+PRICING_FILE_PATH = os.path.join(BASE_PATH, '../libcloud/data/pricing.json')
+PRICING_FILE_PATH = os.path.abspath(PRICING_FILE_PATH)
+
+
+def get_azure_prices():
+    prices_raw = requests.get(PRICES_URL).json()
+    region_map = {}
+    regions = []
+    for region in prices_raw['regions']:
+        regions.append(region['slug'])
+        region_map[region['slug']] = region['displayName']
+
+    result = {"windows": {}, "linux": {}}
+    parsed_sizes = {"lowpriority", "basic", "standard"}
+    for offer, value in prices_raw['offers'].items():
+
+        size_raw = offer.split("-")
+        #  Servers that go by the core with global price are not yet added
+        if len(size_raw) != 3 or size_raw[2] not in parsed_sizes:
+            continue
+        if size_raw[0] not in {'linux', 'windows'}:
+            continue
+        size = size_raw[2] + size_raw[1]
+        prices = {}
+        if not value['prices'].get('perhour'):
+            continue
+        for reg, price in value['prices']['perhour'].items():
+            region = region_map[reg].lower().replace(" ", "")
+            region = region.replace("(public)", "") # for germany
+            region = region.replace("(sovereign)", "") # for germany
+            prices[region] = price['value']
+        result[size_raw[0]][size] = prices
+
+    return result
+
+
+def write_azure_prices(file_path, prices):
+    with open(file_path, 'r') as f:
+        content = f.read()
+
+    data = json.loads(content)
+    data['updated'] = int(time.time())
+    data['compute']['azure_linux'] = prices['linux']
+    data['compute']['azure_windows'] = prices['windows']
+
+    content = json.dumps(data, indent=4)
+    lines = content.splitlines()
+    lines = [line.rstrip() for line in lines]
+    content = '\n'.join(lines)
+
+    with open(file_path, 'w') as fp:
+        fp.write(content)
+
+
+def main():
+    res = get_azure_prices()
+    write_azure_prices(PRICING_FILE_PATH, res)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Azure  ARM Pricing

### Description
A scrape script for ARM prices. The driver will need adaptation in the future since at the moment each size has a price of 0. After the script is run pricing.json will be populated with azure prices in the format azure_linux -->  size (with no spaces all lower case) --> region --> price. For the moment it scrapes prices for azure_linux (without extra cost due to image) and azure_windows, in the future more premium images can be added if the scrape url is parsed properly.
### Status
- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
