### PR TITLE
Make it easier to customize retry logic

### DIFF
--- a/libcloud/common/base.py
+++ b/libcloud/common/base.py
@@ -33,7 +33,8 @@ from libcloud.utils.py3 import httplib
 from libcloud.utils.py3 import urlparse
 from libcloud.utils.py3 import urlencode
 
-from libcloud.utils.misc import lowercase_keys, retry
+from libcloud.utils.misc import lowercase_keys
+from libcloud.utils.retry import Retry
 from libcloud.common.exceptions import exception_from_message
 from libcloud.common.types import LibcloudError, MalformedResponseError
 from libcloud.http import LibcloudConnection, HttpLibResponseProxy
@@ -314,6 +315,7 @@ class Connection(object):
 
     responseCls = Response
     rawResponseCls = RawResponse
+    retryCls = Retry
     connection = None
     host = '127.0.0.1'  # type: str
     port = 443
@@ -610,9 +612,9 @@ class Connection(object):
                     stream=stream)
             else:
                 if retry_enabled:
-                    retry_request = retry(timeout=self.timeout,
-                                          retry_delay=self.retry_delay,
-                                          backoff=self.backoff)
+                    retry_request = self.retryCls(retry_delay=self.retry_delay,
+                                                  timeout=self.timeout,
+                                                  backoff=self.backoff)
                     retry_request(self.connection.request)(method=method,
                                                            url=url,
                                                            body=data,

--- a/libcloud/test/common/test_retry_limit.py
+++ b/libcloud/test/common/test_retry_limit.py
@@ -18,7 +18,7 @@ import ssl
 
 from mock import Mock, patch, MagicMock
 
-from libcloud.utils.misc import TRANSIENT_SSL_ERROR
+from libcloud.utils.retry import TRANSIENT_SSL_ERROR
 from libcloud.common.base import Connection
 from libcloud.test import unittest
 

--- a/libcloud/test/test_connection.py
+++ b/libcloud/test/test_connection.py
@@ -30,7 +30,7 @@ from libcloud.common.base import Connection, CertificateConnection
 from libcloud.http import LibcloudBaseConnection
 from libcloud.http import LibcloudConnection
 from libcloud.http import SignedHTTPSAdapter
-from libcloud.utils.misc import retry
+from libcloud.utils.retry import Retry
 from libcloud.utils.py3 import assertRaisesRegex
 
 
@@ -413,7 +413,7 @@ class ConnectionClassTestCase(unittest.TestCase):
             mock_connect.__name__ = 'mock_connect'
             with self.assertRaises(socket.gaierror):
                 mock_connect.side_effect = socket.gaierror('')
-                retry_request = retry(timeout=0.2, retry_delay=0.1,
+                retry_request = Retry(timeout=0.2, retry_delay=0.1,
                                       backoff=1)
                 retry_request(con.request)(action='/')
 
@@ -429,7 +429,7 @@ class ConnectionClassTestCase(unittest.TestCase):
             mock_connect.__name__ = 'mock_connect'
             with self.assertRaises(socket.gaierror):
                 mock_connect.side_effect = socket.gaierror('')
-                retry_request = retry(timeout=0.2, retry_delay=0.1,
+                retry_request = Retry(timeout=0.2, retry_delay=0.1,
                                       backoff=1)
                 retry_request(con.request)(action='/')
 
@@ -445,7 +445,7 @@ class ConnectionClassTestCase(unittest.TestCase):
             mock_connect.__name__ = 'mock_connect'
             with self.assertRaises(socket.gaierror):
                 mock_connect.side_effect = socket.gaierror('')
-                retry_request = retry(timeout=0.2, retry_delay=0.1,
+                retry_request = Retry(timeout=0.2, retry_delay=0.1,
                                       backoff=1)
                 retry_request(con.request)(action='/')
 

--- a/libcloud/utils/misc.py
+++ b/libcloud/utils/misc.py
@@ -17,16 +17,15 @@ from typing import List
 
 import os
 import binascii
-import socket
-import time
-import ssl
-from datetime import datetime, timedelta
-from functools import wraps
 
-from libcloud.utils.py3 import httplib
-from libcloud.common.exceptions import RateLimitReachedError
 from libcloud.common.providers import get_driver as _get_driver
 from libcloud.common.providers import set_driver as _set_driver
+# Imported for backward compatibility
+# noinspection PyProtectedMember
+from libcloud.utils.retry import (Retry,
+                                  DEFAULT_DELAY, DEFAULT_TIMEOUT, DEFAULT_BACKOFF,
+                                  TRANSIENT_SSL_ERROR, TransientSSLError)
+
 
 __all__ = [
     'find',
@@ -39,28 +38,8 @@ __all__ = [
     'reverse_dict',
     'lowercase_keys',
     'get_secure_random_string',
-    'retry',
-
     'ReprMixin'
 ]
-
-# Error message which indicates a transient SSL error upon which request
-# can be retried
-TRANSIENT_SSL_ERROR = 'The read operation timed out'
-
-
-class TransientSSLError(ssl.SSLError):
-    """Represent transient SSL errors, e.g. timeouts"""
-    pass
-
-
-# Constants used by the ``retry`` decorator
-DEFAULT_TIMEOUT = 30  # default retry timeout
-DEFAULT_DELAY = 1  # default sleep delay used in each iterator
-DEFAULT_BACKOFF = 1  # retry backup multiplier
-RETRY_EXCEPTIONS = (RateLimitReachedError, socket.error, socket.gaierror,
-                    httplib.NotConnected, httplib.ImproperConnectionState,
-                    TransientSSLError)
 
 
 def find(l, predicate):
@@ -72,6 +51,9 @@ def find(l, predicate):
 # been moved to "libcloud.common.providers" module
 get_driver = _get_driver
 set_driver = _set_driver
+# Note: This is an alias for backward-compatibility for a function which has been
+# moved to "libcloud.util.retry" module
+retry = Retry
 
 
 def merge_valid_keys(params, valid_keys, extra):
@@ -274,64 +256,4 @@ class ReprMixin(object):
         return str(self.__repr__())
 
 
-def retry(retry_exceptions=RETRY_EXCEPTIONS, retry_delay=DEFAULT_DELAY,
-          timeout=DEFAULT_TIMEOUT, backoff=DEFAULT_BACKOFF):
-    """
-    Retry decorator that helps to handle common transient exceptions.
 
-    :param retry_exceptions: types of exceptions to retry on.
-    :param retry_delay: retry delay between the attempts.
-    :param timeout: maximum time to wait.
-    :param backoff: multiplier added to delay between attempts.
-
-    :Example:
-
-    retry_request = retry(timeout=1, retry_delay=1, backoff=1)
-    retry_request(self.connection.request)()
-    """
-    if retry_exceptions is None:
-        retry_exceptions = RETRY_EXCEPTIONS
-    if retry_delay is None:
-        retry_delay = DEFAULT_DELAY
-    if timeout is None:
-        timeout = DEFAULT_TIMEOUT
-    if backoff is None:
-        backoff = DEFAULT_BACKOFF
-
-    timeout = max(timeout, 0)
-
-    def transform_ssl_error(func, *args, **kwargs):
-        try:
-            return func(*args, **kwargs)
-        except ssl.SSLError as exc:
-            if TRANSIENT_SSL_ERROR in str(exc):
-                raise TransientSSLError(*exc.args)
-
-            raise exc
-
-    def decorator(func):
-        @wraps(func)
-        def retry_loop(*args, **kwargs):
-            current_delay = retry_delay
-            end = datetime.now() + timedelta(seconds=timeout)
-
-            while True:
-                try:
-                    return transform_ssl_error(func, *args, **kwargs)
-                except retry_exceptions as exc:
-                    if isinstance(exc, RateLimitReachedError):
-                        time.sleep(exc.retry_after)
-
-                        # Reset retries if we're told to wait due to rate
-                        # limiting
-                        current_delay = retry_delay
-                        end = datetime.now() + timedelta(
-                            seconds=exc.retry_after + timeout)
-                    elif datetime.now() >= end:
-                        raise
-                    else:
-                        time.sleep(current_delay)
-                        current_delay *= backoff
-
-        return retry_loop
-    return decorator

--- a/libcloud/utils/retry.py
+++ b/libcloud/utils/retry.py
@@ -18,6 +18,7 @@ import ssl
 import time
 from datetime import datetime, timedelta
 from functools import wraps
+import logging
 
 from libcloud.utils.py3 import httplib
 from libcloud.common.exceptions import RateLimitReachedError
@@ -26,7 +27,7 @@ __all__ = [
     'Retry'
 ]
 
-
+_logger = logging.getLogger(__name__)
 # Error message which indicates a transient SSL error upon which request
 # can be retried
 TRANSIENT_SSL_ERROR = 'The read operation timed out'
@@ -42,6 +43,7 @@ class TransientSSLError(ssl.SSLError):
 DEFAULT_TIMEOUT = 30  # default retry timeout
 DEFAULT_DELAY = 1  # default sleep delay used in each iterator
 DEFAULT_BACKOFF = 1  # retry backup multiplier
+DEFAULT_MAX_RATE_LIMIT_RETRIES = float("inf")  # default max number of times to retry on rate limit
 RETRY_EXCEPTIONS = (RateLimitReachedError, socket.error, socket.gaierror,
                     httplib.NotConnected, httplib.ImproperConnectionState,
                     TransientSSLError)
@@ -50,15 +52,18 @@ RETRY_EXCEPTIONS = (RateLimitReachedError, socket.error, socket.gaierror,
 class MinimalRetry:
 
     def __init__(self, retry_delay=DEFAULT_DELAY,
-                 timeout=DEFAULT_TIMEOUT, backoff=DEFAULT_BACKOFF):
+                 timeout=DEFAULT_TIMEOUT, backoff=DEFAULT_BACKOFF,
+                 max_rate_limit_retries=DEFAULT_MAX_RATE_LIMIT_RETRIES):
         """
         Wrapper around retrying that helps to handle common transient exceptions.
         This minimalistic version only retries SSL errors and rate limiting.
-        :param retry_exceptions: types of exceptions to retry on.
 
         :param retry_delay: retry delay between the attempts.
         :param timeout: maximum time to wait.
         :param backoff: multiplier added to delay between attempts.
+        :param max_rate_limit_retries: The maximum number of retries to do when being rate limited by the server.
+                                       Set to `float("inf")` if retrying forever is desired.
+                                       Being rate limited does not count towards the timeout.
 
         :Example:
 
@@ -72,12 +77,15 @@ class MinimalRetry:
             timeout = DEFAULT_TIMEOUT
         if backoff is None:
             backoff = DEFAULT_BACKOFF
+        if max_rate_limit_retries is None:
+            max_rate_limit_retries = DEFAULT_MAX_RATE_LIMIT_RETRIES
 
         timeout = max(timeout, 0)
 
         self.retry_delay = retry_delay
         self.timeout = timeout
         self.backoff = backoff
+        self.max_rate_limit_retries = max_rate_limit_retries
 
     def __call__(self, func):
         def transform_ssl_error(function, *args, **kwargs):
@@ -93,19 +101,21 @@ class MinimalRetry:
         def retry_loop(*args, **kwargs):
             current_delay = self.retry_delay
             end = datetime.now() + timedelta(seconds=self.timeout)
+            number_rate_limited_retries = 0
 
             while True:
                 try:
                     return transform_ssl_error(func, *args, **kwargs)
                 except Exception as exc:
-                    if isinstance(exc, RateLimitReachedError):
+                    if isinstance(exc, RateLimitReachedError) and number_rate_limited_retries <= self.max_rate_limit_retries:
+                        _logger.debug("You are being rate limited, backing off...")
                         time.sleep(exc.retry_after)
-
                         # Reset retries if we're told to wait due to rate
                         # limiting
                         current_delay = self.retry_delay
                         end = datetime.now() + timedelta(
                             seconds=exc.retry_after + self.timeout)
+                        number_rate_limited_retries += 1
                     elif datetime.now() >= end:
                         raise
                     elif self.should_retry(exc):

--- a/libcloud/utils/retry.py
+++ b/libcloud/utils/retry.py
@@ -1,0 +1,121 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import socket
+import ssl
+import time
+from datetime import datetime, timedelta
+from functools import wraps
+
+from libcloud.utils.py3 import httplib
+from libcloud.common.exceptions import RateLimitReachedError
+
+__all__ = [
+    'Retry'
+]
+
+
+# Error message which indicates a transient SSL error upon which request
+# can be retried
+TRANSIENT_SSL_ERROR = 'The read operation timed out'
+
+
+class TransientSSLError(ssl.SSLError):
+    """Represent transient SSL errors, e.g. timeouts"""
+    pass
+
+
+# Constants used by the ``retry`` class
+
+DEFAULT_TIMEOUT = 30  # default retry timeout
+DEFAULT_DELAY = 1  # default sleep delay used in each iterator
+DEFAULT_BACKOFF = 1  # retry backup multiplier
+RETRY_EXCEPTIONS = (RateLimitReachedError, socket.error, socket.gaierror,
+                    httplib.NotConnected, httplib.ImproperConnectionState,
+                    TransientSSLError)
+
+
+class Retry:
+
+    def __init__(self, retry_exceptions=RETRY_EXCEPTIONS, retry_delay=DEFAULT_DELAY,
+                 timeout=DEFAULT_TIMEOUT, backoff=DEFAULT_BACKOFF):
+        """
+        Wrapper around retrying that helps to handle common transient exceptions.
+
+        :param retry_exceptions: types of exceptions to retry on.
+        :param retry_delay: retry delay between the attempts.
+        :param timeout: maximum time to wait.
+        :param backoff: multiplier added to delay between attempts.
+
+        :Example:
+
+        retry_request = Retry(timeout=1, retry_delay=1, backoff=1)
+        retry_request(self.connection.request)()
+        """
+        if retry_exceptions is None:
+            retry_exceptions = RETRY_EXCEPTIONS
+        if retry_delay is None:
+            retry_delay = DEFAULT_DELAY
+        if timeout is None:
+            timeout = DEFAULT_TIMEOUT
+        if backoff is None:
+            backoff = DEFAULT_BACKOFF
+
+        timeout = max(timeout, 0)
+
+        self.retry_exceptions = retry_exceptions
+        self.retry_delay = retry_delay
+        self.timeout = timeout
+        self.backoff = backoff
+
+    def __call__(self, func):
+        def transform_ssl_error(function, *args, **kwargs):
+            try:
+                return function(*args, **kwargs)
+            except ssl.SSLError as exc:
+                if TRANSIENT_SSL_ERROR in str(exc):
+                    raise TransientSSLError(*exc.args)
+
+                raise exc
+
+        @wraps(func)
+        def retry_loop(*args, **kwargs):
+            current_delay = self.retry_delay
+            end = datetime.now() + timedelta(seconds=self.timeout)
+
+            while True:
+                try:
+                    return transform_ssl_error(func, *args, **kwargs)
+                except Exception as exc:
+                    if isinstance(exc, RateLimitReachedError):
+                        time.sleep(exc.retry_after)
+
+                        # Reset retries if we're told to wait due to rate
+                        # limiting
+                        current_delay = self.retry_delay
+                        end = datetime.now() + timedelta(
+                            seconds=exc.retry_after + self.timeout)
+                    elif datetime.now() >= end:
+                        raise
+                    elif self.should_retry(exc):
+                        time.sleep(current_delay)
+                        current_delay *= self.backoff
+                    else:
+                        raise
+
+        return retry_loop
+
+    def should_retry(self, exception):
+        return type(exception) in self.retry_exceptions


### PR DESCRIPTION
## Retry logic customization

### Description

The old implementation of retrying is fixed for all connection classes and is not customizable.
For example the exception types that are retried are not available as a parameter from within the connection, so
you had to live with what the default value is.
Unfortunately, that is not always enough, e.g. for S3 storage you can [receive 503 Slow Down Responses](https://aws.amazon.com/premiumsupport/knowledge-center/s3-troubleshoot-503-cross-region/) that should be retried with exponential back-off. Google Storage also has a similar mechanism.
These errors lead to exceptions at the moment.

This pull request takes a *first step* in fixing this by making the retry logic explicitly configurable within the connection.

If you deem this reasonable we can make the change to retry S3 slow down requests.
This requires differentiating HTTP exceptions by their status code, similar to what is mentioned in #1577.

In case you do not want to add more exceptions to retry, this change here would still enable end-users to customize the behavior without major hacks:

```python
from libcloud.utils.retry import MinimalRetry

class MyFancyRetry(MinimalRetry):

    def should_retry(self, exception):
        retry = ...  # some logic
        return retry


driver = get_driver(Provider.SOME_PROVIDER)(...)
driver.connection.retryCls = MyFancyRetry
```

I tried my best to be fully backward compatible and no actual behavior is changed yet.
If you are open to breaking changes we could also think about using urllib.Retry as suggested in #1577, and/or unifying the retry parameters that are passed around into some parameter class.

### Status

Done, but could be extended with some feedback

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks) (done via commit hook)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html) (locally)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
