### PR TITLE
Fix object name prefix based filtering in the local storage driver

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -203,6 +203,48 @@ jobs:
         run: |
           script -e -c "tox -e black-check,checks,import-timings,lint,pylint"
 
+  micro-benchmarks:
+    name: Micro Benchmarks
+    runs-on: ubuntu-latest
+
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip == 'false' || github.ref == 'refs/heads/trunk' }}
+
+    strategy:
+      matrix:
+        python_version: [3.7]
+
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 1
+
+      - name: Use Python ${{ matrix.python_version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python_version }}
+
+      - name: Install OS / deb dependencies
+        run: |
+          sudo DEBIAN_FRONTEND=noninteractive apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -yq graphviz gcc libvirt-dev
+
+      - name: Cache Python Dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements-tests.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install Python Dependencies
+        run: |
+          pip install "tox==3.24.4"
+
+      - name: Run Micro Benchmarks
+        run: |
+          script -e -c "tox -e micro-benchmarks"
+
   docs:
     name: Build and upload Documentation
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ report.html
 .pytest_cache
 .mypy_cache/
 libcloud/data/pricing.json.sha*
+benchmark_histograms/

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,16 @@ Compute
   (GITHUB-1628)
   [Arturo Noha - @r2ronoha, Tomaz Muraus - @Kami]
 
+Storage
+~~~~~~~
+
+- [Local Storage] Fix object name prefix based filtering in the
+  ``list_container_objects`` method.
+
+  Reported by @louis-van-der-stam.
+  (GITHUB-1631)
+  [Tomaz Muraus - @Kami]
+
 Common
 ~~~~~~
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,13 +15,17 @@ Storage
 ~~~~~~~
 
 - [Local Storage] Fix object name prefix based filtering in the
-  ``list_container_objects`` method.
+  ``list_container_objects()`` method.
+
+  A change in the previous release inadvertently introduced a regression which
+  changed the behavior so the object name prefix based filtering didn't work
+  correctly in all the scenarios.
 
   Reported by @louis-van-der-stam.
   (GITHUB-1631)
   [Tomaz Muraus - @Kami]
 
-- [Local Storage] Objects returned by the ``list_container_objects`` method
+- [Local Storage] Objects returned by the ``list_container_objects()`` method
   are now returned sorted in the ascending order based on the object name.
 
   Previously the order was arbitrary and not stable and consistent across

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,8 +24,8 @@ Storage
 - [Local Storage] Objects returned by the ``list_container_objects`` method
   are now returned sorted in the ascending order based on the object name.
 
-  Previously the order was not stable and consistent across different Python
-  versions and implementations.
+  Previously the order was arbitrary and not stable and consistent across
+  different environments and runs.
 
   (GITHUB-1631)
   [Tomaz Muraus - @Kami]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,15 @@ Storage
   (GITHUB-1631)
   [Tomaz Muraus - @Kami]
 
+- [Local Storage] Objects returned by the ``list_container_objects`` method
+  are now returned sorted in the ascending order based on the object name.
+
+  Previously the order was not stable and consistent across different Python
+  versions and implementations.
+
+  (GITHUB-1631)
+  [Tomaz Muraus - @Kami]
+
 Common
 ~~~~~~
 

--- a/libcloud/storage/drivers/local.py
+++ b/libcloud/storage/drivers/local.py
@@ -51,10 +51,6 @@ from libcloud.storage.types import InvalidContainerNameError
 
 IGNORE_FOLDERS = [".lock", ".hash"]
 
-# True if objects should be sorted by name in ascending order when listening them. Should only set
-# this to False for tests and similar.
-SORT_OBJECTS_ON_LIST = True
-
 
 class NoOpLockLocalStorage(object):
     def __init__(self, path, timeout=5):
@@ -327,9 +323,7 @@ class LocalStorageDriver(StorageDriver):
         prefix = self._normalize_prefix_argument(prefix, ex_prefix)
 
         objects = self._get_objects(container)
-
-        if SORT_OBJECTS_ON_LIST:
-            objects = sorted(objects, key=lambda o: o.name)
+        objects = sorted(objects, key=lambda o: o.name)
 
         return self._filter_listed_container_objects(objects, prefix)
 

