### PR TITLE
Clean up old / stray Azure resources before the test run, speed up tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -37,7 +37,7 @@ jobs:
   integration_tests:
     name: Run Integration Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 8
 
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip == 'false' || github.ref == 'refs/heads/trunk' }}

--- a/integration/storage/base.py
+++ b/integration/storage/base.py
@@ -292,8 +292,12 @@ class Integration:
 
         def _create_tempfile(self, prefix='', content=b''):
             fobj, path = tempfile.mkstemp(prefix=prefix, text=False)
-            os.write(fobj, content)
-            os.close(fobj)
+
+            try:
+                os.write(fobj, content)
+            finally:
+                os.close(fobj)
+
             self.addCleanup(os.remove, path)
             return path
 

--- a/integration/storage/base.py
+++ b/integration/storage/base.py
@@ -155,7 +155,9 @@ class Integration:
             self.assertEqual([blob.name for blob in blobs], [blob_name])
 
             # check that the file can be read back
-            self.assertEqual(do_download(obj), content)
+            downloaded_content = do_download(obj)
+            self.assertEqual(len(downloaded_content), size)
+            self.assertEqual(downloaded_content, content)
 
             # delete the file
             self.driver.delete_object(obj)

--- a/integration/storage/base.py
+++ b/integration/storage/base.py
@@ -257,7 +257,13 @@ class Integration:
 
         def test_objects_stream_iterable(self):
             def do_upload(container, blob_name, content):
-                content = iter([content[i:i + 1] for i in range(len(content))])
+                # NOTE: We originally used a chunk size of 1 which resulted in many requests and as
+                # such, very slow tests. To speed things up, we use a longer chunk size.
+                chunk_size = 1024
+                # Ensure we still use multiple chunks and iterations
+                assert (len(content) / chunk_size) >= 500
+                content = iter([content[i:i + chunk_size] for i in
+                                range(0, len(content), chunk_size)])
                 return self.driver.upload_object_via_stream(content, container, blob_name)
 
             def do_download(obj):

--- a/integration/storage/test_azure_blobs.py
+++ b/integration/storage/test_azure_blobs.py
@@ -34,7 +34,7 @@ except ImportError as e:
 from integration.storage.base import Integration, random_string
 
 # Prefix which is added to all the groups created by tests
-RESOURCE_GROUP_NAME_PREFIX = 'libcloud-itests-'
+RESOURCE_GROUP_NAME_PREFIX = 'libclouditests'
 DEFAULT_TIMEOUT_SECONDS = 300
 DEFAULT_AZURE_LOCATION = 'EastUS2'
 MAX_STORAGE_ACCOUNT_NAME_LENGTH = 24
@@ -144,7 +144,7 @@ class StorageTest(Integration.TestBase):
         delete_threshold_ts = now_ts - int(datetime.timedelta(hours=6).total_seconds())
 
         for resource_group in resource_groups:
-            resource_create_ts = resource_group.tags.get('create_ts', now_ts)
+            resource_create_ts = int(resource_group.tags.get('create_ts', now_ts))
 
             if resource_group.name.startswith(RESOURCE_GROUP_NAME_PREFIX) and \
                resource_group.location.lower() == location.lower() and \

--- a/integration/storage/test_azure_blobs.py
+++ b/integration/storage/test_azure_blobs.py
@@ -138,6 +138,8 @@ class StorageTest(Integration.TestBase):
         # to clean those up to ensure we dont hit any limits.
         # To avoid deleting groups from concurrent runs, we only delete resources older than a
         # couple (6) of hours
+        print("Checking and cleaning up any old stray resource groups...")
+
         resource_groups = resource_client.resource_groups.list()
         now_ts = int(time.time())
         delete_threshold_ts = now_ts - int(datetime.timedelta(hours=6).total_seconds())
@@ -150,6 +152,7 @@ class StorageTest(Integration.TestBase):
             if resource_group.name.startswith(RESOURCE_GROUP_NAME_PREFIX) and \
                resource_group.location.lower() == location.lower() and \
                'test' in resource_group.tags and resource_create_ts <= delete_threshold_ts:
+                assert resource_group.name.startswith(RESOURCE_GROUP_NAME_PREFIX)
                 print("Deleting old stray resource group: %s..." % (resource_group.name))
 
                 try:

--- a/integration/storage/test_azure_blobs.py
+++ b/integration/storage/test_azure_blobs.py
@@ -125,6 +125,7 @@ class StorageTest(Integration.TestBase):
         )
 
         location = os.getenv('AZURE_LOCATION', DEFAULT_AZURE_LOCATION)
+        name = 'libcloud-itests-'
         name = 'libcloud'
         name += random_string(MAX_STORAGE_ACCOUNT_NAME_LENGTH - len(name))
         timeout = float(os.getenv('AZURE_TIMEOUT_SECONDS', DEFAULT_TIMEOUT_SECONDS))
@@ -142,8 +143,8 @@ class StorageTest(Integration.TestBase):
             resource_create_ts = resource_groups.tags.get('create_ts', now_ts)
 
             if resource_group.name.startswith(name) and resource_group.location == location and \
-               'test' in resource_groups.tags and resource_create_ts <= delete_threshold_ts:
-               #'test' in resource_groups.tags and resource_create_ts <= delete_threshold_ts:
+               'test' in resource_group.tags:
+               #'test' in resource_group.tags and resource_create_ts <= delete_threshold_ts:
                 print("Deleting old stray resource group: %s..." % (resource_group.name))
 
                 try:

--- a/integration/storage/test_azure_blobs.py
+++ b/integration/storage/test_azure_blobs.py
@@ -34,8 +34,7 @@ except ImportError as e:
 from integration.storage.base import Integration, random_string
 
 # Prefix which is added to all the groups created by tests
