### PR TITLE
test: fix test_ssh_client on big-endian architectures

### DIFF
--- a/libcloud/test/compute/test_ssh_client.py
+++ b/libcloud/test/compute/test_ssh_client.py
@@ -626,7 +626,10 @@ class ParamikoSSHClientTests(LibcloudTestCase):
         chan.recv.side_effect = ["🤦".encode("utf-32"), "a", "b"]
 
         stdout = client._consume_stdout(chan).getvalue()
-        self.assertEqual("\x00\x00&\x01\x00ab", stdout)
+        if sys.byteorder == "little":
+            self.assertEqual("\x00\x00&\x01\x00ab", stdout)
+        else:
+            self.assertEqual("\x00\x00\x00\x01&ab", stdout)
         self.assertEqual(len(stdout), 7)
 
     def test_consume_stderr_chunk_contains_non_utf8_character(self):
@@ -639,7 +642,10 @@ class ParamikoSSHClientTests(LibcloudTestCase):
         chan.recv_stderr.side_effect = ["🤦".encode("utf-32"), "a", "b"]
 
         stderr = client._consume_stderr(chan).getvalue()
-        self.assertEqual("\x00\x00&\x01\x00ab", stderr)
+        if sys.byteorder == "little":
+            self.assertEqual("\x00\x00&\x01\x00ab", stderr)
+        else:
+            self.assertEqual("\x00\x00\x00\x01&ab", stderr)
         self.assertEqual(len(stderr), 7)
 
     def test_keep_alive_and_compression(self):


### PR DESCRIPTION
## Fix test_ssh_client on big-endian architectures

### Description

Hello,

The tests `test_consume_*_chunk_contains_no_utf8_character` are meant to ensure support for non-UTF-8 characters. To do so, we include UTF-32 characters and compare their binary representation after being fed to
paramiko.

Unfortunately, UTF-32 is affected by the architecture's endianness, resulting in failed tests on big-endian architectures. In Ubuntu, it makes autopkgtest fail on the s390x platfgorm [1]

```
        chan.recv.side_effect = ['🤦'.encode('utf-32'), 'a', 'b']
    
        stdout = client._consume_stdout(chan).getvalue()
>       self.assertEqual('\x00\x00&\x01\x00ab', stdout)
E       AssertionError: '\x00\x00&\x01\x00ab' != '\x00\x00\x00\x01&ab'
E       - ��&�ab
E       ?    --
E       + ���&ab
E       ?   ++

test/compute/test_ssh_client.py:563: AssertionError
```

Fixed by checking the endianness and comparing the UTF-32 characters to their respective binary representation.

[1] https://en.wikipedia.org/wiki/IBM_System/390

Thanks!
Olivier

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
