### PR TITLE
Support GCE instances with no service accounts

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -4893,7 +4893,7 @@ class GCENodeDriver(NodeDriver):
         :rtype:   ``list`` of ``dict``
         """
         gce_service_accounts = []
-        if not service_accounts:
+        if service_accounts is None:
             gce_service_accounts = [{
                 'email': default_email,
                 'scopes': [self.AUTH_URL + default_scope]


### PR DESCRIPTION
## Support GCE instances with no service accounts

### Description

This fixes #1497.  When an empty list (`[]`) is passed in for ex_service_accounts,
a VM with no service accounts is created.  When None is passed in (the default),
the behavior remains unchanged, giving the default service account.

### Status

done, ready for review

### Checklist (tick everything that applies)

- [X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
