### PR TITLE
Allow duplicates slashes in request URL paths

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -161,6 +161,24 @@ Storage
   (GITHUB-1528)
   [Tomaz Muraus - @Kami]
 
+- Add new ``libcloud.common.base.ALLOW_PATH_DOUBLE_SLASHES`` module level
+  variable.
+
+  When this value is set to ``True`` (defaults to ``False`` for backward
+  compatibility reasons), Libcloud won't try to sanitize the URL path and
+  remove any double slashes.
+
+  In most cases, this won't matter and sanitzing double slashes is a safer
+  default, but in some cases such as S3, where double slashes can be a valid
+  path (e.g. ``/my-bucket//path1/file.txt``), this option may come handy.
+
+  When this variable is set to ``True``, behavior is also consistent with
+  Libcloud versions prior to v2.0.0.
+
+  Reported by Jonathan Hanson - @triplepoint.
+  (GITHUB-1529)
+  [Tomaz Muraus - @Kami]
+
 DNS
 ~~~
 

--- a/docs/storage/drivers/s3.rst
+++ b/docs/storage/drivers/s3.rst
@@ -4,6 +4,16 @@ Amazon S3 Storage Driver Documentation
 `Amazon Simple Storage Service (Amazon S3)`_ is an online cloud storage service
 from Amazon Web Services.
 
+.. note::
+
+    If you are upgrading from Libcloud v2.3.0 or older versions and are
+    utilizing paths with duplicated slashes (e.g. ``/my-bucket//path/1.txt``)
+    or a root bucked named as ``/``, you will need to utilize
+    ``libcloud.common.base.ALLOW_PATH_DOUBLE_SLASHES`` variable which was
+    added in Libcloud v3.3.0 so you can access objects in those paths.
+
+    For more information, please refer to the "Upgrade Notes".
+
 Multipart uploads
 -----------------
 

--- a/docs/upgrade_notes.rst
+++ b/docs/upgrade_notes.rst
@@ -75,6 +75,51 @@ Libcloud 3.3.0
   slashes or similar and are upgrading from Libcloud ``v2.3.0`` or older where
   no path sanitization was performed.
 
+  Example S3 bucket layout with this option disabled (default) and enabled.
+
+  Object with the following name: ``/my-bucket/sub-directory/file.txt``
+
+    .. code-block:: bash
+
+      # Disabled
+
+      root
+      +-- my-bucket/
+        +-- sub-directory/
+          +-- file.txt
+
+      # Enabled
+
+      root
+      +-- /
+        +-- my-bucket/
+          +-- sub-directory/
+            +-- file.txt
+
+  Object with the following name: ``/my-bucket//directory1/file.txt``
+
+    .. code-block:: bash
+
+      # Disabled
+
+      root
+      +-- my-bucket/
+        +-- directory1/
+          +-- file.txt
+
+      # Enabled
+
+      root
+      +-- /
+        +-- my-bucket/
+          +-- /
+            +-- directory1/
+              +-- file.txt
+
+  As you can see from the examples above, directory layout is not the same
+  with this option enabled and disabled so you should be careful when you
+  use it.
+
 Libcloud 3.2.0
 --------------
 

--- a/docs/upgrade_notes.rst
+++ b/docs/upgrade_notes.rst
@@ -64,6 +64,17 @@ Libcloud 3.3.0
       cls = get_driver(Provider.EQUINIXMETAL)
       driver = cls('api_key')
 
+* New ``libcloud.common.base.ALLOW_PATH_DOUBLE_SLASHES`` module level variable
+  has been added which defaults to ``False`` for backward compatibility reasons.
+
+  When set to ``True``, Libcloud code won't perform any URL path sanitization
+  and will allow URL paths with double slashes (e.g.
+  ``/my-bucket//foo/1.txt``).
+
+  This may come handy to the users who have S3 paths which contains double
+  slashes or similar and are upgrading from Libcloud ``v2.3.0`` or older where
+  no path sanitization was performed.
+
 Libcloud 3.2.0
 --------------
 

--- a/libcloud/test/test_connection.py
+++ b/libcloud/test/test_connection.py
@@ -45,10 +45,14 @@ class BaseConnectionClassTestCase(unittest.TestCase):
         elif 'http_proxy' in os.environ:
             del os.environ['http_proxy']
 
+        libcloud.common.base.ALLOW_PATH_DOUBLE_SLASHES = False
+
     @classmethod
     def tearDownClass(cls):
         if 'http_proxy' in os.environ:
             del os.environ['http_proxy']
+
+        libcloud.common.base.ALLOW_PATH_DOUBLE_SLASHES = False
 
     def test_parse_proxy_url(self):
         conn = LibcloudBaseConnection()

--- a/libcloud/test/test_connection.py
+++ b/libcloud/test/test_connection.py
@@ -23,6 +23,8 @@ from mock import Mock, patch
 
 import requests_mock
 
+import libcloud.common.base
+
 from libcloud.test import unittest
 from libcloud.common.base import Connection, CertificateConnection
 from libcloud.http import LibcloudBaseConnection
@@ -208,6 +210,26 @@ class BaseConnectionClassTestCase(unittest.TestCase):
         conn.request_path = 'v1/'
         self.assertEqual(conn.morph_action_hook('/test'), '/v1/test')
         self.assertEqual(conn.morph_action_hook('test'), '/v1/test')
+
+        conn.request_path = '/a'
+        self.assertEqual(conn.morph_action_hook('//b/c.txt'), '/a/b/c.txt')
+
+        conn.request_path = '/b'
+        self.assertEqual(conn.morph_action_hook('/foo//'), '/b/foo/')
+
+        libcloud.common.base.ALLOW_PATH_DOUBLE_SLASHES = True
+
+        conn.request_path = '/'
+        self.assertEqual(conn.morph_action_hook('/'), '//')
+
+        conn.request_path = ''
+        self.assertEqual(conn.morph_action_hook('/'), '/')
+
+        conn.request_path = '/a'
+        self.assertEqual(conn.morph_action_hook('//b/c.txt'), '/a//b/c.txt')
+
+        conn.request_path = '/b'
+        self.assertEqual(conn.morph_action_hook('/foo//'), '/b/foo//')
 
     def test_connect_with_prefix(self):
         """

--- a/scripts/time_imports.sh
+++ b/scripts/time_imports.sh
@@ -18,8 +18,8 @@
 set -e
 
 # Script which fails if any of the import takes more than threshold ms
-LIBCLOUD_CUMULATIVE_IMPORT_TIME_LIMIT_US=350000
-EC2_DRIVER_CUMULATIVE_IMPORT_TIME_LIMIT_US=450000
+LIBCLOUD_CUMULATIVE_IMPORT_TIME_LIMIT_US=400000
+EC2_DRIVER_CUMULATIVE_IMPORT_TIME_LIMIT_US=480000
 
 # Clean up any cached files to ensure consistent and clean environment
 find . -name "*.pyc" -print0 | xargs -0 rm


### PR DESCRIPTION
This pull request adds a workaround / fix for the issue reported in #1529.

## Background, Context

It appears that in the past Libcloud supported URL paths with double slashes (e.g. ``/my-bucket/foo//1.txt``), but once moving to requests we added some code for path sanitization so we don't support that use case anymore.

It appears that change was originally added in - fedace00261bcbb0a45bda003b968101a897d4ed.

From technical perspective, I think it should be fine to support double slashes since that's usually handled / stripped on the server side (e.g. either inside the web server or inside the app), but I'm sure there was a valid reason for that change - with so many providers we support we've seen all kind of weird API issues and implementation so I assume that change was added to guard against such issues.

## Proposed Fix / Solution

I tried a couple of things as a possible fix / workaround.

It seems like that doing no path sanitization brakes a whole lot of other things so in the end I decided to go with a module level variable which can be changed by the user.

This should be much safer change since it won't affect anyone but users who explicitly opt-in.

I've done some testing and it appears to be working correctly end to end, but there could potentially still be edge cases hiding in the other parts of the code base.

## TODO

- [x] Upgrade notes entry
- [x] Documentation entry (S3 driver)

Resolves #1529