### PR TITLE
[Azure Blobs] Forward chunk_size in download_object_as_stream

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,16 @@ Compute
   (#2147)
   [Miguel Caballer - @micafer]
 
+Storage
+~~~~~~~
+
+- [Azure Blobs] Fix ``chunk_size`` argument being ignored by
+  ``download_object_as_stream`` and ``download_object_range_as_stream``. The
+  requested chunk size is now forwarded to the underlying iterator instead of
+  always using ``AZURE_DOWNLOAD_CHUNK_SIZE``.
+  (GITHUB-1698)
+  [Sanjay Santhanam - @Sanjays2402]
+
 Changes in Apache Libcloud 3.9.1
 --------------------------------
 

--- a/libcloud/storage/drivers/azure_blobs.py
+++ b/libcloud/storage/drivers/azure_blobs.py
@@ -793,7 +793,7 @@ class AzureBlobsStorageDriver(StorageDriver):
         """
         obj_path = self._get_object_path(obj.container, obj.name)
         response = self.connection.request(obj_path, method="GET", stream=True, raw=True)
-        iterator = response.iter_content(AZURE_DOWNLOAD_CHUNK_SIZE)
+        iterator = response.iter_content(chunk_size or AZURE_DOWNLOAD_CHUNK_SIZE)
 
         return self._get_object(
             obj=obj,
@@ -848,7 +848,7 @@ class AzureBlobsStorageDriver(StorageDriver):
         response = self.connection.request(
             obj_path, method="GET", headers=headers, stream=True, raw=True
         )
-        iterator = response.iter_content(AZURE_DOWNLOAD_CHUNK_SIZE)
+        iterator = response.iter_content(chunk_size or AZURE_DOWNLOAD_CHUNK_SIZE)
         success_status_codes = [httplib.OK, httplib.PARTIAL_CONTENT]
 
         return self._get_object(

--- a/libcloud/test/storage/test_azure_blobs.py
+++ b/libcloud/test/storage/test_azure_blobs.py
@@ -697,6 +697,40 @@ class AzureBlobsTests(unittest.TestCase):
         consumed_stream = "".join(chunk.decode("utf-8") for chunk in stream)
         self.assertEqual(len(consumed_stream), obj.size)
 
+    def test_download_object_as_stream_uses_chunk_size(self):
+        container = Container(name="foo_bar_container", extra={}, driver=self.driver)
+
+        obj = Object(
+            name="foo_bar_object",
+            size=1000,
+            hash=None,
+            extra={},
+            container=container,
+            meta_data=None,
+            driver=self.driver_type,
+        )
+
+        used_chunk_sizes = []
+
+        def mock_get_object(
+            self, obj, callback, callback_kwargs, response, success_status_code=None
+        ):
+            iterator = callback_kwargs["iterator"]
+            used_chunk_sizes.append(iterator.gi_frame.f_locals.get("chunk_size"))
+            return iterator
+
+        old_func = self.driver_type._get_object
+        self.driver_type._get_object = mock_get_object
+        try:
+            self.driver.download_object_as_stream(obj=obj, chunk_size=1234)
+            self.driver.download_object_range_as_stream(
+                obj=obj, start_bytes=0, end_bytes=10, chunk_size=4321
+            )
+        finally:
+            self.driver_type._get_object = old_func
+
+        self.assertEqual(used_chunk_sizes, [1234, 4321])
+
     def test_download_object_range_success(self):
         container = Container(name="foo_bar_container", extra={}, driver=self.driver)
         obj = Object(


### PR DESCRIPTION
## [Azure Blobs] Forward chunk_size in download_object_as_stream

### Description

Closes #1698. `download_object_as_stream` and `download_object_range_as_stream` in the Azure Blobs driver passed the hardcoded `AZURE_DOWNLOAD_CHUNK_SIZE` to `iter_content` instead of the caller's `chunk_size`, so a requested size was silently ignored. Both now forward `chunk_size` (falling back to the default when `None`), matching the S3 driver's behavior.

### Status

- done, ready for review

### Checklist (tick everything that applies)

- [x] [Code linting](http://libcloud.readthedocs.org/en/latest/development.html#code-style-guide) (required, can be done after the PR checks)
- [ ] Documentation
- [x] [Tests](http://libcloud.readthedocs.org/en/latest/testing.html)
- [ ] [ICLA](http://libcloud.readthedocs.org/en/latest/development.html#contributing-bigger-changes) (required for bigger changes)
