### PR TITLE
tests: add way to skip tests that require access to the network/Internet

### DIFF
--- a/libcloud/test/__init__.py
+++ b/libcloud/test/__init__.py
@@ -16,6 +16,7 @@
 import unittest
 import random
 import requests
+import os
 from libcloud.common.base import Response
 from libcloud.http import LibcloudConnection
 from libcloud.utils.py3 import PY2
@@ -284,6 +285,21 @@ def generate_random_data(size):
         data += value
         current_size += value_size
     return data
+
+
+def no_network():
+    """Return true if the NO_NETWORK environment variable is set.
+    Can be used to skip relevant tests.
+    """
+    return "NO_NETWORK" in os.environ
+
+
+def no_internet():
+    """Return true if the NO_INTERNET or the NO_NETWORK environment variable
+    is set.
+    Can be used to skip relevant tests.
+    """
+    return "NO_INTERNET" in os.environ or no_network()
 
 
 if __name__ == "__main__":

--- a/libcloud/test/compute/test_ovh.py
+++ b/libcloud/test/compute/test_ovh.py
@@ -26,6 +26,8 @@ from libcloud.test.common.test_ovh import BaseOvhMockHttp
 from libcloud.test.secrets import OVH_PARAMS
 from libcloud.test.file_fixtures import ComputeFileFixtures
 
+from libcloud.test import no_internet
+
 
 class OvhMockHttp(BaseOvhMockHttp):
     """Fixtures needed for tests related to rating model"""
@@ -211,6 +213,7 @@ class OvhTests(unittest.TestCase):
         driver = OvhNodeDriver(*OVH_PARAMS, region="ca")
         self.assertEqual(driver.connection.host, "ca.api.ovh.com")
 
+    @unittest.skipIf(no_internet(), "Internet is not reachable")
     def test_list_nodes_invalid_region(self):
         OvhNodeDriver.connectionCls.conn_class = LibcloudConnection
         driver = OvhNodeDriver(*OVH_PARAMS, region="invalid")

--- a/libcloud/test/test_connection.py
+++ b/libcloud/test/test_connection.py
@@ -31,7 +31,7 @@ from libcloud.common.exceptions import RateLimitReachedError
 from libcloud.http import LibcloudBaseConnection
 from libcloud.http import LibcloudConnection
 from libcloud.http import SignedHTTPSAdapter
-from libcloud.test import unittest
+from libcloud.test import unittest, no_internet
 from libcloud.utils.py3 import assertRaisesRegex
 from libcloud.utils.retry import RETRY_EXCEPTIONS
 from libcloud.utils.retry import Retry
@@ -189,6 +189,7 @@ class BaseConnectionClassTestCase(unittest.TestCase):
         conn = LibcloudConnection(host="localhost", port=8080, timeout=10)
         self.assertEqual(conn.session.timeout, 10)
 
+    @unittest.skipIf(no_internet(), "Internet is not reachable")
     def test_connection_timeout_raised(self):
         """
         Test that the connection times out

--- a/libcloud/test/test_http.py
+++ b/libcloud/test/test_http.py
@@ -34,7 +34,7 @@ from libcloud.utils.py3 import reload
 from libcloud.utils.py3 import assertRaisesRegex
 from libcloud.http import LibcloudConnection
 
-from libcloud.test import unittest
+from libcloud.test import unittest, no_network
 
 ORIGINAL_CA_CERTS_PATH = libcloud.security.CA_CERTS_PATH
 
@@ -134,6 +134,7 @@ class HttpLayerTestCase(unittest.TestCase):
         elif "https_proxy" in os.environ:
             del os.environ["https_proxy"]
 
+    @unittest.skipIf(no_network(), "Network is disabled")
     def test_prepared_request_empty_body_chunked_encoding_not_used(self):
         connection = LibcloudConnection(host=self.listen_host, port=self.listen_port)
         connection.prepared_request(
@@ -151,6 +152,7 @@ class HttpLayerTestCase(unittest.TestCase):
         self.assertEqual(connection.response.status_code, httplib.OK)
         self.assertEqual(connection.response.content, b"/test/prepared-request-2")
 
+    @unittest.skipIf(no_network(), "Network is disabled")
     def test_prepared_request_with_body(self):
         connection = LibcloudConnection(host=self.listen_host, port=self.listen_port)
         connection.prepared_request(
@@ -160,6 +162,7 @@ class HttpLayerTestCase(unittest.TestCase):
         self.assertEqual(connection.response.status_code, httplib.OK)
         self.assertEqual(connection.response.content, b"/test/prepared-request-3")
 
+    @unittest.skipIf(no_network(), "Network is disabled")
     def test_request_custom_timeout_no_timeout(self):
         def response_hook(*args, **kwargs):
             # Assert timeout has been passed correctly
@@ -172,6 +175,7 @@ class HttpLayerTestCase(unittest.TestCase):
         )
         connection.request(method="GET", url="/test", hooks=hooks)
 
+    @unittest.skipIf(no_network(), "Network is disabled")
     def test_request_custom_timeout_timeout(self):
         def response_hook(*args, **kwargs):
             # Assert timeout has been passed correctly


### PR DESCRIPTION
## tests: add way to skip tests that require access to the network/Internet

### Description
Hello,

This patch introduces two new variables which allow to skip some of the tests run:

 * `NO_INTERNET` -> skips the tests that require access to the Internet
 * `NO_NETWORK` -> skips the tests that require the network to be up.

`NO_NETWORK` implies `NO_INTERNET`.

Tests that are skipped by `NO_NETWORK` include tests that bind sockets to the loopback interface.

As for the two tests that are skipped with `NO_INTERNET`, they respectively:

 * send DNS queries and expect a NXDOMAIN response
 * attempt to send packets to 10.255.255.1 and expect a timeout (this requires a default route)

#### Rationale

In Ubuntu, we don't have full access to the Internet when running the test suite as part of autopkgtest, so we will set the `NO_INTERNET` variable to skip the tests that we cannot run.
To simulate a lack of Internet access, I ran the tests in a new, clean, network namespace (i.e., `# ip netns add test ; ip netns exec test /bin/bash`). Unfortunately, more tests started to fail (including the ones that bind to the loopback interface).
Therefore, I also added the `NO_NETWORK` variable, that disables more tests.

Thanks,
Olivier

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
