### PR TITLE
Add integration tests for MinIO storage driver

### DIFF
--- a/integration/storage/base.py
+++ b/integration/storage/base.py
@@ -139,14 +139,17 @@ class Integration:
             self.driver.delete_object(obj)
 
             # check that a missing file can't be deleted or looked up
-            with self.assertRaises(types.ObjectDoesNotExistError):
-                self.driver.delete_object(obj)
-            with self.assertRaises(types.ObjectDoesNotExistError):
-                self.driver.get_object(container.name, blob_name)
+            self.assert_file_is_missing(container, obj)
 
             # check that the file is deleted
             blobs = self.driver.list_container_objects(container)
             self.assertEqual([blob.name for blob in blobs], [blob_name[::-1]])
+
+        def assert_file_is_missing(self, container, obj):
+            with self.assertRaises(types.ObjectDoesNotExistError):
+                self.driver.delete_object(obj)
+            with self.assertRaises(types.ObjectDoesNotExistError):
+                self.driver.get_object(container.name, obj.name)
 
         def test_objects(self, size=1 * MB):
             def do_upload(container, blob_name, content):
@@ -285,6 +288,7 @@ class Integration:
         image = None
         version = 'latest'
         environment = {}
+        command = None
         ready_message = None
 
         host = 'localhost'
@@ -312,6 +316,7 @@ class Integration:
 
             cls.container = cls.client.containers.run(
                 '{}:{}'.format(cls.image, cls.version),
+                command=cls.command,
                 detach=True,
                 auto_remove=True,
                 ports={cls.port: cls.port},

--- a/integration/storage/test_minio.py
+++ b/integration/storage/test_minio.py
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the 'License'); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import unittest
+
+from integration.storage.base import Integration
+from libcloud.storage import types
+
+
+class MinioTest(Integration.ContainerTestBase):
+    provider = 'minio'
+
+    account = 'minioaccount'
+    secret = 'miniopassword'
+
+    image = 'minio/minio'
+    port = 9000
+    environment = {'MINIO_ROOT_USER': account, 'MINIO_ROOT_PASSWORD': secret}
+    command = ['server', '/data']
+    ready_message = b'IAM initialization complete'
+
+    def test_cdn_url(self):
+        self.skipTest('Not implemented in driver')
+
+    def assert_file_is_missing(self, container, obj):
+        with self.assertRaises(types.ObjectDoesNotExistError):
+            self.driver.get_object(container.name, obj.name)
+
+
+if __name__ == '__main__':
+    sys.exit(unittest.main())

--- a/libcloud/storage/drivers/s3.py
+++ b/libcloud/storage/drivers/s3.py
@@ -1065,6 +1065,9 @@ class BaseS3StorageDriver(StorageDriver):
                  'etag': headers['etag']}
         meta_data = {}
 
+        if 'content-encoding' in headers:
+            extra['content_encoding'] = headers['content-encoding']
+
         if 'last-modified' in headers:
             extra['last_modified'] = headers['last-modified']
 


### PR DESCRIPTION
## Add integration tests for MinIO storage driver

### Description

This pull requests extends the storage integration test framework to cover the MinIO storage driver.

One of the integration tests failed as the S3 driver from which MinIO derives doesn't pass-through `content_encoding` in `get_object` so this pull request also adds this missing functionality.

### Status

- done, ready for review

### Checklist

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide)
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes)
