### PR TITLE
Update development / testing Docker image, add new bandit lint check

### DIFF
--- a/.bandit.yaml
+++ b/.bandit.yaml
@@ -5,3 +5,6 @@ exclude_dirs:
   - dist
   - venv
   - "tests/*"
+
+skips:
+  - B411

--- a/.bandit.yaml
+++ b/.bandit.yaml
@@ -1,0 +1,7 @@
+exclude_dirs:
+  - .tox
+  - .git
+  - build
+  - dist
+  - venv
+  - "tests/*"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Install Python Dependencies
         run: |
-          pip install "tox==3.24.4"
+          pip install "tox==3.25.1"
 
       - name: Run tox target
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -227,7 +227,7 @@ jobs:
 
       - name: Verify Image Works
         run: |
-          # We run all the checks in the image to verify it works
+          # TODO: Only run it on daily basis since this check is slow
           docker run libcloud_runtest_img
 
   security_checks:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Install Python Dependencies
         run: |
-          pip install "tox==3.24.4"
+          pip install "tox==3.25.1"
 
       - name: Run unit tests tox target
         run: |
@@ -157,7 +157,7 @@ jobs:
 
       - name: Install Python Dependencies
         run: |
-          pip install "tox==3.24.4"
+          pip install "tox==3.25.1"
 
       - name: Run Checks
         run: |
@@ -199,6 +199,7 @@ jobs:
 
       - name: Install Python Dependencies
         run: |
+          pip install "tox==3.25.1"
 
       - name: Run Checks
         run: |
@@ -235,7 +236,7 @@ jobs:
 
       - name: Install Python Dependencies
         run: |
-          pip install "tox==3.24.4"
+          pip install "tox==3.25.1"
 
       - name: Install Library Into Virtualenv
         run: |
@@ -289,7 +290,7 @@ jobs:
 
       - name: Install Python Dependencies
         run: |
-          pip install "tox==3.24.4"
+          pip install "tox==3.25.1"
 
       - name: Run Micro Benchmarks
         run: |
@@ -336,7 +337,7 @@ jobs:
 
       - name: Install Python Dependencies
         run: |
-          pip install "tox==3.24.4"
+          pip install "tox==3.25.1"
 
       - name: Build Docs
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -199,6 +199,42 @@ jobs:
 
       - name: Install Python Dependencies
         run: |
+
+      - name: Run Checks
+        run: |
+          script -e -c "tox -e black-check,checks,import-timings,lint,pylint"
+
+  security_checks:
+    name: Run Security Checks
+    runs-on: ubuntu-latest
+
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip == 'false' || github.ref == 'refs/heads/trunk' }}
+
+    strategy:
+      matrix:
+        python_version: [3.7]
+
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 1
+
+      - name: Use Python ${{ matrix.python_version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python_version }}
+
+      - name: Cache Python Dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements-tests.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install Python Dependencies
+        run: |
           pip install "tox==3.24.4"
 
       - name: Install Library Into Virtualenv
@@ -215,7 +251,7 @@ jobs:
       - name: Run Checks
         run: |
           rm -rf venv/ || true
-          script -e -c "tox -e black-check,checks,import-timings,lint,pylint"
+          script -e -c "tox -e bandit"
 
   micro-benchmarks:
     name: Micro Benchmarks

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -205,6 +205,31 @@ jobs:
         run: |
           script -e -c "tox -e black-check,checks,import-timings,lint,pylint"
 
+  build_test_docker_image:
+    name: Build and Verify Docker Image
+    runs-on: ubuntu-latest
+
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip == 'false' || github.ref == 'refs/heads/trunk' }}
+
+    strategy:
+      matrix:
+        python_version: [3.7]
+
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 1
+
+      - name: Build Testing Docker Image
+        run: |
+          docker build -f contrib/Dockerfile -t libcloud_runtest_img .
+
+      - name: Verify Image Works
+        run: |
+          # We run all the checks in the image to verify it works
+          docker run libcloud_runtest_img
+
   security_checks:
     name: Run Security Checks
     runs-on: ubuntu-latest

