### PR TITLE
Fix list_volumes in the Azure arm driver

### DIFF
--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -25,7 +25,7 @@ import base64
 import binascii
 
 from libcloud.utils import iso8601
-from libcloud.utils.py3 import basestring
+from libcloud.utils.py3 import basestring, urlparse, parse_qs
 from libcloud.common.types import LibcloudError
 from libcloud.compute.base import (
     Node,
@@ -1008,11 +1008,17 @@ class AzureNodeDriver(NodeDriver):
         action = action.format(
             subscription_id=self.subscription_id, resource_group=ex_resource_group
         )
-
-        response = self.connection.request(
-            action, method="GET", params={"api-version": DISK_API_VERSION}
-        )
-        return [self._to_volume(volume) for volume in response.object["value"]]
+        params = {"api-version": DISK_API_VERSION}
+        volumes = []
+        while True:
+            response = self.connection.request(action, method="GET", params=params)
+            volumes.extend(self._to_volume(volume) for volume in response.object["value"])
+            if not response.object.get("nextLink"):
+                break
+            parsed_next_link = urlparse.urlparse(response.object["nextLink"])
+            params.update({k: v[0] for k, v in parse_qs(parsed_next_link.query).items()})
+            action = parsed_next_link.path
+        return volumes
 
     def attach_volume(
         self,

--- a/libcloud/test/compute/fixtures/azure_arm/_subscriptions_99999999_providers_Microsoft_Compute_disks.json
+++ b/libcloud/test/compute/fixtures/azure_arm/_subscriptions_99999999_providers_Microsoft_Compute_disks.json
@@ -73,5 +73,6 @@
       "name": "test-disk-3",
       "zones": ["1", "2", "3"]
     }
-  ]
+  ],
+  "nextLink": "https://management.azure.com:443/subscriptions/99999999-9999-9999-9999-999999999999/providers/Microsoft.Compute/disks?api-version=2018-06-01&$skiptoken=1!/Subscriptions/99999999-9999-9999-9999-999999999999/ResourceGroups/000000/Disks/test-disk-4"
 }

--- a/libcloud/test/compute/fixtures/azure_arm/_subscriptions_99999999_providers_Microsoft_Compute_disks_1.json
+++ b/libcloud/test/compute/fixtures/azure_arm/_subscriptions_99999999_providers_Microsoft_Compute_disks_1.json
@@ -1,0 +1,30 @@
+{
+  "value": [
+    {
+      "properties": {
+        "osType": "Linux",
+        "creationData": {
+          "createOption": "FromImage",
+          "imageReference": {
+            "id": "/Subscriptions/99999999-9999-9999-9999-999999999999/Providers/Microsoft.Compute/Locations/eastus/Publishers/OpenLogic/ArtifactTypes/VMImage/Offers/CentOS/Skus/7.3/Versions/latest"
+          }
+        },
+        "diskSizeGB": 1500,
+        "timeCreated": "2017-03-09T10:12:37.0256203+00:00",
+        "ownerId": "/subscriptions/99999999-9999-9999-9999-999999999999/resourceGroups/REVIZOR/providers/Microsoft.Compute/virtualMachines/test-vm-2",
+        "provisioningState": "Succeeded",
+        "diskState": "Attached"
+      },
+      "sku": {
+        "name": "Standard_LRS",
+        "tier": "Standard"
+      },
+      "type": "Microsoft.Compute/disks",
+      "location": "eastus",
+      "tags": {},
+      "id": "/subscriptions/99999999-9999-9999-9999-999999999999/resourceGroups/000000/providers/Microsoft.Compute/disks/test-disk-4",
+      "name": "test-disk-4",
+      "zones": ["1", "2", "3"]
+    }
+  ]
+}


### PR DESCRIPTION
## Fix the list_volumes function in the Azure ARM driver

### Description

Not all disks are returned when listing disks on Azure. The same change as for list_nodes (#1850) is necessary for list_volumes.

### Status

ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
