### PR TITLE
Replace 3rd party mock package with unittest.mock package from stdlib

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,7 +26,7 @@ Compute
 
   (GITHUB-1672)
   [Miguel Caballer - @micafer]
-  
+
 Storage
 ~~~~~~~
 
@@ -45,6 +45,15 @@ DNS
   missing ``expires`` attribute.
   (GITHUB-1681)
   [Dave Grenier - @livegrenier]
+
+Other
+~~~~~
+
+- Test code has been updated to utilize stdlib ``unittest.mock`` module instead
+  of 3rd party PyPi ``mock`` package.
+
+  (GITHUG-1684)
+  Reported by @pgajdos.
 
 Changes in Apache Libcloud 3.5.1
 --------------------------------

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -17,7 +17,6 @@ dependencies installed:
 
 * ``tox`` (``pip install tox``) - you only need this library if you want to
   use tox to run the tests with all the supported Python versions
-* ``mock`` (``pip install mock``)
 * ``fasteners`` (``pip install fasteners``) - only used in the local storage
   driver
 * ``coverage`` (``pip install coverage``) - you only need this library if you

--- a/libcloud/test/benchmarks/test_list_objects_filtering_performance.py
+++ b/libcloud/test/benchmarks/test_list_objects_filtering_performance.py
@@ -22,7 +22,7 @@ import string
 import tempfile
 
 import pytest
-import mock
+from unittest import mock
 
 from libcloud.storage.drivers.local import LocalStorageDriver
 

--- a/libcloud/test/common/test_aws.py
+++ b/libcloud/test/common/test_aws.py
@@ -17,7 +17,7 @@ import sys
 import unittest
 from datetime import datetime
 
-import mock
+from unittest import mock
 
 from libcloud.common.aws import AWSRequestSignerAlgorithmV4
 from libcloud.common.aws import SignedAWSConnection

--- a/libcloud/test/common/test_base.py
+++ b/libcloud/test/common/test_base.py
@@ -16,7 +16,7 @@
 import unittest
 import sys
 
-import mock
+from unittest import mock
 
 from libcloud.common.base import LazyObject, Response
 from libcloud.common.exceptions import BaseHTTPError, RateLimitReachedError

--- a/libcloud/test/common/test_base_driver.py
+++ b/libcloud/test/common/test_base_driver.py
@@ -15,7 +15,7 @@
 
 import sys
 
-from mock import Mock
+from unittest.mock import Mock
 
 from libcloud.common.base import BaseDriver
 

--- a/libcloud/test/common/test_google.py
+++ b/libcloud/test/common/test_google.py
@@ -16,7 +16,7 @@
 Tests for Google Connection classes.
 """
 import datetime
-import mock
+from unittest import mock
 import os
 import sys
 import unittest

--- a/libcloud/test/common/test_nfsn.py
+++ b/libcloud/test/common/test_nfsn.py
@@ -17,7 +17,7 @@ import string
 import sys
 import unittest
 
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from libcloud.common.nfsn import NFSNConnection
 from libcloud.test import LibcloudTestCase, MockHttp

--- a/libcloud/test/common/test_openstack.py
+++ b/libcloud/test/common/test_openstack.py
@@ -17,7 +17,7 @@ import sys
 import unittest
 from unittest.mock import patch
 
-from mock import Mock
+from unittest.mock import Mock
 from libcloud.common.base import LibcloudConnection
 from libcloud.common.openstack import OpenStackBaseConnection
 

--- a/libcloud/test/common/test_openstack_identity.py
+++ b/libcloud/test/common/test_openstack_identity.py
@@ -21,7 +21,7 @@ try:
 except ImportError:
     import json
 
-from mock import Mock
+from unittest.mock import Mock
 
 from libcloud.utils.py3 import httplib
 from libcloud.utils.py3 import assertRaisesRegex

--- a/libcloud/test/common/test_retry_limit.py
+++ b/libcloud/test/common/test_retry_limit.py
@@ -16,7 +16,7 @@
 import socket
 import ssl
 
-from mock import Mock, patch, MagicMock
+from unittest.mock import Mock, patch, MagicMock
 
 from libcloud.utils.retry import TRANSIENT_SSL_ERROR
 from libcloud.common.base import Connection

--- a/libcloud/test/common/test_upcloud.py
+++ b/libcloud/test/common/test_upcloud.py
@@ -15,7 +15,7 @@
 import sys
 import json
 
-from mock import Mock, call
+from unittest.mock import Mock, call
 
 from libcloud.common.upcloud import (
     UpcloudCreateNodeRequestBody,

--- a/libcloud/test/compute/test_azure_arm.py
+++ b/libcloud/test/compute/test_azure_arm.py
@@ -18,7 +18,7 @@ import sys
 import functools
 from datetime import datetime
 
-import mock
+from unittest import mock
 
 from libcloud.common.exceptions import BaseHTTPError
 from libcloud.common.types import LibcloudError

--- a/libcloud/test/compute/test_deployment.py
+++ b/libcloud/test/compute/test_deployment.py
@@ -39,7 +39,7 @@ from libcloud.compute.drivers.rackspace import RackspaceFirstGenNodeDriver as Ra
 
 from libcloud.test import MockHttp, XML_HEADERS
 from libcloud.test.file_fixtures import ComputeFileFixtures
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from libcloud.test.secrets import RACKSPACE_PARAMS
 

--- a/libcloud/test/compute/test_gce.py
+++ b/libcloud/test/compute/test_gce.py
@@ -17,7 +17,7 @@ Tests for Google Compute Engine Driver
 """
 
 import datetime
