### PR TITLE
Fix codecov

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - trunk
+      - fix_codecov
       - pyjion_cicd_tests
   pull_request:
     branches:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - trunk
-      - fix_codecov
       - pyjion_cicd_tests
   pull_request:
     branches:

--- a/tox.ini
+++ b/tox.ini
@@ -328,7 +328,7 @@ deps =
 setenv =
   CRYPTOGRAPHY_ALLOW_OPENSSL_102=1
 commands = cp libcloud/test/secrets.py-dist libcloud/test/secrets.py
-           coverage run --source=libcloud setup.py test
+           coverage run --source=libcloud --omit=libcloud/test setup.py test
 
 [testenv:coverage-ci]
 passenv = TERM TOXENV CI GITHUB_*
@@ -341,7 +341,7 @@ deps =
 setenv =
   CRYPTOGRAPHY_ALLOW_OPENSSL_102=1
 commands = cp libcloud/test/secrets.py-dist libcloud/test/secrets.py
-           coverage run --source=libcloud setup.py test
+           coverage run --source=libcloud --omit=libcloud/test setup.py test
            codecov
 
 [testenv:mypy]


### PR DESCRIPTION
## Fix coverage

### Description

I saw as part of [1664](https://github.com/apache/libcloud/pull/1664) that coverage is currently being collected also for the tests folder, this ignores them

### Status
- done, ready for review

### Checklist (tick everything that applies)

- [X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [X] Documentation
- [X] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [X] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