-RESOURCE_GROUP_NAME_PREFIX = 'libcloud'
-# RESOURCE_GROUP_NAME_PREFIX = 'libcloud-tests-'
+RESOURCE_GROUP_NAME_PREFIX = 'libcloud-itests-'
 DEFAULT_TIMEOUT_SECONDS = 300
 DEFAULT_AZURE_LOCATION = 'EastUS2'
 MAX_STORAGE_ACCOUNT_NAME_LENGTH = 24
@@ -146,8 +145,6 @@ class StorageTest(Integration.TestBase):
 
         for resource_group in resource_groups:
             resource_create_ts = resource_group.tags.get('create_ts', now_ts)
-            resource_create_ts = int(resource_group.tags.get('create_ts',
-                                                             delete_threshold_ts - 100))
 
             if resource_group.name.startswith(RESOURCE_GROUP_NAME_PREFIX) and \
                resource_group.location.lower() == location.lower() and \

--- a/integration/storage/test_azure_blobs.py
+++ b/integration/storage/test_azure_blobs.py
@@ -164,7 +164,10 @@ class StorageTest(Integration.TestBase):
                 tags={
                     'test': cls.__name__,
                     'create_ts': str(now_ts),
-                    'run': os.getenv('GITHUB_RUN_ID', '-'),
+                    'gh_run_id': os.getenv('GITHUB_RUN_ID', 'unknown'),
+                    'gh_job_id': os.getenv('GITHUB_JOB_ID', 'unknown'),
+                    'gh_sha': os.getenv('GITHUB_SHA', 'unknown'),
+                    'gh_ref': os.getenv('GITHUB_REF', 'unknown'),
                 },
             ),
             timeout=timeout,

--- a/integration/storage/test_azure_blobs.py
+++ b/integration/storage/test_azure_blobs.py
@@ -33,6 +33,9 @@ except ImportError as e:
 
 from integration.storage.base import Integration, random_string
 
+# Prefix which is added to all the groups created by tests
+RESOURCE_GROUP_NAME_PREFIX = 'libcloud'
+# RESOURCE_GROUP_NAME_PREFIX = 'libcloud-tests-'
 DEFAULT_TIMEOUT_SECONDS = 300
 DEFAULT_AZURE_LOCATION = 'EastUS2'
 MAX_STORAGE_ACCOUNT_NAME_LENGTH = 24
@@ -126,8 +129,7 @@ class StorageTest(Integration.TestBase):
         )
 
         location = os.getenv('AZURE_LOCATION', DEFAULT_AZURE_LOCATION)
-        name = 'libcloud-itests-'
-        name = 'libcloud'
+        name = RESOURCE_GROUP_NAME_PREFIX
         name += random_string(MAX_STORAGE_ACCOUNT_NAME_LENGTH - len(name))
         timeout = float(os.getenv('AZURE_TIMEOUT_SECONDS', DEFAULT_TIMEOUT_SECONDS))
 
@@ -145,7 +147,8 @@ class StorageTest(Integration.TestBase):
             resource_create_ts = int(resource_group.tags.get('create_ts',
                                                              delete_threshold_ts - 100))
 
-            if resource_group.name.startswith(name) and resource_group.location == location and \
+            if resource_group.name.startswith(RESOURCE_GROUP_NAME_PREFIX) and \
+               resource_group.location.lower() == location.lower() and \
                'test' in resource_group.tags and resource_create_ts <= delete_threshold_ts:
                 print("Deleting old stray resource group: %s..." % (resource_group.name))
 

--- a/tox.ini
+++ b/tox.ini
@@ -225,12 +225,13 @@ setenv =
   AZURE_CLIENT_ID=16cd65a3-dfa2-4272-bcdb-842cbbedb1b7
   AZURE_TENANT_ID=982317c6-fb7e-4e92-abcd-196557e41c5b
   AZURE_SUBSCRIPTION_ID=d6d608a6-e0c8-42ae-a548-2f41793709d2
+  # Actual secret token is defined as part of Github repo secret
 
 deps =
-    pytest==5.3.2
+    pytest==6.2.5
     -r{toxinidir}/integration/storage/requirements.txt
 
-commands = pytest -vvv -s --durations=10 integration/storage
+commands = pytest -vvv --capture=tee-sys -o log_cli=True --durations=10 integration/storage
 
 [testenv:coverage]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -219,7 +219,7 @@ deps = -r{toxinidir}/integration/compute/requirements.txt
 commands = python -m integration.compute
 
 [testenv:integration-storage]
-passenv = AZURE_CLIENT_SECRET AWS_ACCESS_KEY_ID AWS_ACCESS_KEY_SECRET
+passenv = AZURE_CLIENT_SECRET AWS_ACCESS_KEY_ID AWS_ACCESS_KEY_SECRET GITHUB_*
 
 setenv =
   AZURE_CLIENT_ID=16cd65a3-dfa2-4272-bcdb-842cbbedb1b7

--- a/tox.ini
+++ b/tox.ini
@@ -231,7 +231,7 @@ deps =
     pytest==6.2.5
     -r{toxinidir}/integration/storage/requirements.txt
 
-commands = pytest -vvv --capture=tee-sys -o log_cli=True --durations=10 integration/storage
+commands = pytest -rsx -vvv --capture=tee-sys -o log_cli=True --durations=10 integration/storage
 
 [testenv:coverage]
 deps =


### PR DESCRIPTION
This pull request updates Azure Blobs integration test class so we clean any old stray resource groups left from previous test runs before we actually run the tests.

This should ensure we don't have any limits and we delete any stray resources from previous runs (we can end up with stray resources if the CI build is terminated non-gracefully and ``tearDownClass`` has no chance to run).