### PR TITLE
Adding Documentation to Outscale Driver

### DIFF
--- a/docs/compute/drivers/outscale.rst
+++ b/docs/compute/drivers/outscale.rst
@@ -104,4 +104,16 @@ Volumes
 * ``attach_volume`` - Return a ``boolean``
 * ``detach_volume`` - Returns a ``boolean``
 
+Outscale Extra Functions
+------------------------
 
+The Outscale driver implement the following extra methods:
+
+IP
+__
+* ``ex_create_public_ip`` - Returns a ``boolean``
+* ``ex_delete_public_ip`` - Returns a ``boolean``
+* ``ex_list_public_ips`` - Returns a ``dict``
+* ``ex_list_public_ip_ranges`` - Returns a ``dict``
+* ``ex_attach_public_ip`` - Returns a ``boolean``
+* ``ex_detach_public_ip`` - Returns a ``boolean``

--- a/docs/compute/drivers/outscale.rst
+++ b/docs/compute/drivers/outscale.rst
@@ -1,0 +1,61 @@
+Outscale Driver Documentation
+=================================
+
+`Outscale`_ provides an IaaS platform allowing
+developers to benefit from all the flexibility of the Cloud.
+This IaaS platform relies on TINA OS, its Cloud manager whose purpose is to
+provide great performances on the Cloud.
+TINA OS is software developed by Outscale.
+
+.. figure:: /_static/images/provider_logos/outscale.jpg
+    :align: center
+    :width: 300
+    :target: https://www.outscale.com/
+
+Outscale users can start virtual machines in the following regions:
+
+* cloudgouv-west-1, France
+* eu-west-2, France
+* us-est-2, US
+* us-west-1, US
+* cn-southeast-1, China
+
+Outscale is an European company and is priced in Euros.
+
+Instantiating a driver
+~~~~~~~~~~~~~~~~~~~~~~
+
+When you instantiate a driver you need to pass the following arguments to the
+driver constructor:
+
+* ``key`` - Your Outscale  access key
+* ``secret`` - Your Outscale secret key
+* ``region`` - The region you want to make action on
+* ``service`` - The Outscale service you want to use
+
+Once you have some credentials you can instantiate the driver as shown below.
+
+.. literalinclude:: /examples/compute/outscale/instantiate.py
+   :language: python
+
+List the Virtual Machines (node)
+--------------------------------
+
+Listing the Virtual Machines on Outscale using libcloud works the same as on any
+other platform. This example is just to show exactly that.
+
+This example will list the Virtual Machines in eu-west-2 region.
+
+.. literalinclude:: /examples/compute/outscale/list_nodes.py
+   :language: python
+
+
+API Documentation
+-----------------
+
+.. autoclass:: libcloud.compute.drivers.outscale.OutscaleNodeDriver
+    :members:
+    :inherited-members:
+
+.. _`Outscale`: https://docs.outscale.com/api
+.. _`Outscale Inc.`: outscale_inc.html

--- a/docs/compute/drivers/outscale.rst
+++ b/docs/compute/drivers/outscale.rst
@@ -61,7 +61,7 @@ API Documentation
 .. _`Outscale Inc.`: outscale_inc.html
 
 Outscale Implementation of Libcloud
-------------------------------
+-----------------------------------
 
 The Outscale driver implements the following ``NodeDriver`` functions:
 

--- a/docs/compute/drivers/outscale.rst
+++ b/docs/compute/drivers/outscale.rst
@@ -59,3 +59,49 @@ API Documentation
 
 .. _`Outscale`: https://docs.outscale.com/api
 .. _`Outscale Inc.`: outscale_inc.html
+
+Outscale Implementation of Libcloud
+------------------------------
+
+The Outscale driver implements the following ``NodeDriver`` functions:
+
+Regions
+-------
+* ``list_locations`` - Returns a list of ``NodeLocation``
+
+Nodes
+-----
+* ``create_node`` - Creates a ``Node``
+* ``reboot_node`` - Reboots a ``Node``
+* ``list_nodes`` - Returns a list of ``Node``
+* ``destroy_node`` - Destroys an existing ``Node``
+
+Images
+------
+* ``create_images`` - Returns a ``NodeImage``
+* ``list_images`` - Returns a list of ``NodeImage``
+* ``get_image`` - Returns a ``NodeImage``
+* ``delete_image`` - Return a ``boolean``
+
+Key Pairs
+_________
+* ``create_key_pair`` - Returns a ``KeyPair``
+* ``list_key_pairs`` - Returns a list of ``KeyPair``
+* ``get_key_pair`` - Returns a ``KeyPair``
+* ``delete_key_pair`` - Returns a ``boolean``
+
+Snapshots
+---------
+* ``create_volume_snapshot`` - Returns a ``VolumeSnapshot``
+* ``list_snapshots`` - Returns a list of ``VolumeSnapshot``
+* ``destroy_volume_snapshot`` - Returns a ``boolean``
+
+Volumes
+-------
+* ``create_volume`` - Returns a ``StorageVolume``
+* ``list_volumes`` - Returns a list of ``StorageVolume``
+* ``destroy_volume`` - Returns a ``boolean``
+* ``attach_volume`` - Return a ``boolean``
+* ``detach_volume`` - Returns a ``boolean``
+
+

--- a/docs/examples/compute/outscale/instantiate.py
+++ b/docs/examples/compute/outscale/instantiate.py
@@ -1,0 +1,10 @@
+from libcloud.compute.types import Provider
+from libcloud.compute.providers import get_driver
+
+cls = get_driver(Provider.OUTSCALE)
+driver = cls(
+    key='my_key',
+    secret='my_secret',
+    region="my_region",
+    service="my_service"
+)

--- a/docs/examples/compute/outscale/list_nodes.py
+++ b/docs/examples/compute/outscale/list_nodes.py
@@ -1,0 +1,14 @@
+from libcloud.compute.types import Provider
+from libcloud.compute.providers import get_driver
+
+key = 'my_key'
+secret = 'my_secret'
+region = 'eu-west-2'
+service = 'api'
+
+Driver = get_driver(Provider.OUTSCALE)
+driver = Driver(key=key, secret=secret, region=region, service=service)
+
+node = driver.list_nodes()
+
+print(node)

--- a/docs/examples/compute/outscale/list_nodes.py
+++ b/docs/examples/compute/outscale/list_nodes.py
@@ -9,6 +9,6 @@ service = 'api'
 Driver = get_driver(Provider.OUTSCALE)
 driver = Driver(key=key, secret=secret, region=region, service=service)
 
-node = driver.list_nodes()
+nodes = driver.list_nodes()
 
-print(node)
+print(nodes)


### PR DESCRIPTION
## Adding Documentation to Outscale Driver

### Description

Add documentation and examples to the Outscale Provider.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) n/a, docs only change
- [x] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html) n/a, docs only change
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
