### PR TITLE
Mark MockHttp as not for collection by pytest

### DIFF
--- a/libcloud/test/__init__.py
+++ b/libcloud/test/__init__.py
@@ -97,6 +97,8 @@ class MockHttp(LibcloudConnection):
 
         (int status, str body, dict headers, str reason)
     """
+    # pytest may collect this class, and we don't need or want that
+    __test__ = False
 
     type = None
     use_param = None  # will use this param to namespace the request function


### PR DESCRIPTION
## Mark MockHttp as not for collection by pytest

### Description

pytest 8.2.0 contains a regression that will collect non-test classes, so as to be explicit about it, mark MockHttp (and therefore all of its children classes) as not to be collected.

pytest regression has been filed upstream as https://github.com/pytest-dev/pytest/issues/12425.

After this merges, `pdm` can upgrade pytest to 8.2.x.

### Status

Done, ready for review.

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
