### PR TITLE
Fix Trigger ReadTheDocs build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -434,5 +434,5 @@ jobs:
           RTD_TOKEN: ${{ secrets.RTD_TOKEN }}
           BRANCH_NAME: "trunk"
         run: |
-          python -m pip install requests
+          uv pip install requests
           python ./contrib/trigger_rtd_build.py


### PR DESCRIPTION
## Fix Trigger ReadTheDocs build

### Description

Fix the installation of requests using uv tool.
See error log: https://github.com/apache/libcloud/actions/runs/21355628147/job/61465290378

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
