### PR TITLE
Set minimum permissions got github token for GHA workflows

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -12,6 +12,9 @@ on:
   schedule:
     - cron: '0 1 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   # Special job which skips duplicate jobs
   pre_job:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,12 +4,14 @@ on:
   push:
     branches:
       - trunk
-      - pyjion_cicd_tests
   pull_request:
     branches:
       - trunk
   schedule:
     - cron: '0 1 * * *'
+
+permissions:
+  contents: read
 
 jobs:
   # Special job which skips duplicate jobs


### PR DESCRIPTION
This pull request updates GHA workflows in main.yml and integration-tests.yml to use least amount of permissions needed for github token.

Additional changes on top of #1702 (thanks!).
