### PR TITLE
Update EC2 driver so it doesn't throw when "list_image()" method is called and an image doesn't contain creation date attribute

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,22 @@
 Changelog
 =========
 
+Changes in Apache Libcloud in development
+-----------------------------------------
+
+Compute
+~~~~~~~
+
+- [EC2] Update ``list_images()`` method to better handle scenario when an image
+  doesn't contain ``creationDate`` attribute (previously the code would throw if
+  an image without ``creationDate`` was encountered).
+
+  Reported by Juan Marcos Caicedo Mejía  - @juanmarcosdev.
+
+  (GITHUB-1700, GITHUB-1701)
+  [Tomaz Muraus - @Kami]
+
+
 Changes in Apache Libcloud 3.6.0
 --------------------------------
 

--- a/libcloud/compute/drivers/ec2.py
+++ b/libcloud/compute/drivers/ec2.py
@@ -32,6 +32,7 @@ from libcloud.utils.xml import fixxpath, findtext, findattr, findall
 from libcloud.utils.publickey import get_pubkey_ssh2_fingerprint
 from libcloud.utils.publickey import get_pubkey_comment
 from libcloud.utils.iso8601 import parse_date
+from libcloud.utils.iso8601 import parse_date_allow_empty
 from libcloud.common.aws import AWSBaseResponse, SignedAWSConnection
 from libcloud.common.aws import DEFAULT_SIGNATURE_VERSION
 from libcloud.common.types import (
@@ -637,7 +638,10 @@ Define the extra dictionary for specific resources
 """
 RESOURCE_EXTRA_ATTRIBUTES_MAP = {
     "ebs_instance_block_device": {
-        "attach_time": {"xpath": "ebs/attachTime", "transform_func": parse_date},
+        "attach_time": {
+            "xpath": "ebs/attachTime",
+            "transform_func": parse_date_allow_empty,
+        },
         "delete": {"xpath": "ebs/deleteOnTermination", "transform_func": str},
         "status": {"xpath": "ebs/status", "transform_func": str},
         "volume_id": {"xpath": "ebs/volumeId", "transform_func": str},
@@ -674,7 +678,10 @@ RESOURCE_EXTRA_ATTRIBUTES_MAP = {
         "ramdisk_id": {"xpath": "ramdiskId", "transform_func": str},
         "ena_support": {"xpath": "enaSupport", "transform_func": str},
         "sriov_net_support": {"xpath": "sriovNetSupport", "transform_func": str},
-        "creation_date": {"xpath": "creationDate", "transform_func": parse_date},
+        "creation_date": {
+            "xpath": "creationDate",
+            "transform_func": parse_date_allow_empty,
+        },
     },
     "network": {
         "state": {"xpath": "state", "transform_func": str},
@@ -701,7 +708,10 @@ RESOURCE_EXTRA_ATTRIBUTES_MAP = {
         "owner_id": {"xpath": "attachment/instanceOwnerId", "transform_func": str},
         "device_index": {"xpath": "attachment/deviceIndex", "transform_func": int},
         "status": {"xpath": "attachment/status", "transform_func": str},
-        "attach_time": {"xpath": "attachment/attachTime", "transform_func": parse_date},
+        "attach_time": {
+            "xpath": "attachment/attachTime",
+            "transform_func": parse_date_allow_empty,
+        },
         "delete": {"xpath": "attachment/deleteOnTermination", "transform_func": str},
     },
     "node": {
@@ -758,7 +768,7 @@ RESOURCE_EXTRA_ATTRIBUTES_MAP = {
         "state": {"xpath": "status", "transform_func": str},
         "description": {"xpath": "description", "transform_func": str},
         "progress": {"xpath": "progress", "transform_func": str},
-        "start_time": {"xpath": "startTime", "transform_func": parse_date},
+        "start_time": {"xpath": "startTime", "transform_func": parse_date_allow_empty},
     },
     "subnet": {
         "cidr_block": {"xpath": "cidrBlock", "transform_func": str},
@@ -774,7 +784,10 @@ RESOURCE_EXTRA_ATTRIBUTES_MAP = {
         },
         "iops": {"xpath": "iops", "transform_func": int},
         "zone": {"xpath": "availabilityZone", "transform_func": str},
-        "create_time": {"xpath": "createTime", "transform_func": parse_date},
+        "create_time": {
+            "xpath": "createTime",
+            "transform_func": parse_date_allow_empty,
+        },
         "state": {"xpath": "status", "transform_func": str},
         "encrypted": {
             "xpath": "encrypted",
@@ -782,7 +795,7 @@ RESOURCE_EXTRA_ATTRIBUTES_MAP = {
         },
         "attach_time": {
             "xpath": "attachmentSet/item/attachTime",
-            "transform_func": parse_date,
+            "transform_func": parse_date_allow_empty,
         },
         "attachment_status": {
             "xpath": "attachmentSet/item/status",
@@ -802,13 +815,13 @@ RESOURCE_EXTRA_ATTRIBUTES_MAP = {
 }
 
 VOLUME_MODIFICATION_ATTRIBUTE_MAP = {
-    "end_time": {"xpath": "endTime", "transform_func": parse_date},
+    "end_time": {"xpath": "endTime", "transform_func": parse_date_allow_empty},
     "modification_state": {"xpath": "modificationState", "transform_func": str},
     "original_iops": {"xpath": "originalIops", "transform_func": int},
     "original_size": {"xpath": "originalSize", "transform_func": int},
     "original_volume_type": {"xpath": "originalVolumeType", "transform_func": str},
     "progress": {"xpath": "progress", "transform_func": int},
-    "start_time": {"xpath": "startTime", "transform_func": parse_date},
+    "start_time": {"xpath": "startTime", "transform_func": parse_date_allow_empty},
     "status_message": {"xpath": "statusMessage", "transform_func": str},
     "target_iops": {"xpath": "targetIops", "transform_func": int},
     "target_size": {"xpath": "targetSize", "transform_func": int},
@@ -4430,7 +4443,7 @@ class BaseEC2NodeDriver(NodeDriver):
         except KeyError:
             state = NodeState.UNKNOWN
 
-        created = parse_date(
+        created = parse_date_allow_empty(
             findtext(element=element, xpath="launchTime", namespace=NAMESPACE)
         )
         instance_id = findtext(element=element, xpath="instanceId", namespace=NAMESPACE)
@@ -4573,7 +4586,7 @@ class BaseEC2NodeDriver(NodeDriver):
     def _to_snapshot(self, element, name=None):
         snapId = findtext(element=element, xpath="snapshotId", namespace=NAMESPACE)
         size = findtext(element=element, xpath="volumeSize", namespace=NAMESPACE)
-        created = parse_date(
+        created = parse_date_allow_empty(
             findtext(element=element, xpath="startTime", namespace=NAMESPACE)
         )
 

--- a/libcloud/test/compute/fixtures/ec2/describe_images.xml
+++ b/libcloud/test/compute/fixtures/ec2/describe_images.xml
@@ -68,7 +68,7 @@
             </blockDeviceMapping>
             <virtualizationType>paravirtual</virtualizationType>
             <hypervisor>xen</hypervisor>
-            <creationDate>2021-01-10T18:25:00.000Z</creationDate>
+            <creationDate></creationDate>
         </item>
         <item>
             <imageId>ami-85b2a8ac</imageId>

--- a/libcloud/test/compute/test_ec2.py
+++ b/libcloud/test/compute/test_ec2.py
@@ -605,7 +605,7 @@ class EC2Tests(LibcloudTestCase, TestCaseMixin):
         billing_product2 = images[1].extra["billing_products"][0]
         self.assertEqual(billing_product2, "as-6dr90319")
         self.assertEqual(size, 20)
-        self.assertIsInstance(images[1].extra["creation_date"], datetime)
+        self.assertIsNone(images[1].extra["creation_date"])
 
         self.assertEqual(images[2].id, "ami-85b2a8ac")
         self.assertEqual(images[2].name, "Test Image 3")

--- a/libcloud/utils/iso8601.py
+++ b/libcloud/utils/iso8601.py
@@ -33,7 +33,7 @@ datetime.datetime(2007, 1, 25, 12, 0, tzinfo=<iso8601.iso8601.Utc ...>)
 from datetime import datetime, timedelta, tzinfo
 import re
 
-__all__ = ["parse_date", "ParseError"]
+__all__ = ["parse_date", "parse_date_allow_empty", "ParseError"]
 
 # Adapted from http://delete.me.uk/2005/03/iso8601.html
 ISO8601_REGEX = re.compile(
@@ -108,7 +108,7 @@ def parse_timezone(tzstring, default_timezone=UTC):
     return FixedOffset(hours, minutes, tzstring)
 
 
-def parse_date(datestring, default_timezone=UTC):
+def parse_date(datestring, default_timezone=UTC, allow_empty=False):
     """Parses ISO 8601 dates into datetime objects
 
     The timezone is parsed from the date string. However it is quite common to
@@ -117,6 +117,9 @@ def parse_date(datestring, default_timezone=UTC):
     default.
     """
     if not datestring:
+        if allow_empty:
+            return None
+
         raise ValueError("datestring must be valid date string and not None")
 
     m = ISO8601_REGEX.match(datestring)
@@ -137,4 +140,15 @@ def parse_date(datestring, default_timezone=UTC):
         int(groups["second"]),
         int(groups["fraction"]),
         tz,
+    )
+
+
+def parse_date_allow_empty(datestring, default_timezone=UTC):
+    """
+    Parses ISO 8601 dates into datetime objects, but allow empty values.
+
+    In case empty value is found, None is returned.
+    """
+    return parse_date(
+        datestring=datestring, default_timezone=default_timezone, allow_empty=True
     )


### PR DESCRIPTION
This pull request contains a small fix for the EC2 driver - in some cases when using ``list_image()`` method, returned image doesn't contain ``creationDate`` attribute or it's empty.

In such case, the code would previously throw. This PR updates the code to allow empty ``creationDate`` date - now if an empty attribute is encountered, we simply set that ``Image`` extra attribute value to ``None``.

Resolves #1700.