### PR TITLE
Updates on CloudSigma driver

### DIFF
--- a/libcloud/common/cloudsigma.py
+++ b/libcloud/common/cloudsigma.py
@@ -18,7 +18,9 @@ __all__ = [
     'API_ENDPOINTS_1_0',
     'API_ENDPOINTS_2_0',
     'API_VERSIONS',
-    'INSTANCE_TYPES'
+    'INSTANCE_TYPES',
+    'MAX_VIRTIO_CONTROLLERS',
+    'MAX_VIRTIO_UNITS'
 ]
 
 # API end-points
@@ -37,7 +39,7 @@ API_ENDPOINTS_1_0 = {
 
 API_ENDPOINTS_2_0 = {
     'zrh': {
-        'name': 'Zurich',
+        'name': 'Zurich, Switzerland',
         'country': 'Switzerland',
         'host': 'zrh.cloudsigma.com'
     },
@@ -45,11 +47,6 @@ API_ENDPOINTS_2_0 = {
         'name': 'San Jose, CA',
         'country': 'United States',
         'host': 'sjc.cloudsigma.com'
-    },
-    'mia': {
-        'name': 'Miami, FL',
-        'country': 'United States',
-        'host': 'mia.cloudsigma.com'
     },
     'wdc': {
         'name': 'Washington, DC',
@@ -71,11 +68,51 @@ API_ENDPOINTS_2_0 = {
         'country': 'Philippines',
         'host': 'mnl.cloudsigma.com'
     },
-    'waw': {
-        'name': 'Warsaw, Poland',
-        'country': 'Poland',
-        'host': 'waw.cloudsigma.com'
-    }
+    'fra': {
+        'name': 'Frankfurt, Germany',
+        'country': 'Germany',
+        'host': 'fra.cloudsigma.com'
+    },
+    'mel': {
+        'name': 'Melbourne, Australia',
+        'country': 'Australia',
+        'host': 'mel.cloudsigma.com'
+    },
+    'dbl': {
+        'name': 'Dublin, Ireland',
+        'country': 'Ireland',
+        'host': 'ec.servecentric.com'
+    },
+    'tyo': {
+        'name': 'Tokyo, Japan',
+        'country': 'Japan',
+        'host': 'tyo.cloudsigma.com'
+    },
+    'crk': {
+        'name': 'Clark, Philippines',
+        'country': 'Philippines',
+        'host': 'crk.cloudsigma.com'
+    },
+    'mnl2': {
+        'name': 'Manila-2, Philippines',
+        'country': 'Philippines',
+        'host': 'mnl2.cloudsigma.com'
+    },
+    'ruh': {
+        'name': 'Riyadh, Saudi Arabia',
+        'country': 'Saudi Arabia',
+        'host': 'ruh.cloudsigma.com'
+    },
+    'bdn': {
+        'name': 'Boden, Sweden',
+        'country': 'Sweden',
+        'host': 'cloud.hydro66.com'
+    },
+    'gva': {
+        'name': 'Geneva, Switzerland',
+        'country': 'Switzerland',
+        'host': 'gva.cloudsigma.com'
+    },
 }
 
 DEFAULT_REGION = 'zrh'
@@ -92,79 +129,184 @@ DEFAULT_API_VERSION = '2.0'
 # Basically for CPU any value between 0.5 GHz and 20.0 GHz should work,
 # 500 MB to 32000 MB for ram
 # and 1 GB to 1024 GB for hard drive size.
-# Plans in this file are based on examples listed on http://www.cloudsigma
-# .com/en/pricing/price-schedules
+# Plans in this file are based on examples listed on https://cloudsigma
+# .com/pricing/
 INSTANCE_TYPES = [
     {
-        'id': 'micro-regular',
-        'name': 'Micro/Regular instance',
-        'cpu': 1100,
-        'memory': 640,
-        'disk': 10 + 3,
-        'bandwidth': None,
-    },
-    {
-        'id': 'micro-high-cpu',
-        'name': 'Micro/High CPU instance',
-        'cpu': 2200,
-        'memory': 640,
-        'disk': 80,
-        'bandwidth': None,
-    },
-    {
-        'id': 'standard-small',
-        'name': 'Standard/Small instance',
-        'cpu': 1100,
-        'memory': 1741,
+        'id': 'small-1',
+        'name': 'small-1, 1 CPUs, 512MB RAM, 50GB disk',
+        'cpu': 1,
+        'memory': 512,
         'disk': 50,
         'bandwidth': None,
     },
     {
-        'id': 'standard-large',
-        'name': 'Standard/Large instance',
-        'cpu': 4400,
-        'memory': 7680,
-        'disk': 250,
+        'id': 'small-2',
+        'name': 'small-2, 1 CPUs, 1024MB RAM, 50GB disk',
+        'cpu': 1,
+        'memory': 1024,
+        'disk': 50,
         'bandwidth': None,
     },
     {
-        'id': 'standard-extra-large',
-        'name': 'Standard/Extra Large instance',
-        'cpu': 8800,
-        'memory': 15360,
-        'disk': 500,
+        'id': 'small-3',
+        'name': 'small-3, 1 CPUs, 2048MB RAM, 50GB disk',
+        'cpu': 1,
+        'memory': 2048,
+        'disk': 50,
         'bandwidth': None,
     },
     {
-        'id': 'high-memory-extra-large',
-        'name': 'High Memory/Extra Large instance',
-        'cpu': 7150,
-        'memory': 17510,
-        'disk': 250,
+        'id': 'medium-1',
+        'name': 'medium-1, 2 CPUs, 2048MB RAM, 50GB disk',
+        'cpu': 2,
+        'memory': 2048,
+        'disk': 50,
         'bandwidth': None,
     },
     {
-        'id': 'high-memory-double-extra-large',
-        'name': 'High Memory/Double Extra Large instance',
-        'cpu': 14300,
+        'id': 'medium-2',
+        'name': 'medium-2, 2 CPUs, 4096MB RAM, 60GB disk',
+        'cpu': 2,
+        'memory': 4096,
+        'disk': 60,
+        'bandwidth': None,
+    },
+    {
+        'id': 'medium-3',
+        'name': 'medium-3, 4 CPUs, 8192MB RAM, 80GB disk',
+        'cpu': 4,
+        'memory': 8192,
+        'disk': 80,
+        'bandwidth': None,
+    },
+    {
+        'id': 'large-1',
+        'name': 'large-1, 8 CPUs, 16384MB RAM, 160GB disk',
+        'cpu': 8,
+        'memory': 16384,
+        'disk': 160,
+        'bandwidth': None,
+    },
+    {
+        'id': 'large-2',
+        'name': 'large-2, 12 CPUs, 32768MB RAM, 320GB disk',
+        'cpu': 12,
         'memory': 32768,
-        'disk': 500,
+        'disk': 320,
         'bandwidth': None,
     },
     {
-        'id': 'high-cpu-medium',
-        'name': 'High CPU/Medium instance',
-        'cpu': 5500,
-        'memory': 1741,
-        'disk': 150,
+        'id': 'large-3',
+        'name': 'large-3, 16 CPUs, 49152MB RAM, 480GB disk',
+        'cpu': 16,
+        'memory': 49152,
+        'disk': 480,
         'bandwidth': None,
     },
     {
-        'id': 'high-cpu-extra-large',
-        'name': 'High CPU/Extra Large instance',
-        'cpu': 20000,
-        'memory': 7168,
-        'disk': 500,
+        'id': 'xlarge',
+        'name': 'xlarge, 20 CPUs, 65536MB RAM, 640GB disk',
+        'cpu': 20,
+        'memory': 65536,
+        'disk': 640,
         'bandwidth': None,
-    }
+    },
 ]
+
+# mapping between cpus, ram, disk to example size attributes
+SPECS_TO_SIZE = {
+    (1, 512, 50): {
+        'id': 'small-1',
+        'name': 'small-1, 1 CPUs, 512MB RAM, 50GB disk',
+        'cpu': 1,
+        'ram': 512,
+        'disk': 50,
+        'bandwidth': None,
+        'price': None,
+    },
+    (1, 1024, 50): {
+        'id': 'small-2',
+        'name': 'small-2, 1 CPUs, 1024MB RAM, 50GB disk',
+        'cpu': 1,
+        'ram': 1024,
+        'disk': 50,
+        'bandwidth': None,
+        'price': None,
+    },
+    (1, 2048, 50): {
+        'id': 'small-3',
+        'name': 'small-3, 1 CPUs, 2048MB RAM, 50GB disk',
+        'cpu': 1,
+        'ram': 2048,
+        'disk': 50,
+        'bandwidth': None,
+        'price': None,
+    },
+    (2, 2048, 50): {
+        'id': 'medium-1',
+        'name': 'medium-1, 2 CPUs, 2048MB RAM, 50GB disk',
+        'cpu': 2,
+        'ram': 2048,
+        'disk': 50,
+        'bandwidth': None,
+        'price': None,
+    },
+    (2, 4096, 60): {
+        'id': 'medium-2',
+        'name': 'medium-2, 2 CPUs, 4096MB RAM, 60GB disk',
+        'cpu': 2,
+        'ram': 4096,
+        'disk': 60,
+        'bandwidth': None,
+        'price': None,
+    },
+    (4, 8192, 80): {
+        'id': 'medium-3',
+        'name': 'medium-3, 4 CPUs, 8192MB RAM, 80GB disk',
+        'cpu': 4,
+        'ram': 8192,
+        'disk': 80,
+        'bandwidth': None,
+        'price': None,
+    },
+    (8, 16384, 160): {
+        'id': 'large-1',
+        'name': 'large-1, 8 CPUs, 16384MB RAM, 160GB disk',
+        'cpu': 8,
+        'ram': 16384,
+        'disk': 160,
+        'bandwidth': None,
+        'price': None,
+    },
+    (12, 32768, 320): {
+        'id': 'large-2',
+        'name': 'large-2, 12 CPUs, 32768MB RAM, 320GB disk',
+        'cpu': 12,
+        'ram': 32768,
+        'disk': 320,
+        'bandwidth': None,
+        'price': None,
+    },
+    (16, 49152, 480): {
+        'id': 'large-3',
+        'name': 'large-3, 16 CPUs, 49152MB RAM, 480GB disk',
+        'cpu': 16,
+        'ram': 49152,
+        'disk': 480,
+        'bandwidth': None,
+        'price': None,
+    },
+    (20, 65536, 640): {
+        'id': 'xlarge',
+        'name': 'xlarge, 20 CPUs, 65536MB RAM, 640GB disk',
+        'cpu': 20,
+        'ram': 65536,
+        'disk': 640,
+        'bandwidth': None,
+        'price': None,
+    },
+}
+
+MAX_VIRTIO_CONTROLLERS = 203
+MAX_VIRTIO_UNITS = 4

--- a/libcloud/test/compute/fixtures/cloudsigma_2_0/drives_resize.json
+++ b/libcloud/test/compute/fixtures/cloudsigma_2_0/drives_resize.json
@@ -18,7 +18,7 @@
                 "snapshots_allocated_size": 0,
                 "storage_type": null
             },
