### PR TITLE
Add a tags parser to ecs driver compute list_nodes method

### DIFF
--- a/libcloud/compute/drivers/ecs.py
+++ b/libcloud/compute/drivers/ecs.py
@@ -345,6 +345,16 @@ RESOURCE_EXTRA_ATTRIBUTES_MAP = {
             'xpath': 'ImportOSSObject',
             'transform_func': u
         }
+    },
+    'tags': {
+        'tag_key': {
+            'xpath': 'TagKey',
+            'transform_func': u
+        },
+        'tag_value': {
+            'xpath': 'TagValue',
+            'transform_func': u
+        }
     }
 }
 
@@ -1424,12 +1434,26 @@ class ECSDriver(NodeDriver):
                                  namespace=self.namespace)
         private_ips = _get_ips(private_ip_els)
 
+        def _get_tags(tags):
+            return [
+                self._get_extra_dict(
+                    tag,
+                    RESOURCE_EXTRA_ATTRIBUTES_MAP['tags']
+                ) for tag in tags
+            ]
+
+        tag_els = findall(element=instance,
+                          xpath='Tags//Tag',
+                          namespace=self.namespace)
+        tags = _get_tags(tag_els)
+
         # Extra properties
         extra = self._get_extra_dict(instance,
                                      RESOURCE_EXTRA_ATTRIBUTES_MAP['node'])
         extra['vpc_attributes'] = self._get_vpc_attributes(instance)
         extra['eip_address'] = self._get_eip_address(instance)
         extra['operation_locks'] = self._get_operation_locks(instance)
+        extra['tags'] = tags
 
         node = Node(id=_id, name=name, state=state,
                     public_ips=public_ips, private_ips=private_ips,


### PR DESCRIPTION
## Add tags parser to ecs driver compute `list_nodes` method

### Description

- Add `_get_tags` method to parse list of Tags//Tag from tags element
- Insert parsed `tags` as node.extra

### Status

- work in progress

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
