### PR TITLE
Add expose ports through services for VMs, extra ports and services d…

### DIFF
--- a/libcloud/compute/drivers/kubevirt.py
+++ b/libcloud/compute/drivers/kubevirt.py
@@ -25,8 +25,10 @@ import hashlib
 from datetime import datetime
 
 from libcloud.common.types import LibcloudError
+from libcloud.common.kubernetes import KubernetesBasicAuthConnection
 from libcloud.common.kubernetes import KubernetesDriverMixin
 from libcloud.common.kubernetes import VALID_RESPONSE_CODES
+
 from libcloud.compute.types import Provider, NodeState
 from libcloud.compute.base import NodeDriver, NodeSize, Node
 from libcloud.compute.base import NodeImage, NodeLocation, StorageVolume
@@ -42,7 +44,7 @@ class KubeVirtNodeDriver(KubernetesDriverMixin, NodeDriver):
     type = Provider.KUBEVIRT
     name = "kubevirt"
     website = 'https://www.kubevirt.io'
-    connectionCls = ""
+    connectionCls = KubernetesBasicAuthConnection
 
     NODE_STATE_MAP = {
         'pending': NodeState.PENDING,

--- a/libcloud/compute/drivers/kubevirt.py
+++ b/libcloud/compute/drivers/kubevirt.py
@@ -1233,6 +1233,6 @@ class KubeVirtNodeDriver(KubernetesDriverMixin, NodeDriver):
         try:
             result = self.connection.request(req, method=method, data=data,
                                              headers=headers)
-        except Exception as exc:
+        except Exception:
             raise
         return result.status in VALID_RESPONSE_CODES

--- a/libcloud/test/compute/fixtures/kubevirt/get_services.json
+++ b/libcloud/test/compute/fixtures/kubevirt/get_services.json
@@ -1,0 +1,56 @@
+{"kind": "ServiceList",
+ "apiVersion": "v1",
+ "metadata":
+    {"selfLink": "/api/v1/namespaces/kubevirt/services", "resourceVersion": "34596194"},
+ "items":
+    [{"metadata":
+        {"name": "kubevirt-operator-webhook", "namespace": "kubevirt",
+         "selfLink": "/api/v1/namespaces/kubevirt/services/kubevirt-operator-webhook",
+         "uid": "14b736f5-c135-4af4-b0c7-7395d1009f70", "resourceVersion": "34388137",
+         "creationTimestamp": "2020-07-22T15:48:27Z",
+         "labels":
+            {"app.kubernetes.io/managed-by": "kubevirt-operator", "kubevirt.io": "", "prometheus.kubevirt.io": ""},
+         "annotations":
+            {"kubevirt.io/install-strategy-identifier": "bea570209e6ec804f964c31126509110fcdeef04",
+             "kubevirt.io/install-strategy-registry": "index.docker.io/kubevirt",
+             "kubevirt.io/install-strategy-version": "v0.31.0"}},
+         "spec": {"ports": [{"name": "webhooks", "protocol": "TCP", "port": 443, "targetPort": "webhooks"}],
+                  "selector": {"kubevirt.io": "virt-operator"}, "clusterIP": "10.111.39.5", "type": "ClusterIP",
+                  "sessionAffinity": "None"},
+         "status": {"loadBalancer": {}}}, 
+     {"metadata": 
+        {"name": "kubevirt-prometheus-metrics", "namespace": "kubevirt",
+         "selfLink": "/api/v1/namespaces/kubevirt/services/kubevirt-prometheus-metrics",
+         "uid": "cd5e6e0d-45c7-46b5-9545-043aabb75b4e", "resourceVersion": "34388129",
+         "creationTimestamp": "2020-07-22T15:48:27Z", 
+         "labels":
+            {"app.kubernetes.io/managed-by": "kubevirt-operator", "kubevirt.io": "", "prometheus.kubevirt.io": ""},
+         "annotations":
+            {"kubevirt.io/install-strategy-identifier": "bea570209e6ec804f964c31126509110fcdeef04",
+             "kubevirt.io/install-strategy-registry": "index.docker.io/kubevirt",
+             "kubevirt.io/install-strategy-version": "v0.31.0"}},
+         "spec": {"ports": [{"name": "metrics", "protocol": "TCP", "port": 443, "targetPort": "metrics"}],
+                  "selector": {"prometheus.kubevirt.io": ""}, "clusterIP": "10.96.229.208", "type": "ClusterIP",
+                  "sessionAffinity": "None"}, "status": {"loadBalancer": {}}},
+     {"metadata":
+        {"name": "service-nodeport-testv", "namespace": "kubevirt",
+         "selfLink": "/api/v1/namespaces/kubevirt/services/service-nodeport-testv",
+         "uid": "ae733a33-9c18-46b7-9042-b49fcf453594", "resourceVersion": "34405970",
+         "creationTimestamp": "2020-07-22T17:03:50Z",
+         "labels":
+            {"service": "kubevirt.io"}},
+         "spec": {"ports": [{"name": "port-11222", "protocol": "TCP", "port": 11222, "targetPort": 10000, "nodePort": 32531}],
+                  "selector": {"kubevirt.io/vm": "testv"}, "clusterIP": "10.102.54.176", "type": "NodePort",
+                  "sessionAffinity": "None", "externalTrafficPolicy": "Cluster"}, "status": {"loadBalancer": {}}},
+     {"metadata":
+        {"name": "virt-api", "namespace": "kubevirt", "selfLink": "/api/v1/namespaces/kubevirt/services/virt-api",
+         "uid": "8785768d-8bcb-41f4-8e7d-0255185116ce", "resourceVersion": "34388132",
+         "creationTimestamp": "2020-07-22T15:48:27Z",
+         "labels":
+            {"app.kubernetes.io/managed-by": "kubevirt-operator", "kubevirt.io": "virt-api"},
+         "annotations": {"kubevirt.io/install-strategy-identifier": "bea570209e6ec804f964c31126509110fcdeef04",
+                         "kubevirt.io/install-strategy-registry": "index.docker.io/kubevirt",
+                         "kubevirt.io/install-strategy-version": "v0.31.0"}},
+         "spec": {"ports": [{"protocol": "TCP", "port": 443, "targetPort": 8443}],
+                  "selector": {"kubevirt.io": "virt-api"}, "clusterIP": "10.106.250.243", "type": "ClusterIP",
+                  "sessionAffinity": "None"}, "status": {"loadBalancer": {}}}]}

--- a/libcloud/test/compute/fixtures/kubevirt/get_services.json
+++ b/libcloud/test/compute/fixtures/kubevirt/get_services.json
@@ -17,12 +17,12 @@
          "spec": {"ports": [{"name": "webhooks", "protocol": "TCP", "port": 443, "targetPort": "webhooks"}],
                   "selector": {"kubevirt.io": "virt-operator"}, "clusterIP": "10.111.39.5", "type": "ClusterIP",
                   "sessionAffinity": "None"},
-         "status": {"loadBalancer": {}}}, 
-     {"metadata": 
+         "status": {"loadBalancer": {}}},
+     {"metadata":
         {"name": "kubevirt-prometheus-metrics", "namespace": "kubevirt",
          "selfLink": "/api/v1/namespaces/kubevirt/services/kubevirt-prometheus-metrics",
          "uid": "cd5e6e0d-45c7-46b5-9545-043aabb75b4e", "resourceVersion": "34388129",
-         "creationTimestamp": "2020-07-22T15:48:27Z", 
+         "creationTimestamp": "2020-07-22T15:48:27Z",
          "labels":
             {"app.kubernetes.io/managed-by": "kubevirt-operator", "kubevirt.io": "", "prometheus.kubevirt.io": ""},
          "annotations":

--- a/libcloud/test/compute/test_kubevirt.py
+++ b/libcloud/test/compute/test_kubevirt.py
@@ -101,7 +101,10 @@ class KubeVirtMockHttp(MockHttp):
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
     def _apis_kubevirt_io_v1alpha3_namespaces_default_virtualmachines(self,
-                                                     method, url, body, headers):
+                                                                      method,
+                                                                      url,
+                                                                      body,
+                                                                      headers):
         if method == "GET":
             body = self.fixtures.load('get_default_vms.json')
             resp = httplib.OK
@@ -113,7 +116,10 @@ class KubeVirtMockHttp(MockHttp):
         return (resp, body, {}, httplib.responses[httplib.OK])
 
     def _apis_kubevirt_io_v1alpha3_namespaces_kube_node_lease_virtualmachines(self,
-                                                     method, url, body, headers):
+                                                                              method,
+                                                                              url,
+                                                                              body,
+                                                                              headers):
         if method == "GET":
             body = self.fixtures.load('get_kube_node_lease_vms.json')
         elif method == "POST":
