### PR TITLE
Integration tests changes and fixes

### DIFF
--- a/integration/storage/base.py
+++ b/integration/storage/base.py
@@ -322,7 +322,7 @@ class Integration:
         container = None
         verbose = False
 
-        container_ready_timeout = 30
+        container_ready_timeout = 20
 
         @classmethod
         def setUpClass(cls):
@@ -350,7 +350,6 @@ class Integration:
 
             # We register atexit handler to ensure container is always killed, even if for some
             # reason tearDownClass is sometimes not called (happened locally a couple of times)
-
             atexit.register(cls._kill_container)
 
             wait_for(cls.port, cls.host)

--- a/integration/storage/test_minio.py
+++ b/integration/storage/test_minio.py
@@ -30,7 +30,7 @@ class MinioTest(Integration.ContainerTestBase):
     port = 9000
     environment = {'MINIO_ROOT_USER': account, 'MINIO_ROOT_PASSWORD': secret}
     command = ['server', '/data']
-    ready_message = b'IAM initialization complete'
+    ready_message = b'Console endpoint is listening on a dynamic port'
 
     def test_cdn_url(self):
         self.skipTest('Not implemented in driver')

--- a/libcloud/http.py
+++ b/libcloud/http.py
@@ -35,6 +35,9 @@ __all__ = [
 
 ALLOW_REDIRECTS = 1
 
+# Default timeout for HTTP requests in seconds
+DEFAULT_REQUEST_TIMEOUT = 60
+
 HTTP_PROXY_ENV_VARIABLE_NAME = 'http_proxy'
 HTTPS_PROXY_ENV_VARIABLE_NAME = 'https_proxy'
 
@@ -202,7 +205,7 @@ class LibcloudConnection(LibcloudBaseConnection):
 
         LibcloudBaseConnection.__init__(self)
 
-        self.session.timeout = kwargs.pop('timeout', 60)
+        self.session.timeout = kwargs.pop('timeout', DEFAULT_REQUEST_TIMEOUT)
 
         if 'cert_file' in kwargs or 'key_file' in kwargs:
             self._setup_signing(**kwargs)

--- a/tox.ini
+++ b/tox.ini
@@ -229,7 +229,7 @@ deps =
     pytest==5.3.2
     -r{toxinidir}/integration/storage/requirements.txt
 
-commands = pytest -vv -s --durations=10 integration/storage
+commands = pytest -vvv -s --durations=10 integration/storage
 
 [testenv:coverage]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -175,7 +175,7 @@ commands =
 deps = -r{toxinidir}/requirements-tests.txt
        bottle
        fasteners
-       paramiko==2.7.1
+       paramiko==2.8.0
        pysphere
 setenv =
     PYTHONPATH={toxinidir}
@@ -235,7 +235,7 @@ commands = pytest -vv -s --durations=10 integration/storage
 deps =
     -r{toxinidir}/requirements-tests.txt
     setuptools==42.0.2
-    paramiko==2.7.1
+    paramiko==2.8.0
     pyopenssl==19.1.0
     python-dateutil
     libvirt-python==5.10.0
@@ -249,7 +249,7 @@ commands = cp libcloud/test/secrets.py-dist libcloud/test/secrets.py
 passenv = TERM TOXENV CI GITHUB_*
 deps =
     -r{toxinidir}/requirements-tests.txt
-    paramiko==2.7.1
+    paramiko==2.8.0
     pyopenssl==19.1.0
     libvirt-python==5.10.0
     fasteners


### PR DESCRIPTION
Just trying to figure out what is going on with integration tests and why they are failing / timing out.

Changes included in this PR:

- Add a deadline / timeout and fail the tests if container doesn't start and become ready in defined timeout
- Ensure containers are always killed / stopped on exit (sometimes it happened locally that for some reason ``tearDownClass`` was not called).
- Decrease default HTTP connection and request timeout