--- a/.github/workflows/publish_pricing_to_s3.yml
+++ b/.github/workflows/publish_pricing_to_s3.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Install Python Dependencies
         run: |
-          pip install "tox==3.24.4"
+          pip install "tox==3.25.1"
 
       - name: Generate and publish pricing data
         env:

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -15,7 +15,7 @@
 
 # Docker image used for running tests the under all the supported Python
 # versions
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 RUN set -e && \
     apt-get update && \
@@ -27,15 +27,19 @@ RUN set -e && \
     add-apt-repository ppa:pypy/ppa && \
     apt-get update && \
     apt-get -y install \
-      python3.5 \
       python3.6 \
       python3.7 \
       python3.8 \
+      python3.9 \
+      python3.10 \
       python-dev \
-      python3.5-dev \
       python3.6-dev \
       python3.7-dev \
       python3.8-dev \
+      python3.9-dev \
+      python3.10-dev \
+      python3.7-distutils \
+      python3.8-distutils \
       pypy3 \
       pypy3-dev \
       python3-pip \
@@ -46,13 +50,15 @@ RUN set -e && \
       libssl-dev
 
 # Workaround for zipp import error issue - https://github.com/pypa/virtualenv/issues/1630
-RUN python3 -m pip install --upgrade pip
+RUN python3.8 -m pip install --upgrade pip
 
 RUN set -e && \
-    python3 -m pip install --no-cache-dir "tox==3.20.1"
+    python3.8 -m pip install --no-cache-dir "tox==3.25.1"
 
 COPY . /libcloud
 
+RUN if [ ! -f "/libcloud/README.rst" ]; then echo "libcloud/README.rst file not found, you are likely not running docker build from the repository root directory"; exit 1; fi
+
 WORKDIR /libcloud
 
-CMD ["tox", "-e", "lint,py3.5,py3.6,py3.7,py3.8,pypypy3"]
+CMD ["tox", "-e", "lint,black-check,py3.6,py3.7,py3.8,py3.9,py3.10,pypypy3"]

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -62,4 +62,4 @@ RUN if [ ! -f "/libcloud/README.rst" ]; then echo "libcloud/README.rst file not 
 
 WORKDIR /libcloud
 
-CMD ["tox", "-e", "lint,black-check,bandit,,py3.6,py3.7,py3.8,py3.9,py3.10,pypypy3"]
+CMD ["tox", "-e", "lint,black-check,bandit,,py3.6,py3.7,py3.8,py3.9,py3.10,pypypy-3.8"]

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -38,6 +38,7 @@ RUN set -e && \
       python3.8-dev \
       python3.9-dev \
       python3.10-dev \
+      python3.6-distutils \
       python3.7-distutils \
       python3.8-distutils \
       pypy3 \
@@ -61,4 +62,4 @@ RUN if [ ! -f "/libcloud/README.rst" ]; then echo "libcloud/README.rst file not 
 
 WORKDIR /libcloud
 
-CMD ["tox", "-e", "lint,black-check,py3.6,py3.7,py3.8,py3.9,py3.10,pypypy3"]
+CMD ["tox", "-e", "lint,black-check,bandit,,py3.6,py3.7,py3.8,py3.9,py3.10,pypypy3"]

--- a/libcloud/test/storage/test_s3.py
+++ b/libcloud/test/storage/test_s3.py
@@ -17,6 +17,7 @@ import base64
 import hmac
 import os
 import sys
+import tempfile
 
 from io import BytesIO
 from hashlib import sha1
@@ -380,7 +381,8 @@ class S3Tests(unittest.TestCase):
         self.mock_response_klass.type = None
         self.driver = self.create_driver()
 
-        self._file_path = os.path.abspath(__file__) + ".temp"
+        _, self._file_path = tempfile.mkstemp()
+        self._remove_test_file()
 
     def tearDown(self):
         self._remove_test_file()

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -13,4 +13,4 @@ cryptography==37.0.4
 # NOTE: Only needed by nttcis loadbalancer driver
 pyopenssl==22.0.0
 more-itertools==8.14.0
