### PR TITLE
Make libcloud compliant with the latest Outscale API.

### DIFF
--- a/docs/compute/drivers/outscale.rst
+++ b/docs/compute/drivers/outscale.rst
@@ -349,3 +349,11 @@ Certificate Authority
 * ``ex_delete_certificate_authority`` - Returns a ``bool``
 * ``ex_read_certificate_authorities`` - Returns a ``list`` of ``dict``
 
+API Access Rules
+----------------
+* ``ex_create_api_access_rule`` - Returns a ``dict``
+* ``ex_delete_api_access_rule`` - Returns a ``bool``
+* ``ex_read_api_access_rules`` - Returns a ``list`` of ``dict``
+* ``ex_update_api_access_rule`` - Returns a ``dict``
+
+

--- a/docs/compute/drivers/outscale.rst
+++ b/docs/compute/drivers/outscale.rst
@@ -342,3 +342,10 @@ Nodes
 * ``ex_list_node_types`` - Returns a ``list`` of ``dict``
 * ``ex_list_nodes_states`` - Returns a ``list`` of ``dict``
 * ``ex_update_node`` - Returns a ``list`` of ``dict``
+
+Certificate Authority
+---------------------
+* ``ex_create_certificate_authority`` - Returns a ``dict``
+* ``ex_delete_certificate_authority`` - Returns a ``bool``
+* ``ex_read_certificate_authorities`` - Returns a ``list`` of ``dict``
+

--- a/libcloud/compute/drivers/outscale.py
+++ b/libcloud/compute/drivers/outscale.py
@@ -7711,7 +7711,7 @@ class OutscaleNodeDriver(NodeDriver):
 
     def ex_create_certificate_authority(
         self,
-        ca_perm: str = None,
+        ca_perm: str,
         description: str = None,
         dry_run: bool = False
     ):
@@ -7727,11 +7727,12 @@ class OutscaleNodeDriver(NodeDriver):
         :param      dry_run: If true, checks whether you have the required
         permissions to perform the action.
         :type       dry_run: ``bool``
+
+        :return: the created Ca.
+        :rtype: ``dict``
         """
         action = "CreateCa"
-        data = {"DryRun": dry_run}
-        if ca_perm is not None:
-            data.update({"CaPerm": ca_perm})
+        data = {"DryRun": dry_run, "CaPerm": ca_perm}
         if description is not None:
             data.update({"Description": description})
         response = self._call_api(action, json.dumps(data))
@@ -7741,7 +7742,7 @@ class OutscaleNodeDriver(NodeDriver):
 
     def ex_delete_certificate_authority(
         self,
-        ca_id: str = None,
+        ca_id: str,
         dry_run: bool = False
     ):
         """
@@ -7755,9 +7756,7 @@ class OutscaleNodeDriver(NodeDriver):
         :type       dry_run: ``bool``
         """
         action = "DeleteCa"
-        data = {"DryRun": dry_run}
-        if ca_id is not None:
-            data.update({"CaId": ca_id})
+        data = {"DryRun": dry_run, "CaId": ca_id}
         response = self._call_api(action, json.dumps(data))
         if response.status_code == 200:
             return True
@@ -7786,6 +7785,9 @@ class OutscaleNodeDriver(NodeDriver):
         :param      dry_run: If true, checks whether you have the required
         permissions to perform the action.
         :type       dry_run: ``bool``
+
+        :return: a list of all Ca matching filled filters.
+        :rtype: ``list`` of  ``dict``
         """
         action = "ReadCas"
         data = {"DryRun": dry_run, "Filters": {}}
@@ -7802,7 +7804,7 @@ class OutscaleNodeDriver(NodeDriver):
 
     def ex_update_certificate_authority(
         self,
-        ca_id: str = None,
+        ca_id: str,
         description: str = None,
         dry_run: bool = False
     ):
@@ -7819,11 +7821,12 @@ class OutscaleNodeDriver(NodeDriver):
         :param      dry_run: If true, checks whether you have the required
         permissions to perform the action.
         :type       dry_run: ``bool``
+
+        :return: a the created Ca or the request result.
+        :rtype: ``dict``
         """
         action = "UpdateCa"
-        data = {"DryRun": dry_run}
-        if ca_id is not None:
-            data.update({"CaId": ca_id})
+        data = {"DryRun": dry_run, "CaId": ca_id}
         if description is not None:
             data.update({"Description": description})
         response = self._call_api(action, json.dumps(data))
@@ -7884,14 +7887,15 @@ class OutscaleNodeDriver(NodeDriver):
 
     def ex_delete_api_access_rule(
         self,
-        api_access_rule_id: str = None,
+        api_access_rule_id: str,
         dry_run: bool = False,
     ):
         """
         Delete an API access rule.
         You cannot delete the last remaining API access rule.
 
