### PR TITLE
Add Openstack Application Credential Support

### DIFF
--- a/docs/compute/drivers/openstack.rst
+++ b/docs/compute/drivers/openstack.rst
@@ -73,6 +73,7 @@ Available arguments:
     password
   * ``2.0_voms`` - 2.0 VOMS key
   * ``3.x_password`` - 3.x keystone password
+  * ``3.x_appcred`` - 3.x keystone with application credential
   * ``3.x_oidc_access_token`` - OIDC access token
 
 


### PR DESCRIPTION
##  Add Openstack Application Credential Support

### Description
Added Openstack application credential support. Fixes #1597. 

### Status
- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
