### PR TITLE
Remove deprecated and unused ApiDocs command from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ import os
 import re
 import sys
 import fnmatch
-from distutils.core import Command
 
 import setuptools
 from setuptools import setup
@@ -250,31 +249,6 @@ def forbid_publish():
         sys.exit(1)
 
 
-class ApiDocsCommand(Command):
-    description = "generate API documentation"
-    user_options = []
-
-    def initialize_options(self):
-        pass
-
-    def finalize_options(self):
-        pass
-
-    def run(self):
-        if not has_epydoc:
-            raise RuntimeError('Missing "epydoc" package!')
-
-        os.system(
-            "pydoctor"
-            " --add-package=libcloud"
-            " --project-name=libcloud"
-            " --make-html"
-            ' --html-viewsource-base="%s"'
-            " --project-base-dir=`pwd`"
-            ' --project-url="%s"' % (HTML_VIEWSOURCE_BASE, PROJECT_BASE_DIR)
-        )
-
-
 forbid_publish()
 
 needs_pytest = {"pytest", "test", "ptr"}.intersection(sys.argv)
@@ -302,9 +276,6 @@ setup(
     url="https://libcloud.apache.org/",
     setup_requires=pytest_runner,
     tests_require=TEST_REQUIREMENTS,
-    cmdclass={
-        "apidocs": ApiDocsCommand,
-    },
     zip_safe=False,
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/setup.py
+++ b/setup.py
@@ -21,13 +21,6 @@ import fnmatch
 import setuptools
 from setuptools import setup
 
-try:
-    import epydoc  # NOQA
-
-    has_epydoc = True
-except ImportError:
-    has_epydoc = False
-
 # NOTE: Those functions are intentionally moved in-line to prevent setup.py dependening on any
 # Libcloud code which depends on libraries such as typing, enum, requests, etc.
 # START: Taken From Twisted Python which licensed under MIT license


### PR DESCRIPTION
This pull request removes deprecated and unused "apidocs" command from setup.py (apidocs are being generated using sphinx for a long time already).

This way it also removes dependency on ``distutils.core.Command`` which is not available anymore in Python 3.12.