### PR TITLE
Also run pip audit check in dev / testing / lint dependency

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -48,6 +48,7 @@ github:
           - "Unit Tests (Python 3.10)"
           - "Run Various Lint and Other Checks (3.8)"
           - "Build and upload Documentation (3.8)"
+          - "Dependency Review"
 
 notifications:
   jobs: notifications@libcloud.apache.org

--- a/.github/workflows/depsreview.yaml
+++ b/.github/workflows/depsreview.yaml
@@ -2,7 +2,8 @@ name: 'Dependency Review'
 
 on:
   pull_request:
-    branches: [ trunk ]
+    branches:
+      - trunk
 
 permissions:
   actions: write  # Needed for skip-duplicate-jobs job
@@ -40,5 +41,7 @@ jobs:
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@v3
+
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v2
+        allow-licenses: MIT Apache-2.0 BSD-3-Clause

--- a/.github/workflows/depsreview.yaml
+++ b/.github/workflows/depsreview.yaml
@@ -33,6 +33,7 @@ jobs:
           github_token: ${{ github.token }}
 
   dependency-review:
+    name: Dependency Review
     runs-on: ubuntu-latest
 
     needs: pre_job
@@ -44,4 +45,5 @@ jobs:
 
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v2
-        allow-licenses: MIT Apache-2.0 BSD-3-Clause
+        with:
+          allow-licenses: MIT Apache-2.0 BSD-3-Clause

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -250,6 +250,11 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Install OS / deb dependencies
+        run: |
+          sudo DEBIAN_FRONTEND=noninteractive apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -yq gcc libvirt-dev
+
       - name: Use Python ${{ matrix.python_version }}
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -273,14 +273,22 @@ jobs:
           source venv/bin/activate
           python -m pip install .
 
-      - name: Run Pip Audit Check
+      - name: Run Pip Audit Check On Main Library Dependencies
         uses: ./.github/actions/gh-action-pip-audit/  # v1.0.0
         with:
           virtual-environment: venv/
 
-      - name: Run Checks
+      - name: Cleanup
         run: |
           rm -rf venv/ || true
+
+      - name: Run Pip Audit Check On All Development And Test Dependencies
+        uses: ./.github/actions/gh-action-pip-audit/  # v1.0.0
+        with:
+          inputs: requirements-tests.txt requirements-lint.txt requirements-mypy.txt requirements-docs.txt
+
+      - name: Run Bandit Check
+        run: |
           script -e -c "tox -e bandit"
 
   micro-benchmarks:


### PR DESCRIPTION
Small change to the security checks GHA job to also run pip audit check on the dev / testing dependencies (and not just on the directly library dependencies).