### PR TITLE
Add new pip audit check to Github Actions Workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -201,6 +201,17 @@ jobs:
         run: |
           pip install "tox==3.24.4"
 
+      - name: Install Library Into Virtualenv
+        run: |
+          python -m venv venv/
+          source venv/bin/activate
+          python -m pip install .
+
+      - name: Run Pip Audit Check
+        uses: pypa/gh-action-pip-audit@cce88443a7a495d91316565f5cc077f815a8f1c7  # v1.0.0
+        with:
+          virtual-environment: venv/
+
       - name: Run Checks
         run: |
           script -e -c "tox -e black-check,checks,import-timings,lint,pylint"


### PR DESCRIPTION
This pull request adds new step to the existing Github Actions workflows which runs pip audit check - https://github.com/pypa/gh-action-pip-audit.

NOTE: Right now we only run pip audit on direct dependency of the library (we don't run audit check on any test / dev dependencies).