### PR TITLE
[LUADNS] Fix example keyword arguments

### DIFF
--- a/docs/examples/dns/luadns/instantiate_driver.py
+++ b/docs/examples/dns/luadns/instantiate_driver.py
@@ -2,4 +2,4 @@ from libcloud.dns.types import Provider
 from libcloud.dns.providers import get_driver
 
 cls = get_driver(Provider.LUADNS)
-driver = cls(user="user", key="api_key")
+driver = cls(key="user", secret="api_key")


### PR DESCRIPTION
## [LUADNS] Fix example keyword arguments

### Description

Correct the example keyword arguments to allow successful login.

| Function | Original | Proposed |
|-|-|-|
| Username | `user=` | `key=` |
| Password | `key=` | `secret=` |

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [ ] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
