### PR TITLE
Remove support for Python 3.7 which is EOL

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -44,11 +44,11 @@ github:
         strict: true
         # contexts are the names of checks that must pass
         contexts:
-          - "Unit Tests (Python 3.7)"
           - "Unit Tests (Python 3.8)"
           - "Unit Tests (Python 3.9)"
           - "Unit Tests (Python 3.10)"
           - "Unit Tests (Python 3.11)"
+          - "Unit Tests (Python 3.12)"
           - "Run Various Lint and Other Checks (3.8)"
           - "Build and upload Documentation (3.8)"
           - "Dependency Review"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,14 +32,12 @@ jobs:
       fail-fast: false
       matrix:
         python_version:
-          - 3.7
           - 3.8
           - 3.9
           - "3.10"
           - "3.11"
           - "3.12-dev"
           # cryptography is not compatible with older PyPy versions
-          #- "pypy-3.7"
           - "pypy-3.8"
         os:
           - ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
           - 3.9
           - "3.10"
           - "3.11"
-          - "3.12-dev"
+          - "3.12"
           # cryptography is not compatible with older PyPy versions
           - "pypy-3.8"
         os:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,13 @@ Changes in Apache Libcloud in development
 Common
 ~~~~~~
 
+- Support for Python 3.7 which is EOL has been removed.
+
+  If you still want to use Libcloud with Python 3.7, you should use an older
+  release which still supports Python 3.7.
+  (#1941)
+  [Tomaz Muraus - @Kami]
+
 - Types inheriting from ``libcloud.common.types.Type`` have been made hashable.
   This way they can be directly used for testing memberships in sets which
   contain string representation of the type enum value

--- a/README.rst
+++ b/README.rst
@@ -59,10 +59,11 @@ through a unified and easy to use API.
 :Issues:        https://issues.apache.org/jira/projects/LIBCLOUD/issues
 :Website:       https://libcloud.apache.org/
 :Documentation: https://libcloud.readthedocs.io
-:Supported Python Versions: Python >= 3.7, PyPy >= 3.7, Python 3.10 + Pyjion
+:Supported Python Versions: Python >= 3.8, PyPy >= 3.8, Python 3.10 + Pyjion
                             (Python 2.7 and Python 3.4 is supported by the
                             v2.8.x release series, last version which supports
-                            Python 3.5 is v3.4.0 and v3.6.x for Python 3.6)
+                            Python 3.5 is v3.4.0, v3.6.x for Python 3.6, and
+                            v3.8.x for Python 3.7)
 
 Resources you can manage with Libcloud are divided into the following categories:
 
@@ -85,8 +86,10 @@ Documentation can be found at <https://libcloud.readthedocs.org>.
 Note on Python Version Compatibility
 ====================================
 
-Libcloud supports Python >= 3.7 and PyPy >= 3.7.
+Libcloud supports Python >= 3.8 and PyPy >= 3.8.
 
+* Support for Python 3.7 has been dropped in v3.9.0 release.
+  Last release series which supports Python 3.6 is v3.6.x.
 * Support for Python 3.6 has been dropped in v3.7.0 release.
   Last release series which supports Python 3.6 is v3.6.x.
 * Support for Python 3.5 has been dropped in v3.5.0 release.

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -29,18 +29,15 @@ RUN set -e && \
     add-apt-repository ppa:pypy/ppa && \
     apt-get update && \
     apt-get -y install \
-      python3.7 \
       python3.8 \
       python3.9 \
       python3.10 \
       python3.11 \
       python3-dev \
-      python3.7-dev \
       python3.8-dev \
       python3.9-dev \
       python3.10-dev \
       python3.11-dev \
-      python3.7-distutils \
       python3.8-distutils \
       python3.9-distutils \
       pypy3 \

--- a/docs/upgrade_notes.rst
+++ b/docs/upgrade_notes.rst
@@ -8,6 +8,12 @@ preserve the old behavior when this is possible.
 Libcloud 3.9.0
 --------------
 
+* Support for Python 3.7 which has been EOL for more than a year now has been
+  removed.
+
+  If you still want to use Libcloud with Python 3.7, you should use an older
+  release which still supports Python 3.7.
+
 * [AZURE ARM] Added a new argument to destroy_node() to also delete node's managed
   OS disk as part of the node's deletion. Defaults to true. This can be reverted by
   setting the argument to false in the call:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -52,7 +51,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
     "requests>=2.26.0",
 ]
