### PR TITLE
Fix compatibility with paramiko >= 2.9.0 and older OpenSSH server versions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,10 +35,10 @@ Compute
   with paramiko >= 2.9.0 and older OpenSSH server versions which doesn't
   support SHA-2 variants of RSA key verification algorithm.
 
-  paramiko v2.9.0 introduced a change to prefer SHA-2 based key verification
-  algorithm. With this version paramiko would fail to connect to older OpenSSH
-  servers which don't support this algorithm (e.g. default setup on Ubuntu
-  14.04) and throw authentication error.
+  paramiko v2.9.0 introduced a change to prefer SHA-2 variants of RSA key
+  verification algorithm. With this version paramiko would fail to connect
+  to older OpenSSH servers which don't support this algorithm (e.g. default
+  setup on Ubuntu 14.04) and throw authentication error.
 
   The code has been updated to be backward compatible. It first tries to
   connect to the server using default preferred algorithm values and in case

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,10 +46,12 @@ Compute
   disabled.
 
   This functionality can be disabled by setting
-  ``LIBCLOUD_PARAMIKO_SHA2_COMPATIBILITY``environment variable to ``false``.
+  ``LIBCLOUD_PARAMIKO_SHA2_BACKWARD_COMPATIBILITY``environment variable to
+  ``false``.
 
-  For security reasons you are encouraged to do that in case you know you
-  won't be connecting to any old OpenSSH servers.
+  For security reasons (to prevent possible downgrade attacks and similar) you
+  are encouraged to do that in case you know you won't be connecting to any old
+  OpenSSH servers.
   [Tomaz Muraus]
 
 Storage

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,27 @@ Compute
   (GITHUB-1688)
   [Balazs Baranyi - @balazsbaranyi]
 
+- [SSH] Update deploy node and ParamikoSSHClient related code so it works
+  with paramiko >= 2.9.0 and older OpenSSH server versions which doesn't
+  support SHA-2 variants of RSA key verification algorithm.
+
+  paramiko v2.9.0 introduced a change to prefer SHA-2 based key verification
+  algorithm. With this version paramiko would fail to connect to older OpenSSH
+  servers which don't support this algorithm (e.g. default setup on Ubuntu
+  14.04) and throw authentication error.
+
+  The code has been updated to be backward compatible. It first tries to
+  connect to the server using default preferred algorithm values and in case
+  this fails, it will fall back to the old approach with SHA-2 variants
+  disabled.
+
+  This functionality can be disabled by setting
+  ``LIBCLOUD_PARAMIKO_SHA2_COMPATIBILITY``environment variable to ``false``.
+
+  For security reasons you are encouraged to do that in case you know you
+  won't be connecting to any old OpenSSH servers.
+  [Tomaz Muraus]
+
 Storage
 ~~~~~~~
 

--- a/docs/compute/deployment.rst
+++ b/docs/compute/deployment.rst
@@ -21,6 +21,28 @@ Once your server has been bootstrapped, libcloud.deploy task should be finished
 and replaced by other tools such as previously mentioned configuration
 management software.
 
+.. note::
+
+  paramiko v2.9.0 introduced a change to prefer SHA-2 variants of RSA key
+  verification algorithm.
+
+  With this version paramiko would fail to connect to older OpenSSH
+  servers which don't support this algorithm (e.g. default setup on Ubuntu
+  14.04) and throw authentication error.
+
+  Libcloud code has been updated to be backward compatible. It first tries to
+  connect to the server using default preferred algorithm values and in case
+  that fails, it will fall back to the old approach with SHA-2 variants
+  disabled.
+
+  This functionality can be disabled by setting
+  ``LIBCLOUD_PARAMIKO_SHA2_BACKWARD_COMPATIBILITY`` environment variable to
+  ``false``.
+
+  For security reasons (to prevent possible downgrade attacks and similar) you
+  are encouraged to do that in case you know you won't be connecting to any old
+  OpenSSH servers.
+
 Supported private SSH key types
 -------------------------------
 

--- a/docs/upgrade_notes.rst
+++ b/docs/upgrade_notes.rst
@@ -5,6 +5,30 @@ This page describes how to upgrade from a previous version to a new version
 which contains backward incompatible or semi-incompatible changes and how to
 preserve the old behavior when this is possible.
 
+Libcloud 3.6.0
+--------------
+
+* Compatibility layer has been introduced for paramiko SSH based deployment
+  functionality.
+
+  paramiko v2.9.0 introduced a change to prefer SHA-2 variants of RSA key
+  verification algorithm (https://github.com/paramiko/paramiko/blob/2.9.0/sites/www/changelog.rst#changelog).
+  With this version paramiko would fail to connect to older OpenSSH
+  servers which don't support this algorithm (e.g. default setup on Ubuntu
+  14.04) and throw authentication error.
+
+  The code has been updated to be backward compatible. It first tries to
+  connect to the server using default preferred algorithm values and in case
+  that fails, it will fall back to the old approach with SHA-2 variants
+  disabled.
+
+  This functionality can be disabled by setting
+  ``LIBCLOUD_PARAMIKO_SHA2_BACKWARD_COMPATIBILITY``environment variable to
+  ``false``.
+
+  For security reasons (to prevent possible downgrade attacks and similar) you
+  are encouraged to do that in case you know you won't be connecting to any old
+
 Libcloud 3.5.0
 --------------
 

--- a/libcloud/compute/ssh.py
+++ b/libcloud/compute/ssh.py
@@ -30,8 +30,10 @@ try:
     import paramiko
 
     have_paramiko = True
+
+    PARAMIKO_VERSION_TUPLE = tuple([int(x) for x in paramiko.__version__.split(".")])
 except ImportError:
-    pass
+    PARAMIKO_VERSION_TUPLE = []
 
 # Depending on your version of Paramiko, it may cause a deprecation
 # warning on Python 2.6.
@@ -415,7 +417,7 @@ class ParamikoSSHClient(BaseSSHClient):
             # / granular exception.
             # See https://www.paramiko.org/changelog.html for details.
             if (
-                tuple([int(x) for x in paramiko.__version__.split(".")]) >= (2, 9, 0)
+                PARAMIKO_VERSION_TUPLE >= (2, 9, 0)
                 and LIBCLOUD_PARAMIKO_SHA2_BACKWARD_COMPATIBILITY
             ):
                 self.logger.warn(SHA2_PUBKEY_NOT_SUPPORTED_AUTH_ERROR_MSG)


### PR DESCRIPTION
This pull request updates paramiko SSH connection related code so it works with paramiko >= 2.9.0 and older OpenSSH server versions which don't support SHA-2 variants of the RSA key verification algorithm.

## Background, Context

Paramiko v2.9.0 introduced a change which adds support and prefers SHA-2 variants of the RSA key verification algorithm (https://github.com/paramiko/paramiko/blob/2.9.0/sites/www/changelog.rst#changelog).

This change is backward incompatible and won't work it user tries to use paramiko >= 2.9.0 with older OpenSSH servers such as the default setup on Ubuntu 14.04.

## Proposed Soluton

In this PR I introduced a change to fall back to the previous / old approach in case "authentication error" is throw when connecting to the server when running paramiko >= 2.9.0. Sadly there is no easy way to catch and retry only on more granular / specific exception.

This way the code works and supports older and newer versions of paramiko and OpenSSH servers.

## Note on Security

For security reasons, if user knows they will only connect to new OpenSSH versions which support those variants + ``MSG_EXT_INFO`` extension, they are encouraged to disable this compatibility change by setting ``LIBCLOUD_PARAMIKO_SHA2_BACKWARD_COMPATIBILITY`` environment variable to ``false``.