### PR TITLE
Bump paramiko from 3.4.0 to 3.5.1

### DIFF
--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -10,4 +10,4 @@ rstcheck==6.2.4; python_version >= '3.7'
 codespell==2.4.1
 
 requests>=2.27.1
-paramiko==3.4.0; platform_python_implementation != 'PyPy'
+paramiko==3.5.1; platform_python_implementation != 'PyPy'

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -13,5 +13,5 @@ pyopenssl==25.0.0
 
 # Required by subset of tests
 fasteners
-paramiko==3.4.0; platform_python_implementation != 'PyPy'
+paramiko==3.5.1; platform_python_implementation != 'PyPy'
 libvirt-python==10.2.0


### PR DESCRIPTION
### Description
Paramiko 3.4.0 fills logs with TripleDES warnings which was fixed in 3.4.1 as mentioned in here https://github.com/paramiko/paramiko/issues/2419#issuecomment-2351097126

So bumping to latest version.
