### PR TITLE
Fix Minio homepage links in the docs

### DIFF
--- a/docs/storage/_supported_methods_cdn.rst
+++ b/docs/storage/_supported_methods_cdn.rst
@@ -48,7 +48,7 @@ Provider                      enable container cdn enable object cdn get contain
 .. _`Google Cloud Storage`: http://cloud.google.com/storage
 .. _`KTUCloud Storage`: http://www.rackspace.com/
 .. _`Local Storage`: http://example.com
-.. _`MinIO Storage Driver`: http://cloud.google.com/storage
+.. _`MinIO Storage Driver`: https://min.io/
 .. _`Nimbus.io`: https://nimbus.io/
 .. _`Ninefold`: http://ninefold.com/
 .. _`OpenStack Swift`: http://www.rackspace.com/

--- a/docs/storage/_supported_methods_main.rst
+++ b/docs/storage/_supported_methods_main.rst
@@ -48,7 +48,7 @@ Provider                      list containers list objects create container dele
 .. _`Google Cloud Storage`: http://cloud.google.com/storage
 .. _`KTUCloud Storage`: http://www.rackspace.com/
 .. _`Local Storage`: http://example.com
-.. _`MinIO Storage Driver`: http://cloud.google.com/storage
+.. _`MinIO Storage Driver`: https://min.io/
 .. _`Nimbus.io`: https://nimbus.io/
 .. _`Ninefold`: http://ninefold.com/
 .. _`OpenStack Swift`: http://www.rackspace.com/

--- a/docs/storage/_supported_providers.rst
+++ b/docs/storage/_supported_providers.rst
@@ -30,7 +30,7 @@ Provider                   Documentation                                       P
 .. _`Google Cloud Storage`: http://cloud.google.com/storage
 .. _`KTUCloud Storage`: http://www.rackspace.com/
 .. _`Local Storage`: http://example.com
-.. _`MinIO Storage Driver`: http://cloud.google.com/storage
+.. _`MinIO Storage Driver`: https://min.io/
 .. _`Nimbus.io`: https://nimbus.io/
 .. _`Ninefold`: http://ninefold.com/
 .. _`OpenStack Swift`: http://www.rackspace.com/

--- a/libcloud/storage/drivers/minio.py
+++ b/libcloud/storage/drivers/minio.py
@@ -44,7 +44,7 @@ class MinIOConnectionAWS4(SignedAWSConnection, BaseS3Connection):
 
 class MinIOStorageDriver(BaseS3StorageDriver):
     name = 'MinIO Storage Driver'
-    website = 'http://cloud.google.com/storage'
+    website = 'https://min.io/'
     connectionCls = MinIOConnectionAWS4
     region_name = ""
 


### PR DESCRIPTION
## Fix few Minio homepage links in the documentation

### Description

Some links to Minio storage homepage in the documentation refer in reality to Google cloud storage.
For example in this page: https://libcloud.readthedocs.io/en/latest/storage/supported_providers.html
This small PR fixes that.
I opened a related issue about this.

Fixes #1603 


### Status

Replace this: describe the PR status. Examples:

- done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
