### PR TITLE
Add support for af south 1 in s3 driver

### DIFF
--- a/libcloud/storage/drivers/s3.py
+++ b/libcloud/storage/drivers/s3.py
@@ -78,6 +78,7 @@ S3_AP_NORTHEAST_HOST = S3_AP_NORTHEAST1_HOST
 S3_SA_EAST_HOST = "s3-sa-east-1.amazonaws.com"
 S3_SA_SOUTHEAST2_HOST = "s3-sa-east-2.amazonaws.com"
 S3_CA_CENTRAL_HOST = "s3-ca-central-1.amazonaws.com"
+S3_AF_SOUTH1_HOST= "s3.af-south-1.amazonaws.com"
 
 # Maps AWS region name to connection hostname
 REGION_TO_HOST_MAP = {
@@ -104,6 +105,7 @@ REGION_TO_HOST_MAP = {
     "sa-east-2": S3_SA_SOUTHEAST2_HOST,
     "ca-central-1": S3_CA_CENTRAL_HOST,
     "me-south-1": "s3.me-south-1.amazonaws.com",
+    "af-south-1": S3_AF_SOUTH1_HOST,
 }
 
 API_VERSION = "2006-03-01"
@@ -1400,6 +1402,17 @@ class S3CNNorthStorageDriver(S3StorageDriver):
     region_name = "cn-north-1"
 
 
+class S3AFSouthConnection(S3SignatureV4Connection):
+    host = S3_AF_SOUTH1_HOST
+
+
+class S3AFSouthStorageDriver(S3StorageDriver):
+    name = "Amazon S3 (af-south-1)"
+    connectionCls = S3AFSouthConnection
+    ex_location_name = "af-south-1"
+    region_name = "af-south-1"    
+
+
 class S3EUWestConnection(S3SignatureV4Connection):
     host = S3_EU_WEST_HOST
 
@@ -1525,3 +1538,4 @@ class S3CACentralStorageDriver(S3StorageDriver):
     connectionCls = S3CACentralConnection
     ex_location_name = "ca-central-1"
     region_name = "ca-central-1"
+

--- a/libcloud/storage/drivers/s3.py
+++ b/libcloud/storage/drivers/s3.py
@@ -1410,7 +1410,7 @@ class S3AFSouthStorageDriver(S3StorageDriver):
     name = "Amazon S3 (af-south-1)"
     connectionCls = S3AFSouthConnection
     ex_location_name = "af-south-1"
-    region_name = "af-south-1"    
+    region_name = "af-south-1"
 
 
 class S3EUWestConnection(S3SignatureV4Connection):
@@ -1538,4 +1538,3 @@ class S3CACentralStorageDriver(S3StorageDriver):
     connectionCls = S3CACentralConnection
     ex_location_name = "ca-central-1"
     region_name = "ca-central-1"
-

--- a/libcloud/storage/drivers/s3.py
+++ b/libcloud/storage/drivers/s3.py
@@ -1538,3 +1538,4 @@ class S3CACentralStorageDriver(S3StorageDriver):
     connectionCls = S3CACentralConnection
     ex_location_name = "ca-central-1"
     region_name = "ca-central-1"
+    


### PR DESCRIPTION
## Add support for AWS af-south-1 region to S3 storage driver

### Description

We noticed the following error when running our Ansible automation on af-south-1 VMs on AWS:
```
File "/usr/local/lib/python3.8/dist-packages/libcloud/storage/drivers/s3.py", line 1134, in __init__
        raise ValueError('Invalid or unsupported region: %s' % (region))
    ValueError: Invalid or unsupported region: af-south-1
```
The reason for the error is missing configuration for the `af-south-1` region of AWS in the S3 driver of libcloud, which we have remediated locally and now raising this PR to contribute back to the project.

### Status

- done, ready for review (Used pylint for linting)

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
