### PR TITLE
[Cloudflare] Fix list_record_types advertising URL instead of LOC

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,17 @@ Storage
   (GITHUB-1698)
   [Sanjay Santhanam - @Sanjays2402]
 
+DNS
+~~~~
+
+- [Cloudflare] Fix ``list_record_types`` advertising the unsupported ``URL``
+  record type instead of ``LOC``. The ``RECORD_TYPE_MAP`` entry was keyed on
+  ``RecordType.URL`` while its value was ``"LOC"``; the key is now
+  ``RecordType.LOC`` so Cloudflare's supported ``LOC`` record type is reported
+  and the unsupported ``URL`` type is not.
+  (#2175)
+  [Uttam Limbani - @uttam12331]
+
 Changes in Apache Libcloud 3.9.1
 --------------------------------
 

--- a/libcloud/dns/drivers/cloudflare.py
+++ b/libcloud/dns/drivers/cloudflare.py
@@ -192,7 +192,7 @@ class CloudFlareDNSDriver(DNSDriver):
         RecordType.SPF: "SPF",
         RecordType.NS: "NS",
         RecordType.SRV: "SRV",
-        RecordType.URL: "LOC",
+        RecordType.LOC: "LOC",
     }
 
     ZONES_PAGE_SIZE = 50

--- a/libcloud/test/dns/test_cloudflare.py
+++ b/libcloud/test/dns/test_cloudflare.py
@@ -53,6 +53,10 @@ class CloudFlareDNSDriverTestCase(unittest.TestCase):
         record_types = self.driver.list_record_types()
         self.assertEqual(len(record_types), 9)
         self.assertTrue(RecordType.A in record_types)
+        # LOC is a Cloudflare-supported record type and must be advertised;
+        # URL is not a DNS record type and must not be.
+        self.assertTrue(RecordType.LOC in record_types)
+        self.assertTrue(RecordType.URL not in record_types)
 
     def test_list_zones(self):
         zones = self.driver.list_zones()


### PR DESCRIPTION
### Summary

The CloudFlare DNS driver's `RECORD_TYPE_MAP` has one entry that doesn't match the pattern of the rest:

```python
RECORD_TYPE_MAP = {
    RecordType.A: "A",
    ...
    RecordType.SRV: "SRV",
    RecordType.URL: "LOC",   # <-- key/value mismatch
}
```

Every other entry is an identity mapping, and the value `"LOC"` shows that LOC support was intended — the key is a copy-paste slip. `RecordType.URL` and `RecordType.LOC` both exist in `libcloud/dns/types.py`.

Because `list_record_types()` returns `RECORD_TYPE_MAP.keys()`, the driver:

- **advertises `RecordType.URL`**, which is not a Cloudflare DNS record type (Cloudflare does URL forwarding via Page/Redirect Rules, not DNS records), and
- **omits `RecordType.LOC`**, which Cloudflare *does* support.

### Reproduce

```python
from libcloud.dns.types import RecordType, Provider
from libcloud.dns.providers import get_driver

drv = get_driver(Provider.CLOUDFLARE)("key", "secret")
types = drv.list_record_types()

RecordType.URL in types   # True  -> should be False
RecordType.LOC in types   # False -> should be True
```

### Fix

Correct the key to `RecordType.LOC`, making it an identity mapping like the others:

```python
RecordType.LOC: "LOC",
```

The map value isn't consumed by `create_record` (which passes the record type through directly), so the only observable effect is `list_record_types()`, which now correctly reports `LOC` and no longer reports `URL`. The entry count is unchanged (9).

### Tests

Extended `test_list_record_types` to assert `RecordType.LOC` is present and `RecordType.URL` is absent. It fails on the current code and passes with the fix. Full `test_cloudflare.py` suite: `29 passed`. flake8 clean.