### PR TITLE
Attach/Detach a Floating IP to an OpenStack node does not work with new versions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,19 @@
 ﻿Changelog
 =========
 
+Changes in Apache Libcloud in development
+-----------------------------------------
+
+Compute
+~~~~~~~
+
+- [OpenStack] Fix error attaching a Floating IP to an OpenStack node does not
+  if `ex_force_microversion` is set with 2.44 or newer microversion.
+
+  (GITHUB-1674)
+  [Miguel Caballer - @micafer]
+
+
 Changes in Apache Libcloud 3.5.1
 --------------------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,8 +7,8 @@ Changes in Apache Libcloud in development
 Compute
 ~~~~~~~
 
-- [OpenStack] Fix error attaching a Floating IP to an OpenStack node does not
-  if `ex_force_microversion` is set with 2.44 or newer microversion.
+- [OpenStack] Fix error attaching/detaching a Floating IP to an OpenStack node
+  when `ex_force_microversion` is set with 2.44 or newer microversion.
 
   (GITHUB-1674)
   [Miguel Caballer - @micafer]

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -3038,23 +3038,23 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
             created=created,
             driver=self,
             extra=dict(
-                admin_state_up=element["admin_state_up"],
-                allowed_address_pairs=element["allowed_address_pairs"],
-                binding_vnic_type=element["binding:vnic_type"],
+                admin_state_up=element.get("admin_state_up"),
+                allowed_address_pairs=element.get("allowed_address_pairs"),
+                binding_vnic_type=element.get("binding:vnic_type"),
                 binding_host_id=element.get("binding:host_id", None),
-                device_id=element["device_id"],
+                device_id=element.get("device_id"),
                 description=element.get("description", None),
-                device_owner=element["device_owner"],
-                fixed_ips=element["fixed_ips"],
-                mac_address=element["mac_address"],
-                name=element["name"],
-                network_id=element["network_id"],
+                device_owner=element.get("device_owner"),
+                fixed_ips=element.get("fixed_ips"),
+                mac_address=element.get("mac_address"),
+                name=element.get("name"),
+                network_id=element.get("network_id"),
                 project_id=element.get("project_id", None),
                 port_security_enabled=element.get("port_security_enabled", None),
                 revision_number=element.get("revision_number", None),
-                security_groups=element["security_groups"],
+                security_groups=element.get("security_groups"),
                 tags=element.get("tags", None),
-                tenant_id=element["tenant_id"],
+                tenant_id=element.get("tenant_id"),
                 updated=updated,
             ),
         )
@@ -3633,32 +3633,11 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
         response = self.network_connection.request(
             "/servers/%s/os-interface" % node.id, method="GET"
         )
-        return [self._to_port(port) for port in response["interfaceAttachments"]]
-
-    def ex_attach_floating_ip_to_node(self, node, ip):
-        """
-        Attach the floating IP to the node
-
-        :param      node: node
-        :type       node: :class:`Node`
-
-        :param      ip: floating IP to attach
-        :type       ip: ``str`` or :class:`OpenStack_1_1_FloatingIpAddress`
-
-        :rtype: ``bool``
-        """
-        ports = self.ex_get_node_ports(node)
-        if ports:
-            # Set to the first node port
-            resp = self.network_connection.request(
-                "/v2.0/floatingips/%s" % ip.id,
-                method="PUT",
-                data={"floatingip": {"port_id": ports[0].id}},
-            )
-            return resp.status == httplib.ACCEPTED
-        else:
-            # if there are no ports
-            return False
+        ports = []
+        for port in response.object["interfaceAttachments"]:
+            port['id'] = port.pop('port_id')
+            ports.append(self._to_port(port))
+        return ports
 
     def _get_volume_connection(self):
         """
@@ -4444,6 +4423,40 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
         )
         return resp.status in (httplib.NO_CONTENT, httplib.ACCEPTED)
 
+    def ex_attach_floating_ip_to_node(self, node, ip):
+        """
+        Attach the floating IP to the node
+
+        :param      node: node
+        :type       node: :class:`Node`
+
+        :param      ip: floating IP to attach
+        :type       ip: ``str`` or :class:`OpenStack_1_1_FloatingIpAddress`
+
+        :rtype: ``bool``
+        """
+        ip_id = None
+        if isinstance(ip, OpenStack_1_1_FloatingIpAddress):
+            ip_id = ip.id
+        else:
+            for pool in self.ex_list_floating_ip_pools():
+                fip = pool.get_floating_ip(ip)
+                if fip:
+                    ip_id = fip.id
+        if not ip_id:
+            return False
+        ports = self.ex_get_node_ports(node)
+        if ports:
+            # Set to the first node port
+            resp = self.network_connection.request(
+                "/v2.0/floatingips/%s" % ip_id,
+                method="PUT",
+                data={"floatingip": {"port_id": ports[0].id}},
+            )
+            return resp.status == httplib.OK
+        else:
+            # if there are no ports
+            return False
 
 class OpenStack_1_1_FloatingIpPool(object):
     """

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -3630,7 +3630,7 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
 
         :rtype: ``list`` of :class:`OpenStack_2_PortInterface`
         """
-        response = self.network_connection.request(
+        response = self.connection.request(
             "/servers/%s/os-interface" % node.id, method="GET"
         )
         ports = []

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -3635,7 +3635,7 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
         )
         ports = []
         for port in response.object["interfaceAttachments"]:
-            port['id'] = port.pop('port_id')
+            port["id"] = port.pop("port_id")
             ports.append(self._to_port(port))
         return ports
 
@@ -4457,6 +4457,7 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
         else:
             # if there are no ports
             return False
+
 
 class OpenStack_1_1_FloatingIpPool(object):
     """

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -3653,7 +3653,7 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
             resp = self.network_connection.request(
                 "/v2.0/floatingips/%s" % ip.id,
                 method="PUT",
-                data={"floatingip": {"port_id": ports[0]}},
+                data={"floatingip": {"port_id": ports[0].id}},
             )
             return resp.status == httplib.ACCEPTED
         else:

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -4458,6 +4458,35 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
             # if there are no ports
             return False
 