-            "size": 1164967936,
+            "size": 10737418240,
             "snapshots": [],
             "status": "creating",
             "storage_type": null,

--- a/libcloud/test/compute/fixtures/cloudsigma_2_0/keypairs_get.json
+++ b/libcloud/test/compute/fixtures/cloudsigma_2_0/keypairs_get.json
@@ -1,0 +1,12 @@
+{
+    "fingerprint": "8c:71:a2:f0:bc:a4:45:66:a8:59:77:6d:80:d5:a0:89",
+    "grantees": [],
+    "meta": {},
+    "name": "ala",
+    "permissions": [],
+    "private_key": "-----BEGIN RSA PRIVATE KEY-----\nMIIEqQIBAAKCAQEAvROcpJ/0T5iZUzfRydsJI4zCbuQAfGH3Bl/biggPY1atLqzf\niz6lctY8wsz2sYts9OQomtCB/xtMPfUjHZpLg1EP4/hfP1NCWtsIbIiDYKrzNEFg\nApSO1AkqBZ8tVL2gpPUuSdaK5P3lPjkbt43dgnThIyMvNoi0g7ngC6L6s960JvBq\nuamOvd8wVaW/VpbyZrKqRwvmsMH1pGErhSAeErImOdwM8wtCddLS3O4nxfts06py\nEcGhupvH8lph9q+jKJxpg7whUkOJyZoMN1XgDvtRFbz9PvlxqP0SOecEHP+4yCOg\nDcJa69LSFFxmlSog9BitCv5qRFwrvKGsMYcesQIDAQABAoIBAQCYBufhend/dIx7\n3BsDuemMOwavEQbO/BoadwLX5okw76WKLRgFJxby0g3C9/i3Ywr1kWqQqGyOCY3x\nF2TnzYNAD/K985vqF/D3irwoQE+ab3njn1kqWfbJyKCQKp/RTjOXz0gruKSvYPJt\naI+/tALSfVX04bp5l8vFSrQ5xw7bhiiFifATuDStVLSzzmEli6Pbne4mcKIXiReu\nK1OlSKPF9SbCxCcEvEhUhQqs7U/N+sEYmUSQ/q8rNdolWQD0c/EGn2RF0siNolxp\nylo5c7E/LvwgTW6DLYaEZDgORnYHEwiaG7YxJAuFFPoQNFIjoGEF5wKOGL/kKtVr\npyriY/k9AoIAgQDRKEf+B+SLO/P/rPP7CCCIh4tR9uXl6hbnEp40sx5AomZmIwfy\nZGRp+iIN3YhM2XQ96fb47Lgc4AsDUHKt+9ASqJWWn0f06sbaaVsTfKpxVuI1kPsh\nGVpuOqwQCnXFyTvvirrdTlAw32hOzl1VVL0bL57MsAkpmjHnqsEqYTpIhwKCAIEA\n52wIL3RMT6bGjfx/PMsyTOa9AFSLzsjvoOt1HjyC0v7fhZ3vGfwJSnEQXf7R31um\njA0yoSjyX7uyXYRvUlL8aibqoKw19U0WmwAKj9VCOdf7IFnd6WqcisZACq4IjcZU\nTE6ev3MqxAbdmz4dVPvz4GvqseQ39bktmIHEVkH3hQcCggCAKOx/wZWbwx507GbT\nyh9Z9jzHJr9vViAKYSYEbH1LgwwDiyJ5kJTSDOZTOXFKFPdLRj38A9KVZ5jyrrBT\n7/TgTnZL5o+9zY8OX3fTySlQVCLS2fZHHL/QMNcsCWtyhcONBZ6YV2rWR+m+iATa\nwDJ3WdVkddpPwKMZ9qEzcG5bsAsCggCBANUJBDf7DUy9sEaAy/iA7ZsRRaeKLPF8\n0+sFFdlxxtTJP6bXDoaTF1Jp5rFApJ7C1fxTIeptsUEjnjysb3YPYsGtdYvXPAzG\nnCqvzQk/PinVgx3y3G/FbrnpaobqUoGAs5VTQpvnPtUZpOMGOSZEkepkLbb46fLQ\nNwMPYlgtfdf9AoIAgEEbKzsfgWN72TIdSO7ZsYCdpy4vq9EqNMIYyplY4ue1Ogn+\nGlN6UM60S/+MF0uu+KKa3KBjFD+kZCyM90IESw9rshzRceaXtEetk8Z5kOIKGznt\noyCsfrxJbKn3qbH+zM0HDVEfGCiMmIpB2l/DShQjCRGyPAL7OG0GEDw9uQI6\n-----END RSA PRIVATE KEY-----\n",
+    "public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC9E5ykn/RPmJlTN9HJ2wkjjMJu5AB8YfcGX9uKCA9jVq0urN+LPqVy1jzCzPaxi2z05Cia0IH/G0w99SMdmkuDUQ/j+F8/U0Ja2whsiINgqvM0QWAClI7UCSoFny1UvaCk9S5J1ork/eU+ORu3jd2CdOEjIy82iLSDueALovqz3rQm8Gq5qY693zBVpb9WlvJmsqpHC+awwfWkYSuFIB4SsiY53AzzC0J10tLc7ifF+2zTqnIRwaG6m8fyWmH2r6MonGmDvCFSQ4nJmgw3VeAO+1EVvP0++XGo/RI55wQc/7jII6ANwlrr0tIUXGaVKiD0GK0K/mpEXCu8oawxhx6x",
+    "resource_uri": "/api/2.0/keypairs/186106ac-afb5-40e5-a0de-6f0feba5a3d5/",
+    "tags": [],
+    "uuid": "186106ac-afb5-40e5-a0de-6f0feba5a3d5"
+}