--- a/libcloud/storage/drivers/local.py
+++ b/libcloud/storage/drivers/local.py
@@ -288,6 +288,7 @@ class LocalStorageDriver(StorageDriver):
         prefix = self._normalize_prefix_argument(prefix, ex_prefix)
 
         objects = self._get_objects(container)
+        objects = sorted(objects, key=lambda o: o.name)
         return self._filter_listed_container_objects(objects, prefix)
 
     def get_container(self, container_name):

--- a/libcloud/storage/drivers/local.py
+++ b/libcloud/storage/drivers/local.py
@@ -251,18 +251,14 @@ class LocalStorageDriver(StorageDriver):
                 continue
             yield self._make_container(container_name)
 
-    def _get_objects(self, container, prefix=None):
+    def _get_objects(self, container):
         """
         Recursively iterate through the file-system and return the object names
         """
 
         cpath = self.get_container_cdn_url(container, check=True)
 
-        fpath = cpath
-        if prefix:
-            fpath = os.path.join(cpath, prefix)
-
-        for folder, subfolders, files in os.walk(fpath, topdown=True):
+        for folder, subfolders, files in os.walk(cpath, topdown=True):
             # Remove unwanted subfolders
             for subf in IGNORE_FOLDERS:
                 if subf in subfolders:
@@ -291,7 +287,8 @@ class LocalStorageDriver(StorageDriver):
         """
         prefix = self._normalize_prefix_argument(prefix, ex_prefix)
 
-        return self._get_objects(container, prefix)
+        objects = self._get_objects(container)
+        return self._filter_listed_container_objects(objects, prefix)
 
     def get_container(self, container_name):
         """

--- a/libcloud/storage/drivers/local.py
+++ b/libcloud/storage/drivers/local.py
@@ -51,11 +51,12 @@ from libcloud.storage.types import InvalidContainerNameError
 
 IGNORE_FOLDERS = [".lock", ".hash"]
 
-# This modul level constants if we should use locking or not. Keep in mind that
-# locking should only be disabled in special circumstances (e.g. in some
-# special tests and benchmark)
+# This module level constants if we should use locking or not. Keep in mind that locking should
+# only be disabled in special circumstances (e.g. in some special tests and benchmarks)
 USE_LOCKING = True
 
+# True if objects should be sorted by name in ascending order when listening them. Should only set
+# this to False for tests and similar.
 SORT_OBJECTS_ON_LIST = True
 
 

--- a/libcloud/test/benchmarks/test_list_objects_filtering_performance.py
+++ b/libcloud/test/benchmarks/test_list_objects_filtering_performance.py
@@ -26,8 +26,6 @@ import pytest
 import libcloud.storage.drivers.local
 from libcloud.storage.drivers.local import LocalStorageDriver
 
-libcloud.storage.drivers.local.USE_LOCKING = False
-
 
 def make_tmp_file(content=None):
     if not content:
@@ -91,6 +89,8 @@ def test_list_objects_with_filtering(benchmark, object_count, sort_objects):
     atexit.register(clean_up_lock_files)
 
     driver = LocalStorageDriver(base_path)
+
+    libcloud.storage.drivers.local.USE_LOCKING = False
     libcloud.storage.drivers.local.SORT_OBJECTS_ON_LIST = sort_objects
 
     def run_benchmark():

