### PR TITLE
Require requests >= 2.26.0 as part of install_requires when running on Python >= 3.6

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,6 +33,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    timeout-minutes: 12
 
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip == 'false' || github.ref == 'refs/heads/trunk' }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,9 +9,33 @@ on:
     - cron: '0 3 * * *'
 
 jobs:
+  # Special job which skips duplicate jobs
+  pre_job:
+    name: Skip Duplicate Jobs Pre Job
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+        with:
+          persist-credentials: false
+          submodules: recursive
+
+      - id: skip_check
+        # NOTE: We store action as submodule since ASF doesn't allow directly referencing external
+        # actions
+        uses: ./.github/actions/skip-duplicate-actions # v3.4.0
+        with:
+          github_token: ${{ github.token }}
+
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip == 'false' || github.ref == 'refs/heads/trunk' }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/install_test.yml
+++ b/.github/workflows/install_test.yml
@@ -1,0 +1,47 @@
+# Workflow which verifies that the latest stable version can be installed from
+# pip on all the supported Python versions
+name: Install stable version using pip
+
+on:
+  push:
+    branches:
+      - requests_changes
+  pull_request:
+    branches:
+      - requests_changes
+  schedule:
+    - cron: '0 13 * * *'
+    - cron: '0 2 * * *'
+
+jobs:
+  install_and_verify:
+    name: Install latest stable version
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python_version:
+          - 3.5
+          - 3.6
+          - 3.7
+          - 3.8
+          - 3.9
+          - pypy3
+
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 1
+
+      - name: Use Python ${{ matrix.python_version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python_version }}
+
+      - name: Install Libcloud
+        run: |
+          pip show apache-libcloud && exit 1
+          pip install apache-libcloud
+          pip show apache-libcloud

--- a/.github/workflows/install_test.yml
+++ b/.github/workflows/install_test.yml
@@ -3,12 +3,6 @@
 name: Install stable version using pip
 
 on:
-  push:
-    branches:
-      - requests_changes
-  pull_request:
-    branches:
-      - requests_changes
   schedule:
     - cron: '0 13 * * *'
     - cron: '0 2 * * *'

--- a/.github/workflows/install_test.yml
+++ b/.github/workflows/install_test.yml
@@ -17,7 +17,7 @@ jobs:
   install_and_verify:
     name: Install latest stable version
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 2
 
     strategy:
       fail-fast: false
@@ -42,6 +42,7 @@ jobs:
 
       - name: Install Libcloud
         run: |
+          python --version
           pip show apache-libcloud && exit 1
           pip install apache-libcloud
           pip show apache-libcloud

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,6 +84,54 @@ jobs:
         run: |
          script -e -c "tox -e py${{ matrix.python_version }}"
 
+  dist_install_checks:
+    name: Dist Install Checks
+    runs-on: ${{ matrix.os }}
+
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip == 'false' || github.ref == 'refs/heads/trunk' }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python_version:
+          - 3.5
+          - 3.6
+          - 3.7
+        os:
+          - ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 1
+
+      - name: Use Python ${{ matrix.python_version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python_version }}
+
+      - name: Install OS / deb dependencies
+        run: |
+          sudo DEBIAN_FRONTEND=noninteractive apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -yq gcc libvirt-dev
+
+      - name: Cache Python Dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements-tests.txt', '') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install Python Dependencies
+        run: |
+          pip install "tox==3.24.4"
+
+      - name: Run tox target
+        run: |
+         script -e -c "tox -e py${{ matrix.python_version }}-dist,py${{ matrix.python_version }}-dist-wheel"
+
   code_coverage:
     name: Generate Code Coverage
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,7 @@ jobs:
   unit_tests:
     name: Run Unit Tests And Install Checks
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 8
 
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip == 'false' || github.ref == 'refs/heads/trunk' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
          script -e -c "tox -e py${{ matrix.python_version }}"
 
