### PR TITLE
ParamikoSSHClient file upload performance improvements and other ParamikoSSHClient improvements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -68,6 +68,35 @@ Compute
   re-connecting would help and result in a successful outcome.
   [Tomaz Muraus - @Kami]
 
+- [Deployment] Make ``FileDeployment`` class much faster and more efficient
+  when working with large files or when running multiple ``FileDeployment``
+  steps on a single node.
+
+  This was achieved by implementing two changes on the ``ParamikoSSHClient``
+  class:
+
+  1. ``put()`` method now tries to re-use the existing open SFTP connection
+      if one already exists instead of re-creating a new one for each
+     ``put()`` call.
+
+  2. New ``putfo()`` method has been added to the ``ParamikoSSHClient`` class
+     which utilizes the underlying ``sftp.putfo()`` method.
+
+     This method doesn't need to buffer the whole file content in memory and
+     also supports pipelining which makes uploads much faster and more 
+     efficient for larger files.
+  [Tomaz Muraus - @Kami]
+
+- [Deployment] Add ``__repr__()`` and ``__str__()`` methods to all the
+  Deployment classes.
+  [Tomaz Muraus - @Kami]
+
+- [Deployment] New ``keep_alive`` and ``use_compression`` arguments have been
+  added to the ``ParamikoSSHClient`` class constructor.
+
+  Right now those are not exposed yet to the ``deploy_node()`` method.
+  [Tomaz Muraus - @Kami]
+
 Changes in Apache Libcloud 3.1.0
 --------------------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -83,8 +83,9 @@ Compute
      which utilizes the underlying ``sftp.putfo()`` method.
 
      This method doesn't need to buffer the whole file content in memory and
-     also supports pipelining which makes uploads much faster and more 
+     also supports pipelining which makes uploads much faster and more
      efficient for larger files.
+
   [Tomaz Muraus - @Kami]
 
 - [Deployment] Add ``__repr__()`` and ``__str__()`` methods to all the

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -97,6 +97,13 @@ Compute
   Right now those are not exposed yet to the ``deploy_node()`` method.
   [Tomaz Muraus - @Kami]
 
+- [Deployment] Update ``ParamikoSSHClient.put()`` method so it returns a
+  correct path when commands are being executed on a Windows machine.
+
+  Also update related deployment classes so they correctly handle situation
+  when we are executing commands on a Windows server.
+  [Arthur Kamalov, Tomaz Muraus]
+
 Changes in Apache Libcloud 3.1.0
 --------------------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -76,9 +76,8 @@ Compute
   class:
 
   1. ``put()`` method now tries to re-use the existing open SFTP connection
-      if one already exists instead of re-creating a new one for each
+     if one already exists instead of re-creating a new one for each
      ``put()`` call.
-
   2. New ``putfo()`` method has been added to the ``ParamikoSSHClient`` class
      which utilizes the underlying ``sftp.putfo()`` method.
 

--- a/libcloud/compute/base.py
+++ b/libcloud/compute/base.py
@@ -37,6 +37,7 @@ import socket
 import random
 import binascii
 import datetime
+import traceback
 import atexit
 
 from libcloud.utils.py3 import b
@@ -1900,8 +1901,9 @@ class NodeDriver(BaseDriver):
                         timeout=timeout)
 
                 if tries >= max_tries:
-                    raise LibcloudError(value='Failed after %d tries: %s'
-                                        % (max_tries, str(e)), driver=self)
+                    tb = traceback.format_exc()
+                    raise LibcloudError(value='Failed after %d tries: %s.\n%s'
+                                        % (max_tries, str(e), tb), driver=self)
             else:
                 # Deployment succeeded
                 ssh_client.close()

--- a/libcloud/compute/deployment.py
+++ b/libcloud/compute/deployment.py
@@ -26,6 +26,7 @@ from typing import IO
 from typing import cast
 
 import os
