### PR TITLE
Azure: Add the ability to use Ultra SSDs

### DIFF
--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -898,6 +898,8 @@ class AzureNodeDriver(NodeDriver):
         ex_sku_name=None,
         ex_tags=None,
         ex_zones=None,
+        ex_iops=None,
+        ex_throughput=None,
     ):
         """
         Create a new managed volume.
@@ -928,6 +930,12 @@ class AzureNodeDriver(NodeDriver):
         :param ex_zones: The list of availability zones to create the volume
             in. Options are any or all of ["1", "2", "3"]. (optional)
         :type ex_zones: ``list`` of ``str``
+
+        :param ex_iops: The max IOPS this volume is capable of.
+        :type ex_iops: ``int``
+
+        :param ex_throughput: The max throughput of this volume in MBps.
+        :type ex_throughput: ``int``
 
         :return: The newly created volume.
         :rtype: :class:`StorageVolume`
@@ -963,6 +971,12 @@ class AzureNodeDriver(NodeDriver):
 
         if ex_zones is not None:
             data["zones"] = ex_zones
+
+        if ex_iops is not None:
+            data["properties"]["diskIopsReadWrite"] = ex_iops
+
+        if ex_throughput is not None:
+            data["properties"]["diskMBpsReadWrite"] = ex_throughput
 
         response = self.connection.request(
             action,
@@ -2021,6 +2035,48 @@ class AzureNodeDriver(NodeDriver):
             params={"api-version": TAG_API_VERSION},
             method="PATCH",
         )
+
+    def ex_create_additional_capabilities(
+        self, node, additional_capabilities, resource_group,
+    ):
+        """
+        Set the additional capabilities on a stopped node.
+
+        :param node: The node to be updated
+        :type node: ``str``
+
+        :param ex_additional_capabilities: Optional additional capabilities
+            allowing Ultra SSD and hibernation on this node.
+        :type ex_additional_capabilities: ``dict``
+
+        :param resource_group: The resource group of the node to be updated
+        :type resource_group: ``str``
+
+        :return: True if the update was successful, otherwise False
+        :rtype: ``bool``
+        """
+
+        target = (
+            "/subscriptions/%s/resourceGroups/%s/providers"
+            "/Microsoft.Compute/virtualMachines/%s"
+            % (self.subscription_id, resource_group, node.name)
+        )
+
+        data = {
+            "location": node.extra["location"],
+            "properties": {
+                "additionalCapabilities": additional_capabilities
+            }
+        }
+
+        r = self.connection.request(
+            target,
+            data=data,
+            params={"api-version": VM_API_VERSION},
+            method="PUT",
+        )
+
+        return r.status in [200, 202, 204]
 
     def start_node(self, node):
         """

--- a/libcloud/test/compute/fixtures/azure_arm/_subscriptions_99999999_providers_Microsoft_Compute_virtualMachines.json
+++ b/libcloud/test/compute/fixtures/azure_arm/_subscriptions_99999999_providers_Microsoft_Compute_virtualMachines.json
@@ -3,6 +3,10 @@
     {
       "properties": {
         "vmId": "CCEEBF63-E92B-4A50-9949-6E44BFC61D3F",
+        "additionalCapabilities": {
+          "ultraSSDEnabled": "False",
+          "hibernationEnabled": "False"
+        },
         "hardwareProfile": {
           "vmSize": "Standard_A1"
         },

--- a/libcloud/test/compute/test_azure_arm.py
+++ b/libcloud/test/compute/test_azure_arm.py
@@ -479,6 +479,8 @@ class AzureNodeDriverTests(LibcloudTestCase):
             ex_resource_group="000000",
             ex_tags={"description": "MyVolume"},
             ex_zones=["1", "2", "3"],
+            ex_iops=12345,
+            ex_throughput=6789,
         )
 
         self.assertEqual(volume.size, 2)
@@ -492,6 +494,8 @@ class AzureNodeDriverTests(LibcloudTestCase):
         self.assertEqual(volume.extra["properties"]["diskState"], "Attached")
         self.assertEqual(volume.state, StorageVolumeState.INUSE)
         self.assertEqual(volume.extra["zones"], ["1", "2", "3"])
+        self.assertEqual(volume.extra["properties"]["diskIopsReadWrite"], 12345)
+        self.assertEqual(volume.extra["properties"]["diskMBpsReadWrite"], 6789)
 
     def test_create_volume__with_snapshot(self):
         location = self.driver.list_locations()[0]
@@ -776,6 +780,21 @@ class AzureNodeDriverTests(LibcloudTestCase):
                 self.driver._get_instance_vhd(
                     name="test1", ex_resource_group="000000", ex_storage_account="sga1"
                 )
+
+    def test_ex_create_additional_capabilities(self):
+        add_cap = {
+            "ultraSSDEnabled": True,
+            "hibernationEnabled": True,
+        }
+
+        node = self.driver.list_nodes()[0]
+        self.driver.ex_create_additional_capabilities(node, add_cap, "000000")
+        self.assertTrue(
+            node.extra["properties"]["additionalCapabilities"]["ultraSSDEnabled"]
+        )
+        self.assertTrue(
+            node.extra["properties"]["additionalCapabilities"]["hibernationEnabled"]
+        )
 
 
 class AzureMockHttp(MockHttp):


### PR DESCRIPTION
This change adds a function to update additional_capabilities so that
Ultra SSDs can be added. Additional changes allow specific provisioned
IOPS and throughput.

## Azure: Add the ability to use Ultra SSDs

### Description
To add UltraSSD disks in Azure, a flag must be toggled on the VM
itself. Once the flag is enabled, a disk of this type may be
provisioned with a specific cap on IOPS and throughput. This commit
adds a function to toggle the compatibility flag, and adds the ability
to specify IOPS and throughput numbers.

### Status
- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
