### PR TITLE
Storage: Add support for the SFO2 datacenter

### DIFF
--- a/libcloud/storage/drivers/digitalocean_spaces.py
+++ b/libcloud/storage/drivers/digitalocean_spaces.py
@@ -24,6 +24,7 @@ __all__ = [
 
 DO_SPACES_HOSTS_BY_REGION = {'nyc3': 'nyc3.digitaloceanspaces.com',
                              'ams3': 'ams3.digitaloceanspaces.com',
+                             'sfo2': 'sfo2.digitaloceanspaces.com',
                              'sgp1': 'sgp1.digitaloceanspaces.com'}
 DO_SPACES_DEFAULT_REGION = 'nyc3'
 DEFAULT_SIGNATURE_VERSION = '2'


### PR DESCRIPTION
## DO storage provider: add support for the SFO2 datacenter

### Description

This is just an extremely small and hopefully innocuous PR adding support for the sfo2 region (S3 endpoint = sfo2.digitaloceanspaces.com) of the Digital Ocean Object Storage service. It's literally a one line change adding the new endpoint.

### Status

ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
