### PR TITLE
Try fixing integration tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,6 @@ through a unified and easy to use API.
 .. image:: https://img.shields.io/twitter/follow/Libcloud.svg?style=social&label=Follow
         :target: https://twitter.com/Libcloud
 
-  
 :Code:          https://github.com/apache/libcloud
 :License:       Apache 2.0; see LICENSE file
 :Issues:        https://issues.apache.org/jira/projects/LIBCLOUD/issues

--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,7 @@ through a unified and easy to use API.
 .. image:: https://img.shields.io/twitter/follow/Libcloud.svg?style=social&label=Follow
         :target: https://twitter.com/Libcloud
 
+  
 :Code:          https://github.com/apache/libcloud
 :License:       Apache 2.0; see LICENSE file
 :Issues:        https://issues.apache.org/jira/projects/LIBCLOUD/issues

--- a/integration/storage/test_minio.py
+++ b/integration/storage/test_minio.py
@@ -30,7 +30,10 @@ class MinioTest(Integration.ContainerTestBase):
     port = 9000
     environment = {'MINIO_ROOT_USER': account, 'MINIO_ROOT_PASSWORD': secret}
     command = ['server', '/data']
-    ready_message = b'Console endpoint is listening on a dynamic port'
+    # Output seemed to have changed recently, see
+    # https://github.com/apache/libcloud/runs/7481114211?check_suite_focus=true
+    #ready_message = b'Console endpoint is listening on a dynamic port'
+    ready_message = b'1 Online'
 
     def test_cdn_url(self):
         self.skipTest('Not implemented in driver')

--- a/integration/storage/test_minio.py
+++ b/integration/storage/test_minio.py
@@ -32,7 +32,7 @@ class MinioTest(Integration.ContainerTestBase):
     command = ['server', '/data']
     # Output seemed to have changed recently, see
     # https://github.com/apache/libcloud/runs/7481114211?check_suite_focus=true
-    #ready_message = b'Console endpoint is listening on a dynamic port'
+    # ready_message = b'Console endpoint is listening on a dynamic port'
     ready_message = b'1 Online'
 
     def test_cdn_url(self):


### PR DESCRIPTION
It looks like new version of MinIO container which is used by integration tests now prints a different message on startup so the existing tests are failing:

```
E               ValueError: Container e95d325a2a failed to start and become ready in 20 seconds (did not find "Console endpoint is listening on a dynamic port" message in container logs).
E               
E               Container Logs:
E               Formatting 1st pool, 1 set(s), 1 drives per set.
E               WARNING: Host local has more than 0 drives of set. A host failure will result in data becoming unavailable.
E               MinIO Object Storage Server
E               Copyright: 2015-2022 MinIO, Inc.
E               License: GNU AGPLv3 <https://www.gnu.org/licenses/agpl-3.0.html>
E               Version: RELEASE.2022-07-17T15-43-14Z (go1.18.4 linux/amd64)
E               
E               Status:         1 Online, 0 Offline. 
E               API: http://172.17.0.2:9000/ [ http://127.0.0.1:90](http://127.0.0.1:9000/)
E               Console: http://172.17.0.2:34299/[ http://127.0.0.1:3429](http://127.0.0.1:34299/)
E               
E               Documentation: https://docs.min.io/
```

This change should likely fix the failure.