### PR TITLE
Disable tests temporary to move to py12

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -48,8 +48,8 @@ github:
           - "Unit Tests (Python 3.12)"
           - "Unit Tests (Python 3.13)"
           - "Dependency Review"
-          - "Run Various Lint and Other Checks (3.10)"
-          - "Build and upload Documentation (3.10)"
+#          - "Run Various Lint and Other Checks (3.10)"
+#          - "Build and upload Documentation (3.10)"
 
 notifications:
   jobs: notifications@libcloud.apache.org


### PR DESCRIPTION
## Disable tests temporary to move to py12

### Description

Disable tests temporary to move to py12

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [ ] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
