### PR TITLE
Fix verify_checksums.sh script

### DIFF
--- a/dist/verify_checksums.sh
+++ b/dist/verify_checksums.sh
@@ -30,11 +30,11 @@ TMP_DIR=$(mktemp -d)
 # TODO: Use json endpoint + jq to parse out the url
 # https://pypi.org/pypi/apache-libcloud/3.4.0/json
 EXTENSIONS[0]=".tar.gz"
-EXTENSIONS[1]="-py3-none-any.whl"
+EXTENSIONS[1]="-py2.py3-none-any.whl"
 
 APACHE_MIRROR_URL="http://www.apache.org/dist/libcloud"
 PYPI_MIRROR_URL_SOURCE="https://pypi.python.org/packages/source/a/apache-libcloud"
-PYPI_MIRROR_URL_WHEEL="https://files.pythonhosted.org/packages/py3/a/apache-libcloud"
+PYPI_SIMPLE_URL="https://pypi.org/simple/apache-libcloud/"
 
 # From http://tldp.org/LDP/abs/html/debugging.html#ASSERT
 function assert ()                 #  If condition false,
@@ -69,7 +69,7 @@ do
     extension=${EXTENSIONS[$i]}
     file_name="${VERSION}${extension}"
 
-    if [ "${extension}" = "-py3-none-any.whl" ]; then
+    if [ "${extension}" = "-py2.py3-none-any.whl" ]; then
         # shellcheck disable=SC2001
         file_name=$(echo "${file_name}" | sed "s/apache-libcloud/apache_libcloud/g")
     fi
@@ -77,8 +77,9 @@ do
     apache_url="${APACHE_MIRROR_URL}/${file_name}"
     pypi_url="${PYPI_MIRROR_URL}/${file_name}"
 
-    if [ "${extension}" = "-py3-none-any.whl" ]; then
-        pypi_url="${PYPI_MIRROR_URL_WHEEL}/${file_name}"
+    if [ "${extension}" = "-py2.py3-none-any.whl" ]; then
+        # Get the wheel full URL from PyPi Simple index
+        pypi_url=$(curl -s ${PYPI_SIMPLE_URL} | grep "${file_name}" | sed -n 's/.*href="\([^"]*\)".*/\1/p')
     else
         pypi_url="${PYPI_MIRROR_URL_SOURCE}/${file_name}"
     fi


### PR DESCRIPTION
## Fix verify_checksums.sh script

### Description

[Verify Artifacts Checksum](https://github.com/apache/libcloud/actions/runs/21344723975/job/61429974297#logs) are failing due to an incorrect wheel file name, it uses `-py3-none-any.whl` extension instead of the current `-py2.py3-none-any.whl` (see: https://downloads.apache.org/libcloud/) and in the way it downloads the wheel file from pypi.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