--- a/libcloud/test/compute/fixtures/cloudsigma_2_0/keypairs_import.json
+++ b/libcloud/test/compute/fixtures/cloudsigma_2_0/keypairs_import.json
@@ -1,0 +1,16 @@
+{
+    "objects": [
+        {
+            "fingerprint": "e8:ee:43:72:38:09:6d:1e:8e:46:9e:76:80:a3:0a:01",
+            "grantees": [],
+            "meta": {},
+            "name": "test_key",
+            "permissions": [],
+            "private_key": null,
+            "public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC9E5ykn/RPmJlTN9HJ2wkjjMJu5AB8YfcGX9uKCA9jVq0urN+LPqVy1jzCzPaxi2z05Cia0IH/G0w99SMdmkuDUQ/j+F8/U0Ja2whsiINgqvM0QWAClI7UCSoFny1UvaCk9S5J1ork/eU+ORu3jd2CdOEjIy82iLSDueALovqz3rQm8Gq5qY693zBVpb9WlvJmsqpHC+awwfWkYSuFIB4SsiY53AzzC0J10tLc7ifF+2zTqnIRwaG6m8fyWmH2r6MonGmDvCFSQ4nJmgw3VeAO+1EVvP0++XGo/RI55wQc/7jII6ANwlrr0tIUXGaVKiD0GK0K/mpEXCu8oawxhx6x",
+            "resource_uri": "/api/2.0/keypairs/6d7db550-d1c5-4e3b-9c0a-e83f6a2b8244/",
+            "tags": [],
+            "uuid": "6d7db550-d1c5-4e3b-9c0a-e83f6a2b8244"
+        }
+    ]
+}

