### PR TITLE
Fix exception when using internal URL

### DIFF
--- a/libcloud/storage/drivers/cloudfiles.py
+++ b/libcloud/storage/drivers/cloudfiles.py
@@ -192,23 +192,19 @@ class CloudFilesConnection(OpenStackSwiftConnection):
     def get_endpoint(self):
         region = self._ex_force_service_region.upper()
 
-        if self.use_internal_url:
-            endpoint_type = "internal"
-        else:
-            endpoint_type = "external"
-
         if "2.0" in self._auth_version:
             ep = self.service_catalog.get_endpoint(
                 service_type="object-store",
                 name="cloudFiles",
                 region=region,
-                endpoint_type=endpoint_type,
+                endpoint_type="internal" if self.use_internal_url else "external",
             )
             cdn_ep = self.service_catalog.get_endpoint(
                 service_type="rax:object-cdn",
                 name="cloudFilesCDN",
                 region=region,
-                endpoint_type=endpoint_type,
+                # Cloud Files has no concept of an "internal" CDN.
+                endpoint_type="external",
             )
         else:
             raise LibcloudError('Auth version "%s" not supported' % (self._auth_version))


### PR DESCRIPTION
Cloud Files has no concept of an "internal" CDN so the endpoint type must be hard-coded to "external". Sample Cloud Files service catalog listing: https://docs.rackspace.com/docs/cloud-files/v1/getting-started/authenticate#cloud-files-auth-response

## Fixes Cloud Files exception when using internal URL

### Description

Fixes #1883 

### Status

Ready for review.

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