@@ -123,7 +129,9 @@ class KubeVirtMockHttp(MockHttp):
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
     def _apis_kubevirt_io_v1alpha3_namespaces_kube_public_virtualmachines(self,
-                                                     method, url, body, headers):
+                                                                          method,
+                                                                          url, body,
+                                                                          headers):
         if method == "GET":
             body = self.fixtures.load('get_kube_public_vms.json')
         elif method == "POST":
@@ -131,8 +139,11 @@ class KubeVirtMockHttp(MockHttp):
         else:
             AssertionError('Unsupported method')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+
     def _apis_kubevirt_io_v1alpha3_namespaces_kube_system_virtualmachines(self,
-                                                     method, url, body, headers):
+                                                                          method,
+                                                                          url, body,
+                                                                          headers):
         if method == "GET":
             body = self.fixtures.load('get_kube_system_vms.json')
         elif method == "POST":
@@ -142,7 +153,9 @@ class KubeVirtMockHttp(MockHttp):
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
     def _apis_kubevirt_io_v1alpha3_namespaces_kubevirt_virtualmachines(self,
-                                                     method, url, body, headers):
+                                                                       method,
+                                                                       url, body,
+                                                                       headers):
         if method == "GET":
             body = self.fixtures.load('get_kube_public_vms.json')
         elif method == "POST":
