### PR TITLE
Update the new US based locations.

### DIFF
--- a/libcloud/common/cloudsigma.py
+++ b/libcloud/common/cloudsigma.py
@@ -45,12 +45,12 @@ API_ENDPOINTS_2_0 = {
     "sjc": {
         "name": "San Jose, CA",
         "country": "United States",
-        "host": "sjc.cloudsigma.com",
+        "host": "sjc.alpha3cloud.com",
     },
     "wdc": {
         "name": "Washington, DC",
         "country": "United States",
-        "host": "wdc.cloudsigma.com",
+        "host": "wdc.alpha3cloud.com",
     },
     "hnl": {
         "name": "Honolulu, HI",


### PR DESCRIPTION
## New US location URLs related to CloudSigma are updated.

### Description

The new locations are wdc.alpha3cloud.com and sjc.alpha3cloud.com