+import re
 import binascii
 
 from libcloud.utils.py3 import basestring, PY3
@@ -209,9 +210,12 @@ class ScriptDeployment(Deployment):
                                contents=self.script)
 
         # Pre-pend cwd if user specified a relative path
-        if self.name and self.name[0] != '/':
+        if self.name and (self.name[0] not in ['/', '\\'] and not re.match(r"^\w\:.*$", file_path)):
             base_path = os.path.dirname(file_path)
             name = os.path.join(base_path, self.name)
+        elif self.name and (self.name[0] == '\\' or re.match(r"^\w\:.*$", file_path)):
+            # Absolute Windows path
+            name = file_path
         else:
             self.name = cast(str, self.name)
             name = self.name

--- a/libcloud/compute/deployment.py
+++ b/libcloud/compute/deployment.py
@@ -208,12 +208,13 @@ class ScriptDeployment(Deployment):
         self.name = cast(str, self.name)
         file_path = client.put(path=self.name, chmod=int('755', 8),
                                contents=self.script)
-
         # Pre-pend cwd if user specified a relative path
-        if self.name and (self.name[0] not in ['/', '\\'] and not re.match(r"^\w\:.*$", file_path)):
+        if self.name and (self.name[0] not in ['/', '\\'] and
+                          not re.match(r"^\w\:.*$", file_path)):
             base_path = os.path.dirname(file_path)
             name = os.path.join(base_path, self.name)
-        elif self.name and (self.name[0] == '\\' or re.match(r"^\w\:.*$", file_path)):
+        elif self.name and (self.name[0] == '\\' or
+                            re.match(r"^\w\:.*$", file_path)):
             # Absolute Windows path
             name = file_path
         else:

--- a/libcloud/compute/deployment.py
+++ b/libcloud/compute/deployment.py
@@ -126,10 +126,8 @@ class FileDeployment(Deployment):
         perms = int(oct(os.stat(self.source).st_mode)[4:], 8)
 
         with open(self.source, 'rb') as fp:
-            content = fp.read()
-
-        client.put(path=self.target, chmod=perms,
-                   contents=content)
+            client.putfo(path=self.target, chmod=perms,
+                         fo=fp)
         return node
 
     def __str__(self):

--- a/libcloud/compute/ssh.py
+++ b/libcloud/compute/ssh.py
@@ -338,6 +338,11 @@ class ParamikoSSHClient(BaseSSHClient):
         self.logger.debug('Uploading file', extra=extra)
 
         sftp = self.client.open_sftp()
+
+        transport = self.client.get_transport()
+        transport.use_compression(compress=True)
+        transport.set_keepalive(15)
+
         # less than ideal, but we need to mkdir stuff otherwise file() fails
         head, tail = psplit(path)
 
@@ -399,6 +404,9 @@ class ParamikoSSHClient(BaseSSHClient):
         bufsize = -1
 
         transport = self.client.get_transport()
+        transport.use_compression(compress=True)
+        transport.set_keepalive(15)
+
         chan = transport.open_session()
 
         start_time = time.time()

--- a/libcloud/compute/ssh.py
+++ b/libcloud/compute/ssh.py
@@ -166,6 +166,25 @@ class BaseSSHClient(object):
         raise NotImplementedError(
             'put not implemented for this ssh client')
 
+    def putfo(self, path, fo=None, chmod=None):
+        """
+        Upload file like object to the remote server.
+
+        :param path: Path to upload the file to.
+        :type path: ``str``
+
+        :param fo: File like object to read the content from.
+        :type fo: File handle or file like object.
+
+        :type chmod: ``int``
+        :keyword chmod: chmod file to this after creation.
+
+        :return: Full path to the location where a file has been saved.
+        :rtype: ``str``
+        """
+        raise NotImplementedError(
+            'putfo not implemented for this ssh client')
+
     def delete(self, path):
         # type: (str) -> bool
         """
@@ -394,15 +413,6 @@ class ParamikoSSHClient(BaseSSHClient):
         Unlike put(), this method operates on file objects and not directly on
         file content which makes it much more efficient for large files since
         it utilizes pipelining.
-
-        :param path: Path to upload the file to.
-        :type path: ``str``
-
-        :param fo: File like object to read the content from.
-        :type fo: File handle or file like object.
-
-        :param chmod: Optional permissions to assign to the uploaded file.
-        :type chmod: ``int``
         """
         extra = {'_path': path, '_chmod': chmod}
         self.logger.debug('Uploading file', extra=extra)

