### PR TITLE
[wip] Output correct TTL for DNS records in export_zone_to_bind_format()

### DIFF
--- a/libcloud/dns/base.py
+++ b/libcloud/dns/base.py
@@ -546,7 +546,7 @@ class DNSDriver(BaseDriver):
 
         name += '.'
 
-        ttl = record.extra['ttl'] if 'ttl' in record.extra else record.zone.ttl
+        ttl = record.ttl if record.ttl else record.zone.ttl
         ttl = str(ttl)
         data = record.data
 


### PR DESCRIPTION
## Output correct TTL for records in `export_zone_to_bind_format()`

### Description

`libcloud.dns.base.DNSDriver.export_zone_to_bind_format()` does not correctly list the TTL of individual DNS records if the TTL is different from the default TTL of the zone.

The root cause is a bug in [line 549](https://github.com/macfreek/libcloud/blob/trunk/libcloud/dns/base.py#L549) in the `_get_bind_record_line()` method.

When it tries to find the TTL for the record, it is looking for it in the `extra` dict, while in reality, the TTL (if different from the default) is stored in an attribute, `Record.ttl`, as can be seen in the [`__init__` method of `libcloud.dns.base.Record`](https://github.com/macfreek/libcloud/blob/trunk/libcloud/dns/base.py#L163).

As far as I can see, the ttl is never stored in the `extra` dict, so this if statement is always false, and the zone default TTL is always picked, even in case the Record does have a more specific TTL.

### Status

- work in progress, tests are failing. My bad.
- ~done, ready for review~
- may need additional unit test

### Classification

Suggested labels: `bug fix`, `api: dns`

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [X] Documentation (existing documentation suffices, this is only a small bug fix)
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
