### PR TITLE
Fix crash on missing etag in s3 storage driver

### DIFF
--- a/libcloud/storage/drivers/s3.py
+++ b/libcloud/storage/drivers/s3.py
@@ -1192,8 +1192,10 @@ class BaseS3StorageDriver(StorageDriver):
         return content_length
 
     def _headers_to_object(self, object_name, container, headers):
-        hash = headers["etag"].replace('"', "")
-        extra = {"content_type": headers["content-type"], "etag": headers["etag"]}
+        hash = headers.get("etag", "").replace('"', "")
+        extra = {"content_type": headers["content-type"]}
+        if "etag" in headers:
+            extra["etag"] = headers["etag"]
         meta_data = {}
 
         if "content-encoding" in headers:

--- a/libcloud/storage/drivers/s3.py
+++ b/libcloud/storage/drivers/s3.py
@@ -1196,6 +1196,7 @@ class BaseS3StorageDriver(StorageDriver):
         extra = {"content_type": headers["content-type"]}
         if "etag" in headers:
             extra["etag"] = headers["etag"]
+
         meta_data = {}
 
         if "content-encoding" in headers:

--- a/libcloud/test/conftest.py
+++ b/libcloud/test/conftest.py
@@ -28,7 +28,7 @@ def pytest_configure(config):
         print("Missing " + secrets_current)
         print("Maybe you forgot to copy it from -dist:")
         print("cp libcloud/test/secrets.py-dist libcloud/test/secrets.py")
-        pytest.exit("")
+        pytest.exit(reason="Secrets file missing")
 
     mtime_current = os.path.getmtime(secrets_current)
     mtime_dist = os.path.getmtime(secrets_dist)
@@ -39,4 +39,4 @@ def pytest_configure(config):
             "Please copy the new secrets.py-dist file over otherwise"
             + " tests might fail"
         )
-        pytest.exit("")
+        pytest.exit(reason="Secrets file out of date")


### PR DESCRIPTION
## Fix broken blob access 

### Description

Replaces the required access to the `etag` key with optional access.
I am not sure what implications this has on other components, but you can at least read public blobs again.
This fixes #1682 

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide)
- [X] Documentation (no update required)
- [X] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [X] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (I think I signed this already some time ago)
