### PR TITLE
Fix OpenStack authentication regressions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -87,6 +87,14 @@ Compute
   (GITHUB-1646, GITHUB-1655)
   [Miguel Caballer - @micafer]
 
+- [OpenStack] Fix regression which was inadvertently introduced in #1557 which
+  would cause some OpenStack authentication methods to not work and result in
+  an exception.
+
+  Reported by @LanderOtto via #1659.
+  (GITHUB-1659, GITHUB-1660)
+  [Tomaz Muraus - @Kami]
+
 Storage
 ~~~~~~~
 

--- a/libcloud/common/openstack_identity.py
+++ b/libcloud/common/openstack_identity.py
@@ -46,7 +46,6 @@ AUTH_VERSIONS_WITH_EXPIRES = [
     "2.0_apikey",
     "2.0_password",
     "2.0_voms",
-    "3.0",
     "3.x_password",
     "3.x_appcred",
     "3.x_oidc_access_token",

--- a/libcloud/common/openstack_identity.py
+++ b/libcloud/common/openstack_identity.py
@@ -46,6 +46,7 @@ AUTH_VERSIONS_WITH_EXPIRES = [
     "2.0_apikey",
     "2.0_password",
     "2.0_voms",
+    "3.0",
     "3.x_password",
     "3.x_appcred",
     "3.x_oidc_access_token",

--- a/libcloud/common/openstack_identity.py
+++ b/libcloud/common/openstack_identity.py
@@ -1954,6 +1954,7 @@ class OpenStackIdentity_2_0_Connection_VOMS(
 
         self.auth_url = auth_url
         self.tenant_name = tenant_name
+        self.tenant_domain_id = tenant_domain_id
         self.domain_name = domain_name
         self.token_scope = token_scope
         self.timeout = timeout

--- a/libcloud/common/openstack_identity.py
+++ b/libcloud/common/openstack_identity.py
@@ -1741,6 +1741,7 @@ class OpenStackIdentity_3_0_Connection_AppCred(OpenStackIdentity_3_0_Connection)
         timeout=None,
         proxy_url=None,
         parent_conn=None,
+        auth_cache=None,
     ):
         """
         Tenant, domain and scope options are ignored as they are contained
@@ -1756,6 +1757,7 @@ class OpenStackIdentity_3_0_Connection_AppCred(OpenStackIdentity_3_0_Connection)
             timeout=timeout,
             proxy_url=proxy_url,
             parent_conn=parent_conn,
+            auth_cache=auth_cache,
         )
 
     def _get_auth_data(self):
@@ -1928,6 +1930,7 @@ class OpenStackIdentity_2_0_Connection_VOMS(
         user_id,
         key,
         tenant_name=None,
+        tenant_domain_id="default",
         domain_name="Default",
         token_scope=OpenStackIdentityTokenScope.PROJECT,
         timeout=None,

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -4105,9 +4105,10 @@ class OpenStack_AuthVersions_Tests(unittest.TestCase):
         for auth_version in AUTH_VERSIONS_WITH_EXPIRES:
             driver_kwargs = {}
 
-            if auth_version == "1.1":
-                # 1.1 is old and deprecated so we skip it
-                pass
+            if auth_version in ["1.1", "3.0"]:
+                # 1.1 is old and deprecated, 3.0 is not exposed directly to the endu ser
+                continue
+
 
             user_id = OPENSTACK_PARAMS[0]
             key = OPENSTACK_PARAMS[1]

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -4109,7 +4109,6 @@ class OpenStack_AuthVersions_Tests(unittest.TestCase):
                 # 1.1 is old and deprecated, 3.0 is not exposed directly to the endu ser
                 continue
 
-
             user_id = OPENSTACK_PARAMS[0]
             key = OPENSTACK_PARAMS[1]
 

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -63,7 +63,6 @@ from libcloud.compute.drivers.openstack import (
     OpenStackKeyPair,
     OpenStack_1_0_Connection,
     OpenStack_2_FloatingIpPool,
-    OpenStackNodeDriver,
     OpenStack_2_NodeDriver,
     OpenStack_2_PortInterfaceState,
     OpenStackNetwork,

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -4087,12 +4087,6 @@ class OpenStack_AuthVersions_Tests(unittest.TestCase):
             return "https://servers.api.rackspacecloud.com/v1.0/slug"
 
         OpenStack_1_1_NodeDriver.connectionCls.get_endpoint = get_endpoint
-
-    def test_ex_force_auth_version_all_possible_values(self):
-        """
-        Test case which verifies that the driver can be correctly instantiated using all the
-        supported API versions.
-        """
         OpenStack_1_1_NodeDriver.connectionCls.conn_class = (
             OpenStack_AllAuthVersions_MockHttp
         )
@@ -4100,6 +4094,11 @@ class OpenStack_AuthVersions_Tests(unittest.TestCase):
         OpenStack_1_1_MockHttp.type = None
         OpenStack_2_0_MockHttp.type = None
 
+    def test_ex_force_auth_version_all_possible_values(self):
+        """
+        Test case which verifies that the driver can be correctly instantiated using all the
+        supported API versions.
+        """
         cls = get_driver(Provider.OPENSTACK)
 
         for auth_version in AUTH_VERSIONS_WITH_EXPIRES:

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -39,6 +39,7 @@ from libcloud.utils.py3 import u
 from libcloud.common.base import LibcloudConnection
 from libcloud.common.exceptions import BaseHTTPError
 from libcloud.common.openstack_identity import OpenStackAuthenticationCache
+from libcloud.common.openstack_identity import AUTH_VERSIONS_WITH_EXPIRES
 from libcloud.common.types import (
     InvalidCredsError,
     MalformedResponseError,
@@ -3955,6 +3956,54 @@ class OpenStack_2_0_MockHttp(OpenStack_1_1_MockHttp):
         return (httplib.UNAUTHORIZED, "", {}, httplib.responses[httplib.UNAUTHORIZED])
 
 
+class OpenStack_AllAuthVersions_MockHttp(MockHttp):
+    def __init__(self, *args, **kwargs):
+        super(OpenStack_AllAuthVersions_MockHttp, self).__init__(*args, **kwargs)
+
+        # Lazy import to avoid cyclic depedency issue
+        from libcloud.test.common.test_openstack_identity import OpenStackIdentity_2_0_MockHttp
+        from libcloud.test.common.test_openstack_identity import OpenStackIdentity_3_0_MockHttp
+
+        self.mock_http = OpenStackMockHttp(*args, **kwargs)
+        self.mock_http_1_1 = OpenStack_1_1_MockHttp(*args, **kwargs)
+        self.mock_http_2_0 = OpenStack_2_0_MockHttp(*args, **kwargs)
+        self.mock_http_2_0_identity = OpenStackIdentity_2_0_MockHttp(*args, **kwargs)
+        self.mock_http_3_0_identity = OpenStackIdentity_3_0_MockHttp(*args, **kwargs)
+
+    def _v1_0_slug_servers_detail(self, method, url, body, headers):
+        return self.mock_http_1_1._v1_1_slug_servers_detail(method=method, url=url, body=body, headers=headers)
+        return res
+
+    def _v1_1_auth(self, method, url, body, headers):
+        return self.mock_http._v1_1_auth(method=method, url=url, body=body, headers=headers)
+
+    def _v2_0_tokens(self, method, url, body, headers):
+        return self.mock_http_2_0._v2_0_tokens(method=method, url=url, body=body, headers=headers)
+
+    def _v2_1337_servers_detail(self, method, url, body, headers):
+        return self.mock_http_2_0._v2_1337_servers_detail(method=method, url=url, body=body, headers=headers)
+
+    def _v2_0_tenants(self, method, url, body, headers):
+        return self.mock_http_2_0_identity._v2_0_tenants(method=method, url=url, body=body, headers=headers)
+
+    def _v2_9c4693dce56b493b9b83197d900f7fba_servers_detail(self, method, url, body, headers):
+        return self.mock_http_1_1._v1_1_slug_servers_detail(method=method, url=url, body=body, headers=headers)
+
+    def _v3_OS_FEDERATION_identity_providers_user_name_protocols_tenant_name_auth(
+        self, method, url, body, headers
+    ):
+        return self.mock_http_3_0_identity._v3_OS_FEDERATION_identity_providers_test_user_id_protocols_test_tenant_auth(method=method, url=url, body=body, headers=headers)
+
+    def _v3_auth_tokens(self, method, url, body, headers):
+        return self.mock_http_2_0._v3_auth_tokens(method=method, url=url, body=body, headers=headers)
+
+    def _v3_0_auth_tokens(self, method, url, body, headers):
+        return self.mock_http_3_0_identity._v3_0_auth_tokens(method=method, url=url, body=body, headers=headers)
+
+    def _v3_auth_projects(self, method, url, body, headers):
+        return self.mock_http_3_0_identity._v3_auth_projects(method=method, url=url, body=body, headers=headers)
+
+
 class OpenStack_1_1_Auth_2_0_Tests(OpenStack_1_1_Tests):
     driver_args = OPENSTACK_PARAMS + ("1.1",)
     driver_kwargs = {"ex_force_auth_version": "2.0"}
@@ -3987,6 +4036,52 @@ class OpenStack_1_1_Auth_2_0_Tests(OpenStack_1_1_Tests):
                 ],
             },
         )
+
+
+class OpenStack_AuthVersions_Tests(unittest.TestCase):
+
+    def setUp(self):
+        # monkeypatch get_endpoint because the base openstack driver doesn't actually
+        # work with old devstack but this class/tests are still used by the rackspace
+        # driver
+        def get_endpoint(*args, **kwargs):
+            return "https://servers.api.rackspacecloud.com/v1.0/slug"
+
+        OpenStack_1_1_NodeDriver.connectionCls.get_endpoint = get_endpoint
+
+    def test_ex_force_auth_version_all_possible_values(self):
+        """
+        Test case which verifies that the driver can be correctly instantiated using all the
+        supported API versions.
+        """
+        OpenStack_1_1_NodeDriver.connectionCls.conn_class = OpenStack_AllAuthVersions_MockHttp
+        OpenStackMockHttp.type = None
+        OpenStack_1_1_MockHttp.type = None
+        OpenStack_2_0_MockHttp.type = None
+
+        cls = get_driver(Provider.OPENSTACK)
+
+        for auth_version in AUTH_VERSIONS_WITH_EXPIRES:
+            driver_kwargs = {}
+
+            if auth_version == "1.1":
+                # 1.1 is old and deprecated so we skip it
+                pass
+
+            user_id = OPENSTACK_PARAMS[0]
+            key = OPENSTACK_PARAMS[1]
+
+            if auth_version.startswith("3.x"):
+                driver_kwargs["ex_domina_name"] = "domain-name"
+                driver_kwargs["ex_force_service_region"] = "regionOne"
+                driver_kwargs["ex_tenant_name"] = "tenant-name"
+
+            if auth_version == "3.x_oidc_access_token":
+                key  = "test_key"
+
+            driver = cls(user_id, key, ex_force_auth_url="http://x.y.z.y:5000", ex_force_auth_version=auth_version, **driver_kwargs)
+            nodes = driver.list_nodes()
+            self.assertTrue(len(nodes) >= 1)
 
 
 class OpenStackMockAuthCache(OpenStackAuthenticationCache):

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -4115,7 +4115,7 @@ class OpenStack_AuthVersions_Tests(unittest.TestCase):
             driver_kwargs = {}
 
             if auth_version in ["1.1", "3.0"]:
-                # 1.1 is old and deprecated, 3.0 is not exposed directly to the endu ser
+                # 1.1 is old and deprecated, 3.0 is not exposed directly to the end user
                 continue
 
             user_id = OPENSTACK_PARAMS[0]

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -3961,53 +3961,87 @@ class OpenStack_AllAuthVersions_MockHttp(MockHttp):
         super(OpenStack_AllAuthVersions_MockHttp, self).__init__(*args, **kwargs)
 
         # Lazy import to avoid cyclic depedency issue
-        from libcloud.test.common.test_openstack_identity import OpenStackIdentity_2_0_MockHttp
-        from libcloud.test.common.test_openstack_identity import OpenStackIdentity_3_0_MockHttp
-        from libcloud.test.common.test_openstack_identity import OpenStackIdentity_3_0_AppCred_MockHttp
+        from libcloud.test.common.test_openstack_identity import (
+            OpenStackIdentity_2_0_MockHttp,
+        )
+        from libcloud.test.common.test_openstack_identity import (
+            OpenStackIdentity_3_0_MockHttp,
+        )
+        from libcloud.test.common.test_openstack_identity import (
+            OpenStackIdentity_3_0_AppCred_MockHttp,
+        )
 
         self.mock_http = OpenStackMockHttp(*args, **kwargs)
         self.mock_http_1_1 = OpenStack_1_1_MockHttp(*args, **kwargs)
         self.mock_http_2_0 = OpenStack_2_0_MockHttp(*args, **kwargs)
         self.mock_http_2_0_identity = OpenStackIdentity_2_0_MockHttp(*args, **kwargs)
         self.mock_http_3_0_identity = OpenStackIdentity_3_0_MockHttp(*args, **kwargs)
-        self.mock_http_3_0_appcred_identity = OpenStackIdentity_3_0_AppCred_MockHttp(*args, **kwargs)
+        self.mock_http_3_0_appcred_identity = OpenStackIdentity_3_0_AppCred_MockHttp(
+            *args, **kwargs
+        )
 
     def _v1_0_slug_servers_detail(self, method, url, body, headers):
-        return self.mock_http_1_1._v1_1_slug_servers_detail(method=method, url=url, body=body, headers=headers)
+        return self.mock_http_1_1._v1_1_slug_servers_detail(
+            method=method, url=url, body=body, headers=headers
+        )
 
     def _v1_1_auth(self, method, url, body, headers):
-        return self.mock_http._v1_1_auth(method=method, url=url, body=body, headers=headers)
+        return self.mock_http._v1_1_auth(
+            method=method, url=url, body=body, headers=headers
+        )
 
     def _v2_0_tokens(self, method, url, body, headers):
-        return self.mock_http_2_0._v2_0_tokens(method=method, url=url, body=body, headers=headers)
+        return self.mock_http_2_0._v2_0_tokens(
+            method=method, url=url, body=body, headers=headers
+        )
 
     def _v2_1337_servers_detail(self, method, url, body, headers):
-        return self.mock_http_2_0._v2_1337_servers_detail(method=method, url=url, body=body, headers=headers)
+        return self.mock_http_2_0._v2_1337_servers_detail(
+            method=method, url=url, body=body, headers=headers
+        )
 
     def _v2_0_tenants(self, method, url, body, headers):
-        return self.mock_http_2_0_identity._v2_0_tenants(method=method, url=url, body=body, headers=headers)
+        return self.mock_http_2_0_identity._v2_0_tenants(
+            method=method, url=url, body=body, headers=headers
+        )
 
-    def _v2_9c4693dce56b493b9b83197d900f7fba_servers_detail(self, method, url, body, headers):
-        return self.mock_http_1_1._v1_1_slug_servers_detail(method=method, url=url, body=body, headers=headers)
+    def _v2_9c4693dce56b493b9b83197d900f7fba_servers_detail(
+        self, method, url, body, headers
+    ):
+        return self.mock_http_1_1._v1_1_slug_servers_detail(
+            method=method, url=url, body=body, headers=headers
+        )
 
     def _v3_OS_FEDERATION_identity_providers_user_name_protocols_tenant_name_auth(
         self, method, url, body, headers
     ):
-        return self.mock_http_3_0_identity._v3_OS_FEDERATION_identity_providers_test_user_id_protocols_test_tenant_auth(method=method, url=url, body=body, headers=headers)
+        return self.mock_http_3_0_identity._v3_OS_FEDERATION_identity_providers_test_user_id_protocols_test_tenant_auth(
+            method=method, url=url, body=body, headers=headers
+        )
 
     def _v3_auth_tokens(self, method, url, body, headers):
         if "application_credential" in body:
-            return self.mock_http_3_0_appcred_identity._v3_auth_tokens(method=method, url=url, body=body, headers=headers)
+            return self.mock_http_3_0_appcred_identity._v3_auth_tokens(
+                method=method, url=url, body=body, headers=headers
+            )
         elif "token" in body:
-            return self.mock_http_3_0_identity._v3_auth_tokens(method=method, url=url, body=body, headers=headers)
+            return self.mock_http_3_0_identity._v3_auth_tokens(
+                method=method, url=url, body=body, headers=headers
+            )
         else:
-            return self.mock_http_3_0_identity._v3_auth_tokens(method=method, url=url, body=body, headers=headers)
+            return self.mock_http_3_0_identity._v3_auth_tokens(
+                method=method, url=url, body=body, headers=headers
+            )
 
     def _v3_0_auth_tokens(self, method, url, body, headers):
-        return self.mock_http_3_0_identity._v3_0_auth_tokens(method=method, url=url, body=body, headers=headers)
+        return self.mock_http_3_0_identity._v3_0_auth_tokens(
+            method=method, url=url, body=body, headers=headers
+        )
 
     def _v3_auth_projects(self, method, url, body, headers):
-        return self.mock_http_3_0_identity._v3_auth_projects(method=method, url=url, body=body, headers=headers)
+        return self.mock_http_3_0_identity._v3_auth_projects(
+            method=method, url=url, body=body, headers=headers
+        )
 
 
 class OpenStack_1_1_Auth_2_0_Tests(OpenStack_1_1_Tests):
@@ -4045,7 +4079,6 @@ class OpenStack_1_1_Auth_2_0_Tests(OpenStack_1_1_Tests):
 
 
 class OpenStack_AuthVersions_Tests(unittest.TestCase):
-
     def setUp(self):
         # monkeypatch get_endpoint because the base openstack driver doesn't actually
         # work with old devstack but this class/tests are still used by the rackspace
@@ -4060,7 +4093,9 @@ class OpenStack_AuthVersions_Tests(unittest.TestCase):
         Test case which verifies that the driver can be correctly instantiated using all the
         supported API versions.
         """
-        OpenStack_1_1_NodeDriver.connectionCls.conn_class = OpenStack_AllAuthVersions_MockHttp
+        OpenStack_1_1_NodeDriver.connectionCls.conn_class = (
+            OpenStack_AllAuthVersions_MockHttp
+        )
         OpenStackMockHttp.type = None
         OpenStack_1_1_MockHttp.type = None
         OpenStack_2_0_MockHttp.type = None
@@ -4091,7 +4126,13 @@ class OpenStack_AuthVersions_Tests(unittest.TestCase):
                 user_id = "appcred_id"
                 key = "appcred_secret"
 
-            driver = cls(user_id, key, ex_force_auth_url="http://x.y.z.y:5000", ex_force_auth_version=auth_version, **driver_kwargs)
+            driver = cls(
+                user_id,
+                key,
+                ex_force_auth_url="http://x.y.z.y:5000",
+                ex_force_auth_version=auth_version,
+                **driver_kwargs,
+            )
             nodes = driver.list_nodes()
             self.assertTrue(len(nodes) >= 1)
 


### PR DESCRIPTION
This PR fixes inadvertent regressions introduced in #1557 which broke some of the OpenStack authentication methods.

Issue reported by @LanderOtto via #1659.