### PR TITLE
Fixes an issue where HTTP requests cause HTTP 400 errors

### DIFF
--- a/libcloud/http.py
+++ b/libcloud/http.py
@@ -241,8 +241,6 @@ class LibcloudConnection(LibcloudBaseConnection):
 
         prepped = self.session.prepare_request(req)
 
-        prepped.body = body
-
         self.response = self.session.send(
             prepped,
             stream=stream,


### PR DESCRIPTION

## Fixes an issue where HTTP requests cause HTTP 400 errors

### Description

fixes #1487

Removed a single line of code that was causing problems.

HTTP requests with a body equal to an empty string `''` were incorrectly being chunked and ultimately leading to HTTP 400 errors (in certain providers).

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
