### PR TITLE
Fix Azure ARM create_node JSON error with ex_customdata (#1893)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,12 @@ Compute
   (#2135)
   [Steve Kowalik - @s-t-e-v-e-n-k]
 
+- [Azure ARM] Fix ``create_node`` failing with a JSON serialization error when
+  ``ex_customdata`` is provided. The base64 encoded custom data is now decoded
+  to a ``str`` and both ``str`` and ``bytes`` inputs are accepted.
+  (GITHUB-1893)
+  [Sanjay Santhanam - @Sanjays2402]
+
 Changes in Apache Libcloud 3.9.1
 --------------------------------
 

--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -609,7 +609,7 @@ class AzureNodeDriver(NodeDriver):
             be placed in the file /var/lib/waagent/CustomData
             https://azure.microsoft.com/en-us/documentation/ \
             articles/virtual-machines-how-to-inject-custom-data/
-        :type ex_customdata: ``str``
+        :type ex_customdata: ``str`` or ``bytes``
 
         :param ex_use_managed_disks: Enable this feature to have Azure
             automatically manage the availability of disks to provide data

--- a/libcloud/compute/drivers/azure_arm.py
+++ b/libcloud/compute/drivers/azure_arm.py
@@ -741,7 +741,11 @@ class AzureNodeDriver(NodeDriver):
             data["properties"]["storageProfile"]["osDisk"].update({"diskSizeGB": ex_disk_size})
 
         if ex_customdata:
-            data["properties"]["osProfile"]["customData"] = base64.b64encode(ex_customdata)
+            if isinstance(ex_customdata, str):
+                ex_customdata = ex_customdata.encode("utf-8")
+            data["properties"]["osProfile"]["customData"] = base64.b64encode(ex_customdata).decode(
+                "utf-8"
+            )
 
         data["properties"]["osProfile"]["adminUsername"] = ex_user_name
 

--- a/libcloud/test/compute/test_azure_arm.py
+++ b/libcloud/test/compute/test_azure_arm.py
@@ -15,6 +15,7 @@
 
 import sys
 import json
+import base64
 import functools
 from datetime import datetime
 from unittest import mock
@@ -231,6 +232,56 @@ class AzureNodeDriverTests(LibcloudTestCase):
                 "version": image.version,
             },
         )
+
+    def test_create_node_ex_customdata(self):
+        location = NodeLocation("any_location", "", "", self.driver)
+        size = NodeSize("any_size", "", 0, 0, 0, 0, driver=self.driver)
+        image = AzureImage("1", "1", "ubuntu", "pub", location.id, self.driver)
+        auth = NodeAuthPassword("any_password")
+
+        customdata = "#!/bin/bash\necho hello"
+        expected = base64.b64encode(customdata.encode("utf-8")).decode("utf-8")
+
+        # ex_customdata provided as a str
+        node = self.driver.create_node(
+            "test-node-1",
+            size,
+            image,
+            auth,
+            location=location,
+            ex_resource_group="000000",
+            ex_storage_account="000000",
+            ex_user_name="any_user",
+            ex_network="000000",
+            ex_subnet="000000",
+            ex_use_managed_disks=True,
+            ex_customdata=customdata,
+        )
+        os_profile = node.extra["properties"]["osProfile"]
+        self.assertEqual(os_profile["customData"], expected)
+        # customData must be a JSON-serializable str, not bytes
+        self.assertIsInstance(os_profile["customData"], str)
+        json.dumps(node.extra["properties"])
+
+        # ex_customdata provided as bytes (regression for GH #1893)
+        node = self.driver.create_node(
+            "test-node-1",
+            size,
+            image,
+            auth,
+            location=location,
+            ex_resource_group="000000",
+            ex_storage_account="000000",
+            ex_user_name="any_user",
+            ex_network="000000",
+            ex_subnet="000000",
+            ex_use_managed_disks=True,
+            ex_customdata=customdata.encode("utf-8"),
+        )
+        os_profile = node.extra["properties"]["osProfile"]
+        self.assertEqual(os_profile["customData"], expected)
+        self.assertIsInstance(os_profile["customData"], str)
+        json.dumps(node.extra["properties"])
 
     def test_create_node_ex_os_disk_delete(self):
         location = NodeLocation("any_location", "", "", self.driver)


### PR DESCRIPTION
### Description

Fixes #1893.

For the Azure ARM driver, `create_node` failed when `ex_customdata` was provided:

- `base64.b64encode()` returns `bytes`, which is not JSON serializable, so building the request body raised `Object of type bytes is not JSON serializable`.
- Passing `ex_customdata` as a `str` also failed because `b64encode` requires bytes-like input.

The fix normalizes `ex_customdata` to `bytes`, then decodes the base64 result to a UTF-8 `str` so `customData` is JSON-serializable. Both `str` and `bytes` inputs are now accepted.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks) — `black --check` and `flake8` clean on changed files
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html) — added `test_create_node_ex_customdata` (str + bytes); fails without the fix, passes with it; full `test_azure_arm.py` = 46 passed
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes) — small bugfix