### PR TITLE
Fix #1675: Error in volume api calls if microversion is set in OpenStack

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,14 @@ Compute
   (GITHUB-1661, GITHUB-1661)
   [Dimitris Galanis - @dimgal1]
 
+- [OpenStack] Error in volume api calls if microversion is set in OpenStack.
+  In previous version if `ex_force_microversion`` is set, it is assumed to set
+  it to the compute service. Now if only a version is set `2.67`, compute
+  service is assumed but it can be also set the service name `volume 3.21`.
+
+  (GITHUB-1675)
+  [Miguel Caballer - @micafer]
+
 Changes in Apache Libcloud 3.5.0
 --------------------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,20 @@
 ﻿Changelog
 =========
 
+Changes in Apache Libcloud in development
+-----------------------------------------
+
+Compute
+~~~~~~~
+
+- [OpenStack] Error in volume api calls if microversion is set in OpenStack.
+  In previous version if `ex_force_microversion` is set, it is assumed to set
+  it to the compute service. Now if only a version is set `2.67`, compute
+  service is assumed but it can be also set the service name `volume 3.21`.
+
+  (GITHUB-1675)
+  [Miguel Caballer - @micafer]
+
 Changes in Apache Libcloud 3.5.1
 --------------------------------
 
@@ -22,14 +36,6 @@ Compute
 
   (GITHUB-1661, GITHUB-1661)
   [Dimitris Galanis - @dimgal1]
-
-- [OpenStack] Error in volume api calls if microversion is set in OpenStack.
-  In previous version if `ex_force_microversion` is set, it is assumed to set
-  it to the compute service. Now if only a version is set `2.67`, compute
-  service is assumed but it can be also set the service name `volume 3.21`.
-
-  (GITHUB-1675)
-  [Miguel Caballer - @micafer]
 
 Changes in Apache Libcloud 3.5.0
 --------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,7 +24,7 @@ Compute
   [Dimitris Galanis - @dimgal1]
 
 - [OpenStack] Error in volume api calls if microversion is set in OpenStack.
-  In previous version if `ex_force_microversion`` is set, it is assumed to set
+  In previous version if `ex_force_microversion` is set, it is assumed to set
   it to the compute service. Now if only a version is set `2.67`, compute
   service is assumed but it can be also set the service name `volume 3.21`.
 

--- a/libcloud/common/openstack.py
+++ b/libcloud/common/openstack.py
@@ -355,8 +355,10 @@ class OpenStackBaseConnection(ConnectionUserAndKey):
                 raise LibcloudError("Invalid microversion format.")
 
             if self.service_type and self.service_type.startswith(service_type):
-                headers["OpenStack-API-Version"] = "%s %s" % (service_type,
-                                                              microversion)
+                headers["OpenStack-API-Version"] = "%s %s" % (
+                    service_type,
+                    microversion,
+                )
         return headers
 
     def morph_action_hook(self, action):

--- a/libcloud/common/openstack.py
+++ b/libcloud/common/openstack.py
@@ -343,9 +343,20 @@ class OpenStackBaseConnection(ConnectionUserAndKey):
         headers[AUTH_TOKEN_HEADER] = self.auth_token
         headers["Accept"] = self.accept_format
         if self._ex_force_microversion:
-            headers["OpenStack-API-Version"] = (
-                "compute %s" % self._ex_force_microversion
-            )
+            # If service not set in microversion, asume compute
+            microversion = self._ex_force_microversion.strip().split()
+            if len(microversion) == 2:
+                service_type = microversion[0]
+                microversion = microversion[1]
+            elif len(microversion) == 1:
+                service_type = "compute"
+                microversion = microversion[0]
+            else:
+                raise LibcloudError("Invalid microversion format.")
+
+            if self.service_type and self.service_type.startswith(service_type):
+                headers["OpenStack-API-Version"] = "%s %s" % (service_type,
+                                                              microversion)
         return headers
 
     def morph_action_hook(self, action):

--- a/libcloud/common/openstack.py
+++ b/libcloud/common/openstack.py
@@ -352,7 +352,7 @@ class OpenStackBaseConnection(ConnectionUserAndKey):
                 service_type = "compute"
                 microversion = microversion[0]
             else:
-                raise LibcloudError("Invalid microversion format.")
+                raise LibcloudError("Invalid microversion format: servicename X.XX")
 
             if self.service_type and self.service_type.startswith(service_type):
                 headers["OpenStack-API-Version"] = "%s %s" % (

--- a/libcloud/test/common/test_openstack.py
+++ b/libcloud/test/common/test_openstack.py
@@ -43,9 +43,20 @@ class OpenStackBaseConnectionTest(unittest.TestCase):
         )
 
     def test_set_microversion(self):
+        self.connection.service_type = "compute"
         self.connection._ex_force_microversion = "2.67"
         headers = self.connection.add_default_headers({})
         self.assertEqual(headers["OpenStack-API-Version"], "compute 2.67")
+
+        self.connection.service_type = "compute"
+        self.connection._ex_force_microversion = "volume 2.67"
+        headers = self.connection.add_default_headers({})
+        self.assertNotIn("OpenStack-API-Version", headers)
+
+        self.connection.service_type = "volume"
+        self.connection._ex_force_microversion = "volume 2.67"
+        headers = self.connection.add_default_headers({})
+        self.assertEqual(headers["OpenStack-API-Version"], "volume 2.67")
 
     @patch("libcloud.common.base.ConnectionUserAndKey.request")
     def test_request(self, mock_request):


### PR DESCRIPTION
## Fix error in volume api calls if microversion is set in OpenStack

### Description

See #1675

Fix error in volume api calls if microversion is set in OpenStack.
In previous version if `ex_force_microversion` is set, it is assumed to set
it to the compute service. Now if only a version is set `2.67`, compute
service is assumed but it can be also set the service name `volume 3.21`.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [X] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [X] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
