### PR TITLE
Enable auth to Cloudflare DNS via API Tokens

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,12 @@ Compute
   (GITHUB-1555)
   [Rob Juffermans - @robjuffermans]
 
+DNS
+~~~
+
+- [CloudFlare] Enable authentication via API Tokens.
+  [Clemens Wolff - @c-w]
+
 Changes in Apache Libcloud 3.3.1
 --------------------------------
 

--- a/docs/dns/drivers/cloudflare.rst
+++ b/docs/dns/drivers/cloudflare.rst
@@ -13,10 +13,16 @@ Instantiating the driver
 ------------------------
 
 To instantiate the driver you need to pass email address associated with your
-account and API key available on the `account page`_ to the driver constructor
+account and a Global API key available on the `account page`_ to the driver constructor
 as shown below.
 
 .. literalinclude:: /examples/dns/cloudflare/instantiate_driver.py
+   :language: python
+
+Alternatively, authentication can also be done via an API Token as shown below.
+It is recommended that the token at least has the Zone.DNS permissions.
+
+.. literalinclude:: /examples/dns/cloudflare/instantiate_driver_token.py
    :language: python
 
 API Docs

--- a/docs/examples/dns/cloudflare/instantiate_driver_token.py
+++ b/docs/examples/dns/cloudflare/instantiate_driver_token.py
@@ -1,0 +1,5 @@
+from libcloud.dns.types import Provider
+from libcloud.dns.providers import get_driver
+
+cls = get_driver(Provider.CLOUDFLARE)
+driver = cls('<api token>')

--- a/libcloud/dns/drivers/cloudflare.py
+++ b/libcloud/dns/drivers/cloudflare.py
@@ -147,7 +147,7 @@ class CloudFlareDNSResponse(JsonResponse):
             raise exception_class(**kwargs)
 
 
-class BaseDNSConnection:
+class BaseDNSConnection(object):
     host = API_HOST
     secure = True
     responseCls = CloudFlareDNSResponse

--- a/libcloud/test/dns/test_cloudflare.py
+++ b/libcloud/test/dns/test_cloudflare.py
@@ -21,6 +21,8 @@ from libcloud.common.types import LibcloudError
 from libcloud.test import unittest
 
 from libcloud.dns.drivers.cloudflare import CloudFlareDNSDriver
+from libcloud.dns.drivers.cloudflare import GlobalAPIKeyDNSConnection
+from libcloud.dns.drivers.cloudflare import TokenDNSConnection
 from libcloud.dns.drivers.cloudflare import ZONE_EXTRA_ATTRIBUTES
 from libcloud.dns.drivers.cloudflare import RECORD_EXTRA_ATTRIBUTES
 from libcloud.dns.types import RecordType
@@ -41,6 +43,14 @@ class CloudFlareDNSDriverTestCase(unittest.TestCase):
         CloudFlareMockHttp.type = None
         CloudFlareMockHttp.use_param = 'a'
         self.driver = CloudFlareDNSDriver(*DNS_PARAMS_CLOUDFLARE)
+
+    def test_auth_key(self):
+        driver = CloudFlareDNSDriver('user@example.com', 'key')
+        self.assertEqual(driver.connectionCls, GlobalAPIKeyDNSConnection)
+
+    def test_auth_token(self):
+        driver = CloudFlareDNSDriver('sometoken')
+        self.assertEqual(driver.connectionCls, TokenDNSConnection)
 
     def test_list_record_types(self):
         record_types = self.driver.list_record_types()


### PR DESCRIPTION
## Enable auth to Cloudflare DNS via API Tokens

### Description

This pull request adds support to the Cloudflare DNS driver to authenticate via API Tokens ([see docs](https://api.cloudflare.com/#getting-started-requests)) in addition to the previous Global API Key authentication mechanism.

### Status

- done, ready for review

### Checklist

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes)
