### PR TITLE
setup.py: Fix invalid python_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -271,7 +271,7 @@ setup(
     author='Apache Software Foundation',
     author_email='dev@libcloud.apache.org',
     install_requires=INSTALL_REQUIREMENTS,
-    python_requires=">=3.5.*, <4",
+    python_requires=">=3.5, <4",
     packages=get_packages('libcloud'),
     package_dir={
         'libcloud': 'libcloud',


### PR DESCRIPTION
Fix python_requires to use >=3.5 instead of >=3.5.*, as the latter
is invalid.  It caused distlib to crash:

```
$ python -c "import distlib.database; list(distlib.database.DistributionPath(include_egg=True).get_distributions())"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/lib/python3.8/site-packages/distlib/database.py", line 213, in get_distributions
    self._generate_cache()
  File "/usr/lib/python3.8/site-packages/distlib/database.py", line 167, in _generate_cache
    for dist in self._yield_distributions():
  File "/usr/lib/python3.8/site-packages/distlib/database.py", line 157, in _yield_distributions
    yield old_dist_class(r.path, self)
  File "/usr/lib/python3.8/site-packages/distlib/database.py", line 879, in __init__
    metadata = self._get_metadata(path)
  File "/usr/lib/python3.8/site-packages/distlib/database.py", line 965, in _get_metadata
    metadata.add_requirements(requires)
  File "/usr/lib/python3.8/site-packages/distlib/metadata.py", line 1039, in add_requirements
    self._legacy.add_requirements(requirements)
  File "/usr/lib/python3.8/site-packages/distlib/metadata.py", line 575, in add_requirements
    self['Requires-Dist'] += requirements
  File "/usr/lib/python3.8/site-packages/distlib/metadata.py", line 276, in __setitem__
    return self.set(name, value)
  File "/usr/lib/python3.8/site-packages/distlib/metadata.py", line 453, in set
    if not scheme.is_valid_matcher(v.split(';')[0]):
  File "/usr/lib/python3.8/site-packages/distlib/version.py", line 703, in is_valid_matcher
    self.matcher(s)
  File "/usr/lib/python3.8/site-packages/distlib/version.py", line 115, in __init__
    raise ValueError('\'.*\' not allowed for '
ValueError: '.*' not allowed for '>=' constraints
```

## Changes Title (replace this with a logical title for your changes)

### Description

Replace this with the PR description (mention the changes you have made, why
you have made them, provide some background and any references to the provider
documentation if needed, etc.).

For more information on contributing, please see [Contributing](http://libcloud.readthedocs.org/en/latest/development.html#contributing)
section of our documentation.

### Status

Replace this: describe the PR status. Examples:

- work in progress
- done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