-bandit==1.7.4
+bandit==1.7.4; python_version >= '3.7'

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -13,3 +13,4 @@ cryptography==37.0.4
 # NOTE: Only needed by nttcis loadbalancer driver
 pyopenssl==22.0.0
 more-itertools==8.14.0
+bandit==1.7.4

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ passenv = TERM CI GITHUB_* DOCKER_*
 deps =
     -r{toxinidir}/requirements-tests.txt
     fasteners
-    paramiko==2.11.0
+    paramiko==2.11.0; platform_python_implementation != 'PyPy'
     libvirt-python==7.9.0
 basepython =
     pypypy3: pypy3
@@ -238,7 +238,7 @@ commands =
 deps = -r{toxinidir}/requirements-tests.txt
        bottle
        fasteners
-       paramiko==2.11.0
+       paramiko==2.11.0; platform_python_implementation != 'PyPy'
        pysphere
 setenv =
     PYTHONPATH={toxinidir}
@@ -329,7 +329,7 @@ commands = pytest -rsx -vvv --capture=tee-sys -o log_cli=True --durations=10 int
 [testenv:coverage]
 deps =
     -r{toxinidir}/requirements-tests.txt
-    paramiko==2.11.0
+    paramiko==2.11.0; platform_python_implementation != 'PyPy'
     pyopenssl==22.0.0
     python-dateutil
     libvirt-python==7.9.0
@@ -343,7 +343,7 @@ commands = cp libcloud/test/secrets.py-dist libcloud/test/secrets.py
 passenv = TERM TOXENV CI GITHUB_*
 deps =
     -r{toxinidir}/requirements-tests.txt
-    paramiko==2.11.0
+    paramiko==2.11.0; platform_python_implementation != 'PyPy'
     pyopenssl==22.0.0
     libvirt-python==7.9.0
     fasteners

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ basepython =
     pypypy-3.7: pypy3.7
     pypyjion: pyjion
     {py3.6,py3.6-dist,py3.6-dist-wheel}: python3.6
-    {py3.7,docs,checks,black,lint,pylint,mypy,micro-benchmarks,coverage,docs,py3.7-dist,py3.7-dist-wheel}: python3.7
+    {py3.7,docs,checks,black,lint,pylint,bandit,mypy,micro-benchmarks,coverage,docs,py3.7-dist,py3.7-dist-wheel}: python3.7
     {py3.8,py3.8-windows,integration-storage,py3.8-dist,py3.8-dist-wheel}: python3.8
     {py3.9,py3.9-dist,py3.9-dist-wheel}: python3.9
     {py3.10,py3.10-dist,py3.10-dist-wheel}: python3.10
@@ -268,6 +268,11 @@ commands = flake8 --config ./.flake8 libcloud/
            rstcheck --report-level warning README.rst
            rstcheck --report-level warning CHANGES.rst
            rstcheck --report-level warning CONTRIBUTING.rst
+
+[testenv:bandit]
+deps = -r{toxinidir}/requirements-tests.txt
+
+commands = bandit --configfile .bandit.yaml -lll -r libcloud/
 
 [testenv:black]
 deps = -r{toxinidir}/requirements-tests.txt

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ basepython =
     pypypy3: pypy3
     pypypy3.7: pypy3.7
     pypypy-3.7: pypy3.7
+    pypypy-3.8: pypy3.8
     pypyjion: pyjion
     {py3.6,py3.6-dist,py3.6-dist-wheel}: python3.6
     {py3.7,docs,checks,black,lint,pylint,bandit,mypy,micro-benchmarks,coverage,docs,py3.7-dist,py3.7-dist-wheel}: python3.7


### PR DESCRIPTION
This pull request includes the following changes:

- Add new "bandit" lint check to GHA workflow
- Move "pip audit" security check to "security_checks" GHA job
- Fix / update testing Docker image (remove old / obsolete Python targets, run tox checks for newer Python versions, run other tox targets, use non EOL Ubuntu 20.04 base image, add some additional checks)
- Use latest version of tox
- Add workaround for failing paramiko related tests under PyPy due to bcrypt wheel not being available

## TODO

- [x] Add GHA job which verifies testing Docker image can be built and works