-      - name: Run dist installchecks tox target
+      - name: Run dist install checks tox target
         if: ${{ matrix.python_version != 'pypy3' }}
         run: |
          script -e -c "tox -e py${{ matrix.python_version }}-dist,py${{ matrix.python_version }}-dist-wheel"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
           github_token: ${{ github.token }}
 
   unit_tests:
-    name: Run Unit Tests
+    name: Run Unit Tests And Install Checks
     runs-on: ${{ matrix.os }}
 
     needs: pre_job
@@ -80,55 +80,12 @@ jobs:
         run: |
           pip install "tox==3.24.4"
 
-      - name: Run tox target
+      - name: Run unit tests tox target
         run: |
          script -e -c "tox -e py${{ matrix.python_version }}"
 
-  dist_install_checks:
-    name: Dist Install Checks
-    runs-on: ${{ matrix.os }}
-
-    needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip == 'false' || github.ref == 'refs/heads/trunk' }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        python_version:
-          - 3.5
-          - 3.6
-          - 3.7
-        os:
-          - ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@master
-        with:
-          fetch-depth: 1
-
-      - name: Use Python ${{ matrix.python_version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python_version }}
-
-      - name: Install OS / deb dependencies
-        run: |
-          sudo DEBIAN_FRONTEND=noninteractive apt-get update
-          sudo DEBIAN_FRONTEND=noninteractive apt-get install -yq gcc libvirt-dev
-
-      - name: Cache Python Dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements-tests.txt', '') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
-      - name: Install Python Dependencies
-        run: |
-          pip install "tox==3.24.4"
-
-      - name: Run tox target
+      - name: Run dist installchecks tox target
+        if: ${{ matrix.python_version != 'pypy3' }}
         run: |
          script -e -c "tox -e py${{ matrix.python_version }}-dist,py${{ matrix.python_version }}-dist-wheel"
 

--- a/.github/workflows/publish_pricing_to_s3.yml
+++ b/.github/workflows/publish_pricing_to_s3.yml
@@ -10,6 +10,7 @@ jobs:
   generate_and_publish_pricing_data:
     name: Generate and Publish Pricing file to S3
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     strategy:
       matrix:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,20 @@ Common
 
 - Update setup.py metadata and indicate we also support Python 3.10.
 
+- Update minimum ``requests`` version we require as part for install_requires
+  in setup.py to ``2.26.0`` when using Python >= 3.6.
+
+  This was done to avoid licensing issue with transitive dependency
+  (``chardet``).
+
+  NOTE: requests ``>=2.25.1`` will be used when using Python 3.5 since 2.26.0
+  doesn't support Python 3.5 anymore.
+
+  For more context, see https://github.com/psf/requests/pull/5797.
+  (GITHUB-1594)
+
+  Reported by Jarek Potiuk - @potiuk.
+
 Storage
 ~~~~~~~
 

--- a/docs/compute/_supported_methods_block_storage.rst
+++ b/docs/compute/_supported_methods_block_storage.rst
@@ -12,7 +12,7 @@ Provider                              list volumes create volume destroy volume 
 `Brightbox`_                          no           no            no             no            no            no             no             
 `BSNL`_                               no           no            no             no            no            no             no             
 `Cloudscale`_                         no           no            no             no            no            no             no             
-`CloudSigma (API v2.0)`_              no           no            no             no            no            no             no             
+`CloudSigma (API v2.0)`_              yes          yes           yes            yes           yes           no             no             
 `CloudStack`_                         yes          yes           yes            yes           yes           no             yes            
 `Cloudwatt`_                          yes          yes           yes            yes           yes           yes            yes            
 `DigitalOcean`_                       yes          yes           yes            yes           yes           yes            yes            

--- a/docs/compute/_supported_methods_key_pair_management.rst
+++ b/docs/compute/_supported_methods_key_pair_management.rst
@@ -12,7 +12,7 @@ Provider                              list key pairs get key pair create key pai
 `Brightbox`_                          no             no           no              no                            no                          no             
 `BSNL`_                               no             no           no              no                            no                          no             
 `Cloudscale`_                         no             no           no              no                            no                          no             
