### PR TITLE
[S3] Respect chunk_size in download_object_as_stream

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,16 @@ Compute
   (#2147)
   [Miguel Caballer - @micafer]
 
+Storage
+~~~~~~~
+
+- [S3] Fix ``chunk_size`` argument being ignored by
+  ``download_object_as_stream`` and ``download_object_range_as_stream``. The
+  requested chunk size is now passed through to the underlying iterator
+  instead of the hardcoded default.
+  (GITHUB-1798)
+  [Sanjay Santhanam - @Sanjays2402]
+
 Changes in Apache Libcloud 3.9.1
 --------------------------------
 

--- a/libcloud/storage/drivers/s3.py
+++ b/libcloud/storage/drivers/s3.py
@@ -521,7 +521,7 @@ class BaseS3StorageDriver(StorageDriver):
             callback=read_in_chunks,
             response=response,
             callback_kwargs={
-                "iterator": response.iter_content(CHUNK_SIZE),
+                "iterator": response.iter_content(chunk_size or CHUNK_SIZE),
                 "chunk_size": chunk_size,
             },
             success_status_code=httplib.OK,
@@ -573,7 +573,7 @@ class BaseS3StorageDriver(StorageDriver):
             callback=read_in_chunks,
             response=response,
             callback_kwargs={
-                "iterator": response.iter_content(CHUNK_SIZE),
+                "iterator": response.iter_content(chunk_size or CHUNK_SIZE),
                 "chunk_size": chunk_size,
             },
             success_status_code=httplib.PARTIAL_CONTENT,

--- a/libcloud/test/storage/test_s3.py
+++ b/libcloud/test/storage/test_s3.py
@@ -885,6 +885,35 @@ class S3Tests(unittest.TestCase):
 
         mock_response.iter_content.assert_called_once_with(requested_chunk_size)
 
+    def test_download_object_range_as_stream_uses_chunk_size(self):
+        # Same regression as above, but for the ranged variant which goes
+        # through the same _get_object() code path.
+        container = Container(name="foo_bar_container", extra={}, driver=self.driver)
+        obj = Object(
+            name="foo_bar_object",
+            size=1000,
+            hash=None,
+            extra={},
+            container=container,
+            meta_data=None,
+            driver=self.driver_type,
+        )
+
+        requested_chunk_size = CHUNK_SIZE * 2
+        mock_response = Mock(name="mock response")
+        mock_response.iter_content.return_value = iter([b"a"])
+
+        with mock.patch.object(self.driver.connection, "request", return_value=mock_response):
+            with mock.patch.object(self.driver, "_get_object", side_effect=lambda **kw: kw):
+                self.driver.download_object_range_as_stream(
+                    obj=obj,
+                    start_bytes=0,
+                    end_bytes=100,
+                    chunk_size=requested_chunk_size,
+                )
+
+        mock_response.iter_content.assert_called_once_with(requested_chunk_size)
+
     def test_upload_object_invalid_ex_storage_class(self):
         # Invalid hash is detected on the amazon side and BAD_REQUEST is
         # returned

--- a/libcloud/test/storage/test_s3.py
+++ b/libcloud/test/storage/test_s3.py
@@ -861,6 +861,30 @@ class S3Tests(unittest.TestCase):
         finally:
             self.driver_type._get_object = old_func
 
+    def test_download_object_as_stream_uses_chunk_size(self):
+        # Regression test: the chunk_size passed by the caller must be
+        # forwarded to iter_content instead of the hardcoded CHUNK_SIZE.
+        container = Container(name="foo_bar_container", extra={}, driver=self.driver)
+        obj = Object(
+            name="foo_bar_object",
+            size=1000,
+            hash=None,
+            extra={},
+            container=container,
+            meta_data=None,
+            driver=self.driver_type,
+        )
+
+        requested_chunk_size = CHUNK_SIZE * 2
+        mock_response = Mock(name="mock response")
+        mock_response.iter_content.return_value = iter([b"a"])
+
+        with mock.patch.object(self.driver.connection, "request", return_value=mock_response):
+            with mock.patch.object(self.driver, "_get_object", side_effect=lambda **kw: kw):
+                self.driver.download_object_as_stream(obj=obj, chunk_size=requested_chunk_size)
+
+        mock_response.iter_content.assert_called_once_with(requested_chunk_size)
+
     def test_upload_object_invalid_ex_storage_class(self):
         # Invalid hash is detected on the amazon side and BAD_REQUEST is
         # returned


### PR DESCRIPTION
Closes #1798

### Description

`download_object_as_stream` and `download_object_range_as_stream` in the S3
driver passed the hardcoded module-level `CHUNK_SIZE` to
`response.iter_content()` instead of the `chunk_size` given by the caller, so a
user-specified chunk size was silently ignored. They now forward `chunk_size`
(falling back to `CHUNK_SIZE`), matching the backblaze_b2 and cloudfiles
drivers. Added a regression test.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [x] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
