### PR TITLE
Make classes inheriting from Type hashable

### DIFF
--- a/libcloud/common/types.py
+++ b/libcloud/common/types.py
@@ -82,7 +82,7 @@ class Type(str, Enum):
         return self.value
 
     def __hash__(self):
-        return id(self)
+        return hash(self.value)
 
 
 class LibcloudError(Exception):

--- a/libcloud/test/common/test_types.py
+++ b/libcloud/test/common/test_types.py
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from libcloud.common.types import Type
+from libcloud.compute.types import NodeState
+
+
+class TypeTest(unittest.TestCase):
+    def test_Type(self):
+        class TestType(Type):
+            TESTING = "testing"
+
+        self.assertEqual(hash(TestType.TESTING), hash("testing"))
+        self.assertIn(TestType.TESTING, {"testing"})
+
+    def test_NodeState(self):
+        self.assertEqual(hash(NodeState.RUNNING), hash("running"))
+        self.assertIn(NodeState.RUNNING, {"running"})


### PR DESCRIPTION
## Make classes inheriting from Type hashable

### Description

Attributes of classes that inherit from `libcloud.common.types.Type` are not hashable, so they can't be tested for membership in sets, unlike those that inherit from `libcloud.container.types.Type` which work as intended.

```
$ python
Python 3.11.4 (main, Jun  9 2023, 07:59:55) [GCC 12.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from libcloud.compute.types import NodeState
>>> NodeState.RUNNING
running
>>> NodeState.RUNNING in {"running"}
False
>>> str(NodeState.RUNNING) in {"running"}
True
>>> from libcloud.container.types import ContainerState
>>> ContainerState.RUNNING in {"running"}
True
```

### Status

done, ready for review.

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