--- a/libcloud/test/compute/fixtures/cloudsigma_2_0/keypairs_list.json
+++ b/libcloud/test/compute/fixtures/cloudsigma_2_0/keypairs_list.json
@@ -1,0 +1,33 @@
+{
+    "meta": {
+        "limit": 0,
+        "offset": 0,
+        "total_count": 2
+    },
+    "objects": [
+        {
+            "fingerprint": "8c:71:a2:f0:bc:a4:45:66:a8:59:77:6d:80:d5:a0:89",
+            "grantees": [],
+            "meta": {},
+            "name": "ala",
+            "permissions": [],
+            "private_key": "-----BEGIN RSA PRIVATE KEY-----\nMIIEqQIBAAKCAQEAvROcpJ/0T5iZUzfRydsJI4zCbuQAfGH3Bl/biggPY1atLqzf\niz6lctY8wsz2sYts9OQomtCB/xtMPfUjHZpLg1EP4/hfP1NCWtsIbIiDYKrzNEFg\nApSO1AkqBZ8tVL2gpPUuSdaK5P3lPjkbt43dgnThIyMvNoi0g7ngC6L6s960JvBq\nuamOvd8wVaW/VpbyZrKqRwvmsMH1pGErhSAeErImOdwM8wtCddLS3O4nxfts06py\nEcGhupvH8lph9q+jKJxpg7whUkOJyZoMN1XgDvtRFbz9PvlxqP0SOecEHP+4yCOg\nDcJa69LSFFxmlSog9BitCv5qRFwrvKGsMYcesQIDAQABAoIBAQCYBufhend/dIx7\n3BsDuemMOwavEQbO/BoadwLX5okw76WKLRgFJxby0g3C9/i3Ywr1kWqQqGyOCY3x\nF2TnzYNAD/K985vqF/D3irwoQE+ab3njn1kqWfbJyKCQKp/RTjOXz0gruKSvYPJt\naI+/tALSfVX04bp5l8vFSrQ5xw7bhiiFifATuDStVLSzzmEli6Pbne4mcKIXiReu\nK1OlSKPF9SbCxCcEvEhUhQqs7U/N+sEYmUSQ/q8rNdolWQD0c/EGn2RF0siNolxp\nylo5c7E/LvwgTW6DLYaEZDgORnYHEwiaG7YxJAuFFPoQNFIjoGEF5wKOGL/kKtVr\npyriY/k9AoIAgQDRKEf+B+SLO/P/rPP7CCCIh4tR9uXl6hbnEp40sx5AomZmIwfy\nZGRp+iIN3YhM2XQ96fb47Lgc4AsDUHKt+9ASqJWWn0f06sbaaVsTfKpxVuI1kPsh\nGVpuOqwQCnXFyTvvirrdTlAw32hOzl1VVL0bL57MsAkpmjHnqsEqYTpIhwKCAIEA\n52wIL3RMT6bGjfx/PMsyTOa9AFSLzsjvoOt1HjyC0v7fhZ3vGfwJSnEQXf7R31um\njA0yoSjyX7uyXYRvUlL8aibqoKw19U0WmwAKj9VCOdf7IFnd6WqcisZACq4IjcZU\nTE6ev3MqxAbdmz4dVPvz4GvqseQ39bktmIHEVkH3hQcCggCAKOx/wZWbwx507GbT\nyh9Z9jzHJr9vViAKYSYEbH1LgwwDiyJ5kJTSDOZTOXFKFPdLRj38A9KVZ5jyrrBT\n7/TgTnZL5o+9zY8OX3fTySlQVCLS2fZHHL/QMNcsCWtyhcONBZ6YV2rWR+m+iATa\nwDJ3WdVkddpPwKMZ9qEzcG5bsAsCggCBANUJBDf7DUy9sEaAy/iA7ZsRRaeKLPF8\n0+sFFdlxxtTJP6bXDoaTF1Jp5rFApJ7C1fxTIeptsUEjnjysb3YPYsGtdYvXPAzG\nnCqvzQk/PinVgx3y3G/FbrnpaobqUoGAs5VTQpvnPtUZpOMGOSZEkepkLbb46fLQ\nNwMPYlgtfdf9AoIAgEEbKzsfgWN72TIdSO7ZsYCdpy4vq9EqNMIYyplY4ue1Ogn+\nGlN6UM60S/+MF0uu+KKa3KBjFD+kZCyM90IESw9rshzRceaXtEetk8Z5kOIKGznt\noyCsfrxJbKn3qbH+zM0HDVEfGCiMmIpB2l/DShQjCRGyPAL7OG0GEDw9uQI6\n-----END RSA PRIVATE KEY-----\n",
+            "public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC9E5ykn/RPmJlTN9HJ2wkjjMJu5AB8YfcGX9uKCA9jVq0urN+LPqVy1jzCzPaxi2z05Cia0IH/G0w99SMdmkuDUQ/j+F8/U0Ja2whsiINgqvM0QWAClI7UCSoFny1UvaCk9S5J1ork/eU+ORu3jd2CdOEjIy82iLSDueALovqz3rQm8Gq5qY693zBVpb9WlvJmsqpHC+awwfWkYSuFIB4SsiY53AzzC0J10tLc7ifF+2zTqnIRwaG6m8fyWmH2r6MonGmDvCFSQ4nJmgw3VeAO+1EVvP0++XGo/RI55wQc/7jII6ANwlrr0tIUXGaVKiD0GK0K/mpEXCu8oawxhx6x",
+            "resource_uri": "/api/2.0/keypairs/186106ac-afb5-40e5-a0de-6f0feba5a3d5/",
+            "tags": [],
+            "uuid": "186106ac-afb5-40e5-a0de-6f0feba5a3d5"
+        },
+        {
+            "fingerprint": "99:1e:71:ea:d1:43:80:55:14:ca:27:5c:64:69:3b:10",
+            "grantees": [],
+            "meta": {},
+            "name": "test_name",
+            "permissions": [],
+            "private_key": "-----BEGIN RSA PRIVATE KEY-----\nMIIEpwIBAAKCAQEAs4068mFSGTm025oanVSpityZji/2S3A0jRJW1ku47cd+pRBl\nj9k2c2zC4zPBL2EeY8RNMrN/RqLIBU0LsH9LZ6m7QeFVwg2H0SWdh4joFzzcLRkk\n8shvx54l26Ahac1Owh8yERnyum1mbo4VIpJjBUx2Xd6HukXDIvBbW/fxe3KO7rML\nNStkxACSuRmGX+UptMc1M0B3wdpHmGEsLiJn7Rs1CM8gQS6iI88Eywf+usdaHMzf\n8w2sjC7wmlKfYNKUwnQoUCMhwo646JCdE672584OXdmG+aqO9rNcxhbtiViojLrk\ncbLtsHIdn4lUvU5dOx/iUL+H5vRvdHwTpHZaYwIDAQABAoIBAAadFyTCbPG87GqC\nXKSa77vLsGRKY/oXYfgoSsaN93vas1GFLxiDWbwar3sK9vy1yRbHrkhF0FRbvp5j\nXiDcL3zcBafBkxUYxn3vssPBSTtB5KJMoM3IkEV8D8ztMw3goBwKZh+3Ive2++Tq\nmuCxH7CcRmfiwIEd/LgWvma+1UhEuisw2y9F+m9Xl4TRwt34utyyVcjKDPH146W9\ne2ZyFwAcvDOTA8oI+txgA57m284QqHo04YHZdbPN3ovPBNwpfKCpNjneab91fTXX\nX48RY7O1MpDdvbE4l3ELptJq/E74xRsmsZziwRVAV0X6Eb6B2s/0xvKG2/+eDZz7\n1c/gG/ECggCBAMx6111Xtptw93dNZpYBHGNoulh+jn9p8RLIrbpOCncZ0v7EMdV1\n8TYgEDQ0n5TuUx501jWKTNbvoXyTUsAUkvA7VyyH2o8UTtqPgRi8ShB+DePZmRt8\nCwHzjUo86N4BnD6rcfFlFvQMzHRcAmvLrkMtkImgQHFHHh/JjMDjweYdAoIAgQDg\nyn8qWgueIPphlLW6vP9oL+01dHKU3oDlhtUME6/cOwZtzex4tRmx3NbIN/lpfRS7\ndVczIjwcGwHbWi/yeS0bSTK8QEMZYBEi7Qqzzdr0uCF9OjKTDPhZTKFQdeZLjtU4\neFGQeBpjQzRYojEKZNYL3NJF4v7tNw5i28aEM6tafwKCAIB17RJvfrqNguT1JOpY\n8GMS4b82ciZ0TQD/OEUZAREAByCsVTH4TYDDGlK+COtP1PKSygcP8abG/oQ/eCdt\nJ3Bmo5Ju2BqwEaI4YjKttUlxoYEZOtEWDL+8bF27xsz13C/j5LRd51MJhKgVI0sy\nJ9FkZM7K0GTZ743r/yzxwWh98QKCAIBTQKv4M4E5/1y75yenEXhGTfm8YnRNTlrO\npzEgV+o51mJ7KFj8G5Z4mSGy5Ygp2XlkNAEnnvZEMnxtkOlRFC/wexufPO2c6Edw\nd/oOvZ7qI4fDqVoxvAv+hrL36bJxKWUulOEgcFrViH5KlUc0YkQkAJSf7YIcuNdL\nJbpQHBLKYQKCAIBj9rEmDdnGqoseRMLZPXduUHdv6bXhmsw9jVIlB088sg19ZSW/\nng4UvesHB3vSylZIEYhEdnIBqlc84XeXEMRSYVZ9x+RMDP5jJ44Uq52iGYarIhwg\nW8m4q0JmhnPM0M3fRQxbIXOaUQvDgjGuLlzDCY9JjiEfyTgMJATNKK2O4Q==\n-----END RSA PRIVATE KEY-----\n",
+            "public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCzjTryYVIZObTbmhqdVKmK3JmOL/ZLcDSNElbWS7jtx36lEGWP2TZzbMLjM8EvYR5jxE0ys39GosgFTQuwf0tnqbtB4VXCDYfRJZ2HiOgXPNwtGSTyyG/HniXboCFpzU7CHzIRGfK6bWZujhUikmMFTHZd3oe6RcMi8Ftb9/F7co7usws1K2TEAJK5GYZf5Sm0xzUzQHfB2keYYSwuImftGzUIzyBBLqIjzwTLB/66x1oczN/zDayMLvCaUp9g0pTCdChQIyHCjrjokJ0Trvbnzg5d2Yb5qo72s1zGFu2JWKiMuuRxsu2wch2fiVS9Tl07H+JQv4fm9G90fBOkdlpj",
+            "resource_uri": "/api/2.0/keypairs/b4fa47cf-f929-4dde-b77a-ea1d326862bd/",
+            "tags": [],
+            "uuid": "b4fa47cf-f929-4dde-b77a-ea1d326862bd"
+        }
+    ]
+}

