### PR TITLE
Also run unit tests under Python 3.12 beta

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -16,6 +16,11 @@ permissions:
   actions: write  # Needed for skip-duplicate-jobs job
   contents: read
 
+env:
+  # Needed if we want colors in pytest output without tty and script -e -c wrapper
+  PY_COLORS: "1"
+  FORCE_COLOR: "1"
+
 jobs:
   # Special job which skips duplicate jobs
   pre_job:
@@ -80,7 +85,7 @@ jobs:
 
       - name: Run tox target
         run: |
-          script -e -c "tox -e integration-storage"
+          tox -e integration-storage
         env:
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,6 +54,7 @@ jobs:
           - 3.9
           - "3.10"
           - "3.11"
+          - "3.12-dev"
           # TODO: Investigate why it started failing with cryptic error on CI
           #- "pypy-3.7"
         os:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,12 +120,12 @@ jobs:
 
       - name: Run unit tests tox target
         run: |
-         script -e -c "tox -e py${{ matrix.python_version }}"
+         tox -e py${{ matrix.python_version }}
 
       - name: Run dist install checks tox target
         if: ${{ matrix.python_version != 'pypy-3.7' && matrix.python_version != 'pyjion' }}
         run: |
-         script -e -c "tox -e py${{ matrix.python_version }}-dist,py${{ matrix.python_version }}-dist-wheel"
+         tox -e py${{ matrix.python_version }}-dist,py${{ matrix.python_version }}-dist-wheel
 
   code_coverage:
     name: Generate Code Coverage

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,11 @@ permissions:
   actions: write  # Needed for skip-duplicate-jobs job
   contents: read
 
+env:
+  # Needed if we want colors in pytest output without tty and script -e -c wrapper
+  PY_COLORS: "1"
+  FORCE_COLOR: "1"
+
 jobs:
   # Special job which skips duplicate jobs
   pre_job:
@@ -167,7 +172,7 @@ jobs:
 
       - name: Run Checks
         run: |
-          script -e -c "tox -e coverage-ci"
+          tox -e coverage-ci
 
       - name: Upload Coverage to codecov.io
         uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
@@ -215,7 +220,7 @@ jobs:
 
       - name: Run Checks
         run: |
-          script -e -c "tox -e black-check,isort-check,pyupgrade,checks,import-timings,lint,pylint"
+          tox -e black-check,isort-check,pyupgrade,checks,import-timings,lint,pylint
 
   build_test_docker_image:
     name: Build and Verify Docker Image
@@ -311,7 +316,7 @@ jobs:
 
       - name: Run Bandit Check
         run: |
-          script -e -c "tox -e bandit"
+          tox -e bandit
 
   micro-benchmarks:
     name: Micro Benchmarks
@@ -353,7 +358,7 @@ jobs:
 
       - name: Run Micro Benchmarks
         run: |
-          script -e -c "tox -e micro-benchmarks"
+          tox -e micro-benchmarks
 
   docs:
     name: Build and upload Documentation
@@ -400,7 +405,7 @@ jobs:
 
       - name: Build Docs
         run: |
-          script -e -c "tox -e docs-ci"
+          tox -e docs-ci
 
       - name: Trigger ReadTheDocs build
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools~=66.1", "wheel~=0.37.1"]
+build-backend = "setuptools.build_meta"
+
 [tool.black]
 line_length = 100
 target_version = ['py37', 'py38', 'py39', 'py310']

--- a/setup.py
+++ b/setup.py
@@ -321,6 +321,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ setenv =
 # python setup.py test
 # for pytest-xdist, we want to distribute tests by file aka --dist loadfile
 commands = cp libcloud/test/secrets.py-dist libcloud/test/secrets.py
-           pytest -rsx -vvv --capture=tee-sys -o log_cli=True --durations=10 --timeout=15 -n auto --dist loadfile --ignore libcloud/test/benchmarks/ --ignore-glob "*test_list_objects_filtering_performance*"
+           pytest --color=yes -rsx -vvv --capture=tee-sys -o log_cli=True --durations=10 --timeout=15 -n auto --dist loadfile --ignore libcloud/test/benchmarks/ --ignore-glob "*test_list_objects_filtering_performance*"
 
 [testenv:py3.6-dist]
 # Verify library installs without any dependencies when using python setup.py
@@ -320,7 +320,7 @@ setenv =
 deps =
     -r{toxinidir}/requirements-tests.txt
     -r{toxinidir}/integration/storage/requirements.txt
-commands = pytest -rsx -vvv --capture=tee-sys -o log_cli=True --durations=10 integration/storage
+commands = pytest --color=yes -rsx -vvv --capture=tee-sys -o log_cli=True --durations=10 integration/storage
 
 [testenv:coverage]
 deps =
@@ -387,8 +387,8 @@ commands =
 [testenv:micro-benchmarks]
 commands =
     cp libcloud/test/secrets.py-dist libcloud/test/secrets.py
-    pytest -s -v --timeout 60 --benchmark-only --benchmark-name=short --benchmark-columns=min,max,mean,stddev,median,ops,rounds --benchmark-histogram=benchmark_histograms/benchmark  --benchmark-group-by=group,param:sort_objects libcloud/test/benchmarks/test_list_objects_filtering_performance.py
-    pytest -s -v --timeout 60 --benchmark-only --benchmark-name=short --benchmark-columns=min,max,mean,stddev,median,ops,rounds --benchmark-histogram=benchmark_histograms/benchmark --benchmark-group-by=group,func,param:read_in_chunks_func libcloud/test/benchmarks/test_read_in_chunks.py
+    pytest --color=yes -s -v --timeout 60 --benchmark-only --benchmark-name=short --benchmark-columns=min,max,mean,stddev,median,ops,rounds --benchmark-histogram=benchmark_histograms/benchmark  --benchmark-group-by=group,param:sort_objects libcloud/test/benchmarks/test_list_objects_filtering_performance.py
+    pytest --color=yes -s -v --timeout 60 --benchmark-only --benchmark-name=short --benchmark-columns=min,max,mean,stddev,median,ops,rounds --benchmark-histogram=benchmark_histograms/benchmark --benchmark-group-by=group,func,param:read_in_chunks_func libcloud/test/benchmarks/test_read_in_chunks.py
 
 [testenv:import-timings]
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ allowlist_externals =
     /bin/bash
     scripts/*.sh
 basepython =
+    py3.12-dev: python3.12
     pypypy3: pypy3
     pypypy3.7: pypy3.7
     pypypy-3.7: pypy3.7


### PR DESCRIPTION
This pull request updates tox and GHA config to also run tests under Python 3.12 beta.