### PR TITLE
Add support for Azure Government to Azure Blobs storage driver

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,19 @@
 ﻿Changelog
 =========
 
+Changes in Apache Libcloud 3.3.2
+--------------------------------
+
+Storage
+~~~~~~~
+
+- [Azure Blobs] Enable the Azure storage driver to be used with
+  Azure Government, Azure China, and Azure Private Link by setting
+  the driver host argument to the endpoint suffix for the environment.
+
+  Reported by Melissa Kersh - @mkcello96
+  (GITHUB-1551)
+
 Changes in Apache Libcloud 3.3.1
 --------------------------------
 

--- a/docs/examples/storage/azure/instantiate_gov.py
+++ b/docs/examples/storage/azure/instantiate_gov.py
@@ -1,0 +1,8 @@
+from libcloud.storage.types import Provider
+from libcloud.storage.providers import get_driver
+
+cls = get_driver(Provider.AZURE_BLOBS)
+
+driver = cls(key='your storage account name',
+             secret='your access key',
+             host='blob.core.usgovcloudapi.net')

--- a/docs/storage/drivers/azure_blobs.rst
+++ b/docs/storage/drivers/azure_blobs.rst
@@ -33,6 +33,19 @@ below.
 .. literalinclude:: /examples/storage/azure/instantiate.py
    :language: python
 
+Connecting to Azure Government
+------------------------------
+
+To target an `Azure Government`_ storage account, you can instantiate the driver
+by setting a custom storage host argument as shown below.
+
+.. literalinclude:: /examples/storage/azure/instantiate_gov.py
+   :language: python
+
+Setting a custom host argument can also be leveraged to customize the blob
+endpoint and connect to a storage account in `Azure China`_ or
+`Azure Private Link`_.
+
 Connecting to self-hosted Azure Storage implementations
 -------------------------------------------------------
 
@@ -51,3 +64,6 @@ Azure Storage implementations such as `Azure Blob Storage on IoT Edge`_.
 .. _`BlockBlobStorage accounts`: https://docs.microsoft.com/en-us/azure/storage/common/storage-account-overview#blockblobstorage-accounts
 .. _`Azurite storage emulator`: https://github.com/Azure/Azurite
 .. _`Azure Blob Storage on IoT Edge`: https://docs.microsoft.com/en-us/azure/iot-edge/how-to-store-data-blob
+.. _`Azure Government`: https://docs.microsoft.com/en-us/azure/azure-government/documentation-government-developer-guide
+.. _`Azure China`: https://docs.microsoft.com/en-us/azure/china/resources-developer-guide
+.. _`Azure Private Link`: https://docs.microsoft.com/en-us/azure/private-link/private-link-overview

--- a/libcloud/common/base.py
+++ b/libcloud/common/base.py
@@ -984,19 +984,6 @@ class BaseDriver(object):
         self.key = key
         self.secret = secret
         self.secure = secure
-        args = [self.key]
-
-        if self.secret is not None:
-            args.append(self.secret)
-
-        args.append(secure)
-
-        if host is not None:
-            args.append(host)
-
-        if port is not None:
-            args.append(port)
-
         self.api_version = api_version
         self.region = region
 
@@ -1005,8 +992,23 @@ class BaseDriver(object):
                             'retry_delay': kwargs.pop('retry_delay', None),
                             'backoff': kwargs.pop('backoff', None),
                             'proxy_url': kwargs.pop('proxy_url', None)})
-        self.connection = self.connectionCls(*args, **conn_kwargs)
 
+        args = [self.key]
+
+        if self.secret is not None:
+            args.append(self.secret)
+
+        args.append(secure)
+
+        host = conn_kwargs.pop('host', None) or host
+
+        if host is not None:
+            args.append(host)
+
+        if port is not None:
+            args.append(port)
+
+        self.connection = self.connectionCls(*args, **conn_kwargs)
         self.connection.driver = self
         self.connection.connect()
 

--- a/libcloud/storage/drivers/azure_blobs.py
+++ b/libcloud/storage/drivers/azure_blobs.py
@@ -177,7 +177,7 @@ class AzureBlobsConnection(AzureConnection):
     implements an auditing proxy or similar, the driver can be instantiated
     with ``host='theaccount.somewhere.tld'`` and ``key=''``.
 
