### PR TITLE
Add expires condition

### DIFF
--- a/libcloud/dns/drivers/godaddy.py
+++ b/libcloud/dns/drivers/godaddy.py
@@ -464,7 +464,7 @@ class GoDaddyDNSDriver(DNSDriver):
               extra=extra,
           )
         return zone
-    
+
     def _to_records(self, items, zone=None):
         records = []
 

--- a/libcloud/dns/drivers/godaddy.py
+++ b/libcloud/dns/drivers/godaddy.py
@@ -445,17 +445,26 @@ class GoDaddyDNSDriver(DNSDriver):
         return zones
 
     def _to_zone(self, item):
-        extra = {"expires": item["expires"]}
-        zone = Zone(
-            id=item["domainId"],
-            domain=item["domain"],
-            type="master",
-            ttl=None,
-            driver=self,
-            extra=extra,
-        )
+        if "expires" not in item:
+          zone = Zone(
+              id=item["domainId"],
+              domain=item["domain"],
+              type="master",
+              ttl=None,
+              driver=self,
+          )
+        if "expires" in item:
+          extra = {"expires": item["expires"]}
+          zone = Zone(
+              id=item["domainId"],
+              domain=item["domain"],
+              type="master",
+              ttl=None,
+              driver=self,
+              extra=extra,
+          )
         return zone
-
+    
     def _to_records(self, items, zone=None):
         records = []
 


### PR DESCRIPTION
## Adding expires condition when API does not return an expired item

### Description

Hello, when testing the GoDaddy API on multiple of my domains i have observed that not all my domains return an expired field, adding this condition prevents the following error:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/libcloud/dns/drivers/godaddy.py", line 149, in list_zones
    zones = self._to_zones(result)
  File "/usr/local/lib/python3.7/site-packages/libcloud/dns/drivers/godaddy.py", line 433, in _to_zones
    zones.append(self._to_zone(item))
  File "/usr/local/lib/python3.7/site-packages/libcloud/dns/drivers/godaddy.py", line 437, in _to_zone
    extra = {"expires": item['expires']}
KeyError: 'expires'
```

### Status
- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
