### PR TITLE
optimize read_in_chunks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,16 @@ Changelog
 Changes in Apache Libcloud in development
 -----------------------------------------
 
+Storage
+~~~~~~~
+
+- Optimize ``read_in_chunks()`` function implementation.
+
+  This should result in large performance speedups and lower memory usage when
+  uploading or downloading a large file with a mismatching chunk size.
+  (GITHUB-1847)
+  [Tobias Biester - @Tobi995]
+
 Changes in Apache Libcloud 3.7.0
 --------------------------------
 

--- a/libcloud/test/benchmarks/test_read_in_chunks.py
+++ b/libcloud/test/benchmarks/test_read_in_chunks.py
@@ -69,9 +69,9 @@ def _old_read_in_chunks(iterator, chunk_size=None, fill_size=False, yield_empty=
 @pytest.mark.parametrize(
     "data_chunk_size_tuple",
     [
-        ("c".encode("utf-8") * (40 * 1024 * 1024), 1 * 1024 * 1024),
-        ("c".encode("utf-8") * (40 * 1024 * 1024), 5 * 1024 * 1024),
-        ("c".encode("utf-8") * (80 * 1024 * 1024), 1 * 1024 * 1024),
+        (b"c" * (40 * 1024 * 1024), 1 * 1024 * 1024),
+        (b"c" * (40 * 1024 * 1024), 5 * 1024 * 1024),
+        (b"c" * (80 * 1024 * 1024), 1 * 1024 * 1024),
     ],
     ids=[
         "40mb_data_1mb_chunk_size",
@@ -110,9 +110,9 @@ def test_scenario_1(
 @pytest.mark.parametrize(
     "data_chunk_size_tuple",
     [
-        ("c".encode("utf-8") * (10 * 1024 * 1024), 8 * 1024),
-        ("c".encode("utf-8") * (20 * 1024 * 1024), 1 * 1024 * 1024),
-        ("c".encode("utf-8") * (30 * 1024 * 1024), 1 * 1024 * 1024),
+        (b"c" * (10 * 1024 * 1024), 8 * 1024),
+        (b"c" * (20 * 1024 * 1024), 1 * 1024 * 1024),
+        (b"c" * (30 * 1024 * 1024), 1 * 1024 * 1024),
     ],
     ids=[
         "10mb_data_8k_chunk_size",

--- a/libcloud/test/benchmarks/test_read_in_chunks.py
+++ b/libcloud/test/benchmarks/test_read_in_chunks.py
@@ -1,0 +1,153 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Tuple, Callable
+
+import pytest
+
+from libcloud.utils.py3 import b, next
+from libcloud.utils.files import CHUNK_SIZE, read_in_chunks
+
+
+def _old_read_in_chunks(iterator, chunk_size=None, fill_size=False, yield_empty=False):
+    """
+    Old implementation of read_in_chunks without performance optimizations from #1847.
+
+    It's only here so we can directly measure compare performance of old and the new version.
+    """
+    chunk_size = chunk_size or CHUNK_SIZE
+
+    try:
+        get_data = iterator.read
+        args = (chunk_size,)
+    except AttributeError:
+        get_data = next
+        args = (iterator,)
+
+    data = b("")
+    empty = False
+
+    while not empty or len(data) > 0:
+        if not empty:
+            try:
+                chunk = b(get_data(*args))
+                if len(chunk) > 0:
+                    data += chunk
+                else:
+                    empty = True
+            except StopIteration:
+                empty = True
+
+        if len(data) == 0:
+            if empty and yield_empty:
+                yield b("")
+
+            return
+
+        if fill_size:
+            if empty or len(data) >= chunk_size:
+                yield data[:chunk_size]
+                data = data[chunk_size:]
+        else:
+            yield data
+            data = b("")
+
+
+# fmt: off
+@pytest.mark.parametrize(
+    "data_chunk_size_tuple",
+    [
+        ("c".encode("utf-8") * (40 * 1024 * 1024), 1 * 1024 * 1024),
+        ("c".encode("utf-8") * (40 * 1024 * 1024), 5 * 1024 * 1024),
+        ("c".encode("utf-8") * (80 * 1024 * 1024), 1 * 1024 * 1024),
+    ],
+    ids=[
+        "40mb_data_1mb_chunk_size",
+        "40mb_data_5mb_chunk_size",
+        "80mb_data_1mb_chunk_size",
+    ],
+)
+@pytest.mark.parametrize(
+    "read_in_chunks_func",
+    [
+        _old_read_in_chunks,
+        read_in_chunks,
+    ],
+    ids=[
+        "old",
+        "new",
+    ],
+)
+# fmt: on
+def test_scenario_1(
+    benchmark, data_chunk_size_tuple: Tuple[bytes, int], read_in_chunks_func: Callable
+):
+    # similar to calling _upload_multipart_chunks with one large array of bytes
+    data, chunk_size = data_chunk_size_tuple
+
+    def run_benchmark():
+        for _ in read_in_chunks_func(iter([data]), chunk_size=chunk_size, fill_size=True):
+            pass
+
+    benchmark(run_benchmark)
+
+
+# fmt: off
+# NOTE: Because the old implementation is very slow when there is a chunk size mismatch, we need to
+# use smaller total objects size to prevent this benchmark from running for a very long time.
+@pytest.mark.parametrize(
+    "data_chunk_size_tuple",
+    [
+        ("c".encode("utf-8") * (10 * 1024 * 1024), 8 * 1024),
+        ("c".encode("utf-8") * (20 * 1024 * 1024), 1 * 1024 * 1024),
+        ("c".encode("utf-8") * (30 * 1024 * 1024), 1 * 1024 * 1024),
+    ],
+    ids=[
+        "10mb_data_8k_chunk_size",
+        "20mb_data_1mb_chunk_size",
+        "30mb_data_1mb_chunk_size",
+    ],
+)
+@pytest.mark.parametrize(
+    "read_in_chunks_func",
+    [
+        _old_read_in_chunks,
+        read_in_chunks,
+    ],
+    ids=[
+        "old",
+        "new",
+    ],
+)
+# fmt: on
+def test_scenario_2(
+    benchmark, data_chunk_size_tuple: Tuple[bytes, int], read_in_chunks_func: Callable
+):
+    # similar to calling _upload_multipart_chunks with one large array of bytes
+    data, chunk_size = data_chunk_size_tuple
+    response_chunk = 5 * 1024 * 1024
+
+    # NOTE: It would be nice if we could also assert that data has been correctly add, but this
+    # would add additional overhead (since we would also measure accumulating this data) so we have
+    # those checks done separately in the unit tests.
+    def run_benchmark():
+        for a in read_in_chunks_func(
+            iter([data[i : i + response_chunk] for i in range(0, len(data), response_chunk)]),
+            chunk_size=chunk_size,
+            fill_size=True,
+        ):
+            pass
+
+    benchmark(run_benchmark)

--- a/libcloud/test/test_utils.py
+++ b/libcloud/test/test_utils.py
@@ -215,7 +215,7 @@ class TestUtils(unittest.TestCase):
             iterator(), chunk_size=10, fill_size=True
         ):
             chunk_count += 1
-            self.assertEqual(result, b("aaaaaaaaaa"))
+            self.assertEqual(result, b("a") * 10)
         self.assertEqual(chunk_count, 200)
 
     def test_read_in_chunks_large_iterator_batches(self):
@@ -236,7 +236,7 @@ class TestUtils(unittest.TestCase):
             iterator(), chunk_size=10, fill_size=True
         ):
             chunk_count += 1
-            self.assertEqual(result, b("aaaaaaaaaa"))
+            self.assertEqual(result, b("a") * 10)
         self.assertEqual(chunk_count, 10_000)
 
     def test_read_in_chunks_filelike(self):

--- a/libcloud/test/test_utils.py
+++ b/libcloud/test/test_utils.py
@@ -202,15 +202,42 @@ class TestUtils(unittest.TestCase):
             for x in range(0, 1000):
                 yield "aa"
 
+        chunk_count = 0
         for result in libcloud.utils.files.read_in_chunks(
             iterator(), chunk_size=10, fill_size=False
         ):
+            chunk_count += 1
             self.assertEqual(result, b("aa"))
+        self.assertEqual(chunk_count, 1000)
 
+        chunk_count = 0
         for result in libcloud.utils.files.read_in_chunks(
             iterator(), chunk_size=10, fill_size=True
         ):
+            chunk_count += 1
             self.assertEqual(result, b("aaaaaaaaaa"))
+        self.assertEqual(chunk_count, 200)
+
+    def test_read_in_chunks_large_iterator_batches(self):
+        def iterator():
+            for x in range(0, 10):
+                yield "a" * 10_000
+
+        chunk_count = 0
+        for result in libcloud.utils.files.read_in_chunks(
+            iterator(), chunk_size=10, fill_size=False
+        ):
+            chunk_count += 1
+            self.assertEqual(result, b("a") * 10_000)
+        self.assertEqual(chunk_count, 10)
+
+        chunk_count = 0
+        for result in libcloud.utils.files.read_in_chunks(
+            iterator(), chunk_size=10, fill_size=True
+        ):
+            chunk_count += 1
+            self.assertEqual(result, b("aaaaaaaaaa"))
+        self.assertEqual(chunk_count, 10_000)
 
     def test_read_in_chunks_filelike(self):
         class FakeFile(file):

--- a/libcloud/utils/files.py
+++ b/libcloud/utils/files.py
@@ -75,7 +75,13 @@ def read_in_chunks(iterator, chunk_size=None, fill_size=False, yield_empty=False
             return
 
         if fill_size:
-            if empty or len(data) >= chunk_size:
+            chunk_start = 0
+            while chunk_start + chunk_size < len(data):
+                yield data[chunk_start : chunk_start + chunk_size]
+                chunk_start += chunk_size
+            data = data[chunk_start:]
+            if empty:
+                # Yield last not completely filled chunk
                 yield data[:chunk_size]
                 data = data[chunk_size:]
         else:

--- a/libcloud/utils/files.py
+++ b/libcloud/utils/files.py
@@ -75,6 +75,9 @@ def read_in_chunks(iterator, chunk_size=None, fill_size=False, yield_empty=False
             return
 
         if fill_size:
+            # We want to emit chunk_size large chunks, but chunk_size can be larger or smaller than the chunks returned
+            # by get_data. We need to yield in a loop to avoid large amounts of data piling up.
+            # The loop also avoids copying all data #chunks amount of times by keeping the original data as is.
             chunk_start = 0
             while chunk_start + chunk_size < len(data):
                 yield data[chunk_start : chunk_start + chunk_size]

--- a/libcloud/utils/files.py
+++ b/libcloud/utils/files.py
@@ -15,6 +15,7 @@
 
 import os
 import mimetypes
+from typing import Generator
 
 from libcloud.utils.py3 import b, next
 
@@ -75,14 +76,7 @@ def read_in_chunks(iterator, chunk_size=None, fill_size=False, yield_empty=False
             return
 
         if fill_size:
-            # We want to emit chunk_size large chunks, but chunk_size can be larger or smaller than the chunks returned
-            # by get_data. We need to yield in a loop to avoid large amounts of data piling up.
-            # The loop also avoids copying all data #chunks amount of times by keeping the original data as is.
-            chunk_start = 0
-            while chunk_start + chunk_size < len(data):
-                yield data[chunk_start : chunk_start + chunk_size]
-                chunk_start += chunk_size
-            data = data[chunk_start:]
+            data = yield from _optimized_chunked_generator(data=data, chunk_size=chunk_size)
             if empty:
                 # Yield last not completely filled chunk
                 yield data[:chunk_size]
@@ -90,6 +84,18 @@ def read_in_chunks(iterator, chunk_size=None, fill_size=False, yield_empty=False
         else:
             yield data
             data = b("")
+
+
+def _optimized_chunked_generator(data: bytes, chunk_size: int) -> Generator[bytes, None, bytes]:
+    # We want to emit chunk_size large chunks, but chunk_size can be larger or smaller than the chunks returned
+    # by get_data. We need to yield in a loop to avoid large amounts of data piling up.
+    # The loop also avoids copying all data #chunks amount of times by keeping the original data as is.
+    chunk_start = 0
+    while chunk_start + chunk_size < len(data):
+        yield data[chunk_start : chunk_start + chunk_size]
+        chunk_start += chunk_size
+    data = data[chunk_start:]
+    return data
 
 
 def exhaust_iterator(iterator):

--- a/tox.ini
+++ b/tox.ini
@@ -387,6 +387,7 @@ commands =
 commands =
     cp libcloud/test/secrets.py-dist libcloud/test/secrets.py
     pytest -s -v --timeout 60 --benchmark-only --benchmark-name=short --benchmark-columns=min,max,mean,stddev,median,ops,rounds --benchmark-histogram=benchmark_histograms/benchmark  --benchmark-group-by=group,param:sort_objects libcloud/test/benchmarks/test_list_objects_filtering_performance.py
+    pytest -s -v --timeout 60 --benchmark-only --benchmark-name=short --benchmark-columns=min,max,mean,stddev,median,ops,rounds --benchmark-histogram=benchmark_histograms/benchmark --benchmark-group-by=group,func,param:read_in_chunks_func libcloud/test/benchmarks/test_read_in_chunks.py
 
 [testenv:import-timings]
 setenv =


### PR DESCRIPTION
## Optimize read_in_chunks

### Description

We noticed that utils.files.read_in_chunks has significant memory & CPU cost when up or downloading large files with mismatching chunk sizes. This PR attempts to fix that by potentially yielding multiple chunks per read and by avoiding large slicing ops. This seems to remove some more than quadratic scaling, bringing massive speed ups. 

```python
import tracemalloc

import numpy as np
import time

from libcloud.utils.files import read_in_chunks
import numpy as np

def run_scenario_1(data: bytes):
    # similar to calling _upload_multipart_chunks with one large array of bytes 
    for a in read_in_chunks(iter([data]), chunk_size=5 * 1024 * 1024, fill_size=True):
        ...

def run_scenario_2(data: bytes):
    # as in download_object_as_stream
    response_chunk = 5 * 1024 * 1024
    for a in read_in_chunks(iter([data[i:i+response_chunk] for i in range(0, len(data), response_chunk)]), chunk_size=8096, fill_size=True):
        ...

if __name__ == "__main__":
    tracemalloc.start()
    data = "c".encode("utf-8") * (40 * 1024 * 1024)
    times = []
    for i in range(10):
        start_time = time.time()
        run_scenario_1(data)
        times.append(time.time() - start_time)
    print("scenario 1", np.median(times))

    times = []
    for i in range(10):
        start_time = time.time()
        run_scenario_2(data)
        times.append(time.time() - start_time)
    print("scenario 2", np.median(times))

    current_size, peak = tracemalloc.get_traced_memory()
    print(f'Current consumption: {current_size / 1024 / 1024}mb, '
                f'peak since last log: {peak / 1024 / 1024}mb.')
``` 
Gives the following stats:
Without this PR:
```
scenario 1 0.08405923843383789
scenario 2 30.04505753517151
Current consumption: 40.009538650512695mb, peak since last log: 159.9015874862671mb.
```
With this PR:
```
scenario 1 0.013306617736816406
scenario 2 0.060915589332580566
Current consumption: 40.01009464263916mb, peak since last log: 85.03302574157715mb.
```
Scenario 2 with different data sizes:

- 20Mb: Before 3.97s, After 0.028s
- 30Mb: Before 8.4s, After 0.04s
- 40Mb: Before 30.0s, After 0.05s
- 50Mb: Before 54s, After 0.07s
- 60Mb: Before 102s, After 0.096s

### Status
done, ready for review

### Checklist (tick everything that applies)

- [X] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [X] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
