### PR TITLE
Fix upgrade nodes: #1670 #1638

### DIFF
--- a/docs/upgrade_notes.rst
+++ b/docs/upgrade_notes.rst
@@ -14,6 +14,14 @@ Libcloud 3.5.0
   If you still want to use Libcloud with Python 3.5, you should use an older
   release which still supports Python 3.5.
 
+* The OpenStack compute driver has moved the floating ip related functions
+  from nova to neutron. This change affects all the floating ip related
+  functions of the ``OpenStack_2_NodeDriver`` class. Two new classes have been
+  added ``OpenStack_2_FloatingIpPool`` and ``OpenStack_2_FloatingIpAddress``.
+  The main change applies to the FloatingIP class where node_id property cannot
+  be directly obtained from FloatingIP information and it must be gotten from
+  the related Port information with the ``get_node_id`` method.
+
 Libcloud 3.4.0
 --------------
 

--- a/docs/upgrade_notes.rst
+++ b/docs/upgrade_notes.rst
@@ -18,9 +18,9 @@ Libcloud 3.5.0
   from nova to neutron. This change affects all the floating ip related
   functions of the ``OpenStack_2_NodeDriver`` class. Two new classes have been
   added ``OpenStack_2_FloatingIpPool`` and ``OpenStack_2_FloatingIpAddress``.
-  The main change applies to the FloatingIP class where node_id property cannot
-  be directly obtained from FloatingIP information and it must be gotten from
-  the related Port information with the ``get_node_id`` method.
+  The main change applies to the FloatingIP class where ``node_id`` property
+  cannot be directly obtained from FloatingIP information and it must be
+  gotten from the related Port information with the ``get_node_id()`` method.
 
 Libcloud 3.4.0
 --------------


### PR DESCRIPTION
## Fix upgrade nodes to describe the API changes

### Description

As the OpenStack compute driver has moved the floating ip related functions from nova to neutron. There are one change that affect the users: node_id property cannot be directly obtained from FloatingIP information and it must be gotten from the related Port information with the ``get_node_id`` method.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [X] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