--- a/libcloud/test/benchmarks/test_list_objects_filtering_performance.py
+++ b/libcloud/test/benchmarks/test_list_objects_filtering_performance.py
@@ -1,0 +1,118 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import glob
+import shutil
+import atexit
+import random
+import string
+import tempfile
+
+import pytest
+
+import libcloud.storage.drivers.local
+from libcloud.storage.drivers.local import LocalStorageDriver
+
+libcloud.storage.drivers.local.USE_LOCKING = False
+
+
+def make_tmp_file(content=None):
+    if not content:
+        content = b"1"
+    _, tmppath = tempfile.mkstemp()
+    with open(tmppath, "wb") as fp:
+        fp.write(content)
+    return tmppath
+
+
+def clean_up_lock_files():
+    for file_path in glob.glob("/tmp/*.lock"):
+        os.remove(file_path)
+
+
+# fmt: off
+@pytest.mark.parametrize(
+    "object_count",
+    [
+        100,
+        1000,
+        10000,
+        10000,
+        100000,
+    ],
+    ids=[
+        "100",
+        "1000",
+        "10k",
+        "100k",
+        "1mil",
+    ],
+)
+@pytest.mark.parametrize(
+    "sort_objects",
+    [
+        True,
+        False,
+    ],
+    ids=[
+        "sort_objects",
+        "no_sort",
+    ],
+)
+# fmt: on
+def test_list_objects_with_filtering(benchmark, object_count, sort_objects):
+    """
+    Micro benchmark which measures how long list_container_objects takes with a lot of objects.
+
+    NOTE: To avoid issues with tons of lock files laying around we don't use locking for this
+    benchmark since we are not woried about race conditions and we don't benchmark locking
+    scenario.
+    """
+    base_path = tempfile.mkdtemp()
+
+    def clean_up_base_path():
+        if os.path.exists(base_path):
+            shutil.rmtree(base_path)
+
+    atexit.register(clean_up_base_path)
+    atexit.register(clean_up_lock_files)
+
+    driver = LocalStorageDriver(base_path)
+    libcloud.storage.drivers.local.SORT_OBJECTS_ON_LIST = sort_objects
+
+    def run_benchmark():
+        objects = driver.list_container_objects(container=container)
+        assert len(objects) == object_count
+        return objects
+
+    # 1. Create mock objects
+    container = driver.create_container("test_container_1")
+    tmppath = make_tmp_file()
+
+    for index in range(0, object_count):
+        # To actually exercise overhead of sorting we use random objects name and not sequential
+        # pre-sorted object names
+        name = "".join(random.choices(string.ascii_uppercase + string.digits, k=10))
+        obj = container.upload_object(tmppath, name)
+        assert obj.name == name
+
+    # 2. Run the actual benchmark
+    try:
+        result = benchmark(run_benchmark)
+        assert len(result) == object_count
+    finally:
+        clean_up_base_path()
+        clean_up_lock_files()

--- a/libcloud/test/benchmarks/test_list_objects_filtering_performance.py
+++ b/libcloud/test/benchmarks/test_list_objects_filtering_performance.py
@@ -88,9 +88,8 @@ def test_list_objects_with_filtering(benchmark, object_count, sort_objects):
     atexit.register(clean_up_base_path)
     atexit.register(clean_up_lock_files)
 
-    driver = LocalStorageDriver(base_path)
+    driver = LocalStorageDriver(base_path, ex_use_locking=False)
 
-    libcloud.storage.drivers.local.USE_LOCKING = False
     libcloud.storage.drivers.local.SORT_OBJECTS_ON_LIST = sort_objects
 
     def run_benchmark():

--- a/libcloud/test/storage/test_local.py
+++ b/libcloud/test/storage/test_local.py
@@ -34,6 +34,9 @@ from libcloud.storage.types import InvalidContainerNameError
 from libcloud.utils.files import exhaust_iterator
 
 try:
+    import libcloud.storage.drivers.local
+    libcloud.storage.drivers.local.USE_LOCKING = True
+
     from libcloud.storage.drivers.local import LocalStorageDriver
     from libcloud.storage.drivers.local import LockLocalStorage
     import fasteners  # noqa

--- a/libcloud/test/storage/test_local.py
+++ b/libcloud/test/storage/test_local.py
@@ -190,14 +190,24 @@ class LocalTests(unittest.TestCase):
         prefix = os.path.join("path", "to")
         objects = self.driver.list_container_objects(container=container, prefix=prefix)
         self.assertEqual(len(objects), 2)
+        self.assertEqual(objects[0].name, "path/to/object4.ext")
+        self.assertEqual(objects[1].name, "path/to/object3")
 
         prefix = "foo"
         objects = self.driver.list_container_objects(container=container, prefix=prefix)
         self.assertEqual(len(objects), 2)
+        self.assertEqual(objects[0].name, "foo6")
+        self.assertEqual(objects[1].name, "foo5")
 
         prefix = "foo5"
         objects = self.driver.list_container_objects(container=container, prefix=prefix)
         self.assertEqual(len(objects), 1)