-import mock
+from unittest import mock
 import sys
 import unittest
 

--- a/libcloud/test/compute/test_gig_g8.py
+++ b/libcloud/test/compute/test_gig_g8.py
@@ -18,7 +18,7 @@ import base64
 import json
 import time
 
-import mock
+from unittest import mock
 
 from libcloud.utils.py3 import httplib
 from libcloud.test import MockHttp

--- a/libcloud/test/compute/test_libvirt_driver.py
+++ b/libcloud/test/compute/test_libvirt_driver.py
@@ -15,7 +15,7 @@
 
 import sys
 
-import mock
+from unittest import mock
 
 from libcloud.compute.drivers.libvirt_driver import LibvirtNodeDriver
 from libcloud.compute.drivers.libvirt_driver import have_libvirt

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -19,7 +19,7 @@ import os
 import sys
 import unittest
 import datetime
-import mock
+from unittest import mock
 import pytest
 
 from libcloud.utils.iso8601 import UTC
@@ -29,7 +29,7 @@ try:
 except ImportError:
     import json
 
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 import requests_mock
 
 from libcloud.utils.py3 import httplib

--- a/libcloud/test/compute/test_ovh.py
+++ b/libcloud/test/compute/test_ovh.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 import sys
 import unittest
-from mock import patch
+from unittest.mock import patch
 
 from libcloud.utils.py3 import httplib
 from libcloud.common.exceptions import BaseHTTPError

--- a/libcloud/test/compute/test_ssh_client.py
+++ b/libcloud/test/compute/test_ssh_client.py
@@ -32,7 +32,7 @@ from libcloud.utils.py3 import StringIO
 from libcloud.utils.py3 import u
 from libcloud.utils.py3 import assertRaisesRegex
 
-from mock import patch, Mock, MagicMock, call
+from unittest.mock import patch, Mock, MagicMock, call
 
 if not have_paramiko:
     ParamikoSSHClient = None  # NOQA

--- a/libcloud/test/compute/test_vcloud.py
+++ b/libcloud/test/compute/test_vcloud.py
@@ -45,7 +45,7 @@ from libcloud.compute.types import NodeState
 from libcloud.test import MockHttp
 from libcloud.test.compute import TestCaseMixin
 from libcloud.test.file_fixtures import ComputeFileFixtures
-from mock import patch, mock_open
+from unittest.mock import patch, mock_open
 
 from libcloud.test.secrets import VCLOUD_PARAMS
 

--- a/libcloud/test/dns/test_base.py
+++ b/libcloud/test/dns/test_base.py
@@ -18,7 +18,7 @@ import sys
 import tempfile
 import datetime
 
-from mock import Mock
+from unittest.mock import Mock
 
 from libcloud import __version__
 from libcloud.test import unittest

--- a/libcloud/test/dns/test_durabledns.py
+++ b/libcloud/test/dns/test_durabledns.py
@@ -15,7 +15,7 @@
 import sys
 import unittest
 
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from libcloud.dns.base import Record, Zone
 from libcloud.dns.types import RecordType

--- a/libcloud/test/dns/test_zonomi.py
+++ b/libcloud/test/dns/test_zonomi.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import sys
 import unittest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 
 from libcloud.test import MockHttp

