### PR TITLE
make content-type header is optional to work with S3 servers that do not support content-type header

### DIFF
--- a/libcloud/storage/drivers/s3.py
+++ b/libcloud/storage/drivers/s3.py
@@ -1193,7 +1193,12 @@ class BaseS3StorageDriver(StorageDriver):
 
     def _headers_to_object(self, object_name, container, headers):
         hash = headers.get("etag", "").replace('"', "")
-        extra = {"content_type": headers["content-type"]}
+
+        extra = {}
+
+        if "content-type" in headers:
+            extra["content_type"] = headers["content-type"]
+
         if "etag" in headers:
             extra["etag"] = headers["etag"]
 


### PR DESCRIPTION
## Make content-type header is optional to work with S3 servers that do not support content-type header

### Description

The `content-type` header is optional since [Cohesity S3](https://www.cohesity.com/blogs/cohesity-s3/) does not return any `content-type` in response headers according their specs:
![image](https://user-images.githubusercontent.com/79898499/168850593-d017e5da-9f20-4a36-b97c-30f2fc0dcb2c.png)


The issue appears while backing up the [ThingsBoard](https://thingsboard.io/)'s [Cassandra](https://cassandra.apache.org) data using [cassandra-medusa](https://github.com/thelastpickle/cassandra-medusa) that uses [libcloud](https://github.com/apache/libcloud/) to connect S3 storage.

### Status

- done, working fine on production, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