--- a/libcloud/test/compute/fixtures/cloudsigma_2_0/libdrives.json
+++ b/libcloud/test/compute/fixtures/cloudsigma_2_0/libdrives.json
@@ -26,7 +26,7 @@
             "owner": null,
             "paid": false,
             "resource_uri": "/api/2.0/libdrives/6eca8d96-44bc-4637-af97-77ccd7ba4144/",
-            "size": 1000000000,
+            "size": 1073741824,
             "status": "unmounted",
             "storage_type": null,
             "tags": [],

--- a/libcloud/test/compute/fixtures/cloudsigma_2_0/servers_clone.json
+++ b/libcloud/test/compute/fixtures/cloudsigma_2_0/servers_clone.json
@@ -9,8 +9,8 @@
             "dev_channel": "0:0",
             "device": "ide",
             "drive": {
-                "resource_uri": "/api/2.0/drives/f1e42abe-f7db-4dcc-b37e-e53aca7a3ba9/",
-                "uuid": "f1e42abe-f7db-4dcc-b37e-e53aca7a3ba9"
+                "resource_uri": "/api/2.0/drives/b02311e2-a83c-4c12-af10-b30d51c86913/",
+                "uuid": "b02311e2-a83c-4c12-af10-b30d51c86913"
             }
         }
     ],

