### PR TITLE
Fix list_volumes, and list_nodes in Outscale provider

### DIFF
--- a/libcloud/compute/drivers/outscale.py
+++ b/libcloud/compute/drivers/outscale.py
@@ -7747,7 +7747,12 @@ class OutscaleNodeDriver(NodeDriver):
 
     def _to_node(self, vm):
         name = ""
-        private_ips = [vm["PrivateIp"]]
+        private_ips = []
+        if "PrivateIp" in vm:
+            private_ips = [vm["PrivateIp"]]
+        public_ips = []
+        if "PublicIp" in vm:
+            public_ips = [vm["PublicIp"]]
         for tag in vm["Tags"]:
             if tag["Key"] == "Name":
                 name = tag["Value"]
@@ -7756,7 +7761,7 @@ class OutscaleNodeDriver(NodeDriver):
             id=vm["VmId"],
             name=name,
             state=self.NODE_STATE[vm["State"]],
-            public_ips=[vm["PublicIp"]],
+            public_ips=public_ips,
             private_ips=private_ips,
             driver=self,
             extra=vm,

--- a/libcloud/compute/drivers/outscale.py
+++ b/libcloud/compute/drivers/outscale.py
@@ -7743,7 +7743,7 @@ class OutscaleNodeDriver(NodeDriver):
         )
 
     def _to_volumes(self, volumes):
-        return [self._to_volumes(volume) for volume in volumes]
+        return [self._to_volume(volume) for volume in volumes]
 
     def _to_node(self, vm):
         name = ""

--- a/libcloud/compute/drivers/outscale.py
+++ b/libcloud/compute/drivers/outscale.py
@@ -7747,18 +7747,16 @@ class OutscaleNodeDriver(NodeDriver):
 
     def _to_node(self, vm):
         name = ""
-        private_ips = []
+        private_ips = [vm["PrivateIp"]]
         for tag in vm["Tags"]:
             if tag["Key"] == "Name":
                 name = tag["Value"]
-        if "Nics" in vm:
-            private_ips = vm["Nics"]["PrivateIps"]
 
         return Node(
             id=vm["VmId"],
             name=name,
             state=self.NODE_STATE[vm["State"]],
-            public_ips=[],
+            public_ips=[vm["PublicIp"]],
             private_ips=private_ips,
             driver=self,
             extra=vm,


### PR DESCRIPTION
## Fix list_volumes, and list_nodes in Outsale provider 
### Description

the way `list_nodes` was listing `privates_ips` and `public_ips` was buggy. and either empty, or crash in a few case. (if `"Nics" in vm` where true)
the only was to get IPs was using `node.extra['PublicIp'/'PrivateIp']`, this patch enable user to get ip, using `node.public_ips` (but list only main ip)

also it seems `_to_volumes` was broken due to it calling `_to_volumes` instead of `_to_volume`

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
