### PR TITLE
Fix null value in DigitalOcean create a record

### DIFF
--- a/libcloud/dns/drivers/digitalocean.py
+++ b/libcloud/dns/drivers/digitalocean.py
@@ -171,15 +171,15 @@ class DigitalOceanDNSDriver(DigitalOcean_v2_BaseDriver, DNSDriver):
             try:
                 params['priority'] = extra['priority']
             except KeyError:
-                params['priority'] = 'null'
+                params['priority'] = None
             try:
                 params['port'] = extra['port']
             except KeyError:
-                params['port'] = 'null'
+                params['port'] = None
             try:
                 params['weight'] = extra['weight']
             except KeyError:
-                params['weight'] = 'null'
+                params['weight'] = None
 
             if 'ttl' in extra:
                 params['ttl'] = extra['ttl']


### PR DESCRIPTION
## Fix null value in DigitalOcean create a record

### Description

This fixes "field could not be unmarshalled" error when trying to send
'null' as a boolean value. It needs to be int or bool, not a string.

Ref: https://developers.digitalocean.com/documentation/v2/#create-a-new-domain-record

### Status

Replace this: describe the PR status. Examples:

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- ~[ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)~
