### PR TITLE
dns/digitalocean: send attributes in body for PUT and POST operations.

### DIFF
--- a/libcloud/dns/drivers/digitalocean.py
+++ b/libcloud/dns/drivers/digitalocean.py
@@ -20,6 +20,8 @@ __all__ = [
     'DigitalOceanDNSDriver'
 ]
 
+import json
+
 from libcloud.utils.py3 import httplib
 
 from libcloud.common.digitalocean import DigitalOcean_v2_BaseDriver
@@ -128,7 +130,7 @@ class DigitalOceanDNSDriver(DigitalOcean_v2_BaseDriver, DNSDriver):
         except Exception:
             params['ip_address'] = '127.0.0.1'
 
-        res = self.connection.request('/v2/domains', params=params,
+        res = self.connection.request('/v2/domains', data=json.dumps(params),
                                       method='POST')
 
         return Zone(id=res.object['domain']['name'],
@@ -183,7 +185,7 @@ class DigitalOceanDNSDriver(DigitalOcean_v2_BaseDriver, DNSDriver):
                 params['ttl'] = extra['ttl']
 
         res = self.connection.request('/v2/domains/%s/records' % zone.id,
-                                      params=params,
+                                      data=json.dumps(params),
                                       method='POST')
 
         return Record(id=res.object['domain_record']['id'],
@@ -243,7 +245,7 @@ class DigitalOceanDNSDriver(DigitalOcean_v2_BaseDriver, DNSDriver):
 
         res = self.connection.request('/v2/domains/%s/records/%s' %
                                       (record.zone.id, record.id),
-                                      params=params,
+                                      data=json.dumps(params),
                                       method='PUT')
 
         return Record(id=res.object['domain_record']['id'],

--- a/libcloud/test/dns/fixtures/digitalocean/_v2_domains_UNPROCESSABLE_ENTITY.json
+++ b/libcloud/test/dns/fixtures/digitalocean/_v2_domains_UNPROCESSABLE_ENTITY.json
@@ -1,0 +1,1 @@
+{"id":"unprocessable_entity","message":"Request body malformed."}

--- a/libcloud/test/dns/test_digitalocean.py
+++ b/libcloud/test/dns/test_digitalocean.py
@@ -110,7 +110,8 @@ class DigitalOceanDNSMockHttp(MockHttp):
         'EMPTY': httplib.OK,
         'NOT_FOUND': httplib.NOT_FOUND,
         'UNAUTHORIZED': httplib.UNAUTHORIZED,
-        'UPDATE': httplib.OK
+        'UPDATE': httplib.OK,
+        'UNPROCESSABLE': httplib.UNPROCESSABLE_ENTITY,
     }
 
     def _v2_domains(self, method, url, body, headers):
@@ -119,6 +120,10 @@ class DigitalOceanDNSMockHttp(MockHttp):
                 httplib.responses[self.response_map[self.type]])
 
     def _v2_domains_CREATE(self, method, url, body, headers):
+        if body is None:
+            body = self.fixtures.load('_v2_domains_UNPROCESSABLE_ENTITY.json')
+            return (self.response_map[self.type], body, {},
+                    httplib.responses[self.response_map['UNPROCESSABLE']])
         body = self.fixtures.load('_v2_domains_CREATE.json')
         return (self.response_map[self.type], body, {},
                 httplib.responses[self.response_map[self.type]])
@@ -144,6 +149,10 @@ class DigitalOceanDNSMockHttp(MockHttp):
 
     def _v2_domains_testdomain_records_CREATE(self, method, url,
                                               body, headers):
+        if body is None:
+            body = self.fixtures.load('_v2_domains_UNPROCESSABLE_ENTITY.json')
+            return (self.response_map[self.type], body, {},
+                    httplib.responses[self.response_map['UNPROCESSABLE']])
         body = self.fixtures.load('_v2_domains_testdomain_records_CREATE.json')
         return (self.response_map[self.type], body, {},
                 httplib.responses[self.response_map[self.type]])
@@ -163,6 +172,10 @@ class DigitalOceanDNSMockHttp(MockHttp):
 
     def _v2_domains_testdomain_records_1234564_UPDATE(
             self, method, url, body, headers):
+        if body is None:
+            body = self.fixtures.load('_v2_domains_UNPROCESSABLE_ENTITY.json')
+            return (self.response_map[self.type], body, {},
+                    httplib.responses[self.response_map['UNPROCESSABLE']])
         body = self.fixtures.load(
             '_v2_domains_testdomain_records_1234564_UPDATE.json')
         return (self.response_map[self.type], body, {},


### PR DESCRIPTION
## dns/digitalocean: send attributes in body for PUT and POST operations.

### Description

Like with the DigitalOcean compute driver, requests for the DNS driver should send data in the body for PUT and POST operations rather than in query parameters. e.g. https://developers.digitalocean.com/documentation/v2/#create-a-new-domain-record

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes) (I believe I signed this some time ago, not sure how to check if that's the case)