@@ -163,7 +162,7 @@ indent-string = "    "
 
 
 [tool.mypy]
-python_version = 3.7
+python_version = 3.8
 platform = "linux"
 show_error_context = true
 show_column_numbers = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{pypy3,3.7,3.8,3.9,3.10,pyjion},checks,lint,pylint,pyupgrade,isort,black,mypy,docs,coverage,integration-storage
+envlist = py{pypy3,3.8,3.9,3.10,3.11,pyjion},checks,lint,pylint,pyupgrade,isort,black,mypy,docs,coverage,integration-storage
 skipsdist = true
 requires =
     wheel
@@ -23,12 +23,8 @@ allowlist_externals =
 basepython =
     py3.12-dev: python3.12
     pypypy3: pypy3
-    pypypy3.7: pypy3.7
-    pypypy-3.7: pypy3.7
     pypypy-3.8: pypy3.8
     pypyjion: pyjion
-    {py3.6,py3.6-dist,py3.6-dist-wheel}: python3.6
-    {py3.7,py3.7-dist,py3.7-dist-wheel}: python3.7
     {docs,checks,black,black-check,lint,pylint,bandit,mypy,micro-benchmarks,coverage,import-timings,isort,isort-check,pyupgrade}: python3.8
     {py3.8,py3.8-windows,integration-storage,py3.8-dist,py3.8-dist-wheel}: python3.8
     {py3.9,py3.9-dist,py3.9-dist-wheel}: python3.9
@@ -43,44 +39,6 @@ setenv =
 # for pytest-xdist, we want to distribute tests by file aka --dist loadfile
 commands = cp libcloud/test/secrets.py-dist libcloud/test/secrets.py
            pytest --color=yes -rsx -vvv --capture=tee-sys -o log_cli=True --durations=10 --timeout=15 -n auto --dist loadfile --ignore libcloud/test/benchmarks/ --ignore-glob "*test_list_objects_filtering_performance*"
-
-[testenv:py3.6-dist]
-# Verify library installs without any dependencies when using python setup.py
-# install
-skipdist = True
-recreate = True
-# NOTE: We intentionally set empty deps to ensure it works on a clean
-# environment without any dependencies
-deps =
-commands = bash -c "./scripts/dist_install_check.sh"
-
-[testenv:py3.6-dist-wheel]
-# Verify library installs without any dependencies when using built wheel
-skipdist = True
-recreate = True
-# NOTE: We intentionally set empty deps to ensure it works on a clean
-# environment without any dependencies
-deps =
-commands = bash -c "./scripts/dist_wheel_install_check.sh"
-
-[testenv:py3.7-dist]
-# Verify library installs without any dependencies when using python setup.py
-# install
-skipdist = True
-recreate = True
-# NOTE: We intentionally set empty deps to ensure it works on a clean
-# environment without any dependencies
-deps =
-commands = bash -c "./scripts/dist_install_check.sh"
-
-[testenv:py3.7-dist-wheel]
-# Verify library installs without any dependencies when using built wheel
-skipdist = True
-recreate = True
-# NOTE: We intentionally set empty deps to ensure it works on a clean
-# environment without any dependencies
-deps =
-commands = bash -c "./scripts/dist_wheel_install_check.sh"
 
 [testenv:py3.8-dist]
 # Verify library installs without any dependencies when using python setup.py
@@ -250,7 +208,7 @@ commands =
     bash -c "(cd libcloud/data/ ; sha512sum pricing.json > {toxinidir}/libcloud/data/pricing.json.sha512)"
 
 [testenv:scrape-ec2-prices]
-basepython: python3.7
+basepython: python3.8
 # Needed to avoid urllib3 errors related to old openssl version
 # https://github.com/urllib3/urllib3/issues/2168
 deps = urllib3==1.26.6
@@ -261,7 +219,7 @@ deps = urllib3==1.26.6
 commands = python contrib/scrape-ec2-prices.py
 
 [testenv:scrape-ec2-sizes]
-basepython: python3.7
+basepython: python3.8
 # Needed to avoid urllib3 errors related to old openssl version
 # https://github.com/urllib3/urllib3/issues/2168
 deps = urllib3==1.26.6


### PR DESCRIPTION
This pull request remove support for Python 3.7 which is now EOL (https://endoflife.date/python).