### PR TITLE
Drop support for Python 3.6 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,10 +57,6 @@ jobs:
         os:
           - ubuntu-latest
         include:
-          # python 3.6 is not supported with ubuntu-latest anymore so we need to
-          # use ubuntu 20.04
-          - python_version: 3.6
-            os: ubuntu-20.04
           - python_version: pyjion
             os: ubuntu-20.04
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,16 @@ Changelog
 Changes in Apache Libcloud in development
 -----------------------------------------
 
+Common
+~~~~~~
+
+- Support for Python 3.6 which has been EOL for more than a year now has been
+  removed.
+
+  If you still want to use Libcloud with Python 3.6, you should use an older
+  release which still supports Python 3.6.
+  (GITHUB-1611)
+
 Compute
 ~~~~~~~
 

--- a/docs/upgrade_notes.rst
+++ b/docs/upgrade_notes.rst
@@ -5,6 +5,15 @@ This page describes how to upgrade from a previous version to a new version
 which contains backward incompatible or semi-incompatible changes and how to
 preserve the old behavior when this is possible.
 
+Libcloud 3.7.0
+--------------
+
+* Support for Python 3.6 which has been EOL for more than a year now has been
+  removed.
+
+  If you still want to use Libcloud with Python 3.6, you should use an older
+  release which still supports Python 3.6.
+
 Libcloud 3.6.0
 --------------
 

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -2,9 +2,9 @@ codecov==2.1.12
 coverage==6.5.0; python_version >= '3.8'
 requests>=2.27.1
 requests_mock==1.10.0
-pytest==7.0.1
-pytest-xdist==2.5.0
-pytest-benchmark[histogram]==3.4.1
+pytest==7.2.0
+pytest-xdist==3.1.0
+pytest-benchmark[histogram]==4.0.0
 cryptography==38.0.4
 
 # NOTE: Only needed by nttcis loadbalancer driver

--- a/setup.py
+++ b/setup.py
@@ -157,7 +157,7 @@ def get_data_files(dname, ignore=None, parent=None):
 # Different versions of python have different requirements.  We can't use
 # libcloud.utils.py3 here because it relies on backports dependency being
 # installed / available
-PY_pre_36 = sys.version_info < (3, 6, 0)
+PY_pre_37 = sys.version_info < (3, 7, 0)
 
 HTML_VIEWSOURCE_BASE = "https://svn.apache.org/viewvc/libcloud/trunk"
 PROJECT_BASE_DIR = "https://libcloud.apache.org"
@@ -179,7 +179,7 @@ DOC_TEST_MODULES = [
     "libcloud.backup.drivers.dummy",
 ]
 
-SUPPORTED_VERSIONS = ["PyPy 3.6+", "Python 3.6+"]
+SUPPORTED_VERSIONS = ["PyPy 3.7+", "Python 3.7+"]
 
 # NOTE: python_version syntax is only supported when build system has
 # setuptools >= 36.2
@@ -209,12 +209,12 @@ TEST_REQUIREMENTS = [
     "pytest-runner",
 ] + INSTALL_REQUIREMENTS
 
-if PY_pre_36:
+if PY_pre_37:
     version = ".".join([str(x) for x in sys.version_info[:3]])
     print(
         "Python version %s is not supported. Supported versions are: %s. "
         "Latest version which supports Python 2.7 and Python 3 < 3.5.0 is "
-        "Libcloud v2.8.2 and Libcloud v3.4.0 for Python 3.5."
+        "Libcloud v2.8.2 and Libcloud v3.5.x for Python 3.5."
         % (version, ", ".join(SUPPORTED_VERSIONS))
     )
     sys.exit(1)
@@ -316,7 +316,6 @@ setup(
         "Programming Language :: Python",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
This pull request removes support for Python 3.6 which has been EOL since 2021-12-23 (per  discussion and consensus on the mailing list).