-        :param      api_access_rule_id: The id of the targeted rule.
+        :param      api_access_rule_id: The id of the targeted rule
+        (required).
         :type       api_access_rule_id: ``str``
 
         :param      dry_run: If true, checks whether you have the required
@@ -7966,7 +7970,7 @@ class OutscaleNodeDriver(NodeDriver):
 
     def ex_update_api_access_rule(
         self,
-        api_access_rule_id: str = None,
+        api_access_rule_id: str,
         ca_ids: List[str] = None,
         cns: List[str] = None,
         description: str = None,
@@ -7979,7 +7983,8 @@ class OutscaleNodeDriver(NodeDriver):
         for a parameter that is not specified, any previously set value
         is deleted.
 
-        :param      api_access_rule_id: The id of the rule we want to update.
+        :param      api_access_rule_id: The id of the rule we want to update
+        (required).
         :type       api_access_rule_id: ``str``
 
         :param      ca_ids: One or more IDs of Client Certificate Authorities

--- a/libcloud/compute/drivers/outscale.py
+++ b/libcloud/compute/drivers/outscale.py
@@ -7870,6 +7870,11 @@ class OutscaleNodeDriver(NodeDriver):
         :return: a dict containing the API access rule created.
         :rtype: ``dict``
         """
+
+        if not ca_ids and not ip_ranges:
+            raise ValueError(
+                "Either ca_ids or ip_ranges argument must be provided.")
+
         action = "CreateApiAccessRule"
         data = {"DryRun": dry_run}
         if description is not None:

--- a/libcloud/compute/drivers/outscale.py
+++ b/libcloud/compute/drivers/outscale.py
@@ -7831,6 +7831,196 @@ class OutscaleNodeDriver(NodeDriver):
             return response.json()["Ca"]
         return response.json()
 
+    def ex_create_api_access_rule(
+        self,
+        description: str = None,
+        ip_ranges: List[str] = None,
+        ca_ids: List[str] = None,
+        cns: List[str] = None,
+        dry_run: bool = False,
+    ):
+        """
+        Create an API access rule.
+        It is a rule to allow access to the API from your account.
+        You need to specify at least the CaIds or the IpRanges parameter.
+
+        :param      description: The description of the new rule.
+        :type       description: ``str``
+
+        :param      ip_ranges: One or more IP ranges, in CIDR notation
+        (for example, 192.0.2.0/16).
+        :type       ip_ranges: ``List`` of ``str``
+
+        :param      ca_ids: One or more IDs of Client Certificate Authorities
+        (CAs).
+        :type       ca_ids: ``List`` of ``str``
+
+        :param      cns: One or more Client Certificate Common Names (CNs).
+        If this parameter is specified, you must also specify the ca_ids
+        parameter.
+        :type       cns: ``List`` of ``str``
+
+        :param      dry_run: If true, checks whether you have the required
+        permissions to perform the action.
+        :type       dry_run: ``bool``
+
+        :return: a dict containing the API access rule created.
+        :rtype: ``dict``
+        """
+        action = "CreateApiAccessRule"
+        data = {"DryRun": dry_run}
+        if description is not None:
+            data["Description"] = description
+        if ip_ranges is not None:
+            data["IpRanges"] = ip_ranges
+        if ca_ids is not None:
+            data["CaIds"] = ca_ids
+        if cns is not None:
+            data["Cns"] = cns
+        response = self._call_api(action, json.dumps(data))
+        if response.status_code == 200:
+            return response.json()["ApiAccessRule"]
+        return response.json()
+
+    def ex_delete_api_access_rule(
+        self,
+        api_access_rule_id: str = None,
+        dry_run: bool = False,
+    ):
+        """
+        Delete an API access rule.
+        You cannot delete the last remaining API access rule.
+
+        :param      api_access_rule_id: The id of the targeted rule.
+        :type       api_access_rule_id: ``str``
+
+        :param      dry_run: If true, checks whether you have the required
+        permissions to perform the action.
+        :type       dry_run: ``bool``
+
+        :return: true if successfull.
+        :rtype: ``bool`` if successful or  ``dict``
+        """
+        action = "DeleteApiAccessRule"
+        data = {"ApiAccessRuleId": api_access_rule_id, "DryRun": dry_run}
+        response = self._call_api(action, json.dumps(data))
+        if response.status_code == 200:
+            return True
+        return response.json()
+
+    def ex_read_api_access_rules(
+        self,
+        api_access_rules_ids: List[str] = None,
+        ca_ids: List[str] = None,
+        cns: List[str] = None,
+        descriptions: List[str] = None,
+        ip_ranges: List[str] = None,
+        dry_run: bool = False,
+    ):
+        """
+        Read API access rules.
+
+        :param      api_access_rules_ids: The List containing rules ids to
+        filter the request.
+        :type       api_access_rules_ids: ``List`` of ``str``
+
+        :param      ca_ids: The List containing CA ids to filter the request.
+        :type       ca_ids: ``List`` of ``str``
+
+        :param      cns: The List containing cns to filter the request.
+        :type       cns: ``List`` of ``str``
+
+        :param      descriptions: The List containing descriptions to filter
+        the request.
+        :type       descriptions: ``List`` of ``str``
+
+        :param      ip_ranges: The List containing ip ranges in CIDR notation
+        (for example, 192.0.2.0/16) to filter the request.
+        :type       ip_ranges: ``List`` of ``str``
+
+        :param      dry_run: If true, checks whether you have the required
+        permissions to perform the action.
+        :type       dry_run: ``bool``
+
+        :return: a List of API access rules.
+        :rtype: ``List`` of ``dict`` if successfull or  ``dict``
+        """
+
+        action = "ReadApiAccessRules"
+        filters = {}
+        if api_access_rules_ids is not None:
+            filters["ApiAccessRulesIds"] = api_access_rules_ids
+        if ca_ids is not None:
+            filters["CaIds"] = ca_ids
+        if cns is not None:
+            filters["Cns"] = cns
+        if descriptions is not None:
+            filters["Descriptions"] = descriptions
+        if ip_ranges is not None:
+            filters["IpRanges"] = ip_ranges
+        data = {"Filters": filters, "DryRun": dry_run}
+        response = self._call_api(action, json.dumps(data))
+        if response.status_code == 200:
+            return response.json()["ApiAccessRules"]
+        return response.json()
+
+    def ex_update_api_access_rule(
+        self,
+        api_access_rule_id: str = None,
+        ca_ids: List[str] = None,
+        cns: List[str] = None,
+        description: str = None,
+        ip_ranges: List[str] = None,
+        dry_run: bool = False,
+    ):
+        """
+        Update an API access rules.
+        The new rule you specify fully replaces the old rule. Therefore,
+        for a parameter that is not specified, any previously set value
+        is deleted.
+
+        :param      api_access_rule_id: The id of the rule we want to update.
+        :type       api_access_rule_id: ``str``
+
+        :param      ca_ids: One or more IDs of Client Certificate Authorities
+        (CAs).
+        :type       ca_ids: ``List`` of ``str``
+
+        :param      cns: One or more Client Certificate Common Names (CNs).
+        If this parameter is specified, you must also specify the ca_ids
+        parameter.
+        :type       cns: ``List`` of ``str``
+
+        :param      description: The description of the new rule.
+        :type       description: ``str``
+
+        :param      ip_ranges: One or more IP ranges, in CIDR notation
+        (for example, 192.0.2.0/16).
+        :type       ip_ranges: ``List`` of ``str``
+
+        :param      dry_run: If true, checks whether you have the required
+        permissions to perform the action.
+        :type       dry_run: ``bool``
+
+        :return: a List of API access rules.
+        :rtype: ``List`` of ``dict`` if successfull or  ``dict``
+        """
+
+        action = "UpdateApiAccessRule"
+        data = {"DryRun": dry_run, "ApiAccessRuleId": api_access_rule_id}
+        if description is not None:
+            data["Description"] = description
+        if ip_ranges is not None:
+            data["IpRanges"] = ip_ranges
+        if ca_ids is not None:
+            data["CaIds"] = ca_ids
+        if cns is not None:
+            data["Cns"] = cns
+        response = self._call_api(action, json.dumps(data))
+        if response.status_code == 200:
+            return response.json()["ApiAccessRules"]
+        return response.json()
+
     def _get_outscale_endpoint(self, region: str, version: str, action: str):
         return "https://api.{}.{}/api/{}/{}".format(
             region,

--- a/libcloud/compute/drivers/outscale.py
+++ b/libcloud/compute/drivers/outscale.py
@@ -7709,6 +7709,128 @@ class OutscaleNodeDriver(NodeDriver):
             return response.json()["VpnConnections"]
         return response.json()
 
+    def ex_create_certificate_authority(
+        self,
+        ca_perm: str = None,
+        description: str = None,
+        dry_run: bool = False
+    ):
+        """
+        Creates a Client Certificate Authority (CA).
+
+        :param      ca_perm: The CA in PEM format. (required)
+        :type       ca_perm: ``str``
+
+        :param      description: The description of the CA.
+        :type       description: ``bool``
+
+        :param      dry_run: If true, checks whether you have the required
+        permissions to perform the action.
+        :type       dry_run: ``bool``
+        """
+        action = "CreateCa"
+        data = {"DryRun": dry_run}
+        if ca_perm is not None:
+            data.update({"CaPerm": ca_perm})
+        if description is not None:
+            data.update({"Description": description})
+        response = self._call_api(action, json.dumps(data))
+        if response.status_code == 200:
+            return response.json()["Ca"]
+        return response.json()
+
+    def ex_delete_certificate_authority(
+        self,
+        ca_id: str = None,
+        dry_run: bool = False
+    ):
+        """
+        Deletes a specified Client Certificate Authority (CA).
+
+        :param      ca_id: The ID of the CA you want to delete. (required)
+        :type       ca_id: ``str``
+
+        :param      dry_run: If true, checks whether you have the required
+        permissions to perform the action.
+        :type       dry_run: ``bool``
+        """
+        action = "DeleteCa"
+        data = {"DryRun": dry_run}
+        if ca_id is not None:
+            data.update({"CaId": ca_id})
+        response = self._call_api(action, json.dumps(data))
+        if response.status_code == 200:
+            return True
+        return response.json()
+
+    def ex_read_certificate_authorities(
+        self,
+        ca_fingerprints: List[str] = None,
+        ca_ids: List[str] = None,
+        descriptions: List[str] = None,
+        dry_run: bool = False
+    ):
+        """
+        Returns information about one or more of your Client Certificate
+        Authorities (CAs).
+
+        :param      ca_fingerprints: The fingerprints of the CAs.
+        :type       ca_fingerprints: ``list`` of ``str``
+
+        :param      ca_ids: The IDs of the CAs.
+        :type       ca_ids: ``list`` of ``str``
+
+        :param      descriptions: The descriptions of the CAs.
+        :type       descriptions: ``list`` of ``str``
+
+        :param      dry_run: If true, checks whether you have the required
+        permissions to perform the action.
+        :type       dry_run: ``bool``
+        """
+        action = "ReadCas"
+        data = {"DryRun": dry_run, "Filters": {}}
+        if ca_fingerprints is not None:
+            data["Filters"].update({"CaFingerprints": ca_fingerprints})
+        if ca_ids is not None:
+            data["Filters"].update({"CaIds": ca_ids})
+        if descriptions is not None:
+            data["Filters"].update({"Descriptions": descriptions})
+        response = self._call_api(action, json.dumps(data))
+        if response.status_code == 200:
+            return response.json()["Cas"]
+        return response.json()
+
+    def ex_update_certificate_authority(
+        self,
+        ca_id: str = None,
+        description: str = None,
+        dry_run: bool = False
+    ):
+        """
+        Modifies the specified attribute of a Client Certificate Authority
+        (CA).
+
+        :param      ca_id: The ID of the CA. (required)
+        :type       ca_id: ``str``
+
+        :param      description: The description of the CA.
+        :type       description: ``str``
+
+        :param      dry_run: If true, checks whether you have the required
+        permissions to perform the action.
+        :type       dry_run: ``bool``
+        """
+        action = "UpdateCa"
+        data = {"DryRun": dry_run}
+        if ca_id is not None:
+            data.update({"CaId": ca_id})
+        if description is not None:
+            data.update({"Description": description})
+        response = self._call_api(action, json.dumps(data))
+        if response.status_code == 200:
+            return response.json()["Ca"]
+        return response.json()
+
     def _get_outscale_endpoint(self, region: str, version: str, action: str):
         return "https://api.{}.{}/api/{}/{}".format(
             region,


### PR DESCRIPTION
## Make libcloud compliant with the latest Outscale API.

### Description

Added the API Acess Rules and Client Certificate Authority (CA) enpoints.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
