### PR TITLE
ci: Drop Python 3.9 checks

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -43,7 +43,6 @@ github:
     trunk:
       required_status_checks:
         contexts:
-          - "Unit Tests (Python 3.9)"
           - "Unit Tests (Python 3.10)"
           - "Unit Tests (Python 3.11)"
           - "Unit Tests (Python 3.12)"


### PR DESCRIPTION
This is required by https://github.com/apache/libcloud/pull/2085.