### PR TITLE
Support paramiko 4 changes

### DIFF
--- a/libcloud/compute/ssh.py
+++ b/libcloud/compute/ssh.py
@@ -660,13 +660,15 @@ class ParamikoSSHClient(BaseSSHClient):
         """
         key_types = [
             (paramiko.RSAKey, "RSA"),
-            (paramiko.DSSKey, "DSA"),
             (paramiko.ECDSAKey, "EC"),
         ]
 
         paramiko_version = getattr(paramiko, "__version__", "0.0.0")
         paramiko_version = tuple(int(c) for c in paramiko_version.split("."))
 
+        if paramiko_version < (4, 0, 0):
+            # DSSKey removed in paramiko 4.0.0
+            key_types.insert(1, (paramiko.DSSKey, "DSA"))
         if paramiko_version >= (2, 2, 0):
             # Ed25519 is only supported in paramiko >= 2.2.0
             key_types.append((paramiko.ed25519key.Ed25519Key, "Ed25519"))

--- a/libcloud/test/compute/test_ssh_client.py
+++ b/libcloud/test/compute/test_ssh_client.py
@@ -317,19 +317,21 @@ class ParamikoSSHClientTests(LibcloudTestCase):
         self.assertTrue(isinstance(pkey, paramiko.RSAKey))
 
         # 2. DSA key type with header which is not supported by paramiko
-        path = os.path.join(
-            os.path.dirname(__file__),
-            "fixtures",
-            "misc",
-            "test_dsa_non_paramiko_recognized_header.key",
-        )
+        # ... and only for paramiko < 4
+        if paramiko_version < (4, 0, 0):
+            path = os.path.join(
+                os.path.dirname(__file__),
+                "fixtures",
+                "misc",
+                "test_dsa_non_paramiko_recognized_header.key",
+            )
 
-        with open(path) as fp:
-            private_key = fp.read()
+            with open(path) as fp:
+                private_key = fp.read()
 
-        pkey = client._get_pkey_object(key=private_key)
-        self.assertTrue(pkey)
-        self.assertTrue(isinstance(pkey, paramiko.DSSKey))
+            pkey = client._get_pkey_object(key=private_key)
+            self.assertTrue(pkey)
+            self.assertTrue(isinstance(pkey, paramiko.DSSKey))
 
         # 3. ECDSA key type with header which is not supported by paramiko
         path = os.path.join(
@@ -361,14 +363,16 @@ class ParamikoSSHClientTests(LibcloudTestCase):
         self.assertTrue(isinstance(pkey, paramiko.RSAKey))
 
         # 2. DSA key type with header which is not supported by paramiko
-        path = os.path.join(os.path.dirname(__file__), "fixtures", "misc", "test_dsa.key")
+        # ... and only for paramiko < 4
+        if paramiko_version < (4, 0, 0):
+            path = os.path.join(os.path.dirname(__file__), "fixtures", "misc", "test_dsa.key")
 
-        with open(path) as fp:
-            private_key = fp.read()
+            with open(path) as fp:
+                private_key = fp.read()
 
-        pkey = client._get_pkey_object(key=private_key)
-        self.assertTrue(pkey)
-        self.assertTrue(isinstance(pkey, paramiko.DSSKey))
+            pkey = client._get_pkey_object(key=private_key)
+            self.assertTrue(pkey)
+            self.assertTrue(isinstance(pkey, paramiko.DSSKey))
 
         # 3. ECDSA key type with header which is not supported by paramiko
         path = os.path.join(os.path.dirname(__file__), "fixtures", "misc", "test_ecdsa.key")


### PR DESCRIPTION
## Support paramiko 4

### Description

RSA key support has been removed as of paramiko 4, so only import it and check if the version number is less than 4.

### Status

Replace this: describe the PR status. Examples:

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