--- a/libcloud/test/compute/fixtures/cloudsigma_2_0/servers_create_with_vlan.json
+++ b/libcloud/test/compute/fixtures/cloudsigma_2_0/servers_create_with_vlan.json
@@ -11,8 +11,8 @@
                     "dev_channel": "0:0",
                     "device": "ide",
                     "drive": {
-                        "resource_uri": "/api/2.0/drives/7c0efbb2-b1e8-4e77-9d72-9f9f9d75ae7b/",
-                        "uuid": "7c0efbb2-b1e8-4e77-9d72-9f9f9d75ae7b"
+                        "resource_uri": "/api/2.0/drives/b02311e2-a83c-4c12-af10-b30d51c86913/",
+                        "uuid": "b02311e2-a83c-4c12-af10-b30d51c86913"
                     },
                     "runtime": null
                 }

--- a/libcloud/test/compute/fixtures/cloudsigma_2_0/servers_detail_mixed_state.json
+++ b/libcloud/test/compute/fixtures/cloudsigma_2_0/servers_detail_mixed_state.json
@@ -117,8 +117,8 @@
                     "dev_channel": "0:0",
                     "device": "ide",
                     "drive": {
-                        "resource_uri": "/api/2.0/drives/3f74acec-ba3c-4efd-ab9e-5d95a4c5fca9/",
-                        "uuid": "3f74acec-ba3c-4efd-ab9e-5d95a4c5fca9"
+                        "resource_uri": "/api/2.0/drives/b02311e2-a83c-4c12-af10-b30d51c86913/",
+                        "uuid": "b02311e2-a83c-4c12-af10-b30d51c86913"
                     }
                 }
             ],

