### PR TITLE
Support volume v3 API endpoint in OpenStack driver

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,11 @@ Compute
   (GITHUB-1555)
   [Rob Juffermans - @robjuffermans]
 
+- [OpenStack] Support volume v3 API endpoint in OpenStack driver.
+
+  (GITHUB-1561)
+  [Miguel Caballer - @micafer]
+
 Changes in Apache Libcloud 3.3.1
 --------------------------------
 

--- a/libcloud/test/common/test_openstack_identity.py
+++ b/libcloud/test/common/test_openstack_identity.py
@@ -610,7 +610,7 @@ class OpenStackServiceCatalogTestCase(unittest.TestCase):
         catalog = OpenStackServiceCatalog(service_catalog=service_catalog,
                                           auth_version='2.0')
         entries = catalog.get_entries()
-        self.assertEqual(len(entries), 9)
+        self.assertEqual(len(entries), 10)
 
         entry = [e for e in entries if e.service_name == 'cloudServers'][0]
         self.assertEqual(entry.service_type, 'compute')
@@ -678,7 +678,7 @@ class OpenStackServiceCatalogTestCase(unittest.TestCase):
         service_types = catalog.get_service_types()
         self.assertEqual(service_types, ['compute', 'image', 'network',
                                          'object-store', 'rax:object-cdn',
-                                         'volumev2'])
+                                         'volumev2', 'volumev3'])
 
         service_types = catalog.get_service_types(region='ORD')
         self.assertEqual(service_types, ['rax:object-cdn'])
@@ -692,7 +692,7 @@ class OpenStackServiceCatalogTestCase(unittest.TestCase):
                                           auth_version='2.0')
 
         service_names = catalog.get_service_names()
-        self.assertEqual(service_names, ['cinderv2', 'cloudFiles',
+        self.assertEqual(service_names, ['cinderv2', 'cinderv3', 'cloudFiles',
                                          'cloudFilesCDN', 'cloudServers',
                                          'cloudServersOpenStack',
                                          'cloudServersPreprod',

--- a/libcloud/test/compute/fixtures/openstack/_v2_0__auth.json
+++ b/libcloud/test/compute/fixtures/openstack/_v2_0__auth.json
@@ -145,6 +145,28 @@
             {
                 "endpoints": [
                     {
+                        "region": "RegionOne",
+                        "tenantId": "1337",
+                        "publicURL": "https://test_endpoint.com/v3/1337",
+                        "versionInfo": "https://test_endpoint.com/v3/",
+                        "versionList": "https://test_endpoint.com/",
+                        "versionId": "2"
+                    },
+                    {
+                        "region": "fr1",
+                        "tenantId": "1337",
+                        "publicURL": "https://test_endpoint.com/v3/1337",
+                        "versionInfo": "https://test_endpoint.com/v3/",
+                        "versionList": "https://test_endpoint.com/",
+                        "versionId": "2"
+                    }
+                ],
+                "name": "cinderv3",
+                "type": "volumev3"
+            },
+            {
+                "endpoints": [
+                    {
                         "region": "DFW",
                         "tenantId": "613469",
                         "publicURL": "https://dfw.servers.api.rackspacecloud.com/v2/1337",


### PR DESCRIPTION
## Support volume v3 API endpoint in OpenStack driver

Implements: #1560

### Description

This solution tries to find if the cinderv3 endpoint is available and in this case the volume related functions will use that endpoint, otherwise it will user the cinderv2 one.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
