### PR TITLE
Adjust parameters to GoDaddy get_zone method

### DIFF
--- a/libcloud/dns/drivers/godaddy.py
+++ b/libcloud/dns/drivers/godaddy.py
@@ -288,12 +288,13 @@ class GoDaddyDNSDriver(DNSDriver):
         """
         Get a zone (by domain)
 
-        :param  zone_id: The domain, not the ID
+        :param  zone_id: The domain ID
         :type   zone_id: ``str``
 
         :rtype:  :class:`Zone`
         """
-        result = self.connection.request("/v1/domains/%s/" % zone_id).object
+        domain, = [x.domain for x in self.list_zones() if x.id == zone_id]
+        result = self.connection.request("/v1/domains/%s/" % domain).object
         zone = self._to_zone(result)
         return zone
 


### PR DESCRIPTION
Other drivers take the ID, not the domain name. This puts the GoDaddy driver in-line with how other drivers work.

## Changes Title (replace this with a logical title for your changes)

### Description

Saltstack has been throwing errors when working with GoDaddy dns entries because the driver takes different parameters than other drivers it was designed around. This fixes the interface to put it more in-line with other drivers.

### Status

done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
