### PR TITLE
[Google] Don't retry failed requests on auth when determining if GCE metadata server is available

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,19 @@ Common
 
 - Update setup.py metadata and indicate we also support Python 3.10.
 
+- [Google] Update Google authentication code so we don't try to retry failed
+  request when trying to determine if GCE metadata server is available when
+  retrying is enabled globally (either via module level constant or via
+  environment variable value).
+
+  This will speed up scenarios when trying is enabled globally, but GCE
+  metadata server is not available and different type of credentials are used
+  (e.g. oAuth 2).
+
+  (GITHUB-1591)
+
+  Reported by Veith Röthlingshöfer - @RunOrVeith.
+
 Storage
 ~~~~~~~
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,14 @@ Common
 
 - Update setup.py metadata and indicate we also support Python 3.10.
 
+- [Google] Update Google authentication code so so we don't try to contact
+  GCE metadata server when determining auth credentials type when oAuth 2.0 /
+  installed app type of credentials are used.
+
+  (GITHUB-1591, GITHUB-1621)
+
+  Reported by Veith Röthlingshöfer - @RunOrVeith.
+
 - [Google] Update Google authentication code so we don't try to retry failed
   request when trying to determine if GCE metadata server is available when
   retrying is enabled globally (either via module level constant or via
@@ -25,7 +33,7 @@ Common
   metadata server is not available and different type of credentials are used
   (e.g. oAuth 2).
 
-  (GITHUB-1591)
+  (GITHUB-1591, GITHUB-1621)
 
   Reported by Veith Röthlingshöfer - @RunOrVeith.
 

--- a/libcloud/__init__.py
+++ b/libcloud/__init__.py
@@ -102,7 +102,14 @@ def _init_once():
 
         if have_paramiko and hasattr(paramiko.util, 'log_to_file'):
             import logging
-            paramiko.util.log_to_file(filename=path, level=logging.DEBUG)
+            # paramiko always tries to open file path in append mode which won't work with
+            # /dev/{stdout, stderr} so we just ignore those errors
+
+            try:
+                paramiko.util.log_to_file(filename=path, level=logging.DEBUG)
+            except OSError as e:
+                if "illegal seek" not in str(e).lower():
+                    raise e
 
     # check for broken `yum install python-requests`
     if have_requests and requests.__version__ == '2.6.0':

--- a/libcloud/common/base.py
+++ b/libcloud/common/base.py
@@ -500,7 +500,8 @@ class Connection(object):
         self.ua.append(token)
 
     def request(self, action, params=None, data=None, headers=None,
-                method='GET', raw=False, stream=False, json=None):
+                method='GET', raw=False, stream=False, json=None,
+                retry_failed=None):
         """
         Request a given `action`.
 
@@ -535,6 +536,10 @@ class Connection(object):
                     and allow streaming of the response data
                     (for downloading large files)
 
+        :param retry_failed: True if failed requests should be retried. This
+                              argument can override module level constant and
+                              environment variable value on per-request basis.
+
         :return: An :class:`Response` instance.
         :rtype: :class:`Response` instance
 
@@ -551,6 +556,11 @@ class Connection(object):
 
         retry_enabled = os.environ.get('LIBCLOUD_RETRY_FAILED_HTTP_REQUESTS',
                                        False) or RETRY_FAILED_HTTP_REQUESTS
+
+        # Method level argument has precedence over module level constant and
+        # environment variable
+        if retry_failed is not None:
+            retry_enabled = retry_failed
 
         action = self.morph_action_hook(action)
         self.action = action

--- a/libcloud/common/google.py
+++ b/libcloud/common/google.py
@@ -595,14 +595,24 @@ class GoogleAuthType(object):
             return cls.SA
         elif cls._is_gcs_s3(user_id):
             return cls.GCS_S3
+        elif cls._is_installed_application(user_id):
+            # NOTE: This should be before "_is_gce()" call so we avoid
+            # querying GCE metadata service if that's not necessary
+            return cls.IA
         elif cls._is_gce():
             return cls.GCE
         else:
+            # TODO: It's probably safe to throw here, but we return cls.IA
+            # for backward compatibility reasons
             return cls.IA
 
     @classmethod
     def is_oauth2(cls, auth_type):
         return auth_type in cls.OAUTH2_TYPES
+
+    @staticmethod
+    def _is_installed_application(user_id):
+        return user_id.endswith('apps.googleusercontent.com')
 
     @staticmethod
     def _is_gce():

--- a/libcloud/common/google.py
+++ b/libcloud/common/google.py
@@ -67,6 +67,8 @@ Please remember to secure your keys and access tokens.
 
 from __future__ import with_statement
 
+from typing import Optional
+
 try:
     import simplejson as json
 except ImportError:
@@ -124,7 +126,7 @@ def _from_utc_timestamp(timestamp):
     return datetime.datetime.strptime(timestamp, UTC_TIMESTAMP_FORMAT)
 
 
-def _get_gce_metadata(path='', retry_failed: bool = None):
+def _get_gce_metadata(path='', retry_failed: Optional[bool] = None):
     try:
         url = 'http://metadata/computeMetadata/v1/' + path.lstrip('/')
         headers = {'Metadata-Flavor': 'Google'}

--- a/libcloud/test/common/test_google.py
+++ b/libcloud/test/common/test_google.py
@@ -59,6 +59,7 @@ GCE_PARAMS_PEM_KEY = ('email@developer.gserviceaccount.com', PEM_KEY)
 GCE_PARAMS_JSON_KEY = ('email@developer.gserviceaccount.com', JSON_KEY)
 GCE_PARAMS_KEY = ('email@developer.gserviceaccount.com', KEY_STR)
 GCE_PARAMS_IA = ('client_id', 'client_secret')
+GCE_PARAMS_IA_2 = ('client_id@test.apps.googleusercontent.com', 'client_secret')
 GCE_PARAMS_GCE = ('foo', 'bar')
 # GOOG + 16 alphanumeric chars
 GCS_S3_PARAMS_20 = ('GOOG0123456789ABCXYZ',
@@ -252,6 +253,15 @@ class GoogleAuthTypeTest(GoogleTestCase):
                 GoogleAuthType.GCS_S3)
             self.assertEqual(GoogleAuthType.guess_type(GCE_PARAMS_GCE[0]),
                              GoogleAuthType.GCE)
+
+    def test_guess_gce_metadata_server_not_called_for_ia(self):
+        # Verify that we don't try to contact GCE metadata server in case IA
+        # credentials are used
+        with mock.patch.object(GoogleAuthType, '_is_gce', return_value=False):
+            self.assertEqual(GoogleAuthType._is_gce.call_count, 0)
+            self.assertEqual(GoogleAuthType.guess_type(GCE_PARAMS_IA_2[0]),
+                            GoogleAuthType.IA)
+            self.assertEqual(GoogleAuthType._is_gce.call_count, 0)
 
 
 class GoogleOAuth2CredentialTest(GoogleTestCase):

--- a/libcloud/utils/connection.py
+++ b/libcloud/utils/connection.py
@@ -21,7 +21,7 @@ __all__ = [
 ]
 
 
-def get_response_object(url, method='GET', headers=None):
+def get_response_object(url, method='GET', headers=None, retry_failed=None):
     """
     Utility function which uses libcloud's connection class to issue an HTTP
     request.
