### PR TITLE
Optimized 'iterate_container_objects' by filtering the objects before…

### DIFF
--- a/libcloud/storage/drivers/local.py
+++ b/libcloud/storage/drivers/local.py
@@ -246,10 +246,11 @@ class LocalStorageDriver(StorageDriver):
 
         cpath = self.get_container_cdn_url(container, check=True)
 
+        fpath = cpath
         if prefix:
-            cpath = os.path.join(cpath, prefix)
+            fpath = os.path.join(cpath, prefix)
 
-        for folder, subfolders, files in os.walk(cpath, topdown=True):
+        for folder, subfolders, files in os.walk(fpath, topdown=True):
             # Remove unwanted subfolders
             for subf in IGNORE_FOLDERS:
                 if subf in subfolders:
@@ -279,8 +280,7 @@ class LocalStorageDriver(StorageDriver):
         """
         prefix = self._normalize_prefix_argument(prefix, ex_prefix)
 
-        objects = self._get_objects(container, prefix)
-        return self._filter_listed_container_objects(objects, prefix)
+        return self._get_objects(container, prefix)
 
     def get_container(self, container_name):
         """

--- a/libcloud/storage/drivers/local.py
+++ b/libcloud/storage/drivers/local.py
@@ -239,12 +239,15 @@ class LocalStorageDriver(StorageDriver):
                 continue
             yield self._make_container(container_name)
 
-    def _get_objects(self, container):
+    def _get_objects(self, container, prefix=None):
         """
         Recursively iterate through the file-system and return the object names
         """
 
         cpath = self.get_container_cdn_url(container, check=True)
+
+        if prefix:
+            cpath = os.path.join(cpath, prefix)
 
         for folder, subfolders, files in os.walk(cpath, topdown=True):
             # Remove unwanted subfolders
@@ -276,7 +279,7 @@ class LocalStorageDriver(StorageDriver):
         """
         prefix = self._normalize_prefix_argument(prefix, ex_prefix)
 
-        objects = self._get_objects(container)
+        objects = self._get_objects(container, prefix)
         return self._filter_listed_container_objects(objects, prefix)
 
     def get_container(self, container_name):


### PR DESCRIPTION
… creating the iterator

## Optimized 'iterate_container_objects' by filtering the objects before creating the iterator for the local driver

### Description
In the local driver - if a prefix is present, till now all of the objects in storage would've been serialized and just then filtered, changed it so the filtering would be beforehand.

### Status
done, ready for review

### Checklist (tick everything that applies)

- [v] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [v] Documentation
- [v] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
