### PR TITLE
Only call super() during MockHttp if required

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -135,6 +135,11 @@ Other / Development
   (#1994)
   [Tomaz Muraus - @Kami]
 
+- Add a workaround so tests work with pytest >= 8.2. Also use latest version of
+  pytest for running tests.
+  (#2033)
+  [Steve Kowalik - @s-t-e-v-e-n-k]
+
 Changes in Apache Libcloud 3.8.0
 --------------------------------
 

--- a/libcloud/test/__init__.py
+++ b/libcloud/test/__init__.py
@@ -87,7 +87,7 @@ class BodyStream(StringIO):
         return StringIO.read(self)
 
 
-class MockHttp(LibcloudConnection):
+class MockHttp(LibcloudConnection, unittest.TestCase):
     """
     A mock HTTP client/server suitable for testing purposes. This replaces
     `HTTPConnection` by implementing its API and returning a mock response.
@@ -108,7 +108,11 @@ class MockHttp(LibcloudConnection):
         # within a response
         if isinstance(self, unittest.TestCase):
             unittest.TestCase.__init__(self, "__init__")
-        super().__init__(*args, **kwargs)
+        # When this class is collected, it is instantiated with no arguments,
+        # which breaks any superclasses that expect arguments, so only
+        # do so if we were passed any keyword arguments.
+        if kwargs:
+            super().__init__(*args, **kwargs)
 
     def _get_request(self, method, url, body=None, headers=None):
         # Find a method we can use for this request

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,10 +1,10 @@
 coverage[toml]==7.2.7; python_version >= '3.8'
 requests>=2.31.0
 requests_mock==1.11.0
-pytest==8.1.1
-pytest-xdist==3.5.0
-pytest-timeout==2.2.0
-pytest-benchmark[histogram]==4.0.0
+pytest==8.3.5
+pytest-xdist==3.6.1
+pytest-timeout==2.3.1
+pytest-benchmark[histogram]==5.1.0
 cryptography==44.0.2
 
 # NOTE: Only needed by nttcis loadbalancer driver


### PR DESCRIPTION
## Only instantiate superclasses of MockHttp if we are provided keyword arguments

### Description

With pytest 8.2 and above, any class that contains tests is collected, which means they are instantiated, which MockHttp's superclasses do not accept, since they require keyword arguments. To work around this, only call the superclass's __init__ method if we are passed kwargs.

### Status

Done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation (as code comments)
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
