### PR TITLE
Fix error in py313

### DIFF
--- a/libcloud/test/common/test_openstack_identity.py
+++ b/libcloud/test/common/test_openstack_identity.py
@@ -235,7 +235,7 @@ class OpenStackIdentityConnectionTestCase(unittest.TestCase):
         osa.auth_token = None
         osa.auth_token_expires = YESTERDAY
 
-        mocked_auth_method.call_count = 0
+        mocked_auth_method.reset_mock()
         self.assertEqual(mocked_auth_method.call_count, 0)
 
         for i in range(0, count):
@@ -246,7 +246,7 @@ class OpenStackIdentityConnectionTestCase(unittest.TestCase):
         # No force reauth, valid / non-expired token
         osa.auth_token = None
 
-        mocked_auth_method.call_count = 0
+        mocked_auth_method.reset_mock()
         self.assertEqual(mocked_auth_method.call_count, 0)
 
         for i in range(0, count):
@@ -264,7 +264,7 @@ class OpenStackIdentityConnectionTestCase(unittest.TestCase):
         )
         osa.auth_token = None
 
-        mocked_auth_method.call_count = 0
+        mocked_auth_method.reset_mock()
         self.assertEqual(mocked_auth_method.call_count, 0)
 
         for i in range(0, count):


### PR DESCRIPTION
## Fix error in py313

### Description

Fix error in test with python 3.13:
libcloud.test.common.test_openstack_identity.OpenStackIdentityConnectionTestCase testMethod=test_token_expiration_and_force_reauthentication

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [x] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
