### PR TITLE
Make retry handle http status codes

### DIFF
--- a/libcloud/common/base.py
+++ b/libcloud/common/base.py
@@ -623,8 +623,9 @@ class Connection(object):
                                       headers=headers,
                                       data=data)
 
-    def _retryable_request(self, url: str, data: bytes, headers: Dict[str, Any],
-                           method: str, raw: bool, stream: bool) -> Union[RawResponse, Response]:
+    def _retryable_request(self, url: str, data: bytes,
+                           headers: Dict[str, Any], method: str, raw: bool,
+                           stream: bool) -> Union[RawResponse, Response]:
         try:
             # @TODO: Should we just pass File object as body to request method
             # instead of dealing with splitting and sending the file ourselves?

--- a/libcloud/common/base.py
+++ b/libcloud/common/base.py
@@ -624,7 +624,7 @@ class Connection(object):
                                       data=data)
 
     def _retryable_request(self, url: str, data: bytes, headers: Dict[str, Any],
-                           method: str, raw: bool, stream: bool) -> RawResponse:
+                           method: str, raw: bool, stream: bool) -> Union[RawResponse, Response]:
         try:
             # @TODO: Should we just pass File object as body to request method
             # instead of dealing with splitting and sending the file ourselves?

--- a/libcloud/common/ovh.py
+++ b/libcloud/common/ovh.py
@@ -208,7 +208,7 @@ class OvhConnection(ConnectionUserAndKey):
         })
 
         try:
-            return super(OvhConnection, self)\
+            return super(OvhConnection, self) \
                 .request(action, params=params, data=data, headers=headers,
                          method=method, raw=raw)
         except Exception as e:
@@ -226,7 +226,8 @@ def handle_and_rethrow_user_friendly_invalid_region_error(host, e):
     """
     msg = str(e).lower()
 
-    if 'nodename nor servname provided, or not known' in msg or 'getaddrinfo failed' in msg:
+    if 'name or service not known' in msg \
+        or 'nodename nor servname provided, or not known' in msg or 'getaddrinfo failed' in msg:
         raise ValueError('Received "name or service not known" error '
                          'when sending a request. This likely '
                          'indicates invalid region argument was '

--- a/libcloud/common/ovh.py
+++ b/libcloud/common/ovh.py
@@ -226,7 +226,7 @@ def handle_and_rethrow_user_friendly_invalid_region_error(host, e):
     """
     msg = str(e).lower()
 
-    if 'name or service not known' in msg or 'getaddrinfo failed' in msg:
+    if 'nodename nor servname provided, or not known' in msg or 'getaddrinfo failed' in msg:
         raise ValueError('Received "name or service not known" error '
                          'when sending a request. This likely '
                          'indicates invalid region argument was '

--- a/libcloud/common/ovh.py
+++ b/libcloud/common/ovh.py
@@ -227,7 +227,8 @@ def handle_and_rethrow_user_friendly_invalid_region_error(host, e):
     msg = str(e).lower()
 
     if 'name or service not known' in msg \
-        or 'nodename nor servname provided, or not known' in msg or 'getaddrinfo failed' in msg:
+            or 'nodename nor servname provided, or not known' in msg \
+            or 'getaddrinfo failed' in msg:
         raise ValueError('Received "name or service not known" error '
                          'when sending a request. This likely '
                          'indicates invalid region argument was '

--- a/libcloud/test/storage/test_base.py
+++ b/libcloud/test/storage/test_base.py
@@ -277,6 +277,9 @@ class BaseStorageTests(unittest.TestCase):
 
     @mock.patch('os.environ', {'LIBCLOUD_RETRY_FAILED_HTTP_REQUESTS': True})
     def test_should_retry_rate_limited_errors(self):
+        class SecondException(Exception):
+            pass
+
         count = 0
 
         def raise_on_second(*_, **__):
@@ -311,12 +314,6 @@ class BaseRangeDownloadMockHttpTestCase(unittest.TestCase):
         range_str = 'bytes=3-5'
         result = mock_http._get_start_and_end_bytes_from_range_str(range_str, body)
         self.assertEqual(result, (3, 5))
-
-
-class SecondException(Exception):
-    pass
-
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Retry Raw Http Requests

### Description

We are currently facing some storage driver exceptions when uploading many small files. Stacktrace (parts removed):

```self._driver.upload_object_via_stream( File "/usr/local/lib/python3.8/site-packages/libcloud/storage/drivers/s3.py", line 754, in upload_object_via_stream return self._put_object(container=container, object_name=object_name, File "/usr/local/lib/python3.8/site-packages/libcloud/storage/drivers/s3.py", line 900, in _put_object result_dict = self._upload_object( File "/usr/local/lib/python3.8/site-packages/libcloud/storage/base.py", line 837, in _upload_object response.parse_error() File "/usr/local/lib/python3.8/site-packages/libcloud/storage/drivers/s3.py", line 147, in parse_error raise LibcloudError('Unknown error. Status code: %d' % (self.status), libcloud.common.types.LibcloudError: <LibcloudError in <class 'libcloud.storage.drivers.s3.S3StorageDriver'> 'Unknown error. Status code: 429'>```

This change also enables retrying the raw requests. Together with #1588 (for which we have a workaround), this would solve our issue completely and we could keep using libcloud.

I only added a call to retrying the raw requests.

### Status

done, ready for review

### Checklist (tick everything that applies)

- [X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [X] Documentation
- [X] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
