### PR TITLE
Fix for apache/libcloud #1521

### DIFF
--- a/libcloud/dns/drivers/auroradns.py
+++ b/libcloud/dns/drivers/auroradns.py
@@ -168,7 +168,7 @@ class AuroraDNSResponse(JsonResponse):
             raise InvalidCredsError(**error)
         elif status == httplib.FORBIDDEN:
             error['value'] = 'Authorization failed'
-            error['http_status'] = status
+            error['http_code'] = status
             raise ProviderError(**error)
         elif status == httplib.NOT_FOUND:
             context = self.connection.context


### PR DESCRIPTION
## Bug fix: raise proper exception when using incorrect credentials for AuroraDNS

### Description

This is a minor fix for a bug that was introduced in january 2016. See #1521 for details.

#### Code to reproduce:

```
#!/usr/bin/env python3

from libcloud.dns.types import Provider
from libcloud.dns.providers import get_driver

api_key = '123456'
secret_key = 'this_is_the_wrong_password'

cls = get_driver(Provider.AURORADNS)
driver = cls(api_key, secret_key)

for zone in driver.iterate_zones():
    print(zone)
```

#### Expected exception:

This should have raised an `ProviderError: Authorization failed`

#### Actual exception:

`TypeError: __init__() got an unexpected keyword argument 'http_status'`

### Source of the bug:

This bug was introduced in commit de7862f, which includes the following rewrite:

```
-            raise ProviderError(value='Authorization failed', http_code=status,
-                                driver=self)
+            error['value'] = 'Authorization failed'
+            error['http_status'] = status
+            raise ProviderError(**error)
```

While the intention is clear, the author inadvertently changed the way `ProviderError` was called from `ProviderError(value=..., http_code=status)` to `ProviderError(value=..., http_status=status)`

This PR fixes this bug by changing the line `error['http_status'] = status` to `error['http_code'] = status`

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [X] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
