### PR TITLE
GCE: Retrieve regions & zones lazily, closes #1661

### DIFF
--- a/libcloud/compute/drivers/gce.py
+++ b/libcloud/compute/drivers/gce.py
@@ -2108,19 +2108,17 @@ class GCENodeDriver(NodeDriver):
         # Cache Zone and Region information to reduce API calls and
         # increase speed
         self.base_path = "/compute/%s/projects/%s" % (API_VERSION, self.project)
-        self.zone_list = self.ex_list_zones()
-        self.zone_dict = {}
-        for zone in self.zone_list:
-            self.zone_dict[zone.name] = zone
+
+        self._zone_dict = None
+        self._zone_list = None
+
         if datacenter:
             self.zone = self.ex_get_zone(datacenter)
         else:
             self.zone = None
 
-        self.region_list = self.ex_list_regions()
-        self.region_dict = {}
-        for region in self.region_list:
-            self.region_dict[region.name] = region
+        self._region_dict = None
+        self._region_list = None
 
         if self.zone:
             self.region = self._get_region_from_zone(self.zone)
@@ -2130,6 +2128,32 @@ class GCENodeDriver(NodeDriver):
         # Volume details are looked up in this name-zone dict.
         # It is populated if the volume name is not found or the dict is empty.
         self._ex_volume_dict = {}
+
+    @property
+    def zone_dict(self):
+        if self._zone_dict is None:
+            zones = self.ex_list_zones()
+            self._zone_dict = {zone.name: zone for zone in zones}
+        return self._zone_dict
+
+    @property
+    def zone_list(self):
+        if self._zone_list is None:
+            self._zone_list = list(self.zone_dict.values())
+        return self._zone_list
+
+    @property
+    def region_dict(self):
+        if self._region_dict is None:
+            regions = self.ex_list_regions()
+            self._region_dict = {region.name: region for region in regions}
+        return self._region_dict
+
+    @property
+    def region_list(self):
+        if self._region_list is None:
+            self._region_list = list(self.region_dict.values())
+        return self._region_list
 
     def ex_add_access_config(self, node, name, nic, nat_ip=None, config_type=None):
         """

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -2526,6 +2526,65 @@ class GCENodeDriverTest(GoogleTestCase, TestCaseMixin):
         zone_no_mw = self.driver.ex_get_zone("us-central1-a")
         self.assertIsNone(zone_no_mw.time_until_mw)
 
+    def test_driver_zone_attributes(self):
+        zones = self.driver.ex_list_zones()
+        self.assertEqual(len(self.driver.zone_dict), len(zones))
+        self.assertEqual(len(self.driver.zone_list), len(zones))
+        for zone, fetched_zone in zip(self.driver.zone_list, zones):
+            self.assertEqual(zone.id, fetched_zone.id)
+            self.assertEqual(zone.name, fetched_zone.name)
+            self.assertEqual(zone.status, fetched_zone.status)
+
+    def test_driver_region_attributes(self):
+        regions = self.driver.ex_list_regions()
+        self.assertEqual(len(self.driver.region_dict), len(regions))
+        self.assertEqual(len(self.driver.region_list), len(regions))
+        for region, fetched_region in zip(self.driver.region_list, regions):
+            self.assertEqual(region.id, fetched_region.id)
+            self.assertEqual(region.name, fetched_region.name)
+            self.assertEqual(region.status, fetched_region.status)
+
+
+class GCENodeDriverTest2(GoogleTestCase):
+    """
+    GCE Test Class, test node driver without passing `datacenter` parameter on initialization.
+    """
+
+    def setUp(self):
+        GCEMockHttp.test = self
+        GCENodeDriver.connectionCls.conn_class = GCEMockHttp
+        GoogleBaseAuthConnection.conn_class = GoogleAuthMockHttp
+        GCEMockHttp.type = None
+        kwargs = GCE_KEYWORD_PARAMS.copy()
+        kwargs["auth_type"] = "IA"
+        self.driver = GCENodeDriver(*GCE_PARAMS, **kwargs)
+
+    def test_zone_attributes(self):
+        self.assertIsNone(self.driver._zone_dict)
+        self.assertIsNone(self.driver._zone_list)
+
+        zones = self.driver.ex_list_zones()
+
+        self.assertEqual(len(self.driver.zone_list), len(zones))
+        self.assertEqual(len(self.driver.zone_dict), len(zones))
+        for zone, fetched_zone in zip(self.driver.zone_list, zones):
+            self.assertEqual(zone.id, fetched_zone.id)
+            self.assertEqual(zone.name, fetched_zone.name)
+            self.assertEqual(zone.status, fetched_zone.status)
+
+    def test_region_attributes(self):
+        self.assertIsNone(self.driver._region_dict)
+        self.assertIsNone(self.driver._region_list)
+
+        regions = self.driver.ex_list_regions()
+
+        self.assertEqual(len(self.driver.region_list), len(regions))
+        self.assertEqual(len(self.driver.region_dict), len(regions))
+        for region, fetched_region in zip(self.driver.region_list, regions):
+            self.assertEqual(region.id, fetched_region.id)
+            self.assertEqual(region.name, fetched_region.name)
+            self.assertEqual(region.status, fetched_region.status)
+
 
 class GCEMockHttp(MockHttp, unittest.TestCase):
     fixtures = ComputeFileFixtures("gce")


### PR DESCRIPTION
## Lazily retrieve zones & regions on GCENodeDriver

### Description

Implements #1661

### Status
- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
