### PR TITLE
Add resize node function for azure driver

### DIFF
--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -2161,6 +2161,24 @@ class AzureNodeDriver(NodeDriver):
         # Libcloud v2.7.0
         return self.stop_node(node=node, ex_deallocate=deallocate)
 
+    def ex_resize_node(self, node, size):
+        """
+        Resize the node to a different machine size.
+
+        :param node: Node to rebuild
+        :type node: :class:`Node`
+
+        :param size: New size for this machine
+        :type node: :class:`NodeSize`
+        """
+        target = "%s/resize" % node.id
+        data = {"size": size.id}
+        r = self.connection.request(
+            target, params={"api-version": VM_API_VERSION}, data=data,
+            method="POST"
+        )
+        return r.object
+
     def ex_get_storage_account_keys(self, resource_group, storage_account):
         """
         Get account keys required to access to a storage account

--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -2165,7 +2165,7 @@ class AzureNodeDriver(NodeDriver):
         """
         Resize the node to a different machine size.
 
-        :param node: Node to rebuild
+        :param node: Node to resize
         :type node: :class:`Node`
 
         :param size: New size for this machine

--- a/libcloud/test/compute/fixtures/azure_arm/_subscriptions_99999999_resourceGroups_000000_providers_Microsoft_Compute_virtualMachines_test_node_1_resize.json
+++ b/libcloud/test/compute/fixtures/azure_arm/_subscriptions_99999999_resourceGroups_000000_providers_Microsoft_Compute_virtualMachines_test_node_1_resize.json
@@ -1,0 +1,51 @@
+{
+  "properties": {
+    "vmId": "99999999-9999-9999-9999-999999999999",
+    "hardwareProfile": {
+      "vmSize": "Standard_A1"
+    },
+    "storageProfile": {
+      "osDisk": {
+        "osType": "Linux",
+        "name": "OSD-9999",
+        "createOption": "Attach",
+        "caching": "ReadWrite",
+        "managedDisk": {
+          "storageAccountType": "Standard_LRS",
+          "id": "/subscriptions/99999999-9999-9999-9999-999999999999/resourceGroups/000000/providers/Microsoft.Compute/disks/OSD-9999"
+        }
+      },
+      "dataDisks": [
+        {
+          "lun": 0,
+          "name": "DD0-9999",
+          "createOption": "Attach",
+          "caching": "None",
+          "managedDisk": {
+            "storageAccountType": "Standard_LRS",
+            "id": "/subscriptions/99999999-9999-9999-9999-999999999999/resourceGroups/000000/providers/Microsoft.Compute/disks/DD0-9999"
+          },
+          "diskSizeGB": 8
+        }
+      ]
+    },
+    "networkProfile": {
+      "networkInterfaces": [
+        {
+          "id": "/subscriptions/99999999-9999-9999-9999-999999999999/resourceGroups/0000/providers/Microsoft.Network/networkInterfaces/test-nic",
+          "properties": {
+            "primary": true
+          }
+        }
+      ]
+    },
+    "provisioningState": "Succeeded"
+  },
+  "type": "Microsoft.Compute/virtualMachines",
+  "location": "eastus",
+  "tags": {
+    "tag_key1": "tag_val1"
+  },
+  "id": "/subscriptions/99999999-9999-9999-9999-999999999999/resourceGroups/0000/providers/Microsoft.Compute/virtualMachines/test_vm",
+  "name": "test_vm"
+}

--- a/libcloud/test/compute/test_azure_arm.py
+++ b/libcloud/test/compute/test_azure_arm.py
@@ -630,6 +630,15 @@ class AzureNodeDriverTests(LibcloudTestCase):
 
         self.assertEqual(new_size, original_size + 8)
 
+    def test_resize_node(self):
+        location = self.driver.list_locations()[0]
+        size = self.driver.list_sizes(location=location)[0]
+        node = self.driver.list_nodes()[0]
+
+        value = self.driver.ex_resize_node(node, size)
+
+        self.assertEqual(value["size"], size.id)
+
     def test_detach_volume(self):
         volumes = self.driver.list_volumes()
         node = self.driver.list_nodes()[0]


### PR DESCRIPTION
## Add resize node function for azure driver

### Description

#### Background

https://github.com/apache/libcloud/issues/1964

To start with we have def ex_change_node_size(self, node, new_size) function in [https://github.com/apache/libcloud/blob/trunk/libcloud/compute/drivers/ec2.py] which supports instance type change for AWS.

We need similar functionality for Azure cloud as well where we could change the vmSize for Azure cloud. This could be done by adding node_resize function at (https://github.com/apache/libcloud/blob/trunk/libcloud/compute/drivers/azure_arm.py )

#### Implementation

1. Added `ex_resize_node` to change the azure vm instance type.
2. Added equivalent test `test_resize_node` to test `ex_resize_node` 

### Status
- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
