### PR TITLE
Outscale Provider Updating test so they run with every time zone

### DIFF
--- a/libcloud/test/common/test_osc.py
+++ b/libcloud/test/common/test_osc.py
@@ -57,7 +57,7 @@ class OSCRequestSignerAlgorithmV4TestCase(LibcloudTestCase):
         )
         self.assertIn(
             'Credential=my_key/{}/my_region/my_service/osc4_request'.format(
-                datetime.now().strftime('%Y%m%d')
+                datetime.utcnow().strftime('%Y%m%d')
             ),
             headers["Authorization"]
         )


### PR DESCRIPTION
# Fix an issue with Time Zone compatibility in unit tests for Outscale Provider

### Description

Based on this issue : https://github.com/apache/libcloud/issues/1490 from @yan12125

Create a utc date in place of a local date in ```libcloud/test/common/test_osc.py``` for ```test_v4_signature_contains_credential_scope``` method.

It should now be working independently of the user timezone.

### Status
- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes)