### PR TITLE
Use tuple to compare versions for test against Paramiko.

### DIFF
--- a/libcloud/test/compute/test_ssh_client.py
+++ b/libcloud/test/compute/test_ssh_client.py
@@ -36,11 +36,11 @@ from unittest.mock import patch, Mock, MagicMock, call
 
 if not have_paramiko:
     ParamikoSSHClient = None  # NOQA
-    paramiko_version = "0.0.0"
+    paramiko_version = ()
 else:
     import paramiko
 
-    paramiko_version = paramiko.__version__
+    paramiko_version = tuple([int(x) for x in paramiko.__version__.split(".")])
 
 
 @unittest.skipIf(not have_paramiko, "Skipping because paramiko is not available")
@@ -167,7 +167,7 @@ class ParamikoSSHClientTests(LibcloudTestCase):
 
     @patch("paramiko.SSHClient", Mock)
     @unittest.skipIf(
-        paramiko_version >= "2.7.0",
+        paramiko_version >= (2, 7, 0),
         "New versions of paramiko support OPENSSH key format",
     )
     def test_key_file_non_pem_format_error(self):


### PR DESCRIPTION
## Use tuple to compare versions for test against Paramiko.

### Description

For the test test_key_file_non_pem_format_error() we want to compare and
see if Paramiko version is greater than '2.7.0'. The version is compared as a
string. This breaks when we test against version '2.10' and above.

We change from comparing a string, to comparing a tuple.
This is identical to this commit: 470dc46014e5b89a61a74cb6fd62493c49483a15

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
