### PR TITLE
Respect common HTTP headers when uploading Azure Storage blob via stream

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,18 @@
 ﻿Changelog
 =========
 
+Changes in Apache Libcloud 3.3.2
+--------------------------------
+
+Storage
+~~~~~~~
+
+- [Azure Blobs] Respect Content-Encoding, Content-Language and Cache-Control
+  headers when uploading blobs via stream.
+
+  Reported by Veith Röthlingshöfer - @RunOrVeith.
+  (GITHUB-1550)
+
 Changes in Apache Libcloud 3.3.1
 --------------------------------
 

--- a/libcloud/test/storage/test_azure_blobs.py
+++ b/libcloud/test/storage/test_azure_blobs.py
@@ -935,6 +935,23 @@ class AzureBlobsTests(unittest.TestCase):
         self.assertEqual(host2, 'fakeaccount2.blob.core.windows.net')
         self.assertEqual(host3, 'test.foo.bar.com')
 
+    def test_normalize_http_headers(self):
+        driver = self.driver_type('fakeaccount1', 'deadbeafcafebabe==')
+
+        headers = driver._fix_headers({
+            # should be normalized to include x-ms-blob prefix
+            'Content-Encoding': 'gzip',
+            'content-language': 'en-us',
+            # should be passed through
+            'x-foo': 'bar',
+        })
+
+        self.assertEqual(headers, {
+            'x-ms-blob-content-encoding': 'gzip',
+            'x-ms-blob-content-language': 'en-us',
+            'x-foo': 'bar',
+        })
+
 
 class AzuriteBlobsTests(AzureBlobsTests):
     driver_args = STORAGE_AZURITE_BLOBS_PARAMS


### PR DESCRIPTION
## Respect common HTTP headers when uploading Azure Storage blob via stream

### Description

Resolves https://github.com/apache/libcloud/issues/1550

As per the [documentation](https://docs.microsoft.com/en-us/rest/api/storageservices/put-block-list#request-headers), when uploading an object via stream to Azure Storage, common HTTP headers (e.g. `Content-Encoding`) must be provided via an Azure-specific name (e.g. `x-ms-blob-content-encoding`). The driver was previously ignoring user-provided headers when uploading objects via stream and wasn't adapting the header names to their Azure-specific equivalent, which are both issues fixed by this pull request.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) **[CI passed](https://github.com/apache/libcloud/actions/runs/546750410)**
- [x] Documentation **n/a: bugfix**
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html) **[libcloud-tests passed](https://clewolff.visualstudio.com/libcloud-tests/_build/results?buildId=1591&view=logs&j=1a900d4b-8046-5265-156b-217ea8bd79e8)**
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) **[committer](http://people.apache.org/phonebook.html?uid=clewolff)**