-    :param account_prefix: Optional prefix identifying the sotrage account.
+    :param account_prefix: Optional prefix identifying the storage account.
                            Used when connecting to a custom deployment of the
                            storage service like Azurite or IoT Edge Storage.
     :type account_prefix: ``str``

--- a/libcloud/test/storage/test_azure_blobs.py
+++ b/libcloud/test/storage/test_azure_blobs.py
@@ -935,6 +935,24 @@ class AzureBlobsTests(unittest.TestCase):
         self.assertEqual(host2, 'fakeaccount2.blob.core.windows.net')
         self.assertEqual(host3, 'test.foo.bar.com')
 
+    def test_storage_driver_host_govcloud(self):
+        driver1 = self.driver_type(
+            'fakeaccount1', 'deadbeafcafebabe==',
+            host='blob.core.usgovcloudapi.net')
+        driver2 = self.driver_type(
+            'fakeaccount2', 'deadbeafcafebabe==',
+            host='fakeaccount2.blob.core.usgovcloudapi.net')
+
+        host1 = driver1.connection.host
+        host2 = driver2.connection.host
+        account_prefix_1 = driver1.connection.account_prefix
+        account_prefix_2 = driver2.connection.account_prefix
+
+        self.assertEqual(host1, 'fakeaccount1.blob.core.usgovcloudapi.net')
+        self.assertEqual(host2, 'fakeaccount2.blob.core.usgovcloudapi.net')
+        self.assertIsNone(account_prefix_1)
+        self.assertIsNone(account_prefix_2)
+
 
 class AzuriteBlobsTests(AzureBlobsTests):
     driver_args = STORAGE_AZURITE_BLOBS_PARAMS

--- a/libcloud/test/storage/test_azure_blobs.py
+++ b/libcloud/test/storage/test_azure_blobs.py
@@ -953,6 +953,17 @@ class AzureBlobsTests(unittest.TestCase):
         self.assertIsNone(account_prefix_1)
         self.assertIsNone(account_prefix_2)
 
+    def test_storage_driver_host_azurite(self):
+        driver = self.driver_type(
+            'fakeaccount1', 'deadbeafcafebabe==',
+            host='localhost', port=10000, secure=False)
+
+        host = driver.connection.host
+        account_prefix = driver.connection.account_prefix
+
+        self.assertEqual(host, 'localhost')
+        self.assertEqual(account_prefix, 'fakeaccount1')
+
 
 class AzuriteBlobsTests(AzureBlobsTests):
     driver_args = STORAGE_AZURITE_BLOBS_PARAMS


### PR DESCRIPTION
## Add support for Azure Government to Azure Blobs storage driver

### Description

This pull request adds support to the Azure Blobs storage driver for deployments of Azure Storage that use custom hostnames such as Azure Government, Azure China, and Azure Private Link. To target these deployments, the driver can be initialized as follows:

```py
from libcloud.storage.types import Provider
from libcloud.storage.providers import get_driver

cls = get_driver(Provider.AZURE_BLOBS)

host = 'privatelink.blob.core.windows.net'  # for Azure Private Link
host = 'blob.core.chinacloudapi.cn'  # for Azure China
host = 'blob.core.usgovcloudapi.net'  # for Azure Government

driver = cls(key='your storage account name',
             secret='your access key',
             host=host)
```

The change maintains backwards compatibility with the previous approach of using a custom host argument to target Azurite or IoT Edge Storage by explicitly checking for the Azure China, Azure Government, and Azure Private Link well-known endpoint constants.

Resolves https://github.com/apache/libcloud/issues/1551

### Status

- done, ready for review

### Checklist

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) **[CI passed](https://github.com/apache/libcloud/actions/runs/545677170)**
- [x] Documentation **[Added new docs section](https://github.com/apache/libcloud/blob/505894fa9e2b2776889b673789651ff46734c7d7/docs/storage/drivers/azure_blobs.rst#connecting-to-azure-government)**
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html) **[libcloud-tests passed](https://clewolff.visualstudio.com/libcloud-tests/_build/results?buildId=1589&view=logs&s=ee3800fd-6e81-525f-e564-94108585217d)**
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) **[committer](http://people.apache.org/phonebook.html?uid=clewolff)**