@@ -150,8 +163,11 @@ class KubeVirtMockHttp(MockHttp):
         else:
             AssertionError('Unsupported method')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+
     def _apis_kubevirt_io_v1alpha3_namespaces_default_virtualmachines_testvm(self,
-                                                    method, url, body, headers):
+                                                                             method,
+                                                                             url, body,
+                                                                             headers):
         header = "application/merge-patch+json"
         data_stop = {"spec": {"running": False}}
         data_start = {"spec": {"running": True}}
@@ -168,7 +184,10 @@ class KubeVirtMockHttp(MockHttp):
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
     def _apis_kubevirt_io_v1alpha3_namespaces_default_virtualmachines_vm_cirros(self,
-                                                    method, url, body, headers):
+                                                                                method,
+                                                                                url,
+                                                                                body,
+                                                                                headers):
         header = "application/merge-patch+json"
         data_stop = {"spec": {"running": False}}
         data_start = {"spec": {"running": True}}
@@ -185,7 +204,10 @@ class KubeVirtMockHttp(MockHttp):
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
 
     def _apis_kubevirt_io_v1alpha3_namespaces_default_virtualmachineinstances_testvm(self,
-                                                method, url, body, headers):
+                                                                                     method,
+                                                                                     url,
+                                                                                     body,
+                                                                                     headers):
         if method == "DELETE":
             body = self.fixtures.load('delete_vmi_testvm.json')
         else:
@@ -201,7 +223,7 @@ class KubeVirtMockHttp(MockHttp):
             AssertionError('Unsupported method')
 
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
-    
+
     def _api_v1_namespaces_default_services(self, method, url, body, headers):
         if method == "GET":
             body = self.fixtures.load('get_services.json')

--- a/libcloud/test/compute/test_kubevirt.py
+++ b/libcloud/test/compute/test_kubevirt.py
@@ -131,7 +131,6 @@ class KubeVirtMockHttp(MockHttp):
         else:
             AssertionError('Unsupported method')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
-
     def _apis_kubevirt_io_v1alpha3_namespaces_kube_system_virtualmachines(self,
                                                      method, url, body, headers):
         if method == "GET":
@@ -151,7 +150,6 @@ class KubeVirtMockHttp(MockHttp):
         else:
             AssertionError('Unsupported method')
         return (httplib.OK, body, {}, httplib.responses[httplib.OK])
-
     def _apis_kubevirt_io_v1alpha3_namespaces_default_virtualmachines_testvm(self,
                                                     method, url, body, headers):
         header = "application/merge-patch+json"
@@ -199,6 +197,14 @@ class KubeVirtMockHttp(MockHttp):
 
         if method == "GET":
             body = self.fixtures.load('get_pods.json')
+        else:
+            AssertionError('Unsupported method')
+
+        return (httplib.OK, body, {}, httplib.responses[httplib.OK])
+    
+    def _api_v1_namespaces_default_services(self, method, url, body, headers):
+        if method == "GET":
+            body = self.fixtures.load('get_services.json')
         else:
             AssertionError('Unsupported method')
 


### PR DESCRIPTION
## Add capability of exposing ports for Kubevirt VMs 

### Description
Added methods to create services through which ports can be exposed for VMs, each VM will have one service for each type through which multiple ports can be exposed. 

### Status
- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
