### PR TITLE
Remove fake tasks added to revert name change in required tests 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -436,15 +436,3 @@ jobs:
         run: |
           python -m pip install requests
           python ./contrib/trigger_rtd_build.py
-
-  old_check_name:
-    name: Build and upload Documentation
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "OK"
-
-  old_check_name_2:
-    name: Run Various Lint and Other Checks
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "OK"


### PR DESCRIPTION
## Remove fake tasks added to revert name change in required tests 

### Description

Revert this change (https://github.com/apache/libcloud/commit/0a37446121e07080a8ea9bb4487e72cce4d1c663#diff-b4c2a69650f9ac84008ad9f745859a645c9466350ffdfe5f919655039ee2e2c3L51) as it sets an incorrect name for required tests:

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
