### PR TITLE
Avoid raising exception if ip is not found: Fix #1595

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,10 @@ Compute
   (GITHUB-1629)
   [Miguel Caballer - @micafer]
 
+- [OpenStack] Avoid raising exception if ip is not found.
+  (GITHUB-1595)
+  [Miguel Caballer - @micafer]
+
 Storage
 ~~~~~~~
 

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -2724,9 +2724,10 @@ class OpenStack_1_1_NodeDriver(OpenStackNodeDriver):
 
         :rtype: :class:`OpenStack_1_1_FloatingIpAddress`
         """
-        floating_ips = self.ex_list_floating_ips()
-        (ip_obj,) = [x for x in floating_ips if x.ip_address == ip]
-        return ip_obj
+        for floating_ip in self.ex_list_floating_ips():
+            if floating_ip.ip_address == ip:
+                return floating_ip
+        return None
 
     def ex_create_floating_ip(self, ip_pool=None):
         """
@@ -4369,8 +4370,10 @@ class OpenStack_1_1_FloatingIpPool(object):
 
         :rtype: :class:`OpenStack_1_1_FloatingIpAddress`
         """
-        (ip_obj,) = [x for x in self.list_floating_ips() if x.ip_address == ip]
-        return ip_obj
+        for floating_ip in self.list_floating_ips():
+            if floating_ip.ip_address == ip:
+                return floating_ip
+        return None
 
     def create_floating_ip(self):
         """
@@ -4503,7 +4506,7 @@ class OpenStack_2_FloatingIpPool(object):
                 "/v2.0/floatingips?floating_ip_address" "=%s" % ip
             ).object
         )
-        return floating_ips[0]
+        return floating_ips[0] if floating_ips else None
 
     def create_floating_ip(self):
         """

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -1717,6 +1717,9 @@ class OpenStack_1_1_Tests(unittest.TestCase, TestCaseMixin):
         self.assertEqual(ret.ip_address, "10.3.1.42")
         self.assertIsNone(ret.node_id)
 
+        ret = pool.get_floating_ip("1.2.3.4")
+        self.assertIsNone(ret)
+
     def test_OpenStack_1_1_FloatingIpPool_create_floating_ip(self):
         pool = OpenStack_1_1_FloatingIpPool("foo", self.driver.connection)
         ret = pool.create_floating_ip()


### PR DESCRIPTION
## Avoid raising exception if ip is not found.

### Description

See: #1595.
I also fix similar issues in other functions.
There are no tests for this functions.
I will not add them as this functions are deprecated (see #1636).

### Status

Replace this: describe the PR status. Examples:

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
