### PR TITLE
Add ex_get_network to openstack driver

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,12 @@ Common
 Compute
 ~~~~~~~
 
+- [OpenStack] Add `ex_get_network()` to the OpenStack driver to make it
+  possible to retrieve a single network by using the ID.
+
+  (GITHUB-1474)
+  [Sander Roosingh - @SanderRoosingh]
+
 - [OpenStack] Fix pagination in the ``list_images()`` method and make sure
   method returns all the images, even if the result is spread across multiple
   pages.

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -1817,6 +1817,22 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
         response = self.connection.request(self._networks_url_prefix).object
         return self._to_networks(response)
 
+    def ex_get_network(self, network_id):
+        """
+        Retrieve the Network with the given ID
+
+        :param networkId: ID of the network
+        :type networkId: ``str``
+
+        :rtype :class:`OpenStackNetwork`
+        """
+        request_url = "{networks_url_prefix}/{network_id}".format(
+            networks_url_prefix=self._networks_url_prefix,
+            network_id=network_id
+        )
+        response = self.connection.request(request_url).object
+        return self._to_network(response['network'])
+
     def ex_create_network(self, name, cidr):
         """
         Create a new Network
@@ -3065,6 +3081,22 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
         response = self.network_connection.request(
             self._networks_url_prefix).object
         return self._to_networks(response)
+
+    def ex_get_network(self, network_id):
+        """
+        Retrieve the Network with the given ID
+
+        :param networkId: ID of the network
+        :type networkId: ``str``
+
+        :rtype :class:`OpenStackNetwork`
+        """
+        request_url = "{networks_url_prefix}/{network_id}".format(
+            networks_url_prefix=self._networks_url_prefix,
+            network_id=network_id
+        )
+        response = self.network_connection.request(request_url).object
+        return self._to_network(response['network'])
 
     def ex_create_network(self, name, **kwargs):
         """

--- a/libcloud/test/compute/fixtures/openstack_v1.1/_v2_0__network.json
+++ b/libcloud/test/compute/fixtures/openstack_v1.1/_v2_0__network.json
@@ -1,0 +1,32 @@
+{
+    "network": {
+        "admin_state_up": true,
+        "availability_zone_hints": [],
+        "availability_zones": [
+            "nova"
+        ],
+        "created_at": "2016-03-08T20:19:41",
+        "dns_domain": "my-domain.org.",
+        "id": "cc2dad14-827a-feea-416b-f13e50511a0a",
+        "ipv4_address_scope": null,
+        "ipv6_address_scope": null,
+        "l2_adjacency": false,
+        "mtu": 1500,
+        "name": "net2",
+        "port_security_enabled": true,
+        "project_id": "26a7980765d0414dbc1fc1f88cdb7e6e",
+        "qos_policy_id": "bfdb6c39f71e4d44b1dfbda245c50819",
+        "revision_number": 3,
+        "router:external": false,
+        "shared": false,
+        "status": "ACTIVE",
+        "subnets": [
+            "08eae331-0402-425a-923c-34f7cfe39c1b"
+        ],
+        "tenant_id": "26a7980765d0414dbc1fc1f88cdb7e6e",
+        "updated_at": "2016-03-08T20:19:41",
+        "vlan_transparent": false,
+        "description": "",
+        "is_default": false
+    }
+}

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -1840,6 +1840,13 @@ class OpenStack_2_Tests(OpenStack_1_1_Tests):
         self.assertEqual(network.name, 'net1')
         self.assertEqual(network.extra['subnets'], ['54d6f61d-db07-451c-9ab3-b9609b6b6f0b'])
 
+    def test_ex_get_network(self):
+        network = self.driver.ex_get_network("cc2dad14-827a-feea-416b-f13e50511a0a")
+
+        self.assertEqual(network.id, "cc2dad14-827a-feea-416b-f13e50511a0a")
+        self.assertTrue(isinstance(network, OpenStackNetwork))
+        self.assertEqual(network.name, 'net2')
+
     def test_ex_list_subnets(self):
         subnets = self.driver.ex_list_subnets()
         subnet = subnets[0]
@@ -2633,6 +2640,12 @@ class OpenStack_1_1_MockHttp(MockHttp, unittest.TestCase):
         elif method == 'POST':
             body = self.fixtures.load('_v2_0__networks_POST.json')
             return (httplib.ACCEPTED, body, self.json_content_headers, httplib.responses[httplib.OK])
+        raise NotImplementedError()
+
+    def _v2_1337_v2_0_networks_cc2dad14_827a_feea_416b_f13e50511a0a(self, method, url, body, headers):
+        if method == "GET":
+            body = self.fixtures.load('_v2_0__network.json')
+            return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
         raise NotImplementedError()
 
     def _v2_1337_v2_0_networks_d32019d3_bc6e_4319_9c1d_6722fc136a22(self, method, url, body, headers):


### PR DESCRIPTION
### Description

Currently to retrieve a network from the OpenStack all networks need to be received. Then these can be filtered by ID. If the ID of the network is known it is not needed to retrieve all networks from the OpenStack.

By creating a function called `ex_get_network` and passing an ID we could retrieve a single network, this would increase performance for some systems. This function works similar to `ex_get_volume`.

fixes #1473

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [X] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
