### PR TITLE
fix #1641: [EC2] Add missing "creation_date" NodeImage extra

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,10 @@ Compute
   (GITHUB-1595)
   [Miguel Caballer - @micafer]
 
+- [EC2] Add missing ``creation_date`` NodeImage extra.
+  (GITHUB-1641)
+  [Thomas JOUANNOT - @mazerty]
+
 Storage
 ~~~~~~~
 

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -674,6 +674,7 @@ RESOURCE_EXTRA_ATTRIBUTES_MAP = {
         "ramdisk_id": {"xpath": "ramdiskId", "transform_func": str},
         "ena_support": {"xpath": "enaSupport", "transform_func": str},
         "sriov_net_support": {"xpath": "sriovNetSupport", "transform_func": str},
+        "creation_date": {"xpath": "creationDate", "transform_func": parse_date},
     },
     "network": {
         "state": {"xpath": "state", "transform_func": str},

--- a/libcloud/test/compute/fixtures/ec2/describe_images.xml
+++ b/libcloud/test/compute/fixtures/ec2/describe_images.xml
@@ -36,6 +36,7 @@
             </blockDeviceMapping>
             <virtualizationType>paravirtual</virtualizationType>
             <hypervisor>xen</hypervisor>
+            <creationDate>2021-01-10T18:24:00.000Z</creationDate>
         </item>
         <item>
             <imageId>ami-85b2a8ae</imageId>
@@ -67,6 +68,7 @@
             </blockDeviceMapping>
             <virtualizationType>paravirtual</virtualizationType>
             <hypervisor>xen</hypervisor>
+            <creationDate>2021-01-10T18:25:00.000Z</creationDate>
         </item>
     </imagesSet>
 </DescribeImagesResponse>

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -585,6 +585,7 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
         self.assertEqual(ephemeral, "ephemeral0")
         billing_product1 = images[0].extra["billing_products"][0]
         self.assertEqual(billing_product1, "ab-5dh78019")
+        self.assertIsInstance(images[0].extra["creation_date"], datetime)
 
         location = "123456788908/Test Image 2"
         self.assertEqual(images[1].id, "ami-85b2a8ae")
@@ -595,6 +596,7 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
         billing_product2 = images[1].extra["billing_products"][0]
         self.assertEqual(billing_product2, "as-6dr90319")
         self.assertEqual(size, 20)
+        self.assertIsInstance(images[1].extra["creation_date"], datetime)
 
     def test_list_images_with_image_ids(self):
         EC2MockHttp.type = "ex_imageids"
@@ -615,6 +617,7 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
         self.assertEqual(image.extra["architecture"], "x86_64")
         self.assertEqual(len(image.extra["block_device_mapping"]), 2)
         self.assertEqual(image.extra["billing_products"][0], "ab-5dh78019")
+        self.assertIsInstance(image.extra["creation_date"], datetime)
 
     def test_copy_image(self):
         image = self.driver.list_images()[0]


### PR DESCRIPTION
## [EC2] Add missing "creation_date" NodeImage extra

### Description

Fixes #1641.
Also tested "live" with modified 3.4.1 code in a virtualenv and listing real images.

### Status

- done, ready for review

### Checklist

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
