### PR TITLE
Add Filters to DO Images

### DIFF
--- a/libcloud/test/compute/fixtures/digitalocean_v2/list_images.json
+++ b/libcloud/test/compute/fixtures/digitalocean_v2/list_images.json
@@ -9,6 +9,10 @@
       "regions": [
         "nyc1"
       ],
+      "tags": [
+        "base-image",
+        "prod"
+      ],
       "created_at": "2014-07-29T14:35:40Z",
       "min_disk_size": 20
     },
@@ -20,6 +24,9 @@
       "public": true,
       "regions": [
         "nyc1"
+      ],
+      "tags": [
+        "dev"
       ],
       "created_at": "2014-07-29T14:35:40Z",
       "min_disk_size": 20

--- a/libcloud/test/compute/test_digitalocean_v2.py
+++ b/libcloud/test/compute/test_digitalocean_v2.py
@@ -72,6 +72,22 @@ class DigitalOcean_v2_Tests(LibcloudTestCase):
         self.assertTrue(image.id is not None)
         self.assertTrue(image.name is not None)
 
+    def test_list_images_filter_by_tag_name(self):
+        images = self.driver.list_images(ex_tag_name="base-image")
+        self.assertTrue(len(images) >= 1)
+
+        image = images[0]
+        self.assertTrue(image.id is not None)
+        self.assertTrue(image.name is not None)
+
+    def test_list_images_filter_by_private(self):
+        images = self.driver.list_images(ex_private=True)
+        self.assertTrue(len(images) >= 1)
+
+        image = images[0]
+        self.assertTrue(image.id is not None)
+        self.assertTrue(image.name is not None)
+
     def test_list_sizes_success(self):
         sizes = self.driver.list_sizes()
         self.assertTrue(len(sizes) >= 1)


### PR DESCRIPTION
Adds a `private` and `tag` filter to DigitalOcean Images

### Description

DigitalOcean accepts both `tag_name` and `private` parameters to filter images and Nodes.
This PR adds these parameters using the `ex_*` convention.
https://docs.digitalocean.com/reference/api/api-reference/#tag/Images
Closes #1737

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)

### Others

First contribution, will keep it as a Draft for now.