+        self.assertEqual(objects[0].name, "foo5")
+
+        prefix = "foo6"
+        objects = self.driver.list_container_objects(container=container, prefix=prefix)
+        self.assertEqual(len(objects), 1)
+        self.assertEqual(objects[0].name, "foo6")
 
         for obj in objects:
             self.assertNotEqual(obj.hash, None)

--- a/libcloud/test/storage/test_local.py
+++ b/libcloud/test/storage/test_local.py
@@ -34,9 +34,6 @@ from libcloud.storage.types import InvalidContainerNameError
 from libcloud.utils.files import exhaust_iterator
 
 try:
-    import libcloud.storage.drivers.local
-    libcloud.storage.drivers.local.USE_LOCKING = True
-
     from libcloud.storage.drivers.local import LocalStorageDriver
     from libcloud.storage.drivers.local import LockLocalStorage
     import fasteners  # noqa

--- a/libcloud/test/storage/test_local.py
+++ b/libcloud/test/storage/test_local.py
@@ -171,12 +171,18 @@ class LocalTests(unittest.TestCase):
         obj2 = container.upload_object(tmppath, "path/object2")
         obj3 = container.upload_object(tmppath, "path/to/object3")
         obj4 = container.upload_object(tmppath, "path/to/object4.ext")
+
         with open(tmppath, "rb") as tmpfile:
             obj5 = container.upload_object_via_stream(tmpfile, "object5")
 
-        objects = self.driver.list_container_objects(container=container)
-        self.assertEqual(len(objects), 5)
+        obj6 = container.upload_object(tmppath, "foo5")
+        obj7 = container.upload_object(tmppath, "foo6")
+        obj8 = container.upload_object(tmppath, "Afoo7")
 
+        objects = self.driver.list_container_objects(container=container)
+        self.assertEqual(len(objects), 8)
+
+        # Prefix filtering
         prefix = os.path.join("path", "invalid")
         objects = self.driver.list_container_objects(container=container, prefix=prefix)
         self.assertEqual(len(objects), 0)
@@ -184,6 +190,14 @@ class LocalTests(unittest.TestCase):
         prefix = os.path.join("path", "to")
         objects = self.driver.list_container_objects(container=container, prefix=prefix)
         self.assertEqual(len(objects), 2)
+
+        prefix = "foo"
+        objects = self.driver.list_container_objects(container=container, prefix=prefix)
+        self.assertEqual(len(objects), 2)
+
+        prefix = "foo5"
+        objects = self.driver.list_container_objects(container=container, prefix=prefix)
+        self.assertEqual(len(objects), 1)
 
         for obj in objects:
             self.assertNotEqual(obj.hash, None)
@@ -197,11 +211,14 @@ class LocalTests(unittest.TestCase):
         obj2.delete()
 
         objects = container.list_objects()
-        self.assertEqual(len(objects), 3)
+        self.assertEqual(len(objects), 6)
 
         container.delete_object(obj3)
         container.delete_object(obj4)
         container.delete_object(obj5)
+        container.delete_object(obj6)
+        container.delete_object(obj7)
+        container.delete_object(obj8)
 
         objects = container.list_objects()
         self.assertEqual(len(objects), 0)

--- a/libcloud/test/storage/test_local.py
+++ b/libcloud/test/storage/test_local.py
@@ -190,14 +190,14 @@ class LocalTests(unittest.TestCase):
         prefix = os.path.join("path", "to")
         objects = self.driver.list_container_objects(container=container, prefix=prefix)
         self.assertEqual(len(objects), 2)
-        self.assertEqual(objects[0].name, "path/to/object4.ext")
-        self.assertEqual(objects[1].name, "path/to/object3")
+        self.assertEqual(objects[0].name, "path/to/object3")
+        self.assertEqual(objects[1].name, "path/to/object4.ext")
 
         prefix = "foo"
         objects = self.driver.list_container_objects(container=container, prefix=prefix)
         self.assertEqual(len(objects), 2)
