### PR TITLE
Fixes request path for ex_set_image_labels()

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -9088,6 +9088,7 @@ class GCENodeDriver(NodeDriver):
         extra['options'] = volume.get('options')
         extra['labels'] = volume.get('labels', {})
         extra['labelFingerprint'] = volume.get('labelFingerprint')
+        extra['users'] = volume.get('users', [])
 
         if 'licenses' in volume:
             lic_objs = self._licenses_from_urls(licenses=volume['licenses'])

--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -2080,7 +2080,7 @@ class GCENodeDriver(NodeDriver):
             raise ValueError("Must specify a valid libcloud image object.")
         current_fp = image.extra['labelFingerprint']
         body = {'labels': labels, 'labelFingerprint': current_fp}
-        request = '/global/%s/setLabels' % (image.name)
+        request = '/global/images/%s/setLabels' % (image.name)
         self.connection.async_request(request, method='POST', data=body)
         return True
 


### PR DESCRIPTION
## Fixes request path for ex_set_image_labels()

### Description

A simple fix - the request in ex_set_image_labels was missing the "/images/" path. 

I made this commit against 2.8.x because that's where I needed it, but it's also missing in trunk. 

### Status

Replace this: describe the PR status. Examples:

- done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