--- a/libcloud/test/compute/test_deployment.py
+++ b/libcloud/test/compute/test_deployment.py
@@ -173,11 +173,11 @@ class DeploymentTests(unittest.TestCase):
         client.run.assert_called_once_with(FILE_PATH, timeout=None)
 
     def test_script_deployment_absolute_path(self):
-        client = Mock()
-        client.put.return_value = FILE_PATH
-        client.run.return_value = ('', '', 0)
-
         file_path = '{0}root{0}relative.sh'.format(os.path.sep)
+
+        client = Mock()
+        client.put.return_value = file_path
+        client.run.return_value = ('', '', 0)
 
         sd = ScriptDeployment(script='echo "foo"', name=file_path)
         sd.run(self.node, client)
@@ -185,11 +185,11 @@ class DeploymentTests(unittest.TestCase):
         client.run.assert_called_once_with(file_path, timeout=None)
 
     def test_script_deployment_with_arguments(self):
-        client = Mock()
-        client.put.return_value = FILE_PATH
-        client.run.return_value = ('', '', 0)
-
         file_path = '{0}root{0}relative.sh'.format(os.path.sep)
+
+        client = Mock()
+        client.put.return_value = file_path
+        client.run.return_value = ('', '', 0)
 
         args = ['arg1', 'arg2', '--option1=test']
         sd = ScriptDeployment(script='echo "foo"', args=args,

--- a/libcloud/test/compute/test_deployment.py
+++ b/libcloud/test/compute/test_deployment.py
@@ -69,6 +69,9 @@ class MockClient(BaseSSHClient):
     def put(self, path, contents, chmod=755, mode='w'):
         return contents
 
+    def putfo(self, path, fo, chmod=755):
+        return fo.read()
+
     def run(self, cmd, timeout=None):
         if self.throw_on_timeout and timeout is not None:
             raise ValueError("timeout")


### PR DESCRIPTION
This pull request includes the following improvements to the ``ParamikoSSHClient`` client and related ``deploy_node()`` functionality which utilizes paramiko SSH client.

1. ``put()`` method now tries to re-use the existing sftp connection (if one is already opened) for successive calls to ``ssh_client.put()`` method.

This should speed up ``deploy_node()`` functionality when uploading multiple files (aka using multiple ``FileDeployment`` steps), because it means we don't need to close and re-open sftp connection for each call to ``put()`` method.

2. Add new ``keep_alive`` and ``use_compression`` arguments to the ``ParamikoSSHClient`` class constructor. At this point, those arguments are not exposed directly to the ``deploy_node()`` method yet.

3. Add new ``putfo()`` method to the ``ParamikoSSHClient`` class and update ``FileDeployment.run()`` method to use this method instead of ``put()``.

This method is much more efficient than ``put()`` because it means we don't need to buffer the whole file content in memory when calling ``file_deployment_step.run()`` and we can also utilize pipelining.

Keep in mind that ``FileDeployment`` was primarily meant for uploading small script files and not large binary files, but based on testing, this change substantially increases performance when uploading larger binary files using ``FileDeployment`` class (I've seen speed ups of up to 80% in favor of the new implementation).

4. I implemented and worked on top of a change originally proposed by @ArthurKamalov which fixes ``put()`` method so it correctly handles absolute file paths when executing commands on Windows machine.