+    def ex_detach_floating_ip_from_node(self, node, ip):
+        """
+        Detach the floating IP from the node
+
+        :param      node: node
+        :type       node: :class:`Node`
+
+        :param      ip: floating IP to remove
+        :type       ip: ``str`` or :class:`OpenStack_1_1_FloatingIpAddress`
+
+        :rtype: ``bool``
+        """
+        ip_id = None
+        if hasattr(ip, "id"):
+            ip_id = ip.id
+        else:
+            for pool in self.ex_list_floating_ip_pools():
+                fip = pool.get_floating_ip(ip)
+                if fip:
+                    ip_id = fip.id
+        if not ip_id:
+            return False
+        resp = self.network_connection.request(
+            "/v2.0/floatingips/%s" % ip_id,
+            method="PUT",
+            data={"floatingip": {"port_id": None}},
+        )
+        return resp.status == httplib.OK
+
 
 class OpenStack_1_1_FloatingIpPool(object):
     """

--- a/libcloud/compute/drivers/openstack.py
+++ b/libcloud/compute/drivers/openstack.py
@@ -4436,7 +4436,7 @@ class OpenStack_2_NodeDriver(OpenStack_1_1_NodeDriver):
         :rtype: ``bool``
         """
         ip_id = None
-        if isinstance(ip, OpenStack_1_1_FloatingIpAddress):
+        if hasattr(ip, "id"):
             ip_id = ip.id
         else:
             for pool in self.ex_list_floating_ip_pools():

--- a/libcloud/test/compute/fixtures/openstack_v1.1/_servers_os_intefaces.json
+++ b/libcloud/test/compute/fixtures/openstack_v1.1/_servers_os_intefaces.json
@@ -1,0 +1,16 @@
+{
+    "interfaceAttachments": [
+        {
+            "fixed_ips": [
+                {
+                    "ip_address": "192.168.1.3",
+                    "subnet_id": "f8a6e8f8-c2ec-497c-9f23-da9616de54ef"
+                }
+            ],
+            "mac_addr": "fa:16:3e:4c:2c:30",
+            "net_id": "3cb9bc59-5699-4588-a4b1-b87f96708bc6",
+            "port_id": "ce531f90-199f-48c0-816c-13e38010b442",
+            "port_state": "ACTIVE"
+        }
+    ]
+}

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -3785,9 +3785,14 @@ class OpenStack_1_1_MockHttp(MockHttp, unittest.TestCase):
                 httplib.responses[httplib.OK],
             )
 
-    def _v2_1337_v2_0_floatingips_09ea1784_2f81_46dc_8c91_244b4df75bde(self, method, url, body, headers):
+    def _v2_1337_v2_0_floatingips_09ea1784_2f81_46dc_8c91_244b4df75bde(
+        self, method, url, body, headers
+    ):
         if method == "PUT":
-            self.assertEqual(body, '{"floatingip": {"port_id": "ce531f90-199f-48c0-816c-13e38010b442"}}')
+            self.assertEqual(
+                body,
+                '{"floatingip": {"port_id": "ce531f90-199f-48c0-816c-13e38010b442"}}',
+            )
             body = ""
             return (
                 httplib.OK,

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -3785,6 +3785,17 @@ class OpenStack_1_1_MockHttp(MockHttp, unittest.TestCase):
                 httplib.responses[httplib.OK],
             )
 
+    def _v2_1337_v2_0_floatingips_09ea1784_2f81_46dc_8c91_244b4df75bde(self, method, url, body, headers):
+        if method == "PUT":
+            self.assertEqual(body, '{"floatingip": {"port_id": "ce531f90-199f-48c0-816c-13e38010b442"}}')
+            body = ""
+            return (
+                httplib.OK,
+                body,
+                self.json_content_headers,
+                httplib.responses[httplib.OK],
+            )
+
     def _v2_1337_v2_0_routers_f8a44de0_fc8e_45df_93c7_f79bf3b01c95(
         self, method, url, body, headers
     ):
@@ -3927,6 +3938,16 @@ class OpenStack_1_1_MockHttp(MockHttp, unittest.TestCase):
             body = ""
             return (
                 httplib.NO_CONTENT,
+                body,
+                self.json_content_headers,
+                httplib.responses[httplib.OK],
+            )
+
+    def _v2_1337_servers_4242_os_interface(self, method, url, body, headers):
+        if method == "GET":
+            body = self.fixtures.load("_servers_os_intefaces.json")
+            return (
+                httplib.OK,
                 body,
                 self.json_content_headers,
                 httplib.responses[httplib.OK],

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -3789,9 +3789,12 @@ class OpenStack_1_1_MockHttp(MockHttp, unittest.TestCase):
         self, method, url, body, headers
     ):
         if method == "PUT":
-            self.assertEqual(
+            self.assertIn(
                 body,
-                '{"floatingip": {"port_id": "ce531f90-199f-48c0-816c-13e38010b442"}}',
+                [
+                    '{"floatingip": {"port_id": "ce531f90-199f-48c0-816c-13e38010b442"}}',
+                    '{"floatingip": {"port_id": null}}',
+                ],
             )
             body = ""
             return (


### PR DESCRIPTION
## Attach/Detach a Floating IP to an OpenStack node does not work with new versions

### Description

See #1674

### Status

Replace this: describe the PR status. Examples:

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