--- a/libcloud/test/storage/test_backblaze_b2.py
+++ b/libcloud/test/storage/test_backblaze_b2.py
@@ -17,7 +17,7 @@ import os
 import sys
 import tempfile
 
-import mock
+from unittest import mock
 import json
 
 from libcloud.storage.drivers.backblaze_b2 import BackblazeB2StorageDriver

--- a/libcloud/test/storage/test_base.py
+++ b/libcloud/test/storage/test_base.py
@@ -18,8 +18,8 @@ import hashlib
 import sys
 from io import BytesIO
 
-import mock
-from mock import Mock
+from unittest import mock
+from unittest.mock import Mock
 
 from libcloud.common.exceptions import RateLimitReachedError
 from libcloud.storage.base import DEFAULT_CONTENT_TYPE

--- a/libcloud/test/storage/test_cloudfiles.py
+++ b/libcloud/test/storage/test_cloudfiles.py
@@ -24,9 +24,9 @@ from io import BytesIO
 import hashlib
 from hashlib import sha1
 
-import mock
-from mock import Mock
-from mock import PropertyMock
+from unittest import mock
+from unittest.mock import Mock
+from unittest.mock import PropertyMock
 
 import libcloud.utils.files
 

--- a/libcloud/test/storage/test_google_storage.py
+++ b/libcloud/test/storage/test_google_storage.py
@@ -15,7 +15,7 @@
 
 import copy
 import json
-import mock
+from unittest import mock
 import re
 import sys
 import unittest
@@ -24,8 +24,8 @@ from io import BytesIO
 
 import email.utils
 import pytest
-from mock import Mock
-from mock import PropertyMock
+from unittest.mock import Mock
+from unittest.mock import PropertyMock
 
 from libcloud.common.google import GoogleAuthType
 from libcloud.common.types import InvalidCredsError

--- a/libcloud/test/storage/test_oss.py
+++ b/libcloud/test/storage/test_oss.py
@@ -19,10 +19,7 @@ import os
 import sys
 import unittest
 
-try:
-    import mock
-except ImportError:
-    from unittest import mock
+from unittest import mock
 
 from libcloud.utils.py3 import b
 from libcloud.utils.py3 import httplib

--- a/libcloud/test/storage/test_s3.py
+++ b/libcloud/test/storage/test_s3.py
@@ -21,9 +21,9 @@ import sys
 from io import BytesIO
 from hashlib import sha1
 
-import mock
-from mock import Mock
-from mock import PropertyMock
+from unittest import mock
+from unittest.mock import Mock
+from unittest.mock import PropertyMock
 import libcloud.utils.files  # NOQA: F401
 
 from libcloud.utils.py3 import ET

--- a/libcloud/test/test_connection.py
+++ b/libcloud/test/test_connection.py
@@ -21,7 +21,7 @@ import sys
 from unittest import mock
 
 import requests_mock
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 from requests.exceptions import ConnectTimeout
 
 import libcloud.common.base

--- a/libcloud/test/test_init.py
+++ b/libcloud/test/test_init.py
@@ -26,7 +26,7 @@ try:
 except ImportError:
     have_paramiko = False
 
-from mock import patch
+from unittest.mock import patch
 
 import libcloud
 from libcloud import _init_once

--- a/libcloud/test/test_logging_connection.py
+++ b/libcloud/test/test_logging_connection.py
@@ -19,7 +19,7 @@ from io import StringIO
 import zlib
 import requests_mock
 
-import mock
+from unittest import mock
 
 import libcloud
 from libcloud.test import unittest

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -2,7 +2,6 @@ pep8==1.7.1
 flake8==4.0.1
 astroid==2.11.4
 pylint==2.13.8
-mock==4.0.3
 codecov==2.1.12
 coverage==4.5.4
 requests>=2.27.1

--- a/setup.py
+++ b/setup.py
@@ -208,7 +208,6 @@ if setuptools_version < (36, 2):
         raise RuntimeError(msg)
 
 TEST_REQUIREMENTS = [
-    "mock",
     "requests_mock",
     "pytest",
     "pytest-runner",


### PR DESCRIPTION
This pull request removes the dependency on 3rd party ```mock`` package by utilizing ``unittest.mock`` package from stdlib.

Since mock is just a backport for older Python versions, this is a drop in replacement without any negative side effects.

Thanks to @pgajdos for reporting this.

Resolves #1684.