-        self.assertEqual(objects[0].name, "foo6")
-        self.assertEqual(objects[1].name, "foo5")
+        self.assertEqual(objects[0].name, "foo5")
+        self.assertEqual(objects[1].name, "foo6")
 
         prefix = "foo5"
         objects = self.driver.list_container_objects(container=container, prefix=prefix)

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -9,6 +9,7 @@ requests>=2.26.0; python_version >= '3.6'
 requests_mock==1.9.3
 pytest==6.2.5; python_version >= '3.6'
 pytest-xdist==2.4.0; python_version >= '3.6'
+pytest-benchmark[histogram]==3.2.3; python_version >= '3.6'
 cryptography==35.0.0; python_version >= '3.6'
 # NOTE: Only needed by nttcis loadbalancer driver
 pyopenssl==21.0.0; python_version >= '3.6'

--- a/tox.ini
+++ b/tox.ini
@@ -360,6 +360,7 @@ deps =
     -r{toxinidir}/requirements-tests.txt
     fasteners
 commands =
+    cp libcloud/test/secrets.py-dist libcloud/test/secrets.py
     pytest -s -v --benchmark-only --benchmark-name=short --benchmark-columns=min,max,mean,stddev,median,ops,rounds --benchmark-histogram=benchmark_histograms/benchmark  --benchmark-group-by=group,param:sort_objects libcloud/test/benchmarks/test_list_objects_filtering_performance.py
 
 [testenv:import-timings]

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ basepython =
     pypypy3: pypy3
     pypyjion: pyjion
     {py3.6,py3.6-dist,py3.6-dist-wheel}: python3.6
-    {py3.7,docs,checks,black,lint,pylint,mypy,coverage,docs,py3.7-dist,py3.7-dist-wheel}: python3.7
+    {py3.7,docs,checks,black,lint,pylint,mypy,micro-benchmarks,coverage,docs,py3.7-dist,py3.7-dist-wheel}: python3.7
     {py3.8,py3.8-windows,integration-storage,py3.8-dist,py3.8-dist-wheel}: python3.8
     {py3.9,py3.9-dist,py3.9-dist-wheel}: python3.9
     {py3.10,py3.10-dist,py3.10-dist-wheel}: python3.10
@@ -354,6 +354,13 @@ commands =
     mypy --no-incremental example_storage.py
     mypy --no-incremental example_dns.py
     mypy --no-incremental example_container.py
+
+[testenv:micro-benchmarks]
+deps =
+    -r{toxinidir}/requirements-tests.txt
+    fasteners
+commands =
+    pytest -s -v --benchmark-only --benchmark-name=short --benchmark-columns=min,max,mean,stddev,median,ops,rounds --benchmark-histogram=benchmark_histograms/benchmark  --benchmark-group-by=group,param:sort_objects libcloud/test/benchmarks/test_list_objects_filtering_performance.py
 
 [testenv:import-timings]
 basepython: python3.7

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ setenv =
 # NOTE: tee-sys is not supported by pytest which still supports Python 3.5
 # pytest -rsx -vvv -o log_cli=True --durations=10 -n auto --dist loadfile
 commands = cp libcloud/test/secrets.py-dist libcloud/test/secrets.py
-           pytest -rsx -vvv --capture=tee-sys -o log_cli=True --durations=10 -n auto --dist loadfile
+           pytest -rsx -vvv --capture=tee-sys -o log_cli=True --durations=10 -n auto --dist loadfile --ignore libcloud/test/benchmarks/
 
 whitelist_externals = cp
                       bash


### PR DESCRIPTION
This pull request fixes object name prefix based filtering which was accidentally broken by the change in #1584.

It was reported by a user (https://github.com/apache/libcloud/pull/1584#issuecomment-983712951), that the change breaks the behavior.

I confirmed that myself by adding a test case which was failing with changes from #1584, but should pass if the behavior was correct - prefix based filtering is based on the object name and not on sub-directory names so optimization from #1584 is not a good idea (it's true though that in some cases, bucket / sub-directory name is part of the object name, but that's an implementation detail).

It achieves that by reverting changes from #1584.

Sadly we didn't have good existing tests which would have caught this issue early, but I added some regression tests to help us in the future.