### PR TITLE
fix linux command deployment when running libcloud on windows

### DIFF
--- a/libcloud/compute/deployment.py
+++ b/libcloud/compute/deployment.py
@@ -212,7 +212,7 @@ class ScriptDeployment(Deployment):
         if self.name and (self.name[0] not in ['/', '\\'] and
                           not re.match(r"^\w\:.*$", file_path)):
             base_path = os.path.dirname(file_path)
-            name = os.path.join(base_path, self.name)
+            name = os.path.join(base_path, self.name).replace("\\", "/")
         elif self.name and (self.name[0] == '\\' or
                             re.match(r"^\w\:.*$", file_path)):
             # Absolute Windows path

--- a/libcloud/compute/ssh.py
+++ b/libcloud/compute/ssh.py
@@ -688,7 +688,7 @@ class ParamikoSSHClient(BaseSSHClient):
                 # Windows path
                 file_path = cwd + '\\' + file_path
             else:
-                file_path = pjoin(cwd, file_path)
+                file_path = pjoin(cwd, file_path).replace("\\", "/")
 
         return file_path
 


### PR DESCRIPTION
## Fix right path composition suited for destination machine

### Description

When running libcloud on Windows to deploy a linux machine in the cloud with a ScriptDeployment, it had always promted me an error which was like "stderr: bash: /home/googlelibcloud_deployment_b20d6e1e.sh: No such file or directory". So, the path was not right formatted. The error was in the os.path.join method, which produces a false path on windows like "/home/google\\libcloud_deployment_b20d6e1e.sh". So I had to add the .replace("\\","/") method to the os.path.join.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
