### PR TITLE
test/test_http.py: stop HTTP server (thread) properly

### DIFF
--- a/libcloud/test/test_http.py
+++ b/libcloud/test/test_http.py
@@ -116,8 +116,9 @@ class HttpLayerTestCase(unittest.TestCase):
         cls.mock_server_thread.start()
 
     @classmethod
-    def tearDownCls(cls):
-        cls.mock_server_thread.kill()
+    def tearDownClass(cls):
+        cls.mock_server.shutdown()
+        cls.mock_server_thread.join()
 
     def test_prepared_request_empty_body_chunked_encoding_not_used(self):
         connection = LibcloudConnection(host=self.listen_host, port=self.listen_port)


### PR DESCRIPTION
## test/test_http.py: stop HTTP server (thread) properly

### Description

Hello,

The `HttpLayerTestCase` test class creates a `HTTPServer` instance and runs it in a separate thread.

After running all the test-cases, we attempt to close the server and the thread by killing the thread. Unfortunately, the code that does that is unreachable because the tear-down member function is called `tearDownCls` intead of `tearDownClass` [1].

Moreover, there is no `threading.Thread.kill function`. This was undetected because the code was unreachable.

The proper way to clean things up is to:

1. Stop the HTTP server using `HTTPServer.shutdown()`
2. Join the thread using `threading.Thread.join()`

Thanks!

[1] https://docs.python.org/3/library/unittest.html#unittest.TestCase.tearDownClass

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html) _changes are in the tests only_
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