-`CloudSigma (API v2.0)`_              no             no           no              no                            no                          no             
+`CloudSigma (API v2.0)`_              yes            yes          yes             yes                           no                          yes            
 `CloudStack`_                         yes            yes          yes             yes                           no                          yes            
 `Cloudwatt`_                          yes            yes          yes             yes                           no                          yes            
 `DigitalOcean`_                       yes            yes          yes             no                            no                          yes            

--- a/docs/compute/_supported_methods_main.rst
+++ b/docs/compute/_supported_methods_main.rst
@@ -12,7 +12,7 @@ Provider                              list nodes create node reboot node destroy
 `Brightbox`_                          yes        yes         no          yes          no         no        yes         yes        no         
 `BSNL`_                               yes        yes         yes         yes          yes        yes       yes         yes        yes        
 `Cloudscale`_                         yes        yes         yes         yes          yes        yes       yes         yes        no         
-`CloudSigma (API v2.0)`_              yes        yes         no          yes          yes        yes       yes         yes        no         
+`CloudSigma (API v2.0)`_              yes        yes         yes         yes          yes        yes       yes         yes        no         
 `CloudStack`_                         yes        yes         yes         yes          no         no        yes         yes        yes        
 `Cloudwatt`_                          yes        yes         yes         yes          yes        yes       yes         yes        yes        
 `DigitalOcean`_                       yes        yes         yes         yes          no         no        yes         yes        no         

