### PR TITLE
tests/test_connection.py: fix test failing when https_proxy is set

### DIFF
--- a/libcloud/test/test_connection.py
+++ b/libcloud/test/test_connection.py
@@ -40,13 +40,19 @@ from libcloud.utils.retry import RetryForeverOnRateLimitError
 
 class BaseConnectionClassTestCase(unittest.TestCase):
     def setUp(self):
-        self.orig_proxy = os.environ.pop("http_proxy", None)
+        self.orig_http_proxy = os.environ.pop("http_proxy", None)
+        self.orig_https_proxy = os.environ.pop("https_proxy", None)
 
     def tearDown(self):
-        if self.orig_proxy:
-            os.environ["http_proxy"] = self.orig_proxy
+        if self.orig_http_proxy:
+            os.environ["http_proxy"] = self.orig_http_proxy
         elif "http_proxy" in os.environ:
             del os.environ["http_proxy"]
+
+        if self.orig_https_proxy:
+            os.environ["https_proxy"] = self.orig_https_proxy
+        elif "https_proxy" in os.environ:
+            del os.environ["https_proxy"]
 
         libcloud.common.base.ALLOW_PATH_DOUBLE_SLASHES = False
 

--- a/libcloud/test/test_connection.py
+++ b/libcloud/test/test_connection.py
@@ -50,13 +50,6 @@ class BaseConnectionClassTestCase(unittest.TestCase):
 
         libcloud.common.base.ALLOW_PATH_DOUBLE_SLASHES = False
 
-    @classmethod
-    def tearDownClass(cls):
-        if "http_proxy" in os.environ:
-            del os.environ["http_proxy"]
-
-        libcloud.common.base.ALLOW_PATH_DOUBLE_SLASHES = False
-
     def test_parse_proxy_url(self):
         conn = LibcloudBaseConnection()
 

--- a/libcloud/test/test_http.py
+++ b/libcloud/test/test_http.py
@@ -115,11 +115,24 @@ class HttpLayerTestCase(unittest.TestCase):
         cls.mock_server_thread.setDaemon(True)
         cls.mock_server_thread.start()
 
+        cls.orig_http_proxy = os.environ.pop("http_proxy", None)
+        cls.orig_https_proxy = os.environ.pop("https_proxy", None)
+
     @classmethod
     def tearDownClass(cls):
         cls.mock_server.shutdown()
         cls.mock_server.socket.close()
         cls.mock_server_thread.join()
+
+        if cls.orig_http_proxy:
+            os.environ["http_proxy"] = cls.orig_http_proxy
+        elif "http_proxy" in os.environ:
+            del os.environ["http_proxy"]
+
+        if cls.orig_https_proxy:
+            os.environ["https_proxy"] = cls.orig_https_proxy
+        elif "https_proxy" in os.environ:
+            del os.environ["https_proxy"]
 
     def test_prepared_request_empty_body_chunked_encoding_not_used(self):
         connection = LibcloudConnection(host=self.listen_host, port=self.listen_port)


### PR DESCRIPTION
## tests/test_connection.py: fix test failing when https_proxy is set

### Description

Hello,

In tests/test_connection.py, We have code in setUp & tearDown functions to make tests run properly if the http_proxy variable is already present in the environment when running tests.

For each test, the code:
* backs up the http_proxy variable (if it exists)
* clears the environment variable
* runs the test (sometimes the tests override the http_proxy variable; as in test_constructor)
* restores the variable to its original value (or clears it is we didn't back up any value)

However, we would also need to handle the HTTPS counterpart, the https_proxy variable. Running tests with this variable set currently fails with:

```
          self.assertIsNone(conn.proxy_scheme)
    E       AssertionError: 'http' is not None

    libcloud/test/test_connection.py:127: AssertionError
```
some of Ubuntu's autopkgtest fail because of that.

This patch adds the same logic that we have for HTTP, but for the HTTPS counterpart.

Test case:

```bash
$ https_proxy=http://squid.internal:3128 python3 -m pytest test/test_connection.py
```

I also removed the tearDownClass method that was clearing up the http_proxy variable unconditionally ; which could have side effects. We already have code that restores the http_proxy variable (or clear it) in the tearDown function so there is no need to do it twice.

_EDIT: also added a similar mechanism for test/test_http.py where the client is expected to connect to the loopback interface. Proxies cannot proxy requests to to 127.0.0.1 so we backup and restore the http_proxy & https_proxy variables, just like we did for test/test_connection.py_

Best regards,
Olivier

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
