### PR TITLE
ci: restore status checks for Lint and Docs

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -49,6 +49,8 @@ github:
           - "Unit Tests (Python 3.12)"
           - "Unit Tests (Python 3.13)"
           - "Dependency Review"
+          - "Run Various Lint and Other Checks (3.10)"
+          - "Build and upload Documentation (3.10)"
 
 notifications:
   jobs: notifications@libcloud.apache.org


### PR DESCRIPTION
After #2083 we now have new status checks to include.