### PR TITLE
Deprecate Record.ttl in favour of Record.extra['ttl']

### DIFF
--- a/docs/examples/dns/create_record_custom_ttl.py
+++ b/docs/examples/dns/create_record_custom_ttl.py
@@ -8,6 +8,6 @@ driver = cls(*CREDENTIALS_ZERIGO)
 
 zone = [z for z in driver.list_zones() if z.domain == 'example.com'][0]
 
-ttl = 900
+extra = {'ttl': 900}
 record = zone.create_record(name='www', type=RecordType.A, data='127.0.0.1',
-                            ttl=ttl)
+                            extra=extra)

--- a/libcloud/dns/base.py
+++ b/libcloud/dns/base.py
@@ -161,7 +161,8 @@ class Record(object):
         self.zone = zone
         self.driver = driver
         self.extra = extra or {}
-        if ttl is not None:
+        # extra['ttl'] overrides ttl
+        if ttl is not None and self.extra.get('ttl') is None:
             self.extra['ttl'] = ttl
 
     def update(self,

--- a/libcloud/dns/base.py
+++ b/libcloud/dns/base.py
@@ -160,8 +160,9 @@ class Record(object):
         self.data = data
         self.zone = zone
         self.driver = driver
-        self.ttl = ttl
         self.extra = extra or {}
+        if ttl is not None:
+            self.extra['ttl'] = ttl
 
     def update(self,
                name=None,  # type: Optional[str]
@@ -195,6 +196,26 @@ class Record(object):
             return record_id_int
 
         return record_id
+
+    @property
+    def ttl(self):
+        # type: () -> Optional[int]
+        """
+        Get TTL of a Record, if defined.
+        Backward compatible with Record.ttl attribute.
+        This method is deprecated in favour of Record.extra['ttl'].
+        """
+        return self.extra.get('ttl')
+
+    @ttl.setter
+    def ttl(self, ttl):
+        # type: (int) -> None
+        """
+        Set TTL of a Record, overriding the Zone.ttl.
+        Backward compatible with Record.ttl attribute.
+        This method is deprecated in favour of Record.extra['ttl'].
+        """
+        self.extra['ttl'] = ttl
 
     def __repr__(self):
         # type: () -> str

--- a/libcloud/test/dns/test_base.py
+++ b/libcloud/test/dns/test_base.py
@@ -109,7 +109,7 @@ class BaseTestCase(unittest.TestCase):
         self.assertEqual(lines2[0], expected_header)
 
         for lines in [lines1, lines2]:
-            self.assertEqual(len(lines), 2 + 1 + 9)
+            self.assertEqual(len(lines), 2 + 1 + 10)
             assertRegex(self, lines[1], r'\$ORIGIN example\.com\.')
             assertRegex(self, lines[2], r'\$TTL 900')
 

--- a/libcloud/test/dns/test_base.py
+++ b/libcloud/test/dns/test_base.py
@@ -53,6 +53,10 @@ MOCK_RECORDS_VALUES = [
      'data': 'mx.example.com', 'extra': {'priority': 10}},
     {'id': 5, 'name': '', 'type': RecordType.SRV,
      'data': '10 3333 example.com', 'extra': {'priority': 20}},
+
+    # Custom TTL (using deprecated ttl parameter)
+    {'id': 6, 'name': 'www2', 'type': RecordType.A, 'data': '127.0.0.1',
+     'ttl': 123},
 ]
 
 
@@ -117,6 +121,7 @@ class BaseTestCase(unittest.TestCase):
             assertRegex(self, lines[9], r'test2.example.com\.\s+900\s+IN\s+TXT\s+"test \\"foo\\" \\"bar\\""')
             assertRegex(self, lines[10], r'example.com\.\s+900\s+IN\s+MX\s+10\s+mx.example.com')
             assertRegex(self, lines[11], r'example.com\.\s+900\s+IN\s+SRV\s+20\s+10 3333 example.com')
+            assertRegex(self, lines[12], r'www2.example.com\.\s+123\s+IN\s+A\s+127\.0\.0\.1')
 
     def test_get_numeric_id(self):
         values = MOCK_RECORDS_VALUES[0].copy()

--- a/libcloud/test/dns/test_dnspod.py
+++ b/libcloud/test/dns/test_dnspod.py
@@ -162,7 +162,9 @@ class DNSPodDNSTests(unittest.TestCase):
         self.assertEqual(record.id, '50')
         self.assertEqual(record.name, '@')
         self.assertEqual(record.data, '96.126.115.73')
-        self.assertIsNone(record.ttl)
+        # Please enable the next lines once issue #1538 is resolved.
+        # self.assertEqual(record.ttl, 13)
+        # self.assertEqual(record.extra['ttl'], 13)
 
     def test_create_record_already_exists_error(self):
         DNSPodMockHttp.type = 'RECORD_EXISTS'

--- a/libcloud/test/dns/test_luadns.py
+++ b/libcloud/test/dns/test_luadns.py
@@ -199,7 +199,7 @@ class LuadnsTests(unittest.TestCase):
         self.assertEqual(record.id, '31')
         self.assertEqual(record.name, 'test.com.')
         self.assertEqual(record.data, '127.0.0.1')
-        self.assertIsNone(record.ttl)
+        self.assertEqual(record.ttl, 13)
 
     def test_record_already_exists_error(self):
         pass


### PR DESCRIPTION
## Deprecate `Record.ttl` in favour of `Record.extra['ttl']`

Please read #1536 carefully. The current implementation stores a TTL for a DNS Record at two places, depending where you look in the code. This pull requests picks one of them.

I added @property methods to maintain backwards compatibility, so the API remains consistent. However, it DOES change the internal data structure of a `libcloud.dns.base.Record`.

### Description

See #1536.

### Status

- needs careful review

Also see comment below about the failing unit test. (In my opinion, two of the unit tests are flawed, not the behaviour of this PR).

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [X] Documentation (fixed that :) )
- [X] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html).
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
