### PR TITLE
Bump DISK_API_VERSION for Premium v2 SSDs

### DIFF
--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -46,7 +46,7 @@ from libcloud.compute.providers import Provider
 from libcloud.storage.drivers.azure_blobs import AzureBlobsStorageDriver
 
 RESOURCE_API_VERSION = "2016-04-30-preview"
-DISK_API_VERSION = "2018-06-01"
+DISK_API_VERSION = "2023-01-02"
 IMAGES_API_VERSION = "2015-06-15"
 INSTANCE_VIEW_API_VERSION = "2015-06-15"
 IP_API_VERSION = "2019-06-01"


### PR DESCRIPTION
## Bump DISK_API_VERSION for Premium v2 SSDs

### Description

When using the current disk API version, attempts to create a volume with the Premium v2 SKU fails. The newest API accepts the new SKU.

I've manually tested volume create/destroy/attach/detach/resize and list.

### Status

ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