--- a/libcloud/test/compute/fixtures/cloudsigma_2_0/servers_get.json
+++ b/libcloud/test/compute/fixtures/cloudsigma_2_0/servers_get.json
@@ -1,0 +1,108 @@
+{
+    "allocation_pool": null,
+    "auto_start": false,
+    "context": true,
+    "cpu": 1000,
+    "cpu_model": null,
+    "cpu_type": "intel",
+    "cpus_instead_of_cores": true,
+    "drives": [
+        {
+            "boot_order": 1,
+            "dev_channel": "0:0",
+            "device": "virtio",
+            "drive": {
+                "resource_uri": "/api/2.0/drives/9d1d2cf3-08c1-462f-8485-f4b073560809/",
+                "uuid": "9d1d2cf3-08c1-462f-8485-f4b073560809"
+            },
+            "runtime": null
+        }
+    ],
+    "enable_numa": true,
+    "grantees": [],
+    "hv_relaxed": false,
+    "hv_tsc": false,
+    "hypervisor": "kvm",
+    "jobs": [],
+    "mem": 536870912,
+    "meta": {
+        "description": "",
+        "optimize_for": "linux_vm",
+        "ssh_public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC9E5ykn/RPmJlTN9HJ2wkjjMJu5AB8YfcGX9uKCA9jVq0urN+LPqVy1jzCzPaxi2z05Cia0IH/G0w99SMdmkuDUQ/j+F8/U0Ja2whsiINgqvM0QWAClI7UCSoFny1UvaCk9S5J1ork/eU+ORu3jd2CdOEjIy82iLSDueALovqz3rQm8Gq5qY693zBVpb9WlvJmsqpHC+awwfWkYSuFIB4SsiY53AzzC0J10tLc7ifF+2zTqnIRwaG6m8fyWmH2r6MonGmDvCFSQ4nJmgw3VeAO+1EVvP0++XGo/RI55wQc/7jII6ANwlrr0tIUXGaVKiD0GK0K/mpEXCu8oawxhx6x"
+    },
+    "name": "test_server",
+    "nics": [
+        {
+            "boot_order": null,
+            "firewall_policy": null,
+            "ip_v4_conf": {
+                "conf": "dhcp",
+                "ip": null
+            },
+            "ip_v6_conf": null,
+            "mac": "22:61:ce:67:cd:09",
+            "model": "virtio",
+            "runtime": {
+                "interface_type": "public",
+                "io": {
+                    "bytes_recv": 0,
+                    "bytes_sent": 0,
+                    "packets_recv": 0,
+                    "packets_sent": 0
+                },
+                "ip_v4": {
+                    "resource_uri": "/api/2.0/ips/162.213.38.202/",
+                    "uuid": "162.213.38.202"
+                },
+                "ip_v6": null,
+                "rx_foreign": 0,
+                "rx_local": 0,
+                "tx_foreign": 0,
+                "tx_local": 0
+            },
+            "vlan": null
+        }
+    ],
+    "owner": {
+        "resource_uri": "/api/2.0/user/69fcfc03-d635-4f99-a8b3-e1b73637cb5d/",
+        "uuid": "69fcfc03-d635-4f99-a8b3-e1b73637cb5d"
+    },
+    "permissions": [],
+    "pubkeys": [
+        {
+            "resource_uri": "/api/2.0/pubkeys/186106ac-afb5-40e5-a0de-6f0feba5a3d5/",
+            "uuid": "186106ac-afb5-40e5-a0de-6f0feba5a3d5"
+        }
+    ],
+    "requirements": [],
+    "resource_uri": "/api/2.0/servers/3df825cb-9c1b-470d-acbd-03e1a966c046/",
+    "runtime": {
+        "active_since": "2021-03-01T11:14:30+00:00",
+        "nics": [
+            {
+                "interface_type": "public",
+                "io": {
+                    "bytes_recv": 0,
+                    "bytes_sent": 0,
+                    "packets_recv": 0,
+                    "packets_sent": 0
+                },
+                "ip_v4": {
+                    "resource_uri": "/api/2.0/ips/162.213.38.202/",
+                    "uuid": "162.213.38.202"
+                },
+                "ip_v6": null,
+                "mac": "22:61:ce:67:cd:09",
+                "rx_foreign": 0,
+                "rx_local": 0,
+                "tx_foreign": 0,
+                "tx_local": 0
+            }
+        ]
+    },
+    "smp": 1,
+    "status": "running",
+    "tags": [],
+    "uuid": "3df825cb-9c1b-470d-acbd-03e1a966c046",
+    "vnc_password": "vnc_password"
+}