--- a/libcloud/common/openstack_identity.py
+++ b/libcloud/common/openstack_identity.py
@@ -1422,7 +1422,7 @@ class OpenStackIdentity_3_0_Connection_AppCred(
         Tenant, domain and scope options are ignored as they are contained
         within the app credential itself and can't be changed.
         """
-        super(OpenStackIdentity_3_0_Connection,
+        super(OpenStackIdentity_3_0_Connection_AppCred,
               self).__init__(auth_url=auth_url,
                              user_id=user_id,
                              key=key,

--- a/libcloud/test/dns/test_base.py
+++ b/libcloud/test/dns/test_base.py
@@ -83,6 +83,8 @@ class BaseTestCase(unittest.TestCase):
         self.driver.list_records = Mock()
         self.driver.list_records.return_value = mock_records
 
+        now = datetime.datetime.utcnow()
+
         result = self.driver.export_zone_to_bind_format(zone=zone)
         self.driver.export_zone_to_bind_zone_file(zone=zone,
                                                   file_path=self.tmp_path)
@@ -93,7 +95,6 @@ class BaseTestCase(unittest.TestCase):
         lines1 = result.split('\n')
         lines2 = content.split('\n')
 
-        now = datetime.datetime.utcnow()
         date_str = "%s-%s-%s %s:%s:%s" % (now.year, zero_pad(now.month),
                                           zero_pad(now.day),
                                           zero_pad(now.hour),

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -5,7 +5,8 @@ pylint==2.4.4
 mock==3.0.5
 codecov==2.1.10
 coverage==4.5.4
-requests
+requests>=2.25.0; python_version <= '3.5'
+requests>=2.26.0; python_version >= '3.6'
 requests_mock
 # 5.3.2 is latest version which still supports Python 3.5, >= 6.2.5 is needed for Python 3.10
 pytest==5.3.2; python_version <= '3.5'

--- a/scripts/dist_install_check.sh
+++ b/scripts/dist_install_check.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+# Verify library installs without any dependencies when using python setup.py
+# install
+echo "Running dist checks"
+pip show requests && exit 1
+pip show typing && exit 1
+pip show enum34 && exit 1
+pip show apache-libcloud
+
+# Install the library
+python setup.py install
+pip show apache-libcloud
+
+# Verify all dependencies were installed
+pip show requests
+pip show typing && exit 1
+pip show enum34 && exit 1
+
+echo "Done"

--- a/scripts/dist_install_check.sh
+++ b/scripts/dist_install_check.sh
@@ -18,8 +18,7 @@
 
 # Verify library installs without any dependencies when using python setup.py
 # install
-echo "Running dist checks"
-
+echo "Running dist install checks"
 python --version
 
 # Ensure those packages are not installed. If they are, it indicates unclean

--- a/scripts/dist_install_check.sh
+++ b/scripts/dist_install_check.sh
@@ -19,6 +19,11 @@
 # Verify library installs without any dependencies when using python setup.py
 # install
 echo "Running dist checks"
+
+python --version
+
+# Ensure those packages are not installed. If they are, it indicates unclean
+# environment so those checks won't work correctly
 pip show requests && exit 1
 pip show typing && exit 1
 pip show enum34 && exit 1

--- a/scripts/dist_wheel_install_check.sh
+++ b/scripts/dist_wheel_install_check.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+# Verify library installs without any dependencies when using built wheel
+
+echo "Running dist wheel checks"
+
+# Ensure those packages are not installed. If they are, it indicates unclean
+# environment so those checks won't work correctly
+pip show requests && exit 1
+pip show typing && exit 1
+pip show enum34 && exit 1
+pip show apache-libcloud
+rm -rf dist/apache_libcloud-*.whl
+
+pip install wheel
+python setup.py bdist_wheel
+pip install dist/apache_libcloud-*.whl
+
+# Verify all dependencies were installed
+pip show requests
+pip show typing && exit 1
+pip show enum34 && exit 1
+
+echo "Done"

--- a/scripts/dist_wheel_install_check.sh
+++ b/scripts/dist_wheel_install_check.sh
@@ -18,7 +18,8 @@
 
 # Verify library installs without any dependencies when using built wheel
 
-echo "Running dist wheel checks"
+echo "Running dist wheel install checks"
+python --version
 
 # Ensure those packages are not installed. If they are, it indicates unclean
 # environment so those checks won't work correctly

--- a/setup.py
+++ b/setup.py
@@ -173,9 +173,16 @@ SUPPORTED_VERSIONS = ['PyPy 3', 'Python 3.5+']
 # setuptools >= 36.2
 # For installation, minimum required pip version is 1.4
 # Reference: https://hynek.me/articles/conditional-python-dependencies/
-INSTALL_REQUIREMENTS = [
-    'requests>=2.5.0',
-]
+# We rely on >= 2.26.0 to avoid issues with LGL transitive dependecy
+# See https://github.com/apache/libcloud/issues/1594 for more context
+INSTALL_REQUIREMENTS = []
+
+if sys.version_info < (3, 6, 0):
+    # requests 2.26.0 doesn't support Python 3.5 anymore
+    INSTALL_REQUIREMENTS.append('requests>=2.25.1')
+else:
+    INSTALL_REQUIREMENTS.append('requests>=2.26.0')
+
 
 setuptools_version = tuple(setuptools.__version__.split(".")[0:2])
 setuptools_version = tuple([int(c) for c in setuptools_version])

--- a/tox.ini
+++ b/tox.ini
@@ -170,6 +170,8 @@ deps = pyopenssl==19.1.0
        fasteners
        rstcheck
        requests_mock
+       # Pinned due to a bug in a newer version
+       docutils<=0.16
 changedir = docs
 commands = pip install sphinx==3.3.1
            rstcheck --report warning ../README.rst

--- a/tox.ini
+++ b/tox.ini
@@ -12,8 +12,8 @@ deps =
 basepython =
     pypypy3.5: pypy3.5
     pypypy3: pypy3
-    py3.5: python3.5
-    py3.6: python3.6
+    {py3.5,py3.5-dist,py3.5-dist-wheel}: python3.5
+    {py3.6,py3.6-dist,py3.6-dist-wheel}: python3.6
     {py3.7,docs,checks,lint,pylint,mypy,coverage,docs,py3.7-dist,py3.7-dist-wheel}: python3.7
     {py3.8,py3.8-windows,integration-storage}: python3.8
     {py3.9}: python3.9
@@ -33,7 +33,7 @@ deps =
     fasteners
     setuptools==42.0.2
 
-[testenv:py3.7-dist]
+[testenv:py3.5-dist]
 # Verify library installs without any dependencies when using python setup.py
 # install
 skipdist = True
@@ -43,16 +43,45 @@ recreate = True
 deps =
 # Ensure those packages are not installed. If they are, it indicates unclean
 # environment so those checks won't work correctly
-commands = bash -c "pip show requests && exit 1 || exit 0"
-           bash -c "pip show typing && exit 1 || exit 0"
-           bash -c "pip show enum34 && exit 1 || exit 0"
-           bash -c "pip show apache-libcloud || exit 0"
-           python setup.py install
-           pip show apache-libcloud
-           # Verify all dependencies were installed
-           pip show requests
-           bash -c "pip show typing && exit 1 || exit 0"
-           bash -c "pip show enum34 && exit 1 || exit 0"
+commands = bash ./scripts/dist_install_check.sh
+
+[testenv:py3.5-dist-wheel]
+# Verify library installs without any dependencies when using built wheel
+skipdist = True
+recreate = True
+# NOTE: We intentionally set empty deps to ensure it works on a clean
+# environment without any dependencies
+deps =
+commands = bash -c "./scripts/dist_wheel_install_check.sh"
+
+[testenv:py3.6-dist]
+# Verify library installs without any dependencies when using python setup.py
+# install
+skipdist = True
+recreate = True
+# NOTE: We intentionally set empty deps to ensure it works on a clean
+# environment without any dependencies
+deps =
+commands = bash -c "./scripts/dist_install_check.sh"
+
+[testenv:py3.6-dist-wheel]
+# Verify library installs without any dependencies when using built wheel
+skipdist = True
+recreate = True
+# NOTE: We intentionally set empty deps to ensure it works on a clean
+# environment without any dependencies
+deps =
+commands = bash -c "./scripts/dist_wheel_install_check.sh"
+
+[testenv:py3.7-dist]
+# Verify library installs without any dependencies when using python setup.py
+# install
+skipdist = True
+recreate = True
+# NOTE: We intentionally set empty deps to ensure it works on a clean
+# environment without any dependencies
+deps =
+commands = bash -c "./scripts/dist_install_check.sh"
 
 [testenv:py3.7-dist-wheel]
 # Verify library installs without any dependencies when using built wheel
@@ -61,20 +90,7 @@ recreate = True
 # NOTE: We intentionally set empty deps to ensure it works on a clean
 # environment without any dependencies
 deps =
-# Ensure those packages are not installed. If they are, it indicates unclean
-# environment so those checks won't work correctly
-commands = bash -c "pip show requests && exit 1 || exit 0"
-           bash -c "pip show typing && exit 1 || exit 0"
-           bash -c "pip show enum34 && exit 1 || exit 0"
-           bash -c "pip show apache-libcloud || exit 0"
-           bash -c "rm -rf dist/apache_libcloud-*.whl"
-           pip install wheel
-           python setup.py bdist_wheel
-           bash -c "pip install dist/apache_libcloud-*.whl"
-           # Verify all dependencies were installed
-           pip show requests
-           bash -c "pip show typing && exit 1 || exit 0"
-           bash -c "pip show enum34 && exit 1 || exit 0"
+commands = bash -c "./scripts/dist_wheel_install_check.sh"
 
 [testenv:docs]
 deps = pyopenssl==19.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ basepython =
     {py3.7,docs,checks,lint,pylint,mypy,coverage,docs,py3.7-dist,py3.7-dist-wheel}: python3.7
     {py3.8,py3.8-windows,integration-storage,py3.8-dist,py3.8-dist-wheel}: python3.8
     {py3.9,py3.9-dist,py3.9-dist-wheel}: python3.9
-    {py3.10}: python3.10
+    {py3.10,py3.10-dist,py3.10-dist-wheel}: python3.10
 setenv =
   CRYPTOGRAPHY_ALLOW_OPENSSL_102=1
 commands = cp libcloud/test/secrets.py-dist libcloud/test/secrets.py
@@ -122,6 +122,25 @@ deps =
 commands = bash -c "./scripts/dist_install_check.sh"
 
 [testenv:py3.9-dist-wheel]
+# Verify library installs without any dependencies when using built wheel
+skipdist = True
+recreate = True
+# NOTE: We intentionally set empty deps to ensure it works on a clean
+# environment without any dependencies
+deps =
+commands = bash -c "./scripts/dist_wheel_install_check.sh"
+
+[testenv:py3.10-dist]
+# Verify library installs without any dependencies when using python setup.py
+# install
+skipdist = True
+recreate = True
+# NOTE: We intentionally set empty deps to ensure it works on a clean
+# environment without any dependencies
+deps =
+commands = bash -c "./scripts/dist_install_check.sh"
+
+[testenv:py3.10-dist-wheel]
 # Verify library installs without any dependencies when using built wheel
 skipdist = True
 recreate = True

--- a/tox.ini
+++ b/tox.ini
@@ -15,8 +15,8 @@ basepython =
     {py3.5,py3.5-dist,py3.5-dist-wheel}: python3.5
     {py3.6,py3.6-dist,py3.6-dist-wheel}: python3.6
     {py3.7,docs,checks,lint,pylint,mypy,coverage,docs,py3.7-dist,py3.7-dist-wheel}: python3.7
-    {py3.8,py3.8-windows,integration-storage}: python3.8
-    {py3.9}: python3.9
+    {py3.8,py3.8-windows,integration-storage,py3.8-dist,py3.8-dist-wheel}: python3.8
+    {py3.9,py3.9-dist,py3.9-dist-wheel}: python3.9
     {py3.10}: python3.10
 setenv =
   CRYPTOGRAPHY_ALLOW_OPENSSL_102=1
@@ -84,6 +84,44 @@ deps =
 commands = bash -c "./scripts/dist_install_check.sh"
 
 [testenv:py3.7-dist-wheel]
+# Verify library installs without any dependencies when using built wheel
+skipdist = True
+recreate = True
+# NOTE: We intentionally set empty deps to ensure it works on a clean
+# environment without any dependencies
+deps =
+commands = bash -c "./scripts/dist_wheel_install_check.sh"
+
+[testenv:py3.8-dist]
+# Verify library installs without any dependencies when using python setup.py
+# install
+skipdist = True
+recreate = True
+# NOTE: We intentionally set empty deps to ensure it works on a clean
+# environment without any dependencies
+deps =
+commands = bash -c "./scripts/dist_install_check.sh"
+
+[testenv:py3.8-dist-wheel]
+# Verify library installs without any dependencies when using built wheel
+skipdist = True
+recreate = True
+# NOTE: We intentionally set empty deps to ensure it works on a clean
+# environment without any dependencies
+deps =
+commands = bash -c "./scripts/dist_wheel_install_check.sh"
+
+[testenv:py3.9-dist]
+# Verify library installs without any dependencies when using python setup.py
+# install
+skipdist = True
+recreate = True
+# NOTE: We intentionally set empty deps to ensure it works on a clean
+# environment without any dependencies
+deps =
+commands = bash -c "./scripts/dist_install_check.sh"
+
+[testenv:py3.9-dist-wheel]
 # Verify library installs without any dependencies when using built wheel
 skipdist = True
 recreate = True


### PR DESCRIPTION
This pull request aims to resolve #1594 (at least partially).

Since we still support Python 3.5, we require older version of requests when running under Python 3.6 since the latest version of requests doesn't support Python 3.5 anymore.

In addition to that, I updated CI job to also run all the dist install checks there - I thought we already did that on CI, probably got lost when moving from Travis to Github Actions or similar.