### PR TITLE
Remove hard-coded scheme in azure HTTP requests. Closes #1703

### DIFF
--- a/.github/workflows/install_test.yml
+++ b/.github/workflows/install_test.yml
@@ -26,7 +26,7 @@ jobs:
           - 3.8
           - 3.9
           - "3.10"
-          - pypy3.7
+          - "pypy-3.7"
 
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
           - 3.8
           - 3.9
           - "3.10"
-          #- "pypy3.7"
+          - "pypy-3.7"
           - pyjion
         os:
           - ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,7 +117,7 @@ jobs:
          script -e -c "tox -e py${{ matrix.python_version }}"
 
       - name: Run dist install checks tox target
-        if: ${{ matrix.python_version != 'pypy3.7' && matrix.python_version != 'pyjion' }}
+        if: ${{ matrix.python_version != 'pypy-3.7' && matrix.python_version != 'pyjion' }}
         run: |
          script -e -c "tox -e py${{ matrix.python_version }}-dist,py${{ matrix.python_version }}-dist-wheel"
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,22 @@ Compute
   (GITHUB-1700, GITHUB-1701)
   [Tomaz Muraus - @Kami]
 
+Storage
+~~~~~~~
+
+- [Azure Blobs] Fix ``get_container()`` method and make sure Container ``etag``
+  extra attribute contains the correct scheme (https or http), depending on the
+  used endpoint.
+
+  (GITHUB-1703, GITHUB-1712)
+  [@KatiRG]
+
+- [Azure Blobs] Fix `list_containers()`` method and make sure Container ``etag``
+  extra attribute doesn't contain unncessary double quotes around the value
+  (``"0x8CFBAB7B5B82D8E"`` -> ``0x8CFBAB7B5B82D8E``).
+
+  (GITHUB-1712)
+  [Timaz Muraus - @Kami]
 
 Changes in Apache Libcloud 3.6.0
 --------------------------------

--- a/libcloud/storage/drivers/azure_blobs.py
+++ b/libcloud/storage/drivers/azure_blobs.py
@@ -349,6 +349,11 @@ class AzureBlobsStorageDriver(StorageDriver):
             "meta_data": {},
         }
 
+        if extra["etag"]:
+            # Remove redundant double quotes around etag value
+            # "0x8CFBAB7B5B82D8E" -> 0x8CFBAB7B5B82D8E
+            extra["etag"] = extra["etag"].replace('"', "")
+
         if metadata is not None:
             for meta in list(metadata):
                 extra["meta_data"][meta.tag] = meta.text

--- a/libcloud/storage/drivers/azure_blobs.py
+++ b/libcloud/storage/drivers/azure_blobs.py
@@ -370,9 +370,11 @@ class AzureBlobsStorageDriver(StorageDriver):
         """
 
         headers = response.headers
+        scheme = "https" if self.secure else "http"
+        
         extra = {
-            "url": "http://%s%s"
-            % (response.connection.host, response.connection.action),
+            "url": "%s://%s%s"
+            % (scheme, response.connection.host, response.connection.action),
             "etag": headers["etag"],
             "last_modified": headers["last-modified"],
             "lease": {
@@ -467,10 +469,11 @@ class AzureBlobsStorageDriver(StorageDriver):
         headers = response.headers
         size = int(headers["content-length"])
         etag = headers["etag"]
+        scheme = "https" if self.secure else "http"
 
         extra = {
-            "url": "http://%s%s"
-            % (response.connection.host, response.connection.action),
+            "url": "%s://%s%s"
+            % (scheme, response.connection.host, response.connection.action),
             "etag": etag,
             "md5_hash": headers.get("content-md5", None),
             "content_type": headers.get("content-type", None),

--- a/libcloud/storage/drivers/azure_blobs.py
+++ b/libcloud/storage/drivers/azure_blobs.py
@@ -371,7 +371,7 @@ class AzureBlobsStorageDriver(StorageDriver):
 
         headers = response.headers
         scheme = "https" if self.secure else "http"
-        
+
         extra = {
             "url": "%s://%s%s"
             % (scheme, response.connection.host, response.connection.action),

--- a/libcloud/test/storage/test_azure_blobs.py
+++ b/libcloud/test/storage/test_azure_blobs.py
@@ -442,6 +442,7 @@ class AzureBlobsTests(unittest.TestCase):
         self.assertTrue("etag" in containers[1].extra)
         self.assertTrue("lease" in containers[1].extra)
         self.assertTrue("meta_data" in containers[1].extra)
+        self.assertEqual(containers[1].extra["etag"], "0x8CFBAB7B5B82D8E")
 
     def test_list_container_objects_empty(self):
         self.mock_response_klass.type = "EMPTY"

--- a/libcloud/test/storage/test_azure_blobs.py
+++ b/libcloud/test/storage/test_azure_blobs.py
@@ -514,6 +514,13 @@ class AzureBlobsTests(unittest.TestCase):
         self.assertTrue(container.extra["lease"]["state"], "available")
         self.assertTrue(container.extra["meta_data"]["meta1"], "value1")
 
+        if self.driver.secure:
+            expected_url = "https://account.blob.core.windows.net/test_container200"
+        else:
+            expected_url = "http://localhost/account/test_container200"
+
+        self.assertEqual(container.extra["url"], expected_url)
+
     def test_get_object_cdn_url(self):
         obj = self.driver.get_object(
             container_name="test_container200", object_name="test"

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ deps =
 basepython =
     pypypy3: pypy3
     pypypy3.7: pypy3.7
+    pypypy-3.7: pypy3.7
     pypyjion: pyjion
     {py3.6,py3.6-dist,py3.6-dist-wheel}: python3.6
     {py3.7,docs,checks,black,lint,pylint,mypy,micro-benchmarks,coverage,docs,py3.7-dist,py3.7-dist-wheel}: python3.7


### PR DESCRIPTION
## Dynamically assign scheme to HTTP requests in azure driver

### Description
Per #1703. The hard-coded `http` scheme is replaced with a variable that assigns it to `http` or `https` based on the value of `self.secure`. Otherwise, requests made to a secure Azure blob storage will always start with `http` and will fail, as this is not allowed.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)

Output of `tox`:
```
========================================== 25 passed, 39 skipped in 13.11s ===========================================
______________________________________________________ summary _______________________________________________________
ERROR:  pypypy3: InterpreterNotFound: pypy3
ERROR:  py3.6: InterpreterNotFound: python3.6
ERROR:  py3.7: InterpreterNotFound: python3.7
ERROR:   py3.8: could not install deps [-r/home/ckan29lts/FORKS/libcloud/requirements-tests.txt, fasteners, libvirt-python==7.9.0]; v = InvocationError('/home/ckan29lts/FORKS/libcloud/.tox/py3.8/bin/python -m pip install -r/home/ckan29lts/FORKS/libcloud/requirements-tests.txt fasteners libvirt-python==7.9.0', 1)
ERROR:  py3.9: InterpreterNotFound: python3.9
ERROR:  py3.10: InterpreterNotFound: python3.10
ERROR:  pypyjion: InterpreterNotFound: pyjion
ERROR:  checks: InterpreterNotFound: python3.7
ERROR:  lint: InterpreterNotFound: python3.7
ERROR:  pylint: InterpreterNotFound: python3.7
ERROR:  mypy: InterpreterNotFound: python3.7
ERROR:  docs: InterpreterNotFound: python3.7
ERROR:  coverage: InterpreterNotFound: python3.7
  integration-storage: commands succeeded
```