@@ -35,6 +35,8 @@ def get_response_object(url, method='GET', headers=None):
     :param headers: Optional request headers.
     :type headers: ``dict``
 
+    :param retry_failed: True to retry failed requests.
+
     :return: Response object.
     :rtype: :class:`Response`.
     """
@@ -47,5 +49,6 @@ def get_response_object(url, method='GET', headers=None):
 
     con = Connection(secure=secure, host=parsed_url.netloc)
     response = con.request(action=parsed_url.path, params=parsed_qs,
-                           headers=headers, method=method)
+                           headers=headers, method=method,
+                           retry_failed=retry_failed)
     return response


### PR DESCRIPTION
This pull request should help with an edge case / issue reported in #1591.

## Background, context

Right now if retrying failed HTTP requests is enabled globally (either via module level constant or via environment variable value), Libcloud will also try to retry a request inside ``_is_gce()`` on driver instantiation / authentication where we try to determine if GCE metadata server is available and what kind of auth credentials are provided by the user.

This is not desired when GCE metadata server is not available and a different type of credentials are used (e.g. oAuth 2).

## Proposed Approach

In this PR, I simply disable retrying failed requests for that code piece where we determine if metadata server is available.

I think this should be sufficient, but if needed / desired, we can add another argument to the driver constructor which would cause driver to skip this step all together (e.g. ``ex_don_check_gce_metadata_server``).

## TODO

- [x] Unit tests