### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,6 +31,10 @@ jobs:
           github_token: ${{ github.token }}
 
   analyze:
+    permissions:
+      actions: read  # for github/codeql-action/init to get workflow details
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/autobuild to send a status report
     name: Analyze
     runs-on: ubuntu-latest
     timeout-minutes: 12

--- a/.github/workflows/install_test.yml
+++ b/.github/workflows/install_test.yml
@@ -7,6 +7,9 @@ on:
     - cron: '0 13 * * *'
     - cron: '0 2 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   install_and_verify:
     name: Install latest stable version

--- a/.github/workflows/publish_dev_artifact.yml
+++ b/.github/workflows/publish_dev_artifact.yml
@@ -13,6 +13,9 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+
 jobs:
   generate_and_publish_dev_release_artifacts:
     name: Generate and Publish Dev Release Artifacts

--- a/.github/workflows/publish_pricing_to_s3.yml
+++ b/.github/workflows/publish_pricing_to_s3.yml
@@ -6,6 +6,9 @@ on:
     - cron: '0 13 * * *'
     - cron: '0 2 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   generate_and_publish_pricing_data:
     name: Generate and Publish Pricing file to S3


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
