### PR TITLE
EC2: Add support for gp3 and io2 volumes

### DIFF
--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -929,13 +929,17 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
 
     def test_create_volume(self):
         location = self.driver.list_locations()[0]
-        vol = self.driver.create_volume(10, 'vol', location)
+        vol = self.driver.create_volume(10, 'vol', location=location)
 
         self.assertEqual(10, vol.size)
         self.assertEqual('vol', vol.name)
         self.assertEqual('creating', vol.extra['state'])
         self.assertTrue(isinstance(vol.extra['create_time'], datetime))
         self.assertEqual(False, vol.extra['encrypted'])
+
+        expected_msg = "Invalid volume type specified: invalid-type"
+        self.assertRaisesRegex(ValueError, expected_msg, self.driver.create_volume,
+                          10, 'invalid-vol', location=location, ex_volume_type='invalid-type')
 
     def test_create_encrypted_volume(self):
         location = self.driver.list_locations()[0]


### PR DESCRIPTION
## EC2: Add support for gp3 and io2 volumes

### Description

The ec2 driver currently supports `standard`, `io1`, `gp2`, `st1` and `sc1` volume types. This change adds support for `gp3` and `io2` volume types. The driver currently maintains a list of volume types and raises a `ValueError` if an unsupported volume type is passed. The solution is to simply add the new types to this list. This change also enhances the `create_volume` unit test to verify that a `ValueError` is raised for a volume type that is not in the list.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