--- a/libcloud/test/compute/test_cloudsigma_v1_0.py
+++ b/libcloud/test/compute/test_cloudsigma_v1_0.py
@@ -51,7 +51,7 @@ class CloudSigmaAPI10BaseTestCase(object):
 
     def test_list_sizes(self):
         images = self.driver.list_sizes()
-        self.assertEqual(len(images), 9)
+        self.assertEqual(len(images), 10)
 
     def test_list_images(self):
         sizes = self.driver.list_images()


### PR DESCRIPTION


## Updates on  CloudSigma driver



### Description

- Add all supported regions
- Use example sizes  currently provided by CloudSigma
- Change methods parameters to use actual  cores to define CPUs instead of MHz
- Change Drive methods parameters to use GBs instead of bytes
- Implement SSH key related methods ( `list_key_pairs`, `get_key_pair`, `create_key_pair`, `import_key_pair_from_string`, `delete_key_pair`), add ssh keys param on `create_node` 
- Implement `ex_attach_drive`, `ex_detach_drive`, `ex_destroy_drive`, `reboot_node`, `ex_get_node`
- Make deleting all attached drives on `destroy_node` optional
- Add tests on methods added
- Add volume methods which call the appropriate ex_drive method ( since CloudSigma drives are pretty much volumes in the context of libcloud, I thought this makes sense)

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
