### PR TITLE
Support all S3 storage classes

### DIFF
--- a/libcloud/storage/drivers/s3.py
+++ b/libcloud/storage/drivers/s3.py
@@ -1107,7 +1107,7 @@ class BaseS3StorageDriver(StorageDriver):
         """
         headers = {}
         storage_class = storage_class or "standard"
-        if storage_class not in ["standard", "reduced_redundancy"]:
+        if storage_class not in ["standard", "reduced_redundancy", "standard_ia", "onezone_ia", "intelligent_tiering", "glacier", "deep_archive", "glacier_ir"]:
             raise ValueError("Invalid storage class value: %s" % (storage_class))
 
         key = self.http_vendor_prefix + "-storage-class"

--- a/libcloud/test/storage/test_s3.py
+++ b/libcloud/test/storage/test_s3.py
@@ -1088,6 +1088,24 @@ class S3Tests(unittest.TestCase):
         self.assertEqual(obj.name, object_name)
         self.assertEqual(obj.size, 3)
 
+    def test_upload_small_object_with_glacier_ir(self):
+        if self.driver.supports_s3_multipart_upload:
+            self.mock_response_klass.type = "MULTIPART"
+        else:
+            self.mock_response_klass.type = None
+
+        container = Container(name="foo_bar_container", extra={}, driver=self.driver)
+        object_name = "foo_test_stream_data"
+        storage_class="glacier_ir",
+        iterator = BytesIO(b("234"))
+        extra = {"content_type": "text/plain"}
+        obj = self.driver.upload_object_via_stream(
+            container=container, object_name=object_name, iterator=iterator, extra=extra, ex_storage_class=storage_class
+        )
+
+        self.assertEqual(obj.name, object_name)
+        self.assertEqual(obj.size, 3)
+
     def test_upload_big_object_via_stream(self):
         if self.driver.supports_s3_multipart_upload:
             self.mock_response_klass.type = "MULTIPART"


### PR DESCRIPTION
## Support all S3 storage classes

### Description

Current version of libcloud supports only "standard" and "reduced_redundancy" storage classes. 
AWS S3 add new storage classes during the past two years (https://docs.aws.amazon.com/cli/latest/reference/s3/cp.html). 

This PR is to support all S3 storage classes. 

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)

Closes #1882
