### PR TITLE
chore: remove duplicated keys

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -54,5 +54,4 @@ notifications:
   jobs: notifications@libcloud.apache.org
   issues: notifications@libcloud.apache.org
   pullrequests: notifications@libcloud.apache.org
-  jobs: notifications@libcloud.apache.org
   jira_options: link label comment


### PR DESCRIPTION
Try to fix YAML error.

But so far there is no notification from gitbox automation saying the new asfyaml schema applied.