### PR TITLE
Add binding:host_id in OpenStack port information #1611

### DIFF
--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -2897,7 +2897,7 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
                 admin_state_up=element['admin_state_up'],
                 allowed_address_pairs=element['allowed_address_pairs'],
                 binding_vnic_type=element['binding:vnic_type'],
-                binding_host_id=element.get(['binding:host_id'], None),
+                binding_host_id=element.get('binding:host_id', None),
                 device_id=element['device_id'],
                 description=element.get('description', None),
                 device_owner=element['device_owner'],

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -2897,6 +2897,7 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
                 admin_state_up=element['admin_state_up'],
                 allowed_address_pairs=element['allowed_address_pairs'],
                 binding_vnic_type=element['binding:vnic_type'],
+                binding_host_id=element.get(['binding:host_id'], None),
                 device_id=element['device_id'],
                 description=element.get('description', None),
                 device_owner=element['device_owner'],


### PR DESCRIPTION
## Add binding:host_id in OpenStack port information

### Description

Add binding:host_id in OpenStack port information: see #1611 

### Status

Replace this: describe the PR status. Examples:

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
