### PR TITLE
Support updating allowed_address_pairs on OpenStack ports

### DIFF
--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -3384,7 +3384,8 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
     def ex_update_port(self, port, description=None,
                        admin_state_up=None, name=None,
                        port_security_enabled=None,
-                       qos_policy_id=None, security_groups=None):
+                       qos_policy_id=None, security_groups=None,
+                       allowed_address_pairs=None):
         """
         Update a OpenStack_2_PortInterface
 
@@ -3410,6 +3411,13 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
         :param      security_groups: The IDs of security groups applied
         :type       security_groups: ``list`` of ``str``
 
+        :param      allowed_address_pairs: IP and MAC address that the port
+                    can use when sending packets if port_security_enabled is
+                    true
+        :type       allowed_address_pairs: ``list`` of ``dict`` containing
+                    ip_address and mac_address; mac_address is optional, taken
+                    from the port if not specified
+
         :rtype: :class:`OpenStack_2_PortInterface`
         """
         data = {'port': {}}
@@ -3425,6 +3433,8 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
             data['port']['qos_policy_id'] = qos_policy_id
         if security_groups is not None:
             data['port']['security_groups'] = security_groups
+        if allowed_address_pairs is not None:
+            data['port']['allowed_address_pairs'] = allowed_address_pairs
         response = self.network_connection.request(
             '/v2.0/ports/{}'.format(port.id), method='PUT', data=data
         )

--- a/libcloud/test/compute/fixtures/openstack_v1.1/_port_v2.json
+++ b/libcloud/test/compute/fixtures/openstack_v1.1/_port_v2.json
@@ -3,7 +3,7 @@
     "status": "BUILD",
     "extra_dhcp_opts": [],
     "description": "Some port description",
-    "allowed_address_pairs": [],
+    "allowed_address_pairs": [{"ip_address": "1.2.3.4"}, {"ip_address": "2.3.4.5"}],
     "tags": [],
     "network_id": "123c8a8c-6427-4e8f-a805-2035365f4d43",
     "tenant_id": "abcdec85bee34bb0a44ab8255eb36abc",

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -1974,6 +1974,14 @@ class OpenStack_2_Tests(OpenStack_1_1_Tests):
         ret = self.driver.ex_update_port(port, port_security_enabled=False)
         self.assertEqual(ret.extra['name'], 'Some port name')
 
+    def test_ex_update_port_allowed_address_pairs(self):
+        allowed_address_pairs = [{'ip_address': '1.2.3.4'},
+                                 {'ip_address': '2.3.4.5'}]
+        port = self.driver.ex_get_port('126da55e-cfcb-41c8-ae39-a26cb8a7e723')
+        ret = self.driver.ex_update_port(
+            port, allowed_address_pairs=allowed_address_pairs)
+        self.assertEqual(ret.extra['allowed_address_pairs'], allowed_address_pairs)
+
     def test_detach_port_interface(self):
         node = Node(id='1c01300f-ef97-4937-8f03-ac676d6234be', name=None,
                     state=None, public_ips=None, private_ips=None,


### PR DESCRIPTION
## Support updating allowed_address_pairs on OpenStack ports

### Description

Add support to OpenStack_2_NodeDriver for updating allowed-address-pairs on node ports.  This is a security extension that allows administrators to specify which IP and MAC addresses a node can use to communicate.

https://docs.openstack.org/api-ref/network/v2/index.html#allowed